### PR TITLE
test(e2e): IPv6-drop characterization + content-integrity coverage

### DIFF
--- a/common/splicetcp/src/classifier.rs
+++ b/common/splicetcp/src/classifier.rs
@@ -570,6 +570,81 @@ mod tests {
         );
     }
 
+    /// Builds a minimal IPv6 TCP SYN frame (EtherType 0x86DD). The datapath
+    /// is IPv4-only by design (`classify_frame` drops non-0x0800/0x0806
+    /// EtherTypes; the utun shim likewise drops first-nibble-6 packets), so
+    /// this exists purely to characterize that drop.
+    fn make_ipv6_tcp_syn_frame() -> Vec<u8> {
+        // ETH(14) + IPv6(40) + TCP(20).
+        let mut frame = vec![0u8; ETH_HEADER_LEN + 40 + 20];
+        let guest_mac = [0x02, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE];
+        frame[0..6].copy_from_slice(&[0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
+        frame[6..12].copy_from_slice(&guest_mac);
+        frame[12..14].copy_from_slice(&0x86DDu16.to_be_bytes()); // IPv6
+        let ip = ETH_HEADER_LEN;
+        frame[ip] = 0x60; // version = 6
+        frame[ip + 4..ip + 6].copy_from_slice(&20u16.to_be_bytes()); // payload length
+        frame[ip + 6] = PROTO_TCP; // next header
+        frame[ip + 7] = 64; // hop limit
+        // src ::1, dst 2606:4700:4700::1111 (a real public v6 resolver shape).
+        frame[ip + 8..ip + 24].copy_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+        frame[ip + 24..ip + 40].copy_from_slice(&[
+            0x26, 0x06, 0x47, 0x00, 0x47, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0x11, 0x11,
+        ]);
+        // TCP SYN.
+        let l4 = ip + 40;
+        frame[l4 + 2..l4 + 4].copy_from_slice(&443u16.to_be_bytes()); // dst port
+        frame[l4 + 12] = 0x50; // data offset
+        frame[l4 + 13] = 0x02; // SYN
+        frame
+    }
+
+    /// IPv6 is intentionally unsupported: an IPv6 frame must be dropped
+    /// whole — never queued for TCP, intercept, or ARP handling. This pins
+    /// the documented limitation so a future half-implementation (parsing
+    /// v6 far enough to queue it, then mishandling it) is caught, and
+    /// asserts the drop is a clean no-op (no panic, no state mutation).
+    #[test]
+    fn classify_ipv6_is_dropped_whole() {
+        let gateway_ip = Ipv4Addr::new(192, 168, 64, 1);
+        let mut device = FrameClassifier::new(gateway_ip, DEFAULT_ETHERNET_MTU);
+        device.set_gateway_mac([0x02, 0xAA, 0xBB, 0xCC, 0xDD, 0x01]);
+        let mut guest_mac = None;
+
+        device.classify_frame(&make_ipv6_tcp_syn_frame(), &mut guest_mac);
+
+        assert!(
+            device.rx_queue.is_empty(),
+            "IPv6 must not reach the TCP rx queue"
+        );
+        assert!(
+            device.intercepted.is_empty(),
+            "IPv6 must not be intercepted"
+        );
+        assert!(device.gated_syns.is_empty(), "IPv6 SYN must not be gated");
+        assert!(
+            device.pending_arp_replies.is_empty(),
+            "IPv6 must not trigger an ARP reply"
+        );
+    }
+
+    /// A truncated IPv6 frame (header claims more than is present) must also
+    /// drop cleanly — the EtherType arm rejects it before any length-trusting
+    /// parse, so a malformed v6 frame can never index out of bounds.
+    #[test]
+    fn classify_truncated_ipv6_does_not_panic() {
+        let gateway_ip = Ipv4Addr::new(192, 168, 64, 1);
+        let mut device = FrameClassifier::new(gateway_ip, DEFAULT_ETHERNET_MTU);
+        let mut guest_mac = None;
+
+        let mut frame = make_ipv6_tcp_syn_frame();
+        frame.truncate(ETH_HEADER_LEN + 8); // cut mid-IPv6-header
+        device.classify_frame(&frame, &mut guest_mac);
+
+        assert!(device.rx_queue.is_empty());
+        assert!(device.intercepted.is_empty());
+    }
+
     #[test]
     fn classify_tcp_goes_to_rx_queue() {
         let gateway_ip = Ipv4Addr::new(192, 168, 64, 1);

--- a/internal-docs/plans/network-workload-e2e.md
+++ b/internal-docs/plans/network-workload-e2e.md
@@ -99,6 +99,8 @@ boot time dominates.
 | W12 | long-lived idle flow across idle-shrink | keepalive flow held open past `ARCBOX_IDLE_TIMEOUT_SECS=20`, then reused | works or errors — never zombies (overlaps fault plan Tier 2; implement once, there) |
 | W13 | parallel large downloads (multi-image-pull shape) | 8 × 64 MiB concurrent in the workbench | all complete ≤ deadline; straggler ≤ max(4×median, 10 s); throughput recorded; zombie sweep *(implemented)* |
 | W14 | docker build (compound daily flow) | context with 8 MiB incompressible payload + RUN wget from the blob server; byte-exactness via in-build `RUN test $(wc -c)` | build succeeds ≤ deadline; built image runs; context and download byte-exact *(implemented)* |
+| W15 | download integrity | known-pattern (`fill_pattern`) download piped through in-guest `sha256sum` | hash matches the server's hash of the exact bytes served — content, not just length *(implemented)* |
+| W16 | upload integrity | container hashes a urandom payload it sends; host `spawn_hashing_sink` hashes what it receives | the two SHA-256s match — guards the direction the silent-data-loss bug hit *(implemented)* |
 
 ## External phase (env-gated, never default, still local)
 

--- a/tests/e2e/src/net_fixtures.rs
+++ b/tests/e2e/src/net_fixtures.rs
@@ -15,6 +15,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
+use sha2::{Digest, Sha256};
 
 use crate::docker::docker_output;
 
@@ -22,6 +23,42 @@ use crate::docker::docker_output;
 /// connections to it into host `127.0.0.1` — the `host.docker.internal`
 /// mechanism, and the datapath every fixture here sits behind.
 pub const GUEST_GATEWAY_IP: &str = "10.0.2.1";
+
+/// Fills `buf` with a deterministic, position-dependent pattern.
+///
+/// A seeded xorshift64* stream. Unlike a run of zeroes, this makes any
+/// truncation, reordering, or duplication in transit change the SHA-256 —
+/// the integrity check that byte-count-only assertions miss (the datapath's
+/// silent-upload-loss bug advanced the ACK past unwritten bytes, so a
+/// length check alone could pass on corrupt data). Distinct seeds give
+/// distinct streams (only the degenerate all-zero state is remapped).
+pub fn fill_pattern(buf: &mut [u8], seed: u64) {
+    // xorshift sticks at zero; remap only that one state so every other
+    // seed stays distinct (`seed | 1` would collide 42 and 43).
+    let mut state = if seed == 0 {
+        0x9E37_79B9_7F4A_7C15
+    } else {
+        seed
+    };
+    for chunk in buf.chunks_mut(8) {
+        state ^= state >> 12;
+        state ^= state << 25;
+        state ^= state >> 27;
+        let bytes = state.wrapping_mul(0x2545_F491_4F6C_DD1D).to_le_bytes();
+        chunk.copy_from_slice(&bytes[..chunk.len()]);
+    }
+}
+
+/// Lowercase-hex SHA-256 of `data`.
+pub fn sha256_hex(data: &[u8]) -> String {
+    let digest = Sha256::digest(data);
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
 
 /// Reads request headers until the `\r\n\r\n` terminator. Returns false on
 /// EOF or error before the terminator.
@@ -127,6 +164,66 @@ pub fn spawn_blob_server(blob_bytes: usize) -> Result<BlobServer> {
     Ok(BlobServer { port, timings })
 }
 
+/// HTTP origin serving a fixed deterministic-pattern body of known SHA-256.
+///
+/// For download **integrity** (not just completion) checks: the body is
+/// generated once and served verbatim, so the guest can pipe the download
+/// through `sha256sum` and compare to [`sha256`](Self::sha256).
+pub struct PatternServer {
+    port: u16,
+    sha256: String,
+    len: usize,
+}
+
+impl PatternServer {
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Lowercase-hex SHA-256 of the exact bytes this origin serves.
+    pub fn sha256(&self) -> &str {
+        &self.sha256
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+pub fn spawn_pattern_server(len: usize, seed: u64) -> Result<PatternServer> {
+    let mut body = vec![0u8; len];
+    fill_pattern(&mut body, seed);
+    let sha256 = sha256_hex(&body);
+    let body = std::sync::Arc::new(body);
+
+    let listener = TcpListener::bind("127.0.0.1:0").context("binding pattern server")?;
+    let port = listener.local_addr()?.port();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let body = std::sync::Arc::clone(&body);
+            std::thread::spawn(move || {
+                if !drain_request_headers(&mut stream) {
+                    return;
+                }
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                if stream.write_all(header.as_bytes()).is_err() {
+                    return;
+                }
+                let _ = stream.write_all(&body);
+            });
+        }
+    });
+    Ok(PatternServer { port, sha256, len })
+}
+
 /// HTTP origin that serves `partial_body` bytes of an `advertised_len`
 /// body, then turns its close into a RST (`SO_LINGER` zero).
 ///
@@ -202,6 +299,10 @@ pub struct SlowSink {
     received: Arc<AtomicUsize>,
     done: Arc<AtomicBool>,
     transfer: Arc<Mutex<Option<Duration>>>,
+    /// SHA-256 of the received byte stream, present only when the sink was
+    /// spawned with hashing enabled (upload integrity). Hashing every byte
+    /// costs CPU, so throughput-only sinks leave it `None`.
+    hasher: Option<Arc<Mutex<Sha256>>>,
 }
 
 pub struct SinkReport {
@@ -209,6 +310,9 @@ pub struct SinkReport {
     /// Accept → the sink's read loop ending (byte count reached or client
     /// hangup), measured sink-side. Includes any configured pause.
     pub transfer: Duration,
+    /// Lowercase-hex SHA-256 of the received bytes, when hashing was
+    /// enabled; empty otherwise.
+    pub sha256: String,
 }
 
 impl SlowSink {
@@ -223,6 +327,15 @@ impl SlowSink {
         let started = Instant::now();
         while started.elapsed() < timeout {
             if self.done.load(Ordering::Acquire) {
+                let sha256 = self.hasher.as_ref().map_or_else(String::new, |h| {
+                    let digest = h.lock().expect("hasher poisoned").clone().finalize();
+                    let mut hex = String::with_capacity(64);
+                    for byte in digest {
+                        use std::fmt::Write;
+                        let _ = write!(hex, "{byte:02x}");
+                    }
+                    hex
+                });
                 return Ok(SinkReport {
                     received: self.received.load(Ordering::Acquire),
                     transfer: self
@@ -230,6 +343,7 @@ impl SlowSink {
                         .lock()
                         .expect("transfer poisoned")
                         .unwrap_or_default(),
+                    sha256,
                 });
             }
             std::thread::sleep(Duration::from_millis(50));
@@ -242,14 +356,30 @@ impl SlowSink {
 }
 
 pub fn spawn_slow_sink(expected: usize, pause: Option<SinkPause>) -> Result<SlowSink> {
+    spawn_slow_sink_inner(expected, pause, false)
+}
+
+/// [`spawn_slow_sink`] that also SHA-256s the received stream, for upload
+/// integrity (compare [`SinkReport::sha256`] against what the client sent).
+pub fn spawn_hashing_sink(expected: usize) -> Result<SlowSink> {
+    spawn_slow_sink_inner(expected, None, true)
+}
+
+fn spawn_slow_sink_inner(
+    expected: usize,
+    pause: Option<SinkPause>,
+    hash: bool,
+) -> Result<SlowSink> {
     let listener = TcpListener::bind("127.0.0.1:0").context("binding slow sink")?;
     let port = listener.local_addr()?.port();
     let received = Arc::new(AtomicUsize::new(0));
     let done = Arc::new(AtomicBool::new(false));
     let transfer: Arc<Mutex<Option<Duration>>> = Arc::default();
+    let hasher = hash.then(|| Arc::new(Mutex::new(Sha256::new())));
     let sink_received = Arc::clone(&received);
     let sink_done = Arc::clone(&done);
     let sink_transfer = Arc::clone(&transfer);
+    let sink_hasher = hasher.clone();
     std::thread::spawn(move || {
         for stream in listener.incoming() {
             let Ok(mut stream) = stream else { continue };
@@ -271,6 +401,9 @@ pub fn spawn_slow_sink(expected: usize, pause: Option<SinkPause>) -> Result<Slow
                 match stream.read(&mut buf) {
                     Ok(0) | Err(_) => break,
                     Ok(n) => {
+                        if let Some(h) = &sink_hasher {
+                            h.lock().expect("hasher poisoned").update(&buf[..n]);
+                        }
                         sink_received.fetch_add(n, Ordering::AcqRel);
                     }
                 }
@@ -285,6 +418,7 @@ pub fn spawn_slow_sink(expected: usize, pause: Option<SinkPause>) -> Result<Slow
         received,
         done,
         transfer,
+        hasher,
     })
 }
 
@@ -429,6 +563,48 @@ mod tests {
     use super::*;
 
     const ERR: &str = r#"{"level":"ERROR","fields":{"message":"x"},"target":"arcbox_net::darwin::datapath_loop::guest_tx"}"#;
+
+    #[test]
+    fn pattern_is_deterministic_and_seed_sensitive() {
+        let mut a = vec![0u8; 4096];
+        let mut b = vec![0u8; 4096];
+        fill_pattern(&mut a, 42);
+        fill_pattern(&mut b, 42);
+        assert_eq!(a, b, "same seed ⇒ same bytes");
+        assert_eq!(sha256_hex(&a), sha256_hex(&b));
+
+        let mut c = vec![0u8; 4096];
+        fill_pattern(&mut c, 43);
+        assert_ne!(a, c, "different seed ⇒ different bytes");
+
+        // Not a trivial constant run — this is what makes reordering /
+        // truncation detectable where a zero blob would not be.
+        assert!(a.windows(64).any(|w| w.iter().any(|&x| x != a[0])));
+    }
+
+    #[test]
+    fn pattern_length_changes_the_hash() {
+        let mut short = vec![0u8; 1000];
+        let mut long = vec![0u8; 1001];
+        fill_pattern(&mut short, 7);
+        fill_pattern(&mut long, 7);
+        // A prefix relationship (truncation) must not collide on the hash.
+        assert_ne!(sha256_hex(&short), sha256_hex(&long));
+    }
+
+    #[test]
+    fn sha256_hex_is_lowercase_64_hex() {
+        let h = sha256_hex(b"");
+        assert_eq!(
+            h,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(h.len(), 64);
+        assert!(
+            h.bytes()
+                .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+        );
+    }
 
     fn write_log(dir: &Path, name: &str, lines: &[&str]) {
         std::fs::write(dir.join("log").join(name), lines.join("\n") + "\n").unwrap();

--- a/tests/e2e/src/net_fixtures.rs
+++ b/tests/e2e/src/net_fixtures.rs
@@ -49,15 +49,19 @@ pub fn fill_pattern(buf: &mut [u8], seed: u64) {
     }
 }
 
-/// Lowercase-hex SHA-256 of `data`.
-pub fn sha256_hex(data: &[u8]) -> String {
-    let digest = Sha256::digest(data);
-    let mut hex = String::with_capacity(64);
-    for byte in digest {
-        use std::fmt::Write;
+/// Lowercase-hex encoding of a byte stream.
+fn hex_encode(bytes: impl IntoIterator<Item = u8>) -> String {
+    use std::fmt::Write;
+    let mut hex = String::new();
+    for byte in bytes {
         let _ = write!(hex, "{byte:02x}");
     }
     hex
+}
+
+/// Lowercase-hex SHA-256 of `data`.
+pub fn sha256_hex(data: &[u8]) -> String {
+    hex_encode(Sha256::digest(data))
 }
 
 /// Reads request headers until the `\r\n\r\n` terminator. Returns false on
@@ -328,13 +332,7 @@ impl SlowSink {
         while started.elapsed() < timeout {
             if self.done.load(Ordering::Acquire) {
                 let sha256 = self.hasher.as_ref().map_or_else(String::new, |h| {
-                    let digest = h.lock().expect("hasher poisoned").clone().finalize();
-                    let mut hex = String::with_capacity(64);
-                    for byte in digest {
-                        use std::fmt::Write;
-                        let _ = write!(hex, "{byte:02x}");
-                    }
-                    hex
+                    hex_encode(h.lock().expect("hasher poisoned").clone().finalize())
                 });
                 return Ok(SinkReport {
                     received: self.received.load(Ordering::Acquire),

--- a/tests/e2e/tests/network_workload.rs
+++ b/tests/e2e/tests/network_workload.rs
@@ -22,6 +22,10 @@
 //! - **W14 docker build**: context upload over vsock, RUN-step networking
 //!   through the datapath, layer commits; byte-exactness asserted inside
 //!   the build via `RUN test $(wc -c ...)` steps.
+//! - **W15/W16 integrity**: content, not just completion — a known-pattern
+//!   download and a urandom upload are SHA-256'd end to end and compared,
+//!   catching corruption/reorder/truncation that byte-count checks miss
+//!   (the shape the silent-upload-loss bug produced).
 //!
 //! All scenarios share one booted daemon (boot dominates the runtime) and
 //! run inside a long-lived workbench container whose netns the zombie sweep
@@ -42,7 +46,7 @@ use arcbox_e2e::docker::{docker_ignore, docker_output, ensure_image};
 use arcbox_e2e::metrics::RunMetrics;
 use arcbox_e2e::net_fixtures::{
     GUEST_GATEWAY_IP, SinkPause, assert_no_established_flows, daemon_log_cursor, spawn_blob_server,
-    spawn_slow_sink,
+    spawn_hashing_sink, spawn_pattern_server, spawn_slow_sink,
 };
 use arcbox_e2e::scenario::run_vz_scenario_with_log;
 
@@ -104,6 +108,12 @@ const BUILD_TAG: &str = "net-workload-build:latest";
 /// frozen flow (the 2026-07-19 incident shape) fails.
 const SWEEP_GRACE: Duration = Duration::from_secs(10);
 
+/// Integrity payload size: large enough to span many segments/retransmits
+/// so a reordering/truncation/duplication bug actually shows up in the
+/// SHA-256, small enough to stay quick.
+const INTEGRITY_BYTES: usize = 32 * 1024 * 1024;
+const INTEGRITY_DEADLINE: Duration = Duration::from_secs(120);
+
 #[test]
 #[ignore = "boots a VZ System VM through a real daemon; run on the e2e runner"]
 fn net_workload_egress_suite() -> Result<()> {
@@ -129,7 +139,7 @@ fn net_workload_egress_suite() -> Result<()> {
             // every workload below.
             let log = daemon_log_cursor(data_dir);
 
-            let scenarios: [(&str, ScenarioFn); 7] = [
+            let scenarios: [(&str, ScenarioFn); 9] = [
                 ("upload_steady", upload_steady),
                 ("upload_paused_reader", upload_paused_reader),
                 ("burst_single_container", burst_single_container),
@@ -137,6 +147,8 @@ fn net_workload_egress_suite() -> Result<()> {
                 ("churn_sequential", churn_sequential),
                 ("parallel_large_downloads", parallel_large_downloads),
                 ("docker_build_network", docker_build_network),
+                ("download_integrity", download_integrity),
+                ("upload_integrity", upload_integrity),
             ];
             // Diagnostic filter: run only the named scenario, e.g.
             // ARCBOX_E2E_WORKLOAD_ONLY=burst_single_container.
@@ -572,4 +584,79 @@ fn docker_build_network(data_dir: &Path, metrics: &mut RunMetrics, image: &str) 
     })();
     docker_ignore(data_dir, &["rmi".into(), "-f".into(), BUILD_TAG.into()]);
     result
+}
+
+/// W15: download **integrity** — content, not just completion. The
+/// byte-count checks elsewhere would pass on a stream that arrived the
+/// right length but reordered/duplicated/corrupted (the shape the
+/// silent-upload-loss bug produced on the other direction). The container
+/// pipes a known-pattern download straight through `sha256sum` and we
+/// compare to the server's hash of the exact bytes it served — end to end
+/// through the download retransmission + reassembly path.
+fn download_integrity(data_dir: &Path, _metrics: &mut RunMetrics, _image: &str) -> Result<()> {
+    let server = spawn_pattern_server(INTEGRITY_BYTES, 0xABCD_1234)?;
+    let url = format!("http://{GUEST_GATEWAY_IP}:{}/blob", server.port());
+    let script = format!("wget -q -O - '{url}' | sha256sum | cut -d' ' -f1");
+    let out = docker_output(
+        data_dir,
+        &["exec", BENCH, "sh", "-c", &script],
+        INTEGRITY_DEADLINE + Duration::from_secs(60),
+    )
+    .context("download_integrity: in-container hashed download")?;
+    let got = out.trim();
+    if got != server.sha256() {
+        bail!(
+            "download_integrity: sha256 mismatch — served {}, guest received {got} \
+             (content corrupted in transit despite completing)",
+            server.sha256()
+        );
+    }
+    assert_no_established_flows(data_dir, BENCH, server.port(), SWEEP_GRACE)
+}
+
+/// W16: upload **integrity** — the direction the silent-data-loss bug hit.
+/// The container hashes exactly what it sends (a urandom payload → temp
+/// file → sha256sum → nc), and the host sink hashes exactly what it
+/// receives; the two must match. A source-file hash + sink hash computed
+/// independently at runtime catches any corruption without a predetermined
+/// pattern.
+fn upload_integrity(data_dir: &Path, _metrics: &mut RunMetrics, _image: &str) -> Result<()> {
+    let sink = spawn_hashing_sink(INTEGRITY_BYTES)?;
+    let mib = INTEGRITY_BYTES / (1024 * 1024);
+    // Materialize the payload once, hash it, then stream it — so the
+    // client-side hash is of the exact bytes handed to nc.
+    let script = format!(
+        "dd if=/dev/urandom of=/tmp/up.bin bs=1M count={mib} 2>/dev/null; \
+         sha256sum /tmp/up.bin | cut -d' ' -f1; \
+         nc {GUEST_GATEWAY_IP} {} < /tmp/up.bin; rm -f /tmp/up.bin",
+        sink.port()
+    );
+    let started = Instant::now();
+    let out = docker_output(
+        data_dir,
+        &["exec", BENCH, "sh", "-c", &script],
+        INTEGRITY_DEADLINE + Duration::from_secs(60),
+    )
+    .context("upload_integrity: in-container hashed upload")?;
+    let sent_sha = out
+        .lines()
+        .next()
+        .map(str::trim)
+        .filter(|h| h.len() == 64)
+        .with_context(|| format!("upload_integrity: no client sha in output {out:?}"))?;
+    let report = sink.wait_complete(INTEGRITY_DEADLINE.saturating_sub(started.elapsed()))?;
+    if report.received != INTEGRITY_BYTES {
+        bail!(
+            "upload_integrity: sink received {} of {INTEGRITY_BYTES} bytes",
+            report.received
+        );
+    }
+    if report.sha256 != sent_sha {
+        bail!(
+            "upload_integrity: sha256 mismatch — client sent {sent_sha}, sink received {} \
+             (upload corrupted in transit despite arriving full-length)",
+            report.sha256
+        );
+    }
+    assert_no_established_flows(data_dir, BENCH, sink.port(), SWEEP_GRACE)
 }


### PR DESCRIPTION
Fills two coverage gaps the workload/iperf suites don't reach. No product
code changed — pure test additions.

## 1. IPv6 drop characterization (unit, fast)

The datapath is IPv4-only by design: `FrameClassifier::classify_frame`
drops EtherType 0x86DD in its `_ => drop` arm, and the utun shim drops
first-nibble-6 packets. Product IPv6 support is intentionally out of scope
(per direction); these tests characterize the *current* behavior so a
future half-implementation (parsing v6 far enough to queue it, then
mishandling it) is caught:

- `classify_ipv6_is_dropped_whole` — an IPv6 TCP SYN reaches no queue
  (rx, intercept, gated-SYN) and triggers no ARP reply.
- `classify_truncated_ipv6_does_not_panic` — a malformed/short v6 frame
  drops cleanly (the EtherType arm rejects it before any length-trusting
  parse).

Done at the classifier boundary rather than as an e2e — deterministic,
sub-second, no VM (Rust-testing best practice: unit where the boundary
allows).

## 2. Content integrity, not just completion

Every existing transfer test checks byte *count*. A stream can arrive the
right length but reordered/duplicated/corrupted — exactly the shape the
silent-upload-loss bug produced (it advanced the ACK past unwritten
bytes). New coverage verifies *content*:

- `net_fixtures`: `fill_pattern` (seeded xorshift64* — distinct seeds give
  distinct streams; a zero blob can't detect reordering) + `sha256_hex`,
  both unit-tested (determinism, seed-sensitivity, truncation changes the
  hash). `PatternServer` (download) and a hashing `SlowSink` (upload).
- workload suite: **W15 download-integrity** (known-pattern download piped
  through in-guest `sha256sum`, compared to the server's hash) and **W16
  upload-integrity** (container hashes the urandom payload it sends; the
  host sink hashes what it receives; the two must match) — end to end
  through the real download-reassembly and upload paths.

A unit test caught a real bug in the fixture during development:
`seed | 1` collapsed adjacent even/odd seeds (42 and 43 → same stream);
fixed to remap only the degenerate zero state.

## Verification

- `cargo test -p splicetcp` (classifier IPv6) + `cargo test -p arcbox-e2e
  --lib net_fixtures` (pattern/hash) — green, no VM.
- W15/W16 pass on a real VZ VM (43 s / 40 s), SHA-256 matching end to end.