### PR TITLE
perf(agent): expedite RCU grace periods to cut runc create ~8x (ABX-496)

### DIFF
--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -623,6 +623,20 @@ pub(super) fn ensure_runtime_prerequisites() -> Vec<String> {
         notes.push("enabled ip_forward".to_string());
     }
 
+    // Expedite RCU grace periods. Every container start's `runc create`
+    // (and network-namespace teardown) calls synchronize_rcu; on the
+    // non-expedited guest kernel each grace period parks runc ~70 ms in
+    // uninterruptible sleep (`__wait_rcu_gp`), which is the dominant
+    // runc-create cost — profiled at ~88 ms → ~10 ms with this set, an 8x
+    // cut (ABX-496). Expedited grace periods use IPIs (µs, not ms); the
+    // trade is more IPIs under RCU load, the right call for a
+    // container/build runtime with heavy netns churn.
+    if let Err(e) = std::fs::write("/sys/kernel/rcu_expedited", b"1\n") {
+        notes.push(format!("rcu_expedited failed({e})"));
+    } else {
+        notes.push("enabled rcu_expedited".to_string());
+    }
+
     // Load overlay module (needed for Docker's overlay2 storage driver).
     if !Path::new("/sys/module/overlay").exists() {
         let rc = std::process::Command::new("/sbin/modprobe")


### PR DESCRIPTION
## What

Sets `/sys/kernel/rcu_expedited=1` at guest runtime bringup (agent `ensure_runtime_prerequisites`, alongside the existing `ip_forward` sysctl).

## Why — the ABX-496 profiling chain

Cross-engine bench found ArcBox `docker build` per-step overhead ~8–13× Colima's. Exhaustive differential profiling ruled out every primitive (CPU, spawn, cgroup, fsync, disk, ctx-switch, exec — all identical to Colima), the proxy, GOMAXPROCS, and btrfs. A dockerd-debug lifecycle timeline localized the container-start cost to two containerd operations: snapshot-prepare (~182 ms) and task-create (~170 ms), of which **runc create is ~85 ms** (isolated with a runc-timing wrapper).

Then the decisive measurement: runc create's **wall is ~88 ms but its CPU (user+sys via the shell `times` builtin) is only ~10 ms** — it spends ~70 ms *blocked*, not computing. Polling `/proc/<pid>/wchan` during a container start caught the blocker red-handed:

```
runc.real  state=D  wchan=__wait_rcu_gp
```

runc create (and network-namespace teardown) call `synchronize_rcu`; on the non-expedited guest kernel each grace period parks runc in uninterruptible sleep for tens of ms. A/B with the runtime toggle is unambiguous:

| | runc create wall |
|---|---|
| `rcu_expedited=0` | 70 / 110 / 60 / 80 / 120 ms |
| `rcu_expedited=1` | **10 / 10 / 10 / 10 / 10 ms** |

## Impact (validated end-to-end — the agent sets it at boot, fresh guest measured out-of-the-box)

- **runc create: ~88 ms → ~10 ms (~8×)** — a fundamental container op, so this helps all container churn (`docker run`/`exec`, compose, CI), not just builds.
- container-start floor: ~12% (runc create is ~85 ms of a ~1 s start; snapshot-prepare and export dominate the rest).
- 12-stage build: 12.7 s → 11.1 s (~12%).

## Tradeoff

Expedited grace periods use IPIs (µs instead of ms) — more IPI traffic under RCU load. For a container/build runtime with heavy netns churn this is the right call; it's the same reasoning container-optimized distros use. NO_HZ_IDLE-style idle behavior is unaffected (this only fires when RCU grace periods are actually requested).

Alternative considered: the kernel boot param `rcupdate.rcu_expedited=1` (set from first boot, via the daemon's cmdline construction or kernel config). The agent-sysctl form is equivalent for container-start perf (set before the first container), needs no kernel rebuild, and is validated here; a reviewer preferring the cmdline form can move it later.

Refs: ABX-496. Independent of the snapshot-prepare ~182 ms residual (separate investigation, still open).