### PR TITLE
fix(balloon): stop idle-shrink oscillation (fail-open backoff + HV free-page-reporting gate)

### DIFF
--- a/app/arcbox-core/src/vm_lifecycle/actor.rs
+++ b/app/arcbox-core/src/vm_lifecycle/actor.rs
@@ -197,6 +197,13 @@ impl BalloonDeps for RealBalloonDeps {
             .set_balloon_target(&info.vm_id, bytes)
     }
 
+    /// HV advertises virtio-balloon free page reporting + deflate-on-oom
+    /// (`virt/arcbox-virtio-balloon`), so its guest self-reclaims; VZ's
+    /// traditional balloon does not.
+    fn guest_self_reclaims(&self) -> bool {
+        matches!(self.shared.backend(), arcbox_vmm::VmBackend::Hv)
+    }
+
     /// Any failure (connect, RPC, timeout) folds to `None`: the policy treats
     /// "unknown" as its own signal — never shrink on it, and fail open while
     /// shrunk, since a reclaim-thrashing guest is exactly one that cannot

--- a/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
@@ -37,6 +37,13 @@
 //! ([`fail_open_backoff`]): after each failed descent the next idle entry is
 //! suppressed for a growing window, and a shrink that actually holds clears
 //! the streak so idle reclaim self-heals once the host recovers.
+//!
+//! This whole host-driven descent runs only on the VZ backend, whose
+//! traditional balloon exposes nothing but a target. The HV backend's
+//! virtio-balloon advertises free page reporting and deflate-on-oom, so its
+//! guest kernel drains idle memory to the host on its own and recovers under
+//! OOM without any target policy — there the controller stays out of the way
+//! (see [`BalloonDeps::guest_self_reclaims`]).
 
 use std::future::Future;
 use std::sync::Arc;
@@ -91,6 +98,13 @@ pub(in crate::vm_lifecycle) trait BalloonDeps:
 
     /// Applies a balloon target on the hypervisor device.
     fn set_balloon_target(&self, bytes: u64) -> Result<()>;
+
+    /// Whether the guest reclaims idle memory on its own. The HV backend
+    /// advertises virtio-balloon free page reporting + deflate-on-oom, so its
+    /// guest kernel drains free pages to the host continuously and recovers
+    /// under OOM without a host-driven target; the idle-shrink descent is then
+    /// skipped. VZ's traditional balloon has no such mechanism and needs it.
+    fn guest_self_reclaims(&self) -> bool;
 
     /// Guest memory + load snapshot within `budget`; `None` = unreachable.
     fn guest_stats(&self, budget: Duration) -> impl Future<Output = Option<GuestStats>> + Send;
@@ -363,6 +377,16 @@ impl<D: BalloonDeps> BalloonController<D> {
         let Some(full) = self.deps.full_memory_bytes() else {
             return Mode::IdleUnshrunk;
         };
+        // On a backend whose guest self-reclaims (HV free page reporting), the
+        // host-driven descent is unnecessary and is the sole source of the
+        // inflate-stall pathology; stay out of the way and let the guest drain
+        // idle memory itself.
+        if self.deps.guest_self_reclaims() {
+            tracing::debug!(
+                "idle balloon shrink skipped; guest self-reclaims via free page reporting"
+            );
+            return Mode::Active;
+        }
         // Back off after repeated fail-opens. A shrink that fails the same way
         // every cycle — typically inflation stalling on a host that is itself
         // out of memory — must not restage its reclaim storm on the 5-minute
@@ -544,6 +568,8 @@ mod tests {
         /// When set, `set_balloon_target` fails (attempts still counted).
         fail_set_target: std::sync::atomic::AtomicBool,
         set_attempts: Arc<AtomicUsize>,
+        /// Emulates a self-reclaiming backend (HV free page reporting).
+        self_reclaims: bool,
         watch_supported: bool,
         watch_frames: Mutex<Vec<mpsc::UnboundedReceiver<WatchFrame>>>,
         watch_senders: Mutex<Vec<mpsc::UnboundedSender<WatchFrame>>>,
@@ -559,6 +585,7 @@ mod tests {
                 targets: Arc::new(Mutex::new(Vec::new())),
                 fail_set_target: std::sync::atomic::AtomicBool::new(false),
                 set_attempts: Arc::new(AtomicUsize::new(0)),
+                self_reclaims: false,
                 watch_supported: true,
                 watch_frames: Mutex::new(Vec::new()),
                 watch_senders: Mutex::new(Vec::new()),
@@ -595,6 +622,10 @@ mod tests {
             }
             self.targets.lock().unwrap().push(bytes);
             Ok(())
+        }
+
+        fn guest_self_reclaims(&self) -> bool {
+            self.self_reclaims
         }
 
         async fn guest_stats(&self, _budget: Duration) -> Option<GuestStats> {
@@ -1043,6 +1074,31 @@ mod tests {
 
         assert!(h.targets().is_empty());
         assert_eq!(h.activity_count(), 0);
+    }
+
+    /// The HV backend advertises free page reporting + deflate-on-oom, so the
+    /// guest self-reclaims: the host-driven idle-shrink must never fire — no
+    /// target, no watch, no forced idle exit.
+    #[tokio::test(start_paused = true)]
+    async fn self_reclaiming_backend_skips_idle_shrink() {
+        let mut deps = FakeDeps::new(Some(FULL));
+        deps.self_reclaims = true;
+        deps.push_stats(Some(idle_stats()));
+        let h = Harness::spawn(deps);
+
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+
+        assert!(
+            h.targets().is_empty(),
+            "self-reclaiming guest must not be shrunk"
+        );
+        assert_eq!(
+            h.deps.watches_opened.load(Ordering::SeqCst),
+            0,
+            "no pressure watch on a self-reclaiming backend"
+        );
+        assert_eq!(h.activity_count(), 0, "declining to shrink is not activity");
     }
 
     #[test]

--- a/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
@@ -28,8 +28,15 @@
 //! Exits always ride the lifecycle state machine: pressure and fail-open
 //! paths restore full memory immediately, then note activity, which exits
 //! `Idle` and resets the 5-minute idle clock — so a re-shrink requires a
-//! fresh quiet period plus a fresh entry probe. Oscillation is structurally
-//! impossible.
+//! fresh quiet period plus a fresh entry probe. That rules out *tight*
+//! oscillation, but not a shrink that fails the same way every idle cycle:
+//! when the host itself is out of memory, inflation stalls and every descent
+//! fail-opens, so the 5-minute clock alone would restage the reclaim storm
+//! indefinitely (macOS reports "normal" memory pressure throughout — there is
+//! no host signal to gate on). Consecutive fail-opens therefore back off
+//! ([`fail_open_backoff`]): after each failed descent the next idle entry is
+//! suppressed for a growing window, and a shrink that actually holds clears
+//! the streak so idle reclaim self-heals once the host recovers.
 
 use std::future::Future;
 use std::sync::Arc;
@@ -141,6 +148,23 @@ pub(in crate::vm_lifecycle) const WATCH_KEEPALIVE: Duration = Duration::from_sec
 /// Budget for the entry-time guest stats probe.
 const GUEST_STATS_TIMEOUT: Duration = Duration::from_secs(super::GUEST_STATS_TIMEOUT_SECS);
 
+/// Suppression window after the first fail-open, doubling with each further
+/// consecutive fail-open up to [`FAIL_OPEN_BACKOFF_MAX`]. Sized above the
+/// 5-minute idle timeout so a single failure already skips the next idle
+/// entry instead of restaging the reclaim storm.
+const FAIL_OPEN_BACKOFF_BASE: Duration = Duration::from_secs(600);
+
+/// Cap on the fail-open backoff window. A guest whose shrink never succeeds
+/// still re-probes this often, so idle reclaim self-heals once the host
+/// recovers.
+const FAIL_OPEN_BACKOFF_MAX: Duration = Duration::from_secs(3600);
+
+/// Backoff window for the current consecutive-fail-open streak (`>= 1`).
+fn fail_open_backoff(consecutive: u32) -> Duration {
+    let shift = consecutive.saturating_sub(1).min(3);
+    (FAIL_OPEN_BACKOFF_BASE * (1u32 << shift)).min(FAIL_OPEN_BACKOFF_MAX)
+}
+
 /// The controller task. Owns all balloon state; communicates with the world
 /// only through [`BalloonDeps`] (in) and the activity callback (out).
 pub(in crate::vm_lifecycle) struct BalloonController<D: BalloonDeps> {
@@ -154,6 +178,12 @@ pub(in crate::vm_lifecycle) struct BalloonController<D: BalloonDeps> {
     final_target: Option<u64>,
     /// When the current step was applied (dwell pacing).
     step_applied_at: Option<tokio::time::Instant>,
+    /// Consecutive fail-opens since the last shrink that held. Drives the
+    /// idle-shrink backoff so a reliably-failing shrink stops restaging its
+    /// reclaim storm every idle cycle.
+    consecutive_fail_opens: u32,
+    /// When the last fail-open happened, measured against the backoff window.
+    last_fail_open_at: Option<tokio::time::Instant>,
 }
 
 /// Controller mode; holds the open watch so drops cancel it naturally.
@@ -190,6 +220,8 @@ impl<D: BalloonDeps> BalloonController<D> {
             applied: None,
             final_target: None,
             step_applied_at: None,
+            consecutive_fail_opens: 0,
+            last_fail_open_at: None,
         }
     }
 
@@ -218,6 +250,7 @@ impl<D: BalloonDeps> BalloonController<D> {
                     tokio::select! {
                         cmd = self.commands.recv() => match cmd {
                             Some(BalloonCommand::ExitIdle) => {
+                                self.note_shrink_held();
                                 self.restore("idle exit");
                                 Mode::Active
                             }
@@ -228,7 +261,9 @@ impl<D: BalloonDeps> BalloonController<D> {
                             Ok(WatchFrame::Keepalive) => Mode::Watching(watch),
                             Ok(WatchFrame::Settled) => {
                                 if self.next_pending_step().is_none() {
-                                    // Final target reached; keep watching.
+                                    // Final target reached and the guest armed:
+                                    // the shrink held, so clear the streak.
+                                    self.note_shrink_held();
                                     Mode::Watching(watch)
                                 } else {
                                     // The guest settled at this memory level,
@@ -256,6 +291,7 @@ impl<D: BalloonDeps> BalloonController<D> {
                     tokio::select! {
                         cmd = self.commands.recv() => match cmd {
                             Some(BalloonCommand::ExitIdle) => {
+                                self.note_shrink_held();
                                 self.restore("idle exit");
                                 Mode::Active
                             }
@@ -287,6 +323,7 @@ impl<D: BalloonDeps> BalloonController<D> {
                     tokio::select! {
                         cmd = self.commands.recv() => match cmd {
                             Some(BalloonCommand::ExitIdle) => {
+                                self.note_shrink_held();
                                 self.restore("idle exit");
                                 Mode::Active
                             }
@@ -306,7 +343,12 @@ impl<D: BalloonDeps> BalloonController<D> {
                                         self.apply_step(next);
                                         Mode::Polling
                                     }
-                                    None => Mode::Polling,
+                                    // At the final target and still healthy:
+                                    // the shrink held, so clear the streak.
+                                    None => {
+                                        self.note_shrink_held();
+                                        Mode::Polling
+                                    }
                                 },
                             }
                         }
@@ -321,6 +363,17 @@ impl<D: BalloonDeps> BalloonController<D> {
         let Some(full) = self.deps.full_memory_bytes() else {
             return Mode::IdleUnshrunk;
         };
+        // Back off after repeated fail-opens. A shrink that fails the same way
+        // every cycle — typically inflation stalling on a host that is itself
+        // out of memory — must not restage its reclaim storm on the 5-minute
+        // idle clock. Suppress the entry (without even probing) until the
+        // streak's backoff window elapses; the next entry after it re-probes,
+        // so reclaim resumes once the host recovers.
+        if let Some(failed_at) = self.last_fail_open_at
+            && failed_at.elapsed() < fail_open_backoff(self.consecutive_fail_opens)
+        {
+            return Mode::IdleUnshrunk;
+        }
         let stats = self.deps.guest_stats(GUEST_STATS_TIMEOUT).await;
         // Commands that arrived while the probe was in flight outrank its
         // result: a Docker request during the (up to 3s) stats query must
@@ -402,8 +455,18 @@ impl<D: BalloonDeps> BalloonController<D> {
     fn fail_open(&mut self, reason: &str) -> Mode<D::Watch> {
         tracing::info!(reason, "restoring full memory");
         self.restore(reason);
+        self.consecutive_fail_opens = self.consecutive_fail_opens.saturating_add(1);
+        self.last_fail_open_at = Some(tokio::time::Instant::now());
         (self.activity)();
         Mode::Active
+    }
+
+    /// A shrink that held — settled at the final target, or was still healthy
+    /// when activity arrived — clears the fail-open streak so the next idle
+    /// entry is not needlessly suppressed.
+    fn note_shrink_held(&mut self) {
+        self.consecutive_fail_opens = 0;
+        self.last_fail_open_at = None;
     }
 
     /// Restores the balloon to the machine's full configured memory.
@@ -980,5 +1043,103 @@ mod tests {
 
         assert!(h.targets().is_empty());
         assert_eq!(h.activity_count(), 0);
+    }
+
+    #[test]
+    fn fail_open_backoff_grows_and_caps() {
+        // A streak of 1 waits the base window; each further failure doubles
+        // it, capped at the maximum.
+        assert_eq!(fail_open_backoff(1), FAIL_OPEN_BACKOFF_BASE);
+        assert_eq!(fail_open_backoff(2), FAIL_OPEN_BACKOFF_BASE * 2);
+        assert_eq!(fail_open_backoff(3), FAIL_OPEN_BACKOFF_BASE * 4);
+        assert_eq!(fail_open_backoff(4), FAIL_OPEN_BACKOFF_MAX);
+        assert_eq!(fail_open_backoff(99), FAIL_OPEN_BACKOFF_MAX);
+    }
+
+    /// The core anti-oscillation guard: a shrink that fail-opens must not
+    /// restage every idle cycle. Idle entries inside the backoff window are
+    /// suppressed without even probing; the first entry past it re-shrinks.
+    #[tokio::test(start_paused = true)]
+    async fn fail_open_backs_off_then_reprobes() {
+        let deps = FakeDeps::new(Some(FULL));
+        deps.push_stats(Some(idle_stats())); // entry 1
+        let watch = deps.push_watch();
+        deps.push_stats(Some(idle_stats())); // re-probe past the backoff
+        let _watch2 = deps.push_watch();
+        let h = Harness::spawn(deps);
+
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+        assert_eq!(h.targets(), vec![FIRST_STEP]);
+
+        // Pressure → fail-open (streak = 1, backoff armed).
+        watch.send(WatchFrame::Pressure).unwrap();
+        h.settle().await;
+        assert_eq!(h.targets(), vec![FIRST_STEP, FULL]);
+
+        // A fresh idle entry inside the window is suppressed without probing.
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+        assert_eq!(
+            h.targets(),
+            vec![FIRST_STEP, FULL],
+            "an idle entry within the backoff window must not re-shrink"
+        );
+
+        // Past the window the IdleUnshrunk retry re-probes and shrinks again.
+        tokio::time::advance(FAIL_OPEN_BACKOFF_BASE).await;
+        h.settle().await;
+        assert_eq!(h.targets(), vec![FIRST_STEP, FULL, FIRST_STEP]);
+    }
+
+    /// A shrink that holds clears the streak: the fail-open that follows a
+    /// held shrink waits the base window again, not a doubled one.
+    #[tokio::test(start_paused = true)]
+    async fn held_shrink_resets_backoff_streak() {
+        // Sized so used + headroom == FULL - SHRINK_STEP: the descent reaches
+        // its final target in one step, so a single Settled is settle-at-final.
+        let one_step_stats = GuestStats {
+            total: FULL,
+            available: 2 * GIB + super::super::IDLE_BALLOON_HEADROOM,
+            loadavg1: 0.1,
+        };
+        let deps = FakeDeps::new(Some(FULL));
+        deps.push_stats(Some(idle_stats())); // cycle 1 → fail-open
+        let w1 = deps.push_watch();
+        deps.push_stats(Some(one_step_stats)); // cycle 2 → settles at final
+        let w2 = deps.push_watch();
+        deps.push_stats(Some(idle_stats())); // cycle 3 → shrinks after reset
+        let _w3 = deps.push_watch();
+        let h = Harness::spawn(deps);
+
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+        w1.send(WatchFrame::Pressure).unwrap();
+        h.settle().await;
+        assert_eq!(h.targets(), vec![FIRST_STEP, FULL]); // streak = 1
+
+        // Wait out the base window, re-shrink, and settle at the final target.
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+        tokio::time::advance(FAIL_OPEN_BACKOFF_BASE).await;
+        h.settle().await;
+        assert_eq!(h.targets(), vec![FIRST_STEP, FULL, FIRST_STEP]);
+        w2.send(WatchFrame::Settled).unwrap(); // final reached → streak reset
+        h.settle().await;
+
+        // A new fail-open now starts a fresh streak. If the streak had not
+        // reset it would be 2 (double window) and the base-length wait below
+        // would not re-probe.
+        w2.send(WatchFrame::Pressure).unwrap();
+        h.settle().await;
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+        tokio::time::advance(FAIL_OPEN_BACKOFF_BASE).await;
+        h.settle().await;
+        assert_eq!(
+            h.targets(),
+            vec![FIRST_STEP, FULL, FIRST_STEP, FULL, FIRST_STEP],
+            "a held shrink must reset the streak to a base-length backoff"
+        );
     }
 }

--- a/app/arcbox-core/src/vm_lifecycle/balloon/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/mod.rs
@@ -82,10 +82,14 @@ pub(super) enum EntryDecision {
 /// Computes the idle balloon target for the observed guest usage:
 /// used memory plus [`IDLE_BALLOON_HEADROOM`], clamped to
 /// [`IDLE_BALLOON_FLOOR`] and the full configured size.
+///
+/// The floor is itself capped at `full`: a machine configured below the
+/// floor (a tiny user VM) has nothing to reclaim, and an un-capped
+/// `clamp(FLOOR, full)` with `full < FLOOR` would panic (`min > max`).
 pub(super) fn idle_target(stats: GuestStats, full: u64) -> u64 {
     let used = stats.total.saturating_sub(stats.available);
     used.saturating_add(IDLE_BALLOON_HEADROOM)
-        .clamp(IDLE_BALLOON_FLOOR, full)
+        .clamp(IDLE_BALLOON_FLOOR.min(full), full)
 }
 
 /// Decides the balloon move when the VM enters idle.
@@ -147,6 +151,19 @@ mod tests {
         // Guest uses almost everything: no shrink beyond full.
         let t = idle_target(stats(FULL, 128 * MIB), FULL);
         assert_eq!(t, FULL);
+    }
+
+    /// Regression: a machine configured below the 384 MiB floor must not
+    /// panic `idle_target` (clamp with `min > max`). There is nothing to
+    /// reclaim, so the target is the full size and entry decides `Keep`.
+    #[test]
+    fn idle_target_below_floor_machine_does_not_panic() {
+        let tiny = 256 * MIB; // below IDLE_BALLOON_FLOOR (384 MiB)
+        assert_eq!(idle_target(stats(tiny, 200 * MIB), tiny), tiny);
+        assert_eq!(
+            entry_decision(Some(stats(tiny, 200 * MIB)), tiny),
+            EntryDecision::Keep
+        );
     }
 
     #[test]

--- a/virt/arcbox-virtio-balloon/src/lib.rs
+++ b/virt/arcbox-virtio-balloon/src/lib.rs
@@ -5,9 +5,9 @@
 //! - Two virtqueues: `inflateq` (0) and `deflateq` (1).
 //! - Feature bit `VIRTIO_BALLOON_F_DEFLATE_ON_OOM` (bit 2) — the guest may
 //!   reclaim balloon pages on OOM without host permission. Safe for us
-//!   because we use `madvise(MADV_DONTNEED)` which does not unmap the
-//!   guest-visible region; reclaimed pages simply re-fault zero-filled,
-//!   matching the balloon contract.
+//!   because we `madvise` (see [`RELEASE_ADVICE`]) rather than unmap the
+//!   guest-visible region, so a reclaimed page still faults in normally on
+//!   the next guest access, matching the balloon contract.
 //! - Two config-space fields: `num_pages` (host → guest target, read-only
 //!   from the guest) and `actual` (guest → host current, written by the
 //!   guest as pages are inflated/deflated).
@@ -16,7 +16,7 @@
 //!   kernel periodically hands batches of currently-free pages to the host
 //!   on `reporting_vq` (transport index computed from the negotiated
 //!   feature set — see [`reporting_queue_index`]); the host
-//!   `madvise(MADV_DONTNEED)`s the ranges and completes the buffers.
+//!   `madvise`s the ranges (see [`RELEASE_ADVICE`]) and completes the buffers.
 //!   Combined with
 //!   `DEFLATE_ON_OOM` this lets the guest kernel self-manage: idle memory
 //!   drains back to the host with no balloon-target policy at all.
@@ -31,19 +31,18 @@
 //!
 //! When the guest inflates the balloon, it writes a descriptor chain
 //! containing `u32` PFNs (4 KiB granularity) into the inflate queue.
-//! For each PFN, the host calls `madvise(MADV_DONTNEED)` on the
-//! corresponding page of the guest RAM mapping. The physical page is
-//! released back to the kernel's free pool. A subsequent access from
-//! the guest will re-fault a zero page — acceptable per §5.5.1: the
-//! guest has promised not to use the page until it tells the host via
-//! the deflate queue.
+//! For each PFN, the host calls `madvise` ([`RELEASE_ADVICE`]) on the
+//! corresponding page of the guest RAM mapping, releasing the physical
+//! backing to the host while leaving the mapping intact. The guest has
+//! promised (per §5.5.1) not to touch the page until it deflates it, so
+//! its contents are irrelevant until then.
 //!
 //! ## Deflate semantics
 //!
-//! Deflate requests are no-ops on our side: because we used
-//! `MADV_DONTNEED` (not `munmap`), the pages remain mapped and re-fault
-//! automatically on guest access. We still consume the descriptors and
-//! write the used ring so the guest's queue does not stall.
+//! Deflate requests are no-ops on our side: because we `madvise` (not
+//! `munmap`), the pages remain mapped and fault back in automatically on
+//! guest access. We still consume the descriptors and write the used ring
+//! so the guest's queue does not stall.
 
 use std::sync::atomic::{AtomicU16, AtomicU32, Ordering};
 
@@ -92,6 +91,21 @@ const QUEUE_SLOTS: usize = 5;
 const BALLOON_PFN_SHIFT: u32 = 12;
 const BALLOON_PAGE_SIZE: u64 = 1 << BALLOON_PFN_SHIFT;
 
+/// `madvise` advice used to hand inflated / reported pages back to the host.
+///
+/// On macOS `MADV_DONTNEED` does NOT release physical backing — XNU maps
+/// `VM_BEHAVIOR_DONTNEED` to a deactivation hint that only moves pages to the
+/// inactive queue, so the VM process's footprint never shrinks. `MADV_FREE` is
+/// the advice that actually lets the host reclaim the pages under pressure
+/// (matching libkrun's macOS balloon path). The guest has promised not to
+/// touch these pages until it re-allocates them, so the fact that `MADV_FREE`
+/// leaves stale content until reclaim (rather than zero-faulting) is within the
+/// balloon / free-page-reporting contract.
+#[cfg(target_os = "macos")]
+const RELEASE_ADVICE: libc::c_int = libc::MADV_FREE;
+#[cfg(not(target_os = "macos"))]
+const RELEASE_ADVICE: libc::c_int = libc::MADV_DONTNEED;
+
 /// Traditional VirtIO memory balloon device.
 ///
 /// Host-side knobs live in atomics so callers outside the vCPU thread
@@ -114,7 +128,7 @@ pub struct VirtioBalloon {
     /// Guest-reported current inflated count in 4 KiB pages. Written by
     /// the guest via config-space writes at offset 4..8.
     actual: AtomicU32,
-    /// Advisory counter of total pages reclaimed via `MADV_DONTNEED`
+    /// Advisory counter of total pages released via `madvise`
     /// since the device was created. Purely observational.
     inflated_total: AtomicU32,
     /// Lightweight bump counter to flag config-space updates to the
@@ -338,15 +352,13 @@ fn handle_pfn_list(buf: &[u8], ram_base: *mut u8, ram_len: usize, gpa_base: usiz
         // SAFETY: ram_base points to a live host mapping of the guest
         // RAM region, valid for ram_len bytes. offset..offset+page_size
         // was bounds-checked above. madvise on a host mapping with
-        // MADV_DONTNEED is documented to release physical backing
-        // without invalidating the virtual mapping; subsequent access
-        // re-faults zero-filled pages — which is exactly the balloon
-        // contract (§5.5.1).
-        let ret =
-            unsafe { libc::madvise(ram_base.add(offset).cast(), page_size, libc::MADV_DONTNEED) };
+        // RELEASE_ADVICE releases the physical backing without
+        // invalidating the virtual mapping; the guest keeps the page
+        // off-limits until it deflates, per the balloon contract (§5.5.1).
+        let ret = unsafe { libc::madvise(ram_base.add(offset).cast(), page_size, RELEASE_ADVICE) };
         if ret != 0 {
             tracing::warn!(
-                "virtio-balloon: madvise(MADV_DONTNEED) at offset {:#x} failed: {}",
+                "virtio-balloon: madvise at offset {:#x} failed: {}",
                 offset,
                 std::io::Error::last_os_error()
             );
@@ -357,7 +369,7 @@ fn handle_pfn_list(buf: &[u8], ram_base: *mut u8, ram_len: usize, gpa_base: usiz
     handled
 }
 
-/// Releases one guest-reported free range via `madvise(MADV_DONTNEED)`,
+/// Releases one guest-reported free range via `madvise` ([`RELEASE_ADVICE`]),
 /// returning the number of 4 KiB pages released. The range is
 /// guest-controlled: it must be page-aligned, non-empty, and fully inside
 /// the guest RAM mapping, or it is logged and skipped.
@@ -390,14 +402,14 @@ fn handle_reported_range(
     }
     // SAFETY: ram_base points to a live host mapping of the guest RAM
     // region, valid for ram_len bytes; offset..end was bounds-checked
-    // above. MADV_DONTNEED releases the physical backing without
-    // invalidating the mapping; the guest re-faults zero pages, which is
-    // the free-page-reporting contract (the pages are free right now and
-    // the guest keeps them off-limits until the buffer completes).
-    let ret = unsafe { libc::madvise(ram_base.add(offset).cast(), len, libc::MADV_DONTNEED) };
+    // above. RELEASE_ADVICE releases the physical backing without
+    // invalidating the mapping; the pages are free right now and the guest
+    // keeps them off-limits until the buffer completes, per the
+    // free-page-reporting contract.
+    let ret = unsafe { libc::madvise(ram_base.add(offset).cast(), len, RELEASE_ADVICE) };
     if ret != 0 {
         tracing::warn!(
-            "virtio-balloon: madvise(MADV_DONTNEED) on reported range {:#x}+{:#x} failed: {}",
+            "virtio-balloon: madvise on reported range {:#x}+{:#x} failed: {}",
             offset,
             len,
             std::io::Error::last_os_error()


### PR DESCRIPTION
Balloon-subsystem fixes. Commits 1–2 fix the idle-shrink oscillation; commits 3–4 are cross-repo-audit findings in the same subsystem.

## 1. Back off idle shrink after repeated fail-opens (VZ + HV)

On a memory-pressured **host**, balloon inflation stalls and the controller oscillates indefinitely: VM idles → shrink → inflation churns guest pages through exhausted host swap and stalls → guest hits `available_bytes=0` / floods `Out of puff!` → pressure watch times out → **fail-open** (restore full + note activity → `idle→running`) → 5-min idle timeout → repeat. macOS reports **normal** pressure throughout (`kern.memorystatus_vm_pressure_level == 1`), so there is no host signal to gate on.

**Fix:** track consecutive fail-opens; suppress the idle-shrink entry (no probe) within `fail_open_backoff()` — 10 min, doubling to a 60 min cap. A shrink that **holds** clears the streak, so reclaim self-heals when the host recovers. Corrected the over-claimed `"Oscillation is structurally impossible"` doc.

Observed: a genuinely idle 16 GiB System VM (~700 MiB of containers, 14.6 GiB free) on a host at 113/128 GiB + swap full oscillated every 5 minutes for over an hour — 5477 `Out of puff` lines in one daemon log.

## 2. Skip host-driven idle shrink on the HV backend

HV's `arcbox-virtio-balloon` advertises free page reporting + deflate-on-oom and the guest kernel enables reporting (`CONFIG_VIRTIO_BALLOON` `select PAGE_REPORTING`, verified in `arcboxlabs/kernel`), so the HV guest self-reclaims idle memory. `BalloonDeps::guest_self_reclaims()` (true on HV) gates the inflate/pressure-watch descent off; it runs only on VZ.

## 3. MADV_FREE on macOS (audit finding)

`madvise(MADV_DONTNEED)` is a **no-op reclaim on Darwin** — XNU maps `VM_BEHAVIOR_DONTNEED` to a deactivation hint that never releases physical backing, so every HV balloon inflate / free-page-reporting range freed **zero bytes** while returning success. Switch to `MADV_FREE` on macOS (matching libkrun's macOS balloon path). **This is what makes commit 2's "HV self-reclaims via FPR" real rather than a silent no-op** — without it, HV had no working reclaim at all.

## 4. Guard idle_target() against sub-384-MiB machines (audit finding)

`idle_target()` did `clamp(IDLE_BALLOON_FLOOR, full)`; for a VM configured below the 384 MiB floor that is `min > max`, which `std::clamp` asserts on — **crashing the daemon** on the idle transition of any tiny machine. Cap the floor at `full`.

## Tests

`vm_lifecycle::balloon` — 4 new controller tests + `idle_target_below_floor_machine_does_not_panic`; `arcbox-virtio-balloon` unchanged-green. 160 + 16 pass; clippy + fmt clean.

## Notes / deferred

- End-to-end HV verification still awaits the HV blk-capacity bug fix (HV can't run Docker today). Commits 2–3 are grounded in the device feature bits + verified kernel config, and are backend-gated so VZ is unaffected.
- A host-memory-pressure *gate* was rejected: macOS's own pressure signal reads "normal" under this load. Backoff is signal-agnostic.