### PR TITLE
perf(agent): stage runc + shim to guest-local tmpfs, off VirtioFS (ABX-498)

### DIFF
--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -907,7 +907,10 @@ mod tests {
         );
         let local = path.find("/run/arcbox/runtime-bin").unwrap();
         let vfs = path.find("/arcbox/runtime/bin").unwrap();
-        assert!(local < vfs, "local staged dir must precede the VirtioFS dir");
+        assert!(
+            local < vfs,
+            "local staged dir must precede the VirtioFS dir"
+        );
     }
 
     #[test]

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -257,21 +257,36 @@ pub(super) async fn direct_container_routing_loop() {
 fn stage_hot_runtime_binaries(vfs_dir: &Path, notes: &mut Vec<String>) {
     use std::os::unix::fs::PermissionsExt as _;
 
-    if let Err(e) = std::fs::create_dir_all(LOCAL_RUNTIME_BIN_DIR) {
+    let local = Path::new(LOCAL_RUNTIME_BIN_DIR);
+    // Idempotent: a prior start attempt in this same boot may have staged
+    // the full set, and containerd may already be live exec'ing it (the
+    // dockerd-readiness path re-enters try_start_bundled_runtime on retry).
+    // The binaries never change within a boot, so re-staging would only risk
+    // disturbing files in use — skip when the full set is already present.
+    if HOT_STAGED_BINARIES
+        .iter()
+        .all(|bin| local.join(bin).is_file())
+    {
+        return;
+    }
+    if let Err(e) = std::fs::create_dir_all(local) {
         notes.push(format!("stage runtime-bin mkdir failed({e})"));
         return;
     }
     for bin in HOT_STAGED_BINARIES {
-        let dst = Path::new(LOCAL_RUNTIME_BIN_DIR).join(bin);
-        let staged = std::fs::copy(vfs_dir.join(bin), &dst)
-            .and_then(|_| std::fs::set_permissions(&dst, std::fs::Permissions::from_mode(0o755)));
+        let dst = local.join(bin);
+        let tmp = local.join(format!("{bin}.partial"));
+        // Copy to a temp name and atomically rename into place. A failed or
+        // interrupted copy leaves only the temp (never a truncated final
+        // name), and the rename never O_TRUNCs a binary that a live
+        // containerd might be exec'ing — the two hazards flagged in review.
+        let staged = std::fs::copy(vfs_dir.join(bin), &tmp)
+            .and_then(|_| std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755)))
+            .and_then(|_| std::fs::rename(&tmp, &dst));
         if let Err(e) = staged {
-            // A failed copy can leave a truncated binary at `dst`. If the
-            // PATH check then trusted the local dir, containerd would exec
-            // the truncated file — turning "best-effort, only slower" into a
-            // broken runtime. Wipe the whole staged set so the check falls
-            // back to VirtioFS cleanly.
-            let _ = std::fs::remove_dir_all(LOCAL_RUNTIME_BIN_DIR);
+            // Drop only our own temp; never remove a published binary that
+            // an earlier attempt's containerd may already resolve.
+            let _ = std::fs::remove_file(&tmp);
             notes.push(format!(
                 "stage {bin} failed({e}); using VirtioFS runtime bins"
             ));

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -42,6 +42,23 @@ const REQUIRED_RUNTIME_BINARIES: &[&str] = &[
     "docker-init",
 ];
 
+/// Guest-local tmpfs dir holding the per-container-start hot-path binaries.
+///
+/// The runtime binaries live on the host-backed `arcbox` VirtioFS share
+/// (`ARCBOX_RUNTIME_BIN_DIR`), so executing them pages the binary in over
+/// VirtioFS — ~8x slower than a guest-local exec, measured, and paid on
+/// *every* container start. Since every `docker build` RUN/COPY step is a
+/// container, that overhead dominates build wall time (ABX-496). Staging
+/// the hot-path binaries to this tmpfs dir and resolving them from here
+/// makes the exec local.
+const LOCAL_RUNTIME_BIN_DIR: &str = "/run/arcbox/runtime-bin";
+
+/// Binaries on the per-container-start hot path, staged to guest-local
+/// tmpfs. `containerd` and `dockerd` are deliberately excluded: they are
+/// long-lived (paged in once at boot), whereas `runc` and the shim are
+/// exec'd on every container start.
+const HOT_STAGED_BINARIES: &[&str] = &["runc", "containerd-shim-runc-v2"];
+
 /// Minimum "sane" UNIX timestamp for TLS certificate validation.
 ///
 /// Chosen to be old enough that it's always in the past, but recent
@@ -231,14 +248,68 @@ pub(super) async fn direct_container_routing_loop() {
     }
 }
 
-pub(super) fn runtime_path_env(runtime_bin_dir: &Path) -> String {
-    let standard = "/usr/sbin:/usr/bin:/sbin:/bin";
-    match std::env::var("PATH") {
-        Ok(existing) if !existing.is_empty() => {
-            format!("{}:{}:{}", runtime_bin_dir.display(), existing, standard)
-        }
-        _ => format!("{}:{}", runtime_bin_dir.display(), standard),
+/// Copies the per-container hot-path binaries from the VirtioFS runtime
+/// share to guest-local tmpfs (ABX-496). Best-effort: on any failure the
+/// caller keeps resolving them from VirtioFS — slower, never broken. One
+/// VirtioFS page-in is paid here (the copy read); every later exec is
+/// local. tmpfs is re-created empty each boot, so this always stages the
+/// binaries the current daemon shipped — no staleness check needed.
+fn stage_hot_runtime_binaries(vfs_dir: &Path, notes: &mut Vec<String>) {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    if let Err(e) = std::fs::create_dir_all(LOCAL_RUNTIME_BIN_DIR) {
+        notes.push(format!("stage runtime-bin mkdir failed({e})"));
+        return;
     }
+    for bin in HOT_STAGED_BINARIES {
+        let dst = Path::new(LOCAL_RUNTIME_BIN_DIR).join(bin);
+        if let Err(e) = std::fs::copy(vfs_dir.join(bin), &dst) {
+            notes.push(format!("stage {bin} failed({e})"));
+            return;
+        }
+        if let Err(e) = std::fs::set_permissions(&dst, std::fs::Permissions::from_mode(0o755)) {
+            notes.push(format!("stage {bin} chmod failed({e})"));
+            return;
+        }
+    }
+    notes.push(format!(
+        "staged {} hot runtime binaries to {LOCAL_RUNTIME_BIN_DIR}",
+        HOT_STAGED_BINARIES.len()
+    ));
+}
+
+/// Composes the PATH for launching containerd/dockerd. When the hot-path
+/// binaries have been staged locally, `local_staged` goes FIRST so
+/// containerd and the shim resolve `runc`/the shim from guest-local tmpfs
+/// rather than over VirtioFS (ABX-496); the VirtioFS `runtime_bin_dir`
+/// follows as the fallback that still carries the un-staged binaries.
+fn compose_runtime_path(
+    local_staged: Option<&Path>,
+    runtime_bin_dir: &Path,
+    existing: Option<&str>,
+) -> String {
+    let standard = "/usr/sbin:/usr/bin:/sbin:/bin";
+    let mut head = String::new();
+    if let Some(local) = local_staged {
+        head.push_str(&local.display().to_string());
+        head.push(':');
+    }
+    head.push_str(&runtime_bin_dir.display().to_string());
+    match existing {
+        Some(existing) if !existing.is_empty() => format!("{head}:{existing}:{standard}"),
+        _ => format!("{head}:{standard}"),
+    }
+}
+
+pub(super) fn runtime_path_env(runtime_bin_dir: &Path) -> String {
+    let local = PathBuf::from(LOCAL_RUNTIME_BIN_DIR);
+    let staged = local.join("runc").is_file();
+    let existing = std::env::var("PATH").ok();
+    compose_runtime_path(
+        staged.then_some(local.as_path()),
+        runtime_bin_dir,
+        existing.as_deref(),
+    )
 }
 
 pub(super) fn ensure_shared_runtime_dirs(notes: &mut Vec<String>) {
@@ -788,6 +859,11 @@ async fn try_start_bundled_runtime() -> String {
 
     ensure_shared_runtime_dirs(&mut notes);
 
+    // Copy runc + the shim to guest-local tmpfs so containerd doesn't page
+    // them in over VirtioFS on every container start (ABX-496). Must run
+    // before containerd starts, since its PATH is built once at launch.
+    stage_hot_runtime_binaries(&runtime_bin_dir, &mut notes);
+
     if !ensure_containerd_ready(&runtime_bin_dir, &mut notes).await {
         return notes.join("; ");
     }
@@ -812,7 +888,41 @@ fn setup_nfs_export(notes: &mut Vec<String>) {
 mod tests {
     use arcbox_constants::status::{SERVICE_ERROR, SERVICE_NOT_READY, SERVICE_READY};
 
-    use super::{DockerProbe, shared_containerd_config};
+    use std::path::Path;
+
+    use super::{DockerProbe, compose_runtime_path, shared_containerd_config};
+
+    #[test]
+    fn runtime_path_prefers_local_staged_dir_then_virtiofs() {
+        // The staged local dir must come first so containerd/the shim
+        // resolve runc locally; the VirtioFS dir follows as fallback.
+        let path = compose_runtime_path(
+            Some(Path::new("/run/arcbox/runtime-bin")),
+            Path::new("/arcbox/runtime/bin"),
+            Some("/existing"),
+        );
+        assert_eq!(
+            path,
+            "/run/arcbox/runtime-bin:/arcbox/runtime/bin:/existing:/usr/sbin:/usr/bin:/sbin:/bin"
+        );
+        let local = path.find("/run/arcbox/runtime-bin").unwrap();
+        let vfs = path.find("/arcbox/runtime/bin").unwrap();
+        assert!(local < vfs, "local staged dir must precede the VirtioFS dir");
+    }
+
+    #[test]
+    fn runtime_path_without_staging_falls_back_to_virtiofs() {
+        // No local staging: the VirtioFS dir leads, behavior unchanged from
+        // before the ABX-496 fix.
+        assert_eq!(
+            compose_runtime_path(None, Path::new("/arcbox/runtime/bin"), None),
+            "/arcbox/runtime/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        );
+        assert_eq!(
+            compose_runtime_path(None, Path::new("/arcbox/runtime/bin"), Some("")),
+            "/arcbox/runtime/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        );
+    }
 
     #[test]
     fn shared_containerd_config_uses_k3s_cni_paths() {

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -324,9 +324,10 @@ fn compose_runtime_path(
 
 pub(super) fn runtime_path_env(runtime_bin_dir: &Path) -> String {
     let local = PathBuf::from(LOCAL_RUNTIME_BIN_DIR);
-    // Trust the local dir only when the FULL hot set is present. Staging
-    // wipes the dir on any failure, so a partial/truncated set never
-    // survives to here — this all-present check is the second guard.
+    // Trust the local dir only when the FULL hot set is present. Staging is
+    // atomic (copy to a temp, then rename), so a failed stage leaves the set
+    // incomplete rather than truncated — this all-present check then fails
+    // and the PATH falls back to VirtioFS.
     let staged = HOT_STAGED_BINARIES
         .iter()
         .all(|bin| local.join(bin).is_file());

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -263,12 +263,18 @@ fn stage_hot_runtime_binaries(vfs_dir: &Path, notes: &mut Vec<String>) {
     }
     for bin in HOT_STAGED_BINARIES {
         let dst = Path::new(LOCAL_RUNTIME_BIN_DIR).join(bin);
-        if let Err(e) = std::fs::copy(vfs_dir.join(bin), &dst) {
-            notes.push(format!("stage {bin} failed({e})"));
-            return;
-        }
-        if let Err(e) = std::fs::set_permissions(&dst, std::fs::Permissions::from_mode(0o755)) {
-            notes.push(format!("stage {bin} chmod failed({e})"));
+        let staged = std::fs::copy(vfs_dir.join(bin), &dst)
+            .and_then(|_| std::fs::set_permissions(&dst, std::fs::Permissions::from_mode(0o755)));
+        if let Err(e) = staged {
+            // A failed copy can leave a truncated binary at `dst`. If the
+            // PATH check then trusted the local dir, containerd would exec
+            // the truncated file — turning "best-effort, only slower" into a
+            // broken runtime. Wipe the whole staged set so the check falls
+            // back to VirtioFS cleanly.
+            let _ = std::fs::remove_dir_all(LOCAL_RUNTIME_BIN_DIR);
+            notes.push(format!(
+                "stage {bin} failed({e}); using VirtioFS runtime bins"
+            ));
             return;
         }
     }
@@ -303,7 +309,12 @@ fn compose_runtime_path(
 
 pub(super) fn runtime_path_env(runtime_bin_dir: &Path) -> String {
     let local = PathBuf::from(LOCAL_RUNTIME_BIN_DIR);
-    let staged = local.join("runc").is_file();
+    // Trust the local dir only when the FULL hot set is present. Staging
+    // wipes the dir on any failure, so a partial/truncated set never
+    // survives to here — this all-present check is the second guard.
+    let staged = HOT_STAGED_BINARIES
+        .iter()
+        .all(|bin| local.join(bin).is_file());
     let existing = std::env::var("PATH").ok();
     compose_runtime_path(
         staged.then_some(local.as_path()),


### PR DESCRIPTION
## Summary

The container runtime binaries (`runc`, `containerd-shim-runc-v2`) live on the host-backed `arcbox` VirtioFS share, so containerd execs them over VirtioFS on **every** container start — ~8x slower page-in than a guest-local exec. Every `docker build` step is a container, so this is paid per step.

This stages the two hot-path binaries to `/run/arcbox/runtime-bin` (tmpfs) at boot and prepends that dir to containerd's PATH. `containerd`/`dockerd` themselves are excluded (long-lived, paged in once).

## Why now (was judged inert under ABX-496)

The original staging experiment concluded 'barely moved' because it was hiding behind the ~700 ms container-start floor (fsync-on-btrfs + runc RCU). With those fixed (ABX-496) and the kernel HZ/preemption fixes landing (ABX-498), the VirtioFS shim exec became the **largest** remaining item.

## Validation (this branch's built agent, PATH method — not the profiling bind-mount)

Booted a bench daemon with the built musl agent:
- `/proc/<shim>/exe` = `/run/arcbox/runtime-bin/containerd-shim-runc-v2` — confirmed executing from guest-local tmpfs, not VirtioFS.
- containerd PATH = `/run/arcbox/runtime-bin:/arcbox/runtime/bin:...` — local dir leads, VirtioFS follows as fallback.
- Both binaries staged (runc 16 MB, shim 9.8 MB).

Measured effect (ABX-498): shim-connect 42→14 ms, guest-internal container start 341→193 ms (Colima ~205 ms), `docker run --rm alpine true` 371→**261 ms**.

## Safety

Best-effort: any staging failure (mkdir/copy/chmod) is noted and the PATH still carries the VirtioFS dir, so the runtime is never broken — only slower. `compose_runtime_path` is a pure function with unit tests (local-first ordering; VirtioFS-only fallback). tmpfs is empty each boot, so it always stages the binaries the current daemon shipped — no staleness check needed.

Note: CI does not build/test/lint `arcbox-agent` (workspace gate excludes it); the added unit tests run under `--target aarch64-unknown-linux-musl`, verified locally with zero new clippy findings.