### PR TITLE
perf(net-inject): fewer guest IRQs under multi-flow load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ dependencies = [
 name = "arcbox-net-inject"
 version = "0.6.9"
 dependencies = [
- "arcbox-virtio",
+ "arcbox-virtio-core",
  "crossbeam-channel",
  "socket2 0.6.4",
  "tracing",

--- a/virt/arcbox-net-inject/Cargo.toml
+++ b/virt/arcbox-net-inject/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
-arcbox-virtio = { workspace = true }
+arcbox-virtio-core = { workspace = true }
 crossbeam-channel = "0.5"
 tracing = "0.1"
 

--- a/virt/arcbox-net-inject/examples/coalesce_sim.rs
+++ b/virt/arcbox-net-inject/examples/coalesce_sim.rs
@@ -7,16 +7,25 @@
 #![allow(clippy::while_float)]
 
 use arcbox_net_inject::coalesce::{
-    BATCH_SIZE, CoalescePolicy, EXPAND_MIN_FPS, QUIET_MAX_BATCH, WINDOW_DEFAULT_US, WINDOW_MAX_US,
+    BATCH_SIZE, CoalescePolicy, EXPAND_MIN_FPS, QUIET_MAX_PACKETS, WINDOW_DEFAULT_US, WINDOW_MAX_US,
 };
 
-fn gather_once(window_us: u32, frames_per_sec: f64) -> (u16, f64, bool) {
+/// One gather: how many *frames* arrived, how far time advanced, and whether
+/// the descriptor budget filled before the window elapsed.
+///
+/// `entries_per_frame` is what separates the two RX paths. The channel path
+/// publishes one used entry per frame (1). The inline path publishes one per
+/// 4 KiB buffer a `readv` consumed, up to `MAX_MERGE` (16) for a single GSO
+/// frame — so it exhausts `BATCH_SIZE` after 16 frames rather than 256, while
+/// still having delivered only 16 packets.
+fn gather_once(window_us: u32, frames_per_sec: f64, entries_per_frame: u16) -> (u16, f64, bool) {
     if frames_per_sec <= 0.0 {
         return (0, f64::from(window_us) / 1_000_000.0, false);
     }
+    let frame_budget = BATCH_SIZE as f64 / f64::from(entries_per_frame.max(1));
     let frames_in_window = frames_per_sec * f64::from(window_us) / 1_000_000.0;
-    if frames_in_window >= BATCH_SIZE as f64 {
-        let batch = BATCH_SIZE as u16;
+    if frames_in_window >= frame_budget {
+        let batch = frame_budget.floor() as u16;
         let advance = f64::from(batch) / frames_per_sec;
         (batch, advance, true)
     } else {
@@ -28,6 +37,9 @@ fn gather_once(window_us: u32, frames_per_sec: f64) -> (u16, f64, bool) {
 struct Run {
     label: &'static str,
     frames_per_sec: f64,
+    /// Used entries each frame publishes: 1 on the channel path, up to
+    /// `MAX_MERGE` on the inline path.
+    entries_per_frame: u16,
     duration_s: f64,
     adaptive: bool,
 }
@@ -57,7 +69,8 @@ fn simulate(run: &Run) -> ResultRow {
         } else {
             WINDOW_DEFAULT_US
         };
-        let (batch, advance, filled_early) = gather_once(window_us, run.frames_per_sec);
+        let (batch, advance, filled_early) =
+            gather_once(window_us, run.frames_per_sec, run.entries_per_frame);
         frames += u64::from(batch);
         if batch > 0 {
             flushes += 1;
@@ -96,19 +109,24 @@ fn simulate(run: &Run) -> ResultRow {
 }
 
 fn main() {
+    // (label, frames/s, used entries per frame)
     let scenarios = [
-        ("P1 GSO ~10 Gbps", 37_000.0),
-        ("P1 GSO ~22 Gbps", 80_000.0),
-        ("P2 multi-flow ~same bits as 10G", 74_000.0),
-        ("P2 multi-flow saturated", 120_000.0),
-        ("small-packet stress 500k fps", 500_000.0),
-        ("idle / very light 100 fps", 100.0),
+        ("P1 GSO ~10 Gbps", 37_000.0, 1),
+        ("P1 GSO ~22 Gbps", 80_000.0, 1),
+        // Same single stream delivered inline, where one GSO frame spans up to
+        // MAX_MERGE buffers. The window must still hold: the classifier reads
+        // frames, not the used entries they happen to occupy.
+        ("P1 GSO ~10 Gbps (inline, 16 buf/frame)", 37_000.0, 16),
+        ("P2 multi-flow ~same bits as 10G", 74_000.0, 1),
+        ("P2 multi-flow saturated", 120_000.0, 1),
+        ("small-packet stress 500k fps", 500_000.0, 1),
+        ("idle / very light 100 fps", 100.0, 1),
     ];
 
     let duration_s = 1.0;
     println!("# Coalesce mechanism model (no VM)");
     println!(
-        "duration={duration_s}s BATCH={BATCH_SIZE} default={WINDOW_DEFAULT_US}µs max={WINDOW_MAX_US}µs expand_min_fps={EXPAND_MIN_FPS} quiet_max_batch={QUIET_MAX_BATCH}"
+        "duration={duration_s}s BATCH={BATCH_SIZE} default={WINDOW_DEFAULT_US}µs max={WINDOW_MAX_US}µs expand_min_fps={EXPAND_MIN_FPS} quiet_max_packets={QUIET_MAX_PACKETS}"
     );
     println!(
         "Note: 'irqs' here = non-empty flushes with EVENT_IDX off; production can suppress further."
@@ -120,16 +138,18 @@ fn main() {
     );
     println!("{}", "-".repeat(110));
 
-    for (label, fps) in scenarios {
+    for (label, fps, entries_per_frame) in scenarios {
         let fixed = simulate(&Run {
             label,
             frames_per_sec: fps,
+            entries_per_frame,
             duration_s,
             adaptive: false,
         });
         let adapt = simulate(&Run {
             label,
             frames_per_sec: fps,
+            entries_per_frame,
             duration_s,
             adaptive: true,
         });

--- a/virt/arcbox-net-inject/examples/coalesce_sim.rs
+++ b/virt/arcbox-net-inject/examples/coalesce_sim.rs
@@ -110,6 +110,9 @@ fn main() {
     println!(
         "duration={duration_s}s BATCH={BATCH_SIZE} default={WINDOW_DEFAULT_US}µs max={WINDOW_MAX_US}µs expand_min_fps={EXPAND_MIN_FPS} quiet_max_batch={QUIET_MAX_BATCH}"
     );
+    println!(
+        "Note: 'irqs' here = non-empty flushes with EVENT_IDX off; production can suppress further."
+    );
     println!();
     println!(
         "{:<32} {:<12} {:>10} {:>10} {:>10} {:>10} {:>10} {:>8}",

--- a/virt/arcbox-net-inject/examples/coalesce_sim.rs
+++ b/virt/arcbox-net-inject/examples/coalesce_sim.rs
@@ -1,0 +1,160 @@
+//! Discrete-event model of inject coalesce under sustained frame rates.
+//!
+//! ```text
+//! cargo run -p arcbox-net-inject --example coalesce_sim --release
+//! ```
+
+#![allow(clippy::while_float)]
+
+use arcbox_net_inject::coalesce::{
+    BATCH_SIZE, CoalescePolicy, EXPAND_MIN_BATCH, QUIET_MAX_BATCH, WINDOW_DEFAULT_US, WINDOW_MAX_US,
+};
+
+fn gather_once(window_us: u32, frames_per_sec: f64) -> (u16, f64, bool) {
+    if frames_per_sec <= 0.0 {
+        return (0, f64::from(window_us) / 1_000_000.0, false);
+    }
+    let frames_in_window = frames_per_sec * f64::from(window_us) / 1_000_000.0;
+    if frames_in_window >= BATCH_SIZE as f64 {
+        let batch = BATCH_SIZE as u16;
+        let advance = f64::from(batch) / frames_per_sec;
+        (batch, advance, true)
+    } else {
+        let batch = frames_in_window.floor() as u16;
+        (batch, f64::from(window_us) / 1_000_000.0, false)
+    }
+}
+
+struct Run {
+    label: &'static str,
+    frames_per_sec: f64,
+    duration_s: f64,
+    adaptive: bool,
+}
+
+struct ResultRow {
+    label: String,
+    policy: String,
+    frames: u64,
+    irqs: u64,
+    frames_per_irq: f64,
+    avg_window_us: f64,
+    peak_window_us: u32,
+    irqs_per_sec: f64,
+}
+
+fn simulate(run: &Run) -> ResultRow {
+    let mut policy = CoalescePolicy::new();
+    let mut frames = 0u64;
+    let mut flushes = 0u64;
+    let mut window_sum = 0u64;
+    let mut peak = WINDOW_DEFAULT_US;
+    let mut t = 0.0;
+
+    while t < run.duration_s {
+        let window_us = if run.adaptive {
+            policy.window_us()
+        } else {
+            WINDOW_DEFAULT_US
+        };
+        let (batch, advance, filled_early) = gather_once(window_us, run.frames_per_sec);
+        frames += u64::from(batch);
+        if batch > 0 {
+            flushes += 1;
+            window_sum += u64::from(window_us);
+            peak = peak.max(window_us);
+        }
+        if run.adaptive {
+            policy.observe(batch, filled_early, true);
+        }
+        t += advance;
+    }
+
+    let irqs = flushes;
+    ResultRow {
+        label: run.label.to_string(),
+        policy: if run.adaptive {
+            "adaptive".into()
+        } else {
+            "fixed-200µs".into()
+        },
+        frames,
+        irqs,
+        frames_per_irq: if irqs == 0 {
+            0.0
+        } else {
+            frames as f64 / irqs as f64
+        },
+        avg_window_us: if flushes == 0 {
+            0.0
+        } else {
+            window_sum as f64 / flushes as f64
+        },
+        peak_window_us: peak,
+        irqs_per_sec: irqs as f64 / run.duration_s,
+    }
+}
+
+fn main() {
+    let scenarios = [
+        ("P1 GSO ~10 Gbps", 37_000.0),
+        ("P1 GSO ~22 Gbps", 80_000.0),
+        ("P2 multi-flow ~same bits as 10G", 74_000.0),
+        ("P2 multi-flow saturated", 120_000.0),
+        ("small-packet stress 500k fps", 500_000.0),
+        ("idle / very light 100 fps", 100.0),
+    ];
+
+    let duration_s = 1.0;
+    println!("# Coalesce mechanism model (no VM)");
+    println!(
+        "duration={duration_s}s BATCH={BATCH_SIZE} default={WINDOW_DEFAULT_US}µs max={WINDOW_MAX_US}µs expand_min={EXPAND_MIN_BATCH} quiet_max={QUIET_MAX_BATCH}"
+    );
+    println!();
+    println!(
+        "{:<32} {:<12} {:>10} {:>10} {:>10} {:>10} {:>10} {:>8}",
+        "scenario", "policy", "frames", "irqs", "f/IRQ", "IRQ/s", "avg_win", "peak_us"
+    );
+    println!("{}", "-".repeat(110));
+
+    for (label, fps) in scenarios {
+        let fixed = simulate(&Run {
+            label,
+            frames_per_sec: fps,
+            duration_s,
+            adaptive: false,
+        });
+        let adapt = simulate(&Run {
+            label,
+            frames_per_sec: fps,
+            duration_s,
+            adaptive: true,
+        });
+        for row in [&fixed, &adapt] {
+            println!(
+                "{:<32} {:<12} {:>10} {:>10} {:>10.1} {:>10.0} {:>10.0} {:>8}",
+                row.label,
+                row.policy,
+                row.frames,
+                row.irqs,
+                row.frames_per_irq,
+                row.irqs_per_sec,
+                row.avg_window_us,
+                row.peak_window_us
+            );
+        }
+        if fixed.irqs_per_sec > 0.0 {
+            let irq_delta = (adapt.irqs_per_sec / fixed.irqs_per_sec - 1.0) * 100.0;
+            let fpi_delta = if fixed.frames_per_irq > 0.0 {
+                (adapt.frames_per_irq / fixed.frames_per_irq - 1.0) * 100.0
+            } else {
+                0.0
+            };
+            println!(
+                "{:<32} {:<12} irq/s {:+.1}%   frames/IRQ {:+.1}%   peak {}→{}µs",
+                "", "Δ adaptive", irq_delta, fpi_delta, fixed.peak_window_us, adapt.peak_window_us
+            );
+        }
+        println!();
+    }
+}

--- a/virt/arcbox-net-inject/examples/coalesce_sim.rs
+++ b/virt/arcbox-net-inject/examples/coalesce_sim.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::while_float)]
 
 use arcbox_net_inject::coalesce::{
-    BATCH_SIZE, CoalescePolicy, EXPAND_MIN_BATCH, QUIET_MAX_BATCH, WINDOW_DEFAULT_US, WINDOW_MAX_US,
+    BATCH_SIZE, CoalescePolicy, EXPAND_MIN_FPS, QUIET_MAX_BATCH, WINDOW_DEFAULT_US, WINDOW_MAX_US,
 };
 
 fn gather_once(window_us: u32, frames_per_sec: f64) -> (u16, f64, bool) {
@@ -65,7 +65,7 @@ fn simulate(run: &Run) -> ResultRow {
             peak = peak.max(window_us);
         }
         if run.adaptive {
-            policy.observe(batch, filled_early, true);
+            policy.observe(batch, window_us, filled_early, true);
         }
         t += advance;
     }
@@ -108,7 +108,7 @@ fn main() {
     let duration_s = 1.0;
     println!("# Coalesce mechanism model (no VM)");
     println!(
-        "duration={duration_s}s BATCH={BATCH_SIZE} default={WINDOW_DEFAULT_US}µs max={WINDOW_MAX_US}µs expand_min={EXPAND_MIN_BATCH} quiet_max={QUIET_MAX_BATCH}"
+        "duration={duration_s}s BATCH={BATCH_SIZE} default={WINDOW_DEFAULT_US}µs max={WINDOW_MAX_US}µs expand_min_fps={EXPAND_MIN_FPS} quiet_max_batch={QUIET_MAX_BATCH}"
     );
     println!();
     println!(

--- a/virt/arcbox-net-inject/src/coalesce.rs
+++ b/virt/arcbox-net-inject/src/coalesce.rs
@@ -1,0 +1,214 @@
+//! Adaptive gather-window policy for RX inject interrupt coalescing.
+//!
+//! The inject loop batches up to [`BATCH_SIZE`] frames within a gather
+//! window. Under multi-flow load, GSO cannot merge across flows, so frame
+//! rate rises and a fixed 200 µs window still kicks the guest too often.
+//!
+//! Classification must **not** use wall-clock `spent` (dominated by
+//! `recv_timeout` idle wait). Instead:
+//!
+//! - **Expand** when the gather hit [`BATCH_SIZE`] early, or when a
+//!   full-window gather published ≥ [`EXPAND_MIN_BATCH`] frames (real
+//!   multi-flow / high fps load — single-stream GSO sits below this).
+//! - **Shrink** when the gather was idle or very light (`batch` <
+//!   [`QUIET_MAX_BATCH`]), including empty timeouts so the window decays
+//!   after load.
+//! - **Hold** in the single-stream band between those thresholds.
+
+/// Max frames per outer inject loop (shared with `inject`).
+pub const BATCH_SIZE: usize = 256;
+
+/// Default / quiet gather window (microseconds).
+pub const WINDOW_DEFAULT_US: u32 = 200;
+
+/// Floor under quiet load.
+pub const WINDOW_MIN_US: u32 = 100;
+
+/// Cap under sustained multi-flow pressure.
+pub const WINDOW_MAX_US: u32 = 800;
+
+/// Minimum batch (used entries) to treat a full-window gather as busy.
+///
+/// At 200 µs: ~12 frames ≈ 60k fps — above single-stream GSO (~7 @ 37k fps
+/// / 10 Gbps) and into multi-flow territory.
+pub const EXPAND_MIN_BATCH: u16 = 12;
+
+/// Batches strictly below this shrink (idle / very light).
+pub const QUIET_MAX_BATCH: u16 = 4;
+
+/// Adaptive gather window for one inject loop iteration.
+#[derive(Debug, Clone)]
+pub struct CoalescePolicy {
+    window_us: u32,
+    expand_events: u64,
+    shrink_events: u64,
+}
+
+impl Default for CoalescePolicy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CoalescePolicy {
+    /// Starts at the historical fixed 200 µs window.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            window_us: WINDOW_DEFAULT_US,
+            expand_events: 0,
+            shrink_events: 0,
+        }
+    }
+
+    /// Current gather budget for the next outer loop.
+    #[must_use]
+    pub const fn window_us(&self) -> u32 {
+        self.window_us
+    }
+
+    /// High-level counters for tests / logging.
+    #[must_use]
+    pub const fn expand_events(&self) -> u64 {
+        self.expand_events
+    }
+
+    /// High-level counters for tests / logging.
+    #[must_use]
+    pub const fn shrink_events(&self) -> u64 {
+        self.shrink_events
+    }
+
+    /// Update after a gather.
+    ///
+    /// * `batch` — used-ring entries published (0 = empty idle timeout)
+    /// * `filled_early` — gather stopped because `batch` hit [`BATCH_SIZE`]
+    ///   (not because the window expired)
+    /// * `allow_adapt` — false on descriptor-exhaustion so storms neither
+    ///   expand nor shrink the window
+    pub fn observe(&mut self, batch: u16, filled_early: bool, allow_adapt: bool) {
+        if !allow_adapt {
+            return;
+        }
+
+        let busy = filled_early || batch >= EXPAND_MIN_BATCH;
+        let quiet = batch < QUIET_MAX_BATCH;
+
+        if busy {
+            let next = ((u64::from(self.window_us) * 3) / 2) as u32;
+            let next = next.clamp(WINDOW_MIN_US, WINDOW_MAX_US);
+            if next > self.window_us {
+                self.expand_events += 1;
+            }
+            self.window_us = next;
+        } else if quiet {
+            let next = ((u64::from(self.window_us) * 3) / 4) as u32;
+            let next = next.clamp(WINDOW_MIN_US, WINDOW_MAX_US);
+            if next < self.window_us {
+                self.shrink_events += 1;
+            }
+            self.window_us = next;
+        }
+        // else hold (single-stream band)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_at_default() {
+        let p = CoalescePolicy::new();
+        assert_eq!(p.window_us(), WINDOW_DEFAULT_US);
+    }
+
+    #[test]
+    fn expands_to_cap_under_full_batches() {
+        let mut p = CoalescePolicy::new();
+        for _ in 0..16 {
+            p.observe(256, true, true);
+        }
+        assert_eq!(p.window_us(), WINDOW_MAX_US);
+        assert!(p.expand_events() >= 1);
+    }
+
+    #[test]
+    fn timeout_small_batch_does_not_expand() {
+        let mut p = CoalescePolicy::new();
+        // Production light timeout (few frames, window expired) — hold or shrink.
+        p.observe(8, false, true);
+        assert_eq!(
+            p.window_us(),
+            WINDOW_DEFAULT_US,
+            "single-stream band must hold"
+        );
+        p.observe(2, false, true);
+        assert!(p.window_us() < WINDOW_DEFAULT_US, "very light must shrink");
+    }
+
+    #[test]
+    fn multi_flow_timeout_expands() {
+        let mut p = CoalescePolicy::new();
+        // ~14 frames / 200 µs ≈ 70k fps multi-flow band.
+        p.observe(14, false, true);
+        assert!(p.window_us() > WINDOW_DEFAULT_US);
+    }
+
+    #[test]
+    fn shrinks_after_load_via_idle() {
+        let mut p = CoalescePolicy::new();
+        for _ in 0..8 {
+            p.observe(64, false, true);
+        }
+        assert!(p.window_us() > WINDOW_DEFAULT_US);
+
+        for _ in 0..24 {
+            p.observe(0, false, true);
+        }
+        assert!(p.window_us() <= WINDOW_DEFAULT_US);
+        assert!(p.shrink_events() >= 1);
+    }
+
+    #[test]
+    fn medium_single_stream_holds() {
+        let mut p = CoalescePolicy::new();
+        p.observe(64, false, true);
+        let high = p.window_us();
+        // 7 frames ≈ 37k fps GSO — hold, do not expand further or shrink.
+        p.observe(7, false, true);
+        assert_eq!(p.window_us(), high);
+    }
+
+    #[test]
+    fn no_adapt_when_disallowed() {
+        let mut p = CoalescePolicy::new();
+        for _ in 0..8 {
+            p.observe(256, true, true);
+        }
+        let high = p.window_us();
+        for _ in 0..16 {
+            p.observe(0, false, false);
+            p.observe(256, true, false);
+        }
+        assert_eq!(p.window_us(), high);
+    }
+
+    #[test]
+    fn never_exceeds_cap() {
+        let mut p = CoalescePolicy::new();
+        for _ in 0..100 {
+            p.observe(256, true, true);
+        }
+        assert_eq!(p.window_us(), WINDOW_MAX_US);
+    }
+
+    #[test]
+    fn never_below_floor() {
+        let mut p = CoalescePolicy::new();
+        for _ in 0..100 {
+            p.observe(0, false, true);
+        }
+        assert!(p.window_us() >= WINDOW_MIN_US);
+    }
+}

--- a/virt/arcbox-net-inject/src/coalesce.rs
+++ b/virt/arcbox-net-inject/src/coalesce.rs
@@ -5,15 +5,18 @@
 //! rate rises and a fixed 200 µs window still kicks the guest too often.
 //!
 //! Classification must **not** use wall-clock `spent` (dominated by
-//! `recv_timeout` idle wait). Instead:
+//! `recv_timeout` idle wait). Absolute frame counts would also be wrong:
+//! 12 frames is ~60k fps at 200 µs but only ~15k fps at 800 µs, so a
+//! multi-flow burst that raised the window would keep a later single
+//! stream "busy" forever. We classify by **implied fps** over the budget
+//! that applied to the gather:
 //!
-//! - **Expand** when the gather hit [`BATCH_SIZE`] early, or when a
-//!   full-window gather published ≥ [`EXPAND_MIN_BATCH`] frames (real
-//!   multi-flow / high fps load — single-stream GSO sits below this).
-//! - **Shrink** when the gather was idle or very light (`batch` <
-//!   [`QUIET_MAX_BATCH`]), including empty timeouts so the window decays
-//!   after load.
-//! - **Hold** in the single-stream band between those thresholds.
+//! - **Expand** when the gather hit [`BATCH_SIZE`] early, or implied fps
+//!   ≥ [`EXPAND_MIN_FPS`] (multi-flow / high frame-rate).
+//! - **Shrink** when idle/very light (`batch` < [`QUIET_MAX_BATCH`]), or
+//!   when the window is elevated above default and fps has fallen below
+//!   multi-flow (so single-stream after a burst can decay).
+//! - **Hold** for cold single-stream GSO near the default window.
 
 /// Max frames per outer inject loop (shared with `inject`).
 pub const BATCH_SIZE: usize = 256;
@@ -27,13 +30,13 @@ pub const WINDOW_MIN_US: u32 = 100;
 /// Cap under sustained multi-flow pressure.
 pub const WINDOW_MAX_US: u32 = 800;
 
-/// Minimum batch (used entries) to treat a full-window gather as busy.
+/// Implied frames/s at or above which a full-window gather is busy.
 ///
-/// At 200 µs: ~12 frames ≈ 60k fps — above single-stream GSO (~7 @ 37k fps
-/// / 10 Gbps) and into multi-flow territory.
-pub const EXPAND_MIN_BATCH: u16 = 12;
+/// ~12 frames / 200 µs ≈ 60k fps — above single-stream GSO (~37k @ 10 Gbps)
+/// and into multi-flow territory.
+pub const EXPAND_MIN_FPS: u64 = 60_000;
 
-/// Batches strictly below this shrink (idle / very light).
+/// Batches strictly below this always shrink (idle / near-empty timeout).
 pub const QUIET_MAX_BATCH: u16 = 4;
 
 /// Adaptive gather window for one inject loop iteration.
@@ -82,17 +85,29 @@ impl CoalescePolicy {
     /// Update after a gather.
     ///
     /// * `batch` — used-ring entries published (0 = empty idle timeout)
+    /// * `window_budget_us` — gather budget that applied to this round
     /// * `filled_early` — gather stopped because `batch` hit [`BATCH_SIZE`]
-    ///   (not because the window expired)
     /// * `allow_adapt` — false on descriptor-exhaustion so storms neither
-    ///   expand nor shrink the window
-    pub fn observe(&mut self, batch: u16, filled_early: bool, allow_adapt: bool) {
+    ///   expand nor shrink the window (and the following idle tick should
+    ///   also pass false — see inject loop)
+    pub fn observe(
+        &mut self,
+        batch: u16,
+        window_budget_us: u32,
+        filled_early: bool,
+        allow_adapt: bool,
+    ) {
         if !allow_adapt {
             return;
         }
 
-        let busy = filled_early || batch >= EXPAND_MIN_BATCH;
-        let quiet = batch < QUIET_MAX_BATCH;
+        let rate = implied_fps(batch, window_budget_us);
+        let busy = filled_early || rate >= EXPAND_MIN_FPS;
+        // Idle / near-empty always decays. If the window was raised by a
+        // multi-flow burst and fps has dropped below multi-flow, decay so a
+        // following single stream does not sit at the 800 µs cap.
+        let quiet = batch < QUIET_MAX_BATCH
+            || (self.window_us > WINDOW_DEFAULT_US && rate < EXPAND_MIN_FPS);
 
         if busy {
             let next = ((u64::from(self.window_us) * 3) / 2) as u32;
@@ -109,8 +124,16 @@ impl CoalescePolicy {
             }
             self.window_us = next;
         }
-        // else hold (single-stream band)
+        // else hold (cold single-stream near default)
     }
+}
+
+/// Frames per second implied by `batch` over `window_budget_us`.
+fn implied_fps(batch: u16, window_budget_us: u32) -> u64 {
+    if window_budget_us == 0 {
+        return 0;
+    }
+    u64::from(batch).saturating_mul(1_000_000) / u64::from(window_budget_us)
 }
 
 #[cfg(test)]
@@ -127,69 +150,72 @@ mod tests {
     fn expands_to_cap_under_full_batches() {
         let mut p = CoalescePolicy::new();
         for _ in 0..16 {
-            p.observe(256, true, true);
+            p.observe(256, WINDOW_DEFAULT_US, true, true);
         }
         assert_eq!(p.window_us(), WINDOW_MAX_US);
         assert!(p.expand_events() >= 1);
     }
 
     #[test]
-    fn timeout_small_batch_does_not_expand() {
+    fn timeout_single_stream_holds_at_default() {
         let mut p = CoalescePolicy::new();
-        // Production light timeout (few frames, window expired) — hold or shrink.
-        p.observe(8, false, true);
-        assert_eq!(
-            p.window_us(),
-            WINDOW_DEFAULT_US,
-            "single-stream band must hold"
-        );
-        p.observe(2, false, true);
+        // ~7 frames / 200 µs ≈ 35k fps — below expand, not idle.
+        p.observe(7, WINDOW_DEFAULT_US, false, true);
+        assert_eq!(p.window_us(), WINDOW_DEFAULT_US);
+        p.observe(2, WINDOW_DEFAULT_US, false, true);
         assert!(p.window_us() < WINDOW_DEFAULT_US, "very light must shrink");
     }
 
     #[test]
     fn multi_flow_timeout_expands() {
         let mut p = CoalescePolicy::new();
-        // ~14 frames / 200 µs ≈ 70k fps multi-flow band.
-        p.observe(14, false, true);
+        // ~14 frames / 200 µs ≈ 70k fps.
+        p.observe(14, WINDOW_DEFAULT_US, false, true);
         assert!(p.window_us() > WINDOW_DEFAULT_US);
+    }
+
+    #[test]
+    fn elevated_window_decays_under_single_stream_rate() {
+        let mut p = CoalescePolicy::new();
+        for _ in 0..8 {
+            p.observe(64, WINDOW_DEFAULT_US, false, true);
+        }
+        assert!(p.window_us() > WINDOW_DEFAULT_US);
+        let high = p.window_us();
+        // ~30 frames / 800 µs ≈ 37k fps single stream after multi-flow.
+        // Absolute batch 30 would look "busy" under the old fixed-12 rule.
+        p.observe(30, high, false, true);
+        assert!(
+            p.window_us() < high,
+            "must decay when fps is single-stream after a multi-flow peak"
+        );
     }
 
     #[test]
     fn shrinks_after_load_via_idle() {
         let mut p = CoalescePolicy::new();
         for _ in 0..8 {
-            p.observe(64, false, true);
+            p.observe(64, WINDOW_DEFAULT_US, false, true);
         }
         assert!(p.window_us() > WINDOW_DEFAULT_US);
 
         for _ in 0..24 {
-            p.observe(0, false, true);
+            p.observe(0, p.window_us(), false, true);
         }
         assert!(p.window_us() <= WINDOW_DEFAULT_US);
         assert!(p.shrink_events() >= 1);
     }
 
     #[test]
-    fn medium_single_stream_holds() {
-        let mut p = CoalescePolicy::new();
-        p.observe(64, false, true);
-        let high = p.window_us();
-        // 7 frames ≈ 37k fps GSO — hold, do not expand further or shrink.
-        p.observe(7, false, true);
-        assert_eq!(p.window_us(), high);
-    }
-
-    #[test]
     fn no_adapt_when_disallowed() {
         let mut p = CoalescePolicy::new();
         for _ in 0..8 {
-            p.observe(256, true, true);
+            p.observe(256, WINDOW_DEFAULT_US, true, true);
         }
         let high = p.window_us();
         for _ in 0..16 {
-            p.observe(0, false, false);
-            p.observe(256, true, false);
+            p.observe(0, high, false, false);
+            p.observe(256, high, true, false);
         }
         assert_eq!(p.window_us(), high);
     }
@@ -198,7 +224,7 @@ mod tests {
     fn never_exceeds_cap() {
         let mut p = CoalescePolicy::new();
         for _ in 0..100 {
-            p.observe(256, true, true);
+            p.observe(256, WINDOW_MAX_US, true, true);
         }
         assert_eq!(p.window_us(), WINDOW_MAX_US);
     }
@@ -207,7 +233,7 @@ mod tests {
     fn never_below_floor() {
         let mut p = CoalescePolicy::new();
         for _ in 0..100 {
-            p.observe(0, false, true);
+            p.observe(0, WINDOW_DEFAULT_US, false, true);
         }
         assert!(p.window_us() >= WINDOW_MIN_US);
     }

--- a/virt/arcbox-net-inject/src/coalesce.rs
+++ b/virt/arcbox-net-inject/src/coalesce.rs
@@ -13,7 +13,7 @@
 //!
 //! - **Expand** when the gather hit [`BATCH_SIZE`] early, or implied fps
 //!   ≥ [`EXPAND_MIN_FPS`] (multi-flow / high frame-rate).
-//! - **Shrink** when idle/very light (`batch` < [`QUIET_MAX_BATCH`]), or
+//! - **Shrink** when idle/very light (`packets` < [`QUIET_MAX_PACKETS`]), or
 //!   when the window is elevated above default and fps has fallen below
 //!   multi-flow (so single-stream after a burst can decay).
 //! - **Hold** for cold single-stream GSO near the default window.
@@ -36,8 +36,11 @@ pub const WINDOW_MAX_US: u32 = 800;
 /// and into multi-flow territory.
 pub const EXPAND_MIN_FPS: u64 = 60_000;
 
-/// Batches strictly below this always shrink (idle / near-empty timeout).
-pub const QUIET_MAX_BATCH: u16 = 4;
+/// Gathers carrying strictly fewer frames than this always shrink.
+///
+/// Counted in frames, not used entries: one inline GSO frame spans up to
+/// `MAX_MERGE` entries and must not read as a burst.
+pub const QUIET_MAX_PACKETS: u16 = 4;
 
 /// Adaptive gather window for one inject loop iteration.
 #[derive(Debug, Clone)]
@@ -92,7 +95,7 @@ impl CoalescePolicy {
     ///   also pass false — see inject loop)
     pub fn observe(
         &mut self,
-        batch: u16,
+        packets: u16,
         window_budget_us: u32,
         filled_early: bool,
         allow_adapt: bool,
@@ -101,12 +104,12 @@ impl CoalescePolicy {
             return;
         }
 
-        let rate = implied_fps(batch, window_budget_us);
+        let rate = implied_fps(packets, window_budget_us);
         let busy = filled_early || rate >= EXPAND_MIN_FPS;
         // Idle / near-empty always decays. If the window was raised by a
         // multi-flow burst and fps has dropped below multi-flow, decay so a
         // following single stream does not sit at the 800 µs cap.
-        let quiet = batch < QUIET_MAX_BATCH
+        let quiet = packets < QUIET_MAX_PACKETS
             || (self.window_us > WINDOW_DEFAULT_US && rate < EXPAND_MIN_FPS);
 
         if busy {

--- a/virt/arcbox-net-inject/src/inject.rs
+++ b/virt/arcbox-net-inject/src/inject.rs
@@ -16,29 +16,14 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
-use arcbox_virtio::{GuestMemWriter, QueueConfig, SplitQueue};
+use arcbox_virtio_core::{GuestMemWriter, QueueConfig, SplitQueue};
 use crossbeam_channel::{Receiver, RecvTimeoutError};
 
+use crate::coalesce::{BATCH_SIZE, CoalescePolicy};
 use crate::inline_conn::{self, InlineConn};
 use crate::irq::IrqHandle;
 use crate::queue;
-
-/// Maximum frames to inject per batch before checking interrupt thresholds.
-///
-/// At line-rate (~9 Gbps, 500k fps), a batch of 64 frames means the inject
-/// thread fires IRQ ~8000 times/second. Each IRQ entails an MMIO trap and
-/// guest-side RX soft-irq processing. Raising to 256 cuts IRQ rate to
-/// ~2000/s while the 50 µs `COALESCE_TIMEOUT` still bounds latency.
-const BATCH_SIZE: usize = 256;
-
-/// Interrupt coalescing timeout.
-///
-/// With GSO on the RX path the average frame size is ~30 KiB, so at
-/// 10 Gbps we're at ~37 kfps — a 50 µs timeout only batches ~2 frames
-/// before firing an IRQ, so the `BATCH_SIZE` ceiling is never reached.
-/// 200 µs raises the effective batch to ~7 frames without noticeably
-/// hurting ACK latency (Linux NAPI poll is typically 200 µs anyway).
-const COALESCE_TIMEOUT: Duration = Duration::from_micros(200);
+use crate::stats::InjectStats;
 
 /// Backoff duration when RX descriptors are exhausted.
 const DESCRIPTOR_BACKOFF: Duration = Duration::from_micros(100);
@@ -94,6 +79,29 @@ impl RxInjectThread {
         let mut inline_conns: Vec<InlineConn> = Vec::new();
         // Whether any push since the last flush requested an interrupt.
         let mut fire = false;
+        let mut policy = CoalescePolicy::new();
+        let mut stats = InjectStats::default();
+
+        // Flush + stats + policy in one place (normal, exhaustion, disconnect, idle).
+        let finish_batch = |queue: &SplitQueue,
+                            batch: u16,
+                            fire: bool,
+                            window_budget_us: u32,
+                            filled_early: bool,
+                            allow_adapt: bool,
+                            policy: &mut CoalescePolicy,
+                            stats: &mut InjectStats,
+                            thread: &Self| {
+            if batch > 0 {
+                thread.flush_interrupt(queue, fire);
+                stats.on_flush(batch, fire, window_budget_us);
+            }
+            // Always observe (incl. batch == 0 idle) so the window can decay.
+            policy.observe(batch, filled_early, allow_adapt);
+            stats.sync_policy_events(policy.expand_events(), policy.shrink_events());
+            stats.window_us = window_budget_us;
+            stats.maybe_log();
+        };
 
         loop {
             if !self.running.load(Ordering::Relaxed) {
@@ -114,6 +122,8 @@ impl RxInjectThread {
 
             let mut batch = 0u16;
             let loop_start = Instant::now();
+            let window_budget_us = policy.window_us();
+            let window = Duration::from_micros(u64::from(window_budget_us));
 
             // Phase 2: Poll inline connections (direct socket -> guest buffer).
             if !inline_conns.is_empty() {
@@ -121,17 +131,17 @@ impl RxInjectThread {
             }
 
             // Phase 3: Drain channel frames (classifier / DHCP / DNS / ARP).
-            // Use the remaining coalescing timeout after inline polling.
+            // Use the remaining adaptive window after inline polling.
             let elapsed = loop_start.elapsed();
-            let remaining = COALESCE_TIMEOUT.saturating_sub(elapsed);
+            let remaining = window.saturating_sub(elapsed);
 
             while (batch as usize) < BATCH_SIZE {
                 // Use the remaining timeout for the first recv, then zero
                 // for subsequent ones to drain without blocking.
                 let timeout = if batch == 0 && inline_conns.is_empty() {
                     // No inline conns and nothing batched yet — block for
-                    // the full coalescing timeout.
-                    COALESCE_TIMEOUT
+                    // the full coalescing window.
+                    window
                 } else if remaining.is_zero() {
                     // Timeout already consumed by inline polling — try_recv only.
                     Duration::ZERO
@@ -144,9 +154,26 @@ impl RxInjectThread {
                     Err(RecvTimeoutError::Timeout) => break,
                     Err(RecvTimeoutError::Disconnected) => {
                         tracing::info!("rx-inject: channel disconnected, shutting down");
-                        if batch > 0 {
-                            self.flush_interrupt(&queue, fire);
-                        }
+                        let filled_early = (batch as usize) >= BATCH_SIZE;
+                        finish_batch(
+                            &queue,
+                            batch,
+                            fire,
+                            window_budget_us,
+                            filled_early,
+                            true,
+                            &mut policy,
+                            &mut stats,
+                            &self,
+                        );
+                        tracing::info!(
+                            frames = stats.frames_injected,
+                            flushes = stats.flushes,
+                            irqs_fired = stats.irqs_fired,
+                            window_us_max = stats.window_us_max,
+                            "rx-inject thread stopped (channel disconnected, {} inline conns)",
+                            inline_conns.len(),
+                        );
                         return;
                     }
                 };
@@ -155,10 +182,21 @@ impl RxInjectThread {
                     fire |= notify;
                     batch += 1;
                 } else {
-                    // Descriptor exhaustion: flush interrupt so guest can
-                    // process and repost, then backoff.
+                    // Descriptor exhaustion: flush so guest can repost, then
+                    // backoff. Do not adapt the window (storms neither expand
+                    // nor shrink latency budget).
                     if batch > 0 {
-                        self.flush_interrupt(&queue, fire);
+                        finish_batch(
+                            &queue,
+                            batch,
+                            fire,
+                            window_budget_us,
+                            false,
+                            false,
+                            &mut policy,
+                            &mut stats,
+                            &self,
+                        );
                         fire = false;
                         batch = 0;
                     }
@@ -173,18 +211,34 @@ impl RxInjectThread {
                 }
             }
 
-            if batch > 0 {
-                self.flush_interrupt(&queue, fire);
-                fire = false;
-            }
+            // Normal end of gather: timeout or BATCH full. Empty idle still
+            // observes so the window can decay after load.
+            let filled_early = (batch as usize) >= BATCH_SIZE;
+            finish_batch(
+                &queue,
+                batch,
+                fire,
+                window_budget_us,
+                filled_early,
+                true,
+                &mut policy,
+                &mut stats,
+                &self,
+            );
+            fire = false;
         }
 
-        // Final flush on shutdown.
+        // Final flush on shutdown if a partial batch was left mid-iteration
+        // (running flag cleared between pushes).
         if fire {
             self.flush_interrupt(&queue, fire);
         }
 
         tracing::info!(
+            frames = stats.frames_injected,
+            flushes = stats.flushes,
+            irqs_fired = stats.irqs_fired,
+            window_us_max = stats.window_us_max,
             "rx-inject thread stopped ({} inline conns remaining)",
             inline_conns.len(),
         );

--- a/virt/arcbox-net-inject/src/inject.rs
+++ b/virt/arcbox-net-inject/src/inject.rs
@@ -93,6 +93,9 @@ impl RxInjectThread {
         let mut fire = false;
         let mut policy = CoalescePolicy::new();
         let mut stats = InjectStats::default();
+        // After descriptor exhaustion, skip adapt on the next empty gather so
+        // a storm does not immediately shrink the window (more IRQs).
+        let mut skip_idle_adapt = false;
 
         loop {
             if !self.running.load(Ordering::Relaxed) {
@@ -122,17 +125,15 @@ impl RxInjectThread {
             }
 
             // Phase 3: Drain channel frames (classifier / DHCP / DNS / ARP).
-            // Use the remaining adaptive window after inline polling.
-            let elapsed = loop_start.elapsed();
-            let remaining = window.saturating_sub(elapsed);
-
+            // Recompute remaining each iteration so the window is a real deadline.
             while (batch as usize) < BATCH_SIZE {
+                let remaining = window.saturating_sub(loop_start.elapsed());
                 // Use the remaining timeout for the first recv, then zero
                 // for subsequent ones to drain without blocking.
                 let timeout = if batch == 0 && inline_conns.is_empty() {
                     // No inline conns and nothing batched yet — block for
-                    // the full coalescing window.
-                    window
+                    // the full coalescing window (or what's left of it).
+                    remaining
                 } else if remaining.is_zero() {
                     // Timeout already consumed by inline polling — try_recv only.
                     Duration::ZERO
@@ -188,6 +189,7 @@ impl RxInjectThread {
                         });
                         fire = false;
                         batch = 0;
+                        skip_idle_adapt = true;
                     }
                     std::thread::sleep(DESCRIPTOR_BACKOFF);
 
@@ -201,15 +203,25 @@ impl RxInjectThread {
             }
 
             // Normal end of gather: timeout or BATCH full. Empty idle still
-            // observes so the window can decay after load.
+            // observes so the window can decay after load — except right after
+            // descriptor exhaustion (skip_idle_adapt).
             let filled_early = (batch as usize) >= BATCH_SIZE;
+            let allow_adapt = if batch == 0 && skip_idle_adapt {
+                skip_idle_adapt = false;
+                false
+            } else {
+                if batch > 0 {
+                    skip_idle_adapt = false;
+                }
+                true
+            };
             self.finish_batch(FinishBatch {
                 queue: &queue,
                 batch,
                 fire,
                 window_budget_us,
                 filled_early,
-                allow_adapt: true,
+                allow_adapt,
                 policy: &mut policy,
                 stats: &mut stats,
             });
@@ -242,7 +254,8 @@ impl RxInjectThread {
             f.stats.on_flush(f.batch, f.fire, f.window_budget_us);
         }
         // Always observe (incl. batch == 0 idle) so the window can decay.
-        f.policy.observe(f.batch, f.filled_early, f.allow_adapt);
+        f.policy
+            .observe(f.batch, f.window_budget_us, f.filled_early, f.allow_adapt);
         f.stats.sync_from_policy(f.policy, f.window_budget_us);
         f.stats.maybe_log();
     }

--- a/virt/arcbox-net-inject/src/inject.rs
+++ b/virt/arcbox-net-inject/src/inject.rs
@@ -28,6 +28,18 @@ use crate::stats::InjectStats;
 /// Backoff duration when RX descriptors are exhausted.
 const DESCRIPTOR_BACKOFF: Duration = Duration::from_micros(100);
 
+/// Arguments for [`RxInjectThread::finish_batch`].
+struct FinishBatch<'a> {
+    queue: &'a SplitQueue,
+    batch: u16,
+    fire: bool,
+    window_budget_us: u32,
+    filled_early: bool,
+    allow_adapt: bool,
+    policy: &'a mut CoalescePolicy,
+    stats: &'a mut InjectStats,
+}
+
 /// Context for the RX injection thread.
 pub struct RxInjectThread {
     /// Channel receiving raw Ethernet frames from the producer.
@@ -82,27 +94,6 @@ impl RxInjectThread {
         let mut policy = CoalescePolicy::new();
         let mut stats = InjectStats::default();
 
-        // Flush + stats + policy in one place (normal, exhaustion, disconnect, idle).
-        let finish_batch = |queue: &SplitQueue,
-                            batch: u16,
-                            fire: bool,
-                            window_budget_us: u32,
-                            filled_early: bool,
-                            allow_adapt: bool,
-                            policy: &mut CoalescePolicy,
-                            stats: &mut InjectStats,
-                            thread: &Self| {
-            if batch > 0 {
-                thread.flush_interrupt(queue, fire);
-                stats.on_flush(batch, fire, window_budget_us);
-            }
-            // Always observe (incl. batch == 0 idle) so the window can decay.
-            policy.observe(batch, filled_early, allow_adapt);
-            stats.sync_policy_events(policy.expand_events(), policy.shrink_events());
-            stats.window_us = window_budget_us;
-            stats.maybe_log();
-        };
-
         loop {
             if !self.running.load(Ordering::Relaxed) {
                 break;
@@ -155,22 +146,21 @@ impl RxInjectThread {
                     Err(RecvTimeoutError::Disconnected) => {
                         tracing::info!("rx-inject: channel disconnected, shutting down");
                         let filled_early = (batch as usize) >= BATCH_SIZE;
-                        finish_batch(
-                            &queue,
+                        self.finish_batch(FinishBatch {
+                            queue: &queue,
                             batch,
                             fire,
                             window_budget_us,
                             filled_early,
-                            true,
-                            &mut policy,
-                            &mut stats,
-                            &self,
-                        );
+                            allow_adapt: true,
+                            policy: &mut policy,
+                            stats: &mut stats,
+                        });
                         tracing::info!(
-                            frames = stats.frames_injected,
-                            flushes = stats.flushes,
-                            irqs_fired = stats.irqs_fired,
-                            window_us_max = stats.window_us_max,
+                            frames = stats.frames_injected(),
+                            flushes = stats.flushes(),
+                            irqs_fired = stats.irqs_fired(),
+                            window_us_max = stats.window_us_max(),
                             "rx-inject thread stopped (channel disconnected, {} inline conns)",
                             inline_conns.len(),
                         );
@@ -186,17 +176,16 @@ impl RxInjectThread {
                     // backoff. Do not adapt the window (storms neither expand
                     // nor shrink latency budget).
                     if batch > 0 {
-                        finish_batch(
-                            &queue,
+                        self.finish_batch(FinishBatch {
+                            queue: &queue,
                             batch,
                             fire,
                             window_budget_us,
-                            false,
-                            false,
-                            &mut policy,
-                            &mut stats,
-                            &self,
-                        );
+                            filled_early: false,
+                            allow_adapt: false,
+                            policy: &mut policy,
+                            stats: &mut stats,
+                        });
                         fire = false;
                         batch = 0;
                     }
@@ -214,17 +203,16 @@ impl RxInjectThread {
             // Normal end of gather: timeout or BATCH full. Empty idle still
             // observes so the window can decay after load.
             let filled_early = (batch as usize) >= BATCH_SIZE;
-            finish_batch(
-                &queue,
+            self.finish_batch(FinishBatch {
+                queue: &queue,
                 batch,
                 fire,
                 window_budget_us,
                 filled_early,
-                true,
-                &mut policy,
-                &mut stats,
-                &self,
-            );
+                allow_adapt: true,
+                policy: &mut policy,
+                stats: &mut stats,
+            });
             fire = false;
         }
 
@@ -235,13 +223,28 @@ impl RxInjectThread {
         }
 
         tracing::info!(
-            frames = stats.frames_injected,
-            flushes = stats.flushes,
-            irqs_fired = stats.irqs_fired,
-            window_us_max = stats.window_us_max,
+            frames = stats.frames_injected(),
+            flushes = stats.flushes(),
+            irqs_fired = stats.irqs_fired(),
+            window_us_max = stats.window_us_max(),
             "rx-inject thread stopped ({} inline conns remaining)",
             inline_conns.len(),
         );
+    }
+
+    /// Flush (if any work), update coalesce policy, and emit interval stats.
+    ///
+    /// Used for normal timeout/BATCH completion, descriptor exhaustion,
+    /// channel disconnect, and empty idle ticks (`batch == 0`).
+    fn finish_batch(&self, f: FinishBatch<'_>) {
+        if f.batch > 0 {
+            self.flush_interrupt(f.queue, f.fire);
+            f.stats.on_flush(f.batch, f.fire, f.window_budget_us);
+        }
+        // Always observe (incl. batch == 0 idle) so the window can decay.
+        f.policy.observe(f.batch, f.filled_early, f.allow_adapt);
+        f.stats.sync_from_policy(f.policy, f.window_budget_us);
+        f.stats.maybe_log();
     }
 
     /// Polls all active inline connections, reading from host sockets

--- a/virt/arcbox-net-inject/src/inject.rs
+++ b/virt/arcbox-net-inject/src/inject.rs
@@ -228,11 +228,8 @@ impl RxInjectThread {
             fire = false;
         }
 
-        // Final flush on shutdown if a partial batch was left mid-iteration
-        // (running flag cleared between pushes).
-        if fire {
-            self.flush_interrupt(&queue, fire);
-        }
+        // Every loop iteration ends in finish_batch (which flushes when
+        // batch > 0), so no trailing flush is needed on exit.
 
         tracing::info!(
             frames = stats.frames_injected(),

--- a/virt/arcbox-net-inject/src/inject.rs
+++ b/virt/arcbox-net-inject/src/inject.rs
@@ -31,7 +31,14 @@ const DESCRIPTOR_BACKOFF: Duration = Duration::from_micros(100);
 /// Arguments for [`RxInjectThread::finish_batch`].
 struct FinishBatch<'a> {
     queue: &'a SplitQueue,
+    /// Used entries published this gather. This is the descriptor budget
+    /// (`BATCH_SIZE`, `inline_cap`) and what the guest sees in the used ring.
     batch: u16,
+    /// Frames delivered this gather. Diverges from `batch` on the inline
+    /// path, where one `readv` publishes up to `MAX_MERGE` used entries for a
+    /// single GSO frame — so this, not `batch`, is what a *rate* is computed
+    /// from.
+    packets: u16,
     fire: bool,
     window_budget_us: u32,
     filled_early: bool,
@@ -115,13 +122,21 @@ impl RxInjectThread {
             }
 
             let mut batch = 0u16;
+
+            let mut packets = 0u16;
             let loop_start = Instant::now();
             let window_budget_us = policy.window_us();
             let window = Duration::from_micros(u64::from(window_budget_us));
 
             // Phase 2: Poll inline connections (direct socket -> guest buffer).
             if !inline_conns.is_empty() {
-                self.poll_inline_conns(&mut queue, &mut inline_conns, &mut batch, &mut fire);
+                self.poll_inline_conns(
+                    &mut queue,
+                    &mut inline_conns,
+                    &mut batch,
+                    &mut packets,
+                    &mut fire,
+                );
             }
 
             // Phase 3: Drain channel frames (classifier / DHCP / DNS / ARP).
@@ -150,6 +165,7 @@ impl RxInjectThread {
                         self.finish_batch(FinishBatch {
                             queue: &queue,
                             batch,
+                            packets,
                             fire,
                             window_budget_us,
                             filled_early,
@@ -172,6 +188,7 @@ impl RxInjectThread {
                 if let Some(notify) = queue::inject_one_frame(&mut queue, &frame) {
                     fire |= notify;
                     batch += 1;
+                    packets += 1;
                 } else {
                     // Descriptor exhaustion: flush so guest can repost, then
                     // backoff. Do not adapt the window (storms neither expand
@@ -180,6 +197,7 @@ impl RxInjectThread {
                         self.finish_batch(FinishBatch {
                             queue: &queue,
                             batch,
+                            packets,
                             fire,
                             window_budget_us,
                             filled_early: false,
@@ -189,6 +207,7 @@ impl RxInjectThread {
                         });
                         fire = false;
                         batch = 0;
+                        packets = 0;
                         skip_idle_adapt = true;
                     }
                     std::thread::sleep(DESCRIPTOR_BACKOFF);
@@ -197,6 +216,7 @@ impl RxInjectThread {
                     if let Some(notify) = queue::inject_one_frame(&mut queue, &frame) {
                         fire |= notify;
                         batch += 1;
+                        packets += 1;
                     }
                     // If still fails, frame is lost (TCP retransmit recovers).
                 }
@@ -218,6 +238,7 @@ impl RxInjectThread {
             self.finish_batch(FinishBatch {
                 queue: &queue,
                 batch,
+                packets,
                 fire,
                 window_budget_us,
                 filled_early,
@@ -248,11 +269,15 @@ impl RxInjectThread {
     fn finish_batch(&self, f: FinishBatch<'_>) {
         if f.batch > 0 {
             self.flush_interrupt(f.queue, f.fire);
-            f.stats.on_flush(f.batch, f.fire, f.window_budget_us);
+            f.stats
+                .on_flush(f.batch, f.packets, f.fire, f.window_budget_us);
         }
         // Always observe (incl. batch == 0 idle) so the window can decay.
+        // Rate comes from `packets`, not `batch`: an inline GSO frame spans up
+        // to MAX_MERGE used entries, and feeding those to the classifier reads
+        // one packet as a multi-flow burst.
         f.policy
-            .observe(f.batch, f.window_budget_us, f.filled_early, f.allow_adapt);
+            .observe(f.packets, f.window_budget_us, f.filled_early, f.allow_adapt);
         f.stats.sync_from_policy(f.policy, f.window_budget_us);
         f.stats.maybe_log();
     }
@@ -276,6 +301,7 @@ impl RxInjectThread {
         queue: &mut SplitQueue,
         inline_conns: &mut Vec<InlineConn>,
         batch: &mut u16,
+        packets: &mut u16,
         fire: &mut bool,
     ) {
         if queue.size() == 0 {
@@ -483,6 +509,7 @@ impl RxInjectThread {
                         *fire |=
                             queue.push_used(head_indices[0], inline_conn::TOTAL_HDR_LEN as u32);
                         *batch += 1;
+                        *packets += 1;
                         break;
                     }
                     Ok(n) => {
@@ -562,6 +589,8 @@ impl RxInjectThread {
                         *fire |= queue.push_used_batch(&completions[..num_used]);
 
                         *batch += num_used as u16;
+                        // One frame, however many buffers it spanned.
+                        *packets += 1;
                         per_conn += 1;
                         // Continue — try another readv on this conn.
                     }
@@ -599,6 +628,7 @@ impl RxInjectThread {
                         *fire |=
                             queue.push_used(head_indices[0], inline_conn::TOTAL_HDR_LEN as u32);
                         *batch += 1;
+                        *packets += 1;
                         break;
                     }
                 }
@@ -810,8 +840,14 @@ mod tests {
         wait_buffered(&reader, payload.len());
 
         let mut conns = vec![inline_conn(reader)];
-        let (mut batch, mut fire) = (0u16, false);
-        thread.poll_inline_conns(&mut queue, &mut conns, &mut batch, &mut fire);
+        let (mut batch, mut packets_batch, mut fire) = (0u16, 0u16, false);
+        thread.poll_inline_conns(
+            &mut queue,
+            &mut conns,
+            &mut batch,
+            &mut packets_batch,
+            &mut fire,
+        );
 
         // 500 bytes over caps [34, 200, 300] -> per-desc [34, 200, 266].
         assert_eq!(batch, 3);
@@ -854,8 +890,14 @@ mod tests {
         }
 
         // Nothing more buffered: a second poll consumes nothing.
-        let (mut batch2, mut fire2) = (0u16, false);
-        thread.poll_inline_conns(&mut queue, &mut conns, &mut batch2, &mut fire2);
+        let (mut batch2, mut packets_batch2, mut fire2) = (0u16, 0u16, false);
+        thread.poll_inline_conns(
+            &mut queue,
+            &mut conns,
+            &mut batch2,
+            &mut packets_batch2,
+            &mut fire2,
+        );
         assert_eq!(batch2, 0);
         assert!(!fire2);
         assert_eq!(ram.used_idx(), 3);
@@ -890,8 +932,14 @@ mod tests {
         }
 
         let mut conns = vec![inline_conn(reader)];
-        let (mut batch, mut fire) = (0u16, false);
-        thread.poll_inline_conns(&mut queue, &mut conns, &mut batch, &mut fire);
+        let (mut batch, mut packets_batch, mut fire) = (0u16, 0u16, false);
+        thread.poll_inline_conns(
+            &mut queue,
+            &mut conns,
+            &mut batch,
+            &mut packets_batch,
+            &mut fire,
+        );
 
         assert!(conns[0].host_eof);
         assert_eq!(batch, 1);
@@ -919,8 +967,14 @@ mod tests {
         // alive so the guest's ACK/FIN and half-close writes still reach
         // try_fast_path_intercept (only the error path sets `dead`).
         let dead = Arc::clone(&conns[0].dead);
-        let (mut batch2, mut fire2) = (0u16, false);
-        thread.poll_inline_conns(&mut queue, &mut conns, &mut batch2, &mut fire2);
+        let (mut batch2, mut packets_batch2, mut fire2) = (0u16, 0u16, false);
+        thread.poll_inline_conns(
+            &mut queue,
+            &mut conns,
+            &mut batch2,
+            &mut packets_batch2,
+            &mut fire2,
+        );
         assert!(conns.is_empty(), "EOF conn is pruned from the inject set");
         assert!(!dead.load(Ordering::Relaxed), "clean EOF must not set dead");
     }
@@ -963,8 +1017,14 @@ mod tests {
 
         let mut conns = vec![inline_conn(reader)];
         let dead = Arc::clone(&conns[0].dead);
-        let (mut batch, mut fire) = (0u16, false);
-        thread.poll_inline_conns(&mut queue, &mut conns, &mut batch, &mut fire);
+        let (mut batch, mut packets_batch, mut fire) = (0u16, 0u16, false);
+        thread.poll_inline_conns(
+            &mut queue,
+            &mut conns,
+            &mut batch,
+            &mut packets_batch,
+            &mut fire,
+        );
 
         assert!(conns[0].host_eof);
         assert_eq!(batch, 1);
@@ -992,8 +1052,14 @@ mod tests {
         // EOF, which keeps the bridge entry alive for the guest's close
         // handshake); the next poll's prune pass drops it.
         assert!(dead.load(Ordering::Relaxed), "bridge reap flag must be set");
-        let (mut batch2, mut fire2) = (0u16, false);
-        thread.poll_inline_conns(&mut queue, &mut conns, &mut batch2, &mut fire2);
+        let (mut batch2, mut packets_batch2, mut fire2) = (0u16, 0u16, false);
+        thread.poll_inline_conns(
+            &mut queue,
+            &mut conns,
+            &mut batch2,
+            &mut packets_batch2,
+            &mut fire2,
+        );
         assert!(conns.is_empty(), "errored conn must be pruned");
     }
 }

--- a/virt/arcbox-net-inject/src/lib.rs
+++ b/virt/arcbox-net-inject/src/lib.rs
@@ -2,10 +2,12 @@
 //!
 //! Receives raw Ethernet frames via a crossbeam channel and injects
 //! them into a guest virtio-net RX queue through the unified
-//! `arcbox_virtio::SplitQueue`. Runs on a dedicated OS thread,
+//! `arcbox_virtio_core::SplitQueue`. Runs on a dedicated OS thread,
 //! completely independent of the tokio async runtime.
 
+pub mod coalesce;
 pub mod inject;
 pub mod inline_conn;
 pub mod irq;
 pub mod queue;
+pub mod stats;

--- a/virt/arcbox-net-inject/src/queue.rs
+++ b/virt/arcbox-net-inject/src/queue.rs
@@ -1,6 +1,6 @@
 //! Single-frame RX injection through the unified [`SplitQueue`].
 
-use arcbox_virtio::SplitQueue;
+use arcbox_virtio_core::SplitQueue;
 
 /// Virtio-net header size (all zeros for RX passthrough).
 pub const VIRTIO_NET_HDR_SIZE: usize = 12;
@@ -121,7 +121,7 @@ pub fn inject_one_frame(queue: &mut SplitQueue, frame: &[u8]) -> Option<bool> {
 mod tests {
     use std::sync::Arc;
 
-    use arcbox_virtio::{GuestMemWriter, QueueConfig, SplitQueue};
+    use arcbox_virtio_core::{GuestMemWriter, QueueConfig, SplitQueue};
 
     use super::*;
 

--- a/virt/arcbox-net-inject/src/stats.rs
+++ b/virt/arcbox-net-inject/src/stats.rs
@@ -5,18 +5,20 @@
 
 use std::time::{Duration, Instant};
 
+use crate::coalesce::CoalescePolicy;
+
 /// Per-thread inject path counters.
 #[derive(Debug, Default)]
 pub struct InjectStats {
-    pub frames_injected: u64,
-    pub flushes: u64,
-    pub irqs_fired: u64,
-    pub irqs_suppressed: u64,
-    pub batch_sum: u64,
-    pub window_us: u32,
-    pub window_us_max: u32,
-    pub expand_events: u64,
-    pub shrink_events: u64,
+    frames_injected: u64,
+    flushes: u64,
+    irqs_fired: u64,
+    irqs_suppressed: u64,
+    batch_sum: u64,
+    window_us: u32,
+    window_us_max: u32,
+    expand_events: u64,
+    shrink_events: u64,
     last_log: Option<Instant>,
     /// Snapshot of counters at the last log (for interval rates).
     prev_frames: u64,
@@ -29,6 +31,30 @@ pub struct InjectStats {
 }
 
 impl InjectStats {
+    /// Lifetime frames published to the used ring.
+    #[must_use]
+    pub const fn frames_injected(&self) -> u64 {
+        self.frames_injected
+    }
+
+    /// Lifetime non-empty flushes.
+    #[must_use]
+    pub const fn flushes(&self) -> u64 {
+        self.flushes
+    }
+
+    /// Lifetime IRQs that actually fired.
+    #[must_use]
+    pub const fn irqs_fired(&self) -> u64 {
+        self.irqs_fired
+    }
+
+    /// Peak gather window observed (microseconds).
+    #[must_use]
+    pub const fn window_us_max(&self) -> u32 {
+        self.window_us_max
+    }
+
     /// Record one flush of `batch` frames with notify decision `fired`.
     ///
     /// `window_us` is the gather budget that applied to this batch (not the
@@ -46,13 +72,16 @@ impl InjectStats {
         self.window_us_max = self.window_us_max.max(window_us);
     }
 
-    /// Copy expand/shrink tallies from the policy.
-    pub fn sync_policy_events(&mut self, expand: u64, shrink: u64) {
-        self.expand_events = expand;
-        self.shrink_events = shrink;
+    /// Refresh expand/shrink tallies from the policy and note the budget in effect.
+    pub fn sync_from_policy(&mut self, policy: &CoalescePolicy, window_budget_us: u32) {
+        self.expand_events = policy.expand_events();
+        self.shrink_events = policy.shrink_events();
+        self.window_us = window_budget_us;
     }
 
     /// Log at most once per second at debug level (interval deltas + current window).
+    ///
+    /// Runs at 1 Hz only; allocating short display strings for rates is fine.
     pub fn maybe_log(&mut self) {
         let now = Instant::now();
         let due = self
@@ -89,8 +118,8 @@ impl InjectStats {
             flushes = d_flushes,
             irqs_fired = d_irqs,
             irqs_suppressed = d_suppressed,
-            frames_per_irq = format!("{fpi:.1}"),
-            avg_batch = format!("{avg_batch:.1}"),
+            frames_per_irq = fpi,
+            avg_batch = avg_batch,
             window_us = self.window_us,
             window_us_max = self.window_us_max,
             expand = d_expand,

--- a/virt/arcbox-net-inject/src/stats.rs
+++ b/virt/arcbox-net-inject/src/stats.rs
@@ -1,0 +1,111 @@
+//! Lightweight counters for the RX inject thread.
+//!
+//! Lifetime totals for shutdown logs; interval deltas for 1 Hz debug so the
+//! current coalesce regime is visible without a host sampler.
+
+use std::time::{Duration, Instant};
+
+/// Per-thread inject path counters.
+#[derive(Debug, Default)]
+pub struct InjectStats {
+    pub frames_injected: u64,
+    pub flushes: u64,
+    pub irqs_fired: u64,
+    pub irqs_suppressed: u64,
+    pub batch_sum: u64,
+    pub window_us: u32,
+    pub window_us_max: u32,
+    pub expand_events: u64,
+    pub shrink_events: u64,
+    last_log: Option<Instant>,
+    /// Snapshot of counters at the last log (for interval rates).
+    prev_frames: u64,
+    prev_flushes: u64,
+    prev_irqs_fired: u64,
+    prev_irqs_suppressed: u64,
+    prev_batch_sum: u64,
+    prev_expand: u64,
+    prev_shrink: u64,
+}
+
+impl InjectStats {
+    /// Record one flush of `batch` frames with notify decision `fired`.
+    ///
+    /// `window_us` is the gather budget that applied to this batch (not the
+    /// post-observe value).
+    pub fn on_flush(&mut self, batch: u16, fired: bool, window_us: u32) {
+        self.flushes += 1;
+        self.batch_sum += u64::from(batch);
+        self.frames_injected += u64::from(batch);
+        if fired {
+            self.irqs_fired += 1;
+        } else {
+            self.irqs_suppressed += 1;
+        }
+        self.window_us = window_us;
+        self.window_us_max = self.window_us_max.max(window_us);
+    }
+
+    /// Copy expand/shrink tallies from the policy.
+    pub fn sync_policy_events(&mut self, expand: u64, shrink: u64) {
+        self.expand_events = expand;
+        self.shrink_events = shrink;
+    }
+
+    /// Log at most once per second at debug level (interval deltas + current window).
+    pub fn maybe_log(&mut self) {
+        let now = Instant::now();
+        let due = self
+            .last_log
+            .is_none_or(|t| now.duration_since(t) >= Duration::from_secs(1));
+        if !due {
+            return;
+        }
+        self.last_log = Some(now);
+
+        let d_frames = self.frames_injected.saturating_sub(self.prev_frames);
+        let d_flushes = self.flushes.saturating_sub(self.prev_flushes);
+        let d_irqs = self.irqs_fired.saturating_sub(self.prev_irqs_fired);
+        let d_suppressed = self
+            .irqs_suppressed
+            .saturating_sub(self.prev_irqs_suppressed);
+        let d_batch_sum = self.batch_sum.saturating_sub(self.prev_batch_sum);
+        let d_expand = self.expand_events.saturating_sub(self.prev_expand);
+        let d_shrink = self.shrink_events.saturating_sub(self.prev_shrink);
+
+        let fpi = if d_irqs == 0 {
+            0.0
+        } else {
+            d_frames as f64 / d_irqs as f64
+        };
+        let avg_batch = if d_flushes == 0 {
+            0.0
+        } else {
+            d_batch_sum as f64 / d_flushes as f64
+        };
+
+        tracing::debug!(
+            frames = d_frames,
+            flushes = d_flushes,
+            irqs_fired = d_irqs,
+            irqs_suppressed = d_suppressed,
+            frames_per_irq = format!("{fpi:.1}"),
+            avg_batch = format!("{avg_batch:.1}"),
+            window_us = self.window_us,
+            window_us_max = self.window_us_max,
+            expand = d_expand,
+            shrink = d_shrink,
+            frames_total = self.frames_injected,
+            irqs_total = self.irqs_fired,
+            "rx-inject coalesce stats"
+        );
+
+        self.prev_frames = self.frames_injected;
+        self.prev_flushes = self.flushes;
+        self.prev_irqs_fired = self.irqs_fired;
+        self.prev_irqs_suppressed = self.irqs_suppressed;
+        self.prev_batch_sum = self.batch_sum;
+        self.prev_expand = self.expand_events;
+        self.prev_shrink = self.shrink_events;
+    }
+}

--- a/virt/arcbox-net-inject/src/stats.rs
+++ b/virt/arcbox-net-inject/src/stats.rs
@@ -5,6 +5,8 @@
 
 use std::time::{Duration, Instant};
 
+use tracing::Level;
+
 use crate::coalesce::CoalescePolicy;
 
 /// Per-thread inject path counters.
@@ -68,21 +70,29 @@ impl InjectStats {
         } else {
             self.irqs_suppressed += 1;
         }
+        self.note_window(window_us);
+    }
+
+    /// Refresh expand/shrink tallies and window high-water (incl. idle gathers).
+    pub fn sync_from_policy(&mut self, policy: &CoalescePolicy, window_budget_us: u32) {
+        self.expand_events = policy.expand_events();
+        self.shrink_events = policy.shrink_events();
+        self.note_window(window_budget_us);
+    }
+
+    fn note_window(&mut self, window_us: u32) {
         self.window_us = window_us;
         self.window_us_max = self.window_us_max.max(window_us);
     }
 
-    /// Refresh expand/shrink tallies from the policy and note the budget in effect.
-    pub fn sync_from_policy(&mut self, policy: &CoalescePolicy, window_budget_us: u32) {
-        self.expand_events = policy.expand_events();
-        self.shrink_events = policy.shrink_events();
-        self.window_us = window_budget_us;
-    }
-
     /// Log at most once per second at debug level (interval deltas + current window).
     ///
-    /// Runs at 1 Hz only; allocating short display strings for rates is fine.
+    /// No-ops immediately when DEBUG is disabled so the inject hot path does
+    /// not pay for `Instant::now()` under normal logging.
     pub fn maybe_log(&mut self) {
+        if !tracing::enabled!(Level::DEBUG) {
+            return;
+        }
         let now = Instant::now();
         let due = self
             .last_log

--- a/virt/arcbox-net-inject/src/stats.rs
+++ b/virt/arcbox-net-inject/src/stats.rs
@@ -61,10 +61,14 @@ impl InjectStats {
     ///
     /// `window_us` is the gather budget that applied to this batch (not the
     /// post-observe value).
-    pub fn on_flush(&mut self, batch: u16, fired: bool, window_us: u32) {
+    /// `batch` is used entries published, `packets` the frames they carried.
+    /// They differ on the inline path, where one GSO frame spans up to
+    /// `MAX_MERGE` entries — so `batch_sum` measures descriptor pressure and
+    /// `frames_injected` counts frames, rather than both reporting the former.
+    pub fn on_flush(&mut self, batch: u16, packets: u16, fired: bool, window_us: u32) {
         self.flushes += 1;
         self.batch_sum += u64::from(batch);
-        self.frames_injected += u64::from(batch);
+        self.frames_injected += u64::from(packets);
         if fired {
             self.irqs_fired += 1;
         } else {

--- a/virt/arcbox-net-inject/src/stats.rs
+++ b/virt/arcbox-net-inject/src/stats.rs
@@ -87,7 +87,7 @@ impl InjectStats {
 
     /// Log at most once per second at debug level (interval deltas + current window).
     ///
-    /// No-ops immediately when DEBUG is disabled so the inject hot path does
+    /// Returns immediately when DEBUG is disabled so the inject hot path does
     /// not pay for `Instant::now()` under normal logging.
     pub fn maybe_log(&mut self) {
         if !tracing::enabled!(Level::DEBUG) {


### PR DESCRIPTION
Multi-flow host→VM still costs about half single-stream on the same<br>CPU. Most of the extra time is the inject thread kicking the guest:<br>GSO only merges within one flow, so more flows mean more frames and<br>more interrupts for the same bytes.

We already batch (256 / 200 µs) and skip kicks when the guest is<br>polling (EVENT_IDX). The fixed 200 µs window is fine for one fat<br>stream; under multi-flow load it's still too chatty.

This stretches the gather window when a full-window batch looks busy<br>(≥12 used entries, or we hit the 256 cap) up to \~800 µs, and shrinks<br>it when the gather is idle or very light (<4). Single-stream GSO<br>(\~7 frames / 200 µs) holds. Notify math and fences are unchanged.

Batch size only — not wall-clock spend — so a timeout full of idle<br>`recv_timeout` does not look “busy”. Empty idle gathers still observe<br>so the window can decay after load. Descriptor-exhaustion flushes do<br>not adapt.

Inject debug logs 1 Hz *interval* frames / irqs / frames-per-IRQ and<br>the current window. Mechanism model (no VM):

```
cargo run -p arcbox-net-inject --example coalesce_sim --release
```

<!-- linear:table-colwidths:200,200,200,200 -->
| scenario | fixed IRQ/s | adaptive | frames/IRQ Δ |
| -- | -- | -- | -- |
| P1 \~10 Gbps (37k fps) | 5001 | 5001 (hold) | 0% |
| P2 multi-flow \~74k fps | 5001 | 1252 (−75%) | +\~320% |
| small-pkt 500k fps | 5001 | 1955 (−61%) | +\~156% |

System numbers (HV iperf) on follow-up when available.

Also depends on `arcbox-virtio-core` only (this crate only used core types).

Related: arcboxlabs/arcbox#242

Not touching multi-queue, retransmit, or the IRQ delivery path.