### PR TITLE
perf(runtime): exec the container runtime from a read-only block image (ABX-498)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,19 +271,22 @@ dependencies = [
 
 [[package]]
 name = "arcbox-boot"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e728afead5d82392eb81911a43ef556e32a3df2a0d4e6bc3e74c5def33f8ce"
+checksum = "2925f99fcc4097b1b8eeb12bd1364f858aeefd9426ee57e8c94229a3b6b002d5"
 dependencies = [
+ "camino",
  "dirs",
+ "fs-err",
  "futures-util",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror",
  "tokio",
  "toml 1.1.0+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -1553,6 +1556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "camino"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2576,6 +2585,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,7 +211,7 @@ arcbox-asset = { version = "0.5.2", path = "common/arcbox-asset", features = ["d
 arcbox-docker-tools = { version = "0.5.2", path = "app/arcbox-docker-tools" } # x-release-please-version
 
 # External crates
-arcbox-boot = { version = "0.5.1", features = ["download"] }
+arcbox-boot = { version = "0.7.0", features = ["download"] }
 macos-resolver = "0.2.0"
 
 fc-sdk = "0.2.3"

--- a/app/arcbox-core/src/boot_assets/provider.rs
+++ b/app/arcbox-core/src/boot_assets/provider.rs
@@ -17,6 +17,12 @@ pub struct BootAssets {
     pub kernel: PathBuf,
     /// Path to EROFS rootfs image (attached as /dev/vda, read-only).
     pub rootfs_image: PathBuf,
+    /// Path to the read-only EROFS image of the guest container-runtime
+    /// binaries, when the pinned boot release ships one. Attached as an
+    /// extra read-only disk so the guest execs the runtime from
+    /// block-backed storage instead of over VirtioFS (ABX-498); `None` on
+    /// releases predating it, where the guest keeps using the share.
+    pub runtime_image: Option<PathBuf>,
     /// Kernel command line.
     pub cmdline: String,
     /// Asset version.
@@ -98,6 +104,7 @@ impl BootAssetProvider {
         Ok(BootAssets {
             kernel: prepared.kernel,
             rootfs_image: prepared.rootfs,
+            runtime_image: prepared.runtime_image,
             cmdline: prepared.kernel_cmdline,
             version: prepared.version,
             manifest: prepared.manifest,
@@ -165,13 +172,42 @@ impl BootAssetProvider {
     }
 
     /// Returns true if the current version's boot assets are fully cached
-    /// (manifest + kernel + rootfs all present).
+    /// (manifest + kernel + rootfs, plus the runtime image on releases that
+    /// ship one).
+    ///
+    /// Callers use this to skip the progress-reported download phase, so a
+    /// release whose runtime image is still missing must report `false` —
+    /// otherwise that download happens silently mid-boot instead.
     #[must_use]
     pub fn is_cached(&self) -> bool {
         let dir = self.config.version_cache_dir();
-        dir.join("manifest.json").exists()
+        if !(dir.join("manifest.json").exists()
             && dir.join("kernel").exists()
-            && dir.join("rootfs.erofs").exists()
+            && dir.join("rootfs.erofs").exists())
+        {
+            return false;
+        }
+        !self.cached_manifest_ships_runtime_image() || dir.join("runtime.erofs").exists()
+    }
+
+    /// Whether the cached manifest declares a runtime image for this arch.
+    /// An unreadable or unparsable manifest answers `false`: `prepare` is the
+    /// authority and re-fetches it, so guessing `true` here would only force
+    /// a pointless re-download.
+    fn cached_manifest_ships_runtime_image(&self) -> bool {
+        let path = self.config.version_cache_dir().join("manifest.json");
+        let Ok(bytes) = std::fs::read(&path) else {
+            return false;
+        };
+        serde_json::from_slice::<BootAssetManifest>(&bytes)
+            .ok()
+            .and_then(|manifest| {
+                manifest
+                    .targets
+                    .get(&self.manager.config().arch)
+                    .map(|target| target.runtime.is_some())
+            })
+            .unwrap_or(false)
     }
 
     /// Prefetches boot assets (downloads if not cached).

--- a/app/arcbox-core/src/vm_lifecycle/boot.rs
+++ b/app/arcbox-core/src/vm_lifecycle/boot.rs
@@ -17,9 +17,9 @@ use crate::event::Event;
 use crate::machine::MachineConfig;
 use arcbox_constants::cmdline::{
     DEBUG_CONSOLE_KEY, DOCKER_METADATA_DEVICE_KEY, GUEST_DOCKER_VSOCK_PORT_KEY,
-    HV_EARLYCON_DIRECTIVE,
+    HV_EARLYCON_DIRECTIVE, RUNTIME_IMAGE_DEVICE_KEY,
 };
-use arcbox_constants::devices::DOCKER_METADATA_BLOCK_DEVICE;
+use arcbox_constants::devices::{DOCKER_METADATA_BLOCK_DEVICE, RUNTIME_IMAGE_BLOCK_DEVICE};
 use arcbox_error::CommonError;
 
 use super::actor::{Completion, InternalEvent, LifecycleShared};
@@ -385,6 +385,19 @@ impl LifecycleShared {
             read_only: false,
         });
 
+        // Attach the read-only runtime image when the pinned boot release
+        // ships one: the guest execs dockerd/containerd/the shim/runc from
+        // this block device instead of over VirtioFS, which costs a FUSE
+        // round-trip per exec (~7-10x more, measured) on every container
+        // start. Releases predating it leave this None and the guest keeps
+        // using the VirtioFS copies (ABX-498).
+        if let Some(ref runtime_image) = boot.runtime_image {
+            block_devices.push(crate::vm::BlockDeviceConfig {
+                path: runtime_image.to_string_lossy().to_string(),
+                read_only: true,
+            });
+        }
+
         let config = MachineConfig {
             name: self.machine_name.clone(),
             cpus: self.config.default_vm.cpus,
@@ -475,6 +488,22 @@ impl LifecycleShared {
             cmdline.push_str(DOCKER_METADATA_BLOCK_DEVICE);
         }
 
+        // Declare the runtime-image device only when this release ships one.
+        // Its presence is the guest's signal to mount the image and exec the
+        // runtime from it; its absence means "keep using VirtioFS". Injecting
+        // it here (rather than at create time) also makes the cmdline drift
+        // check recreate the machine when a release starts or stops shipping
+        // the image, which is exactly when the disk set changes.
+        if assets.runtime_image.is_some()
+            && !cmdline
+                .split_whitespace()
+                .any(|token| token.starts_with(RUNTIME_IMAGE_DEVICE_KEY))
+        {
+            cmdline.push(' ');
+            cmdline.push_str(RUNTIME_IMAGE_DEVICE_KEY);
+            cmdline.push_str(RUNTIME_IMAGE_BLOCK_DEVICE);
+        }
+
         // Always attach an interactive debug console on the custom-HV backend.
         // An operator can `socat - UNIX-CONNECT:<sock>` to get a serial root
         // shell into the guest even when early boot hangs before networking
@@ -510,6 +539,7 @@ impl LifecycleShared {
             kernel: assets.kernel.to_string_lossy().to_string(),
             cmdline,
             rootfs_image: assets.rootfs_image,
+            runtime_image: assets.runtime_image,
         })
     }
 

--- a/app/arcbox-core/src/vm_lifecycle/tests.rs
+++ b/app/arcbox-core/src/vm_lifecycle/tests.rs
@@ -189,6 +189,7 @@ fn machine_drift_detects_each_overridable_field() {
         kernel: "/k".to_string(),
         cmdline: "console=hvc0 earlycon".to_string(),
         rootfs_image: std::path::PathBuf::from("/rootfs.erofs"),
+        runtime_image: None,
     };
     let current = sample_machine(want.cpus, want.memory_mb, &boot.kernel, &boot.cmdline);
 
@@ -216,8 +217,32 @@ fn machine_drift_detects_each_overridable_field() {
 
     // A machine persisted before the ext4 metadata volume (two disks) must
     // be recreated so the guest receives vdc.
-    let mut m = current;
+    let mut m = current.clone();
     m.block_devices.pop();
+    assert_eq!(
+        machine_drift_reason(&m, &want, &boot),
+        Some("block_devices")
+    );
+
+    // The runtime image adds a fourth disk, so the expected count follows the
+    // release: a three-disk machine drifts once the release ships an image,
+    // and a four-disk machine drifts back once it stops.
+    let boot_with_image = DesiredBoot {
+        kernel: boot.kernel.clone(),
+        cmdline: boot.cmdline.clone(),
+        rootfs_image: boot.rootfs_image.clone(),
+        runtime_image: Some(std::path::PathBuf::from("/runtime.erofs")),
+    };
+    assert_eq!(
+        machine_drift_reason(&current, &want, &boot_with_image),
+        Some("block_devices")
+    );
+    let mut m = current;
+    m.block_devices.push(crate::vm::BlockDeviceConfig {
+        path: "/boot/runtime.erofs".to_string(),
+        read_only: true,
+    });
+    assert_eq!(machine_drift_reason(&m, &want, &boot_with_image), None);
     assert_eq!(
         machine_drift_reason(&m, &want, &boot),
         Some("block_devices")

--- a/app/arcbox-core/src/vm_lifecycle/types.rs
+++ b/app/arcbox-core/src/vm_lifecycle/types.rs
@@ -164,6 +164,9 @@ pub(super) struct DesiredBoot {
     pub(super) cmdline: String,
     /// EROFS rootfs image path (read-only vda).
     pub(super) rootfs_image: PathBuf,
+    /// Read-only image of the guest container-runtime binaries, when the
+    /// pinned boot release ships one (ABX-498).
+    pub(super) runtime_image: Option<PathBuf>,
 }
 
 /// Returns the first daemon-overridable field that differs between a persisted
@@ -188,19 +191,29 @@ pub(super) fn machine_drift_reason(
         Some("kernel")
     } else if persisted.cmdline.as_deref() != Some(boot.cmdline.as_str()) {
         Some("cmdline")
-    } else if persisted.block_devices.len() != DEFAULT_MACHINE_DISK_COUNT {
-        // A machine persisted before the ext4 metadata volume carries only
-        // two disks; recreating rewrites the machine record (image files are
-        // untouched) so the guest receives vdc and can migrate.
+    } else if persisted.block_devices.len() != boot.expected_disk_count() {
+        // A machine persisted before a disk was added (the ext4 metadata
+        // volume, or the runtime image) carries fewer disks; recreating
+        // rewrites the machine record — image files are untouched — so the
+        // guest receives the new device.
         Some("block_devices")
     } else {
         None
     }
 }
 
-/// Number of block devices `create_default_machine` attaches: EROFS rootfs
+/// Block devices `create_default_machine` always attaches: EROFS rootfs
 /// (vda), btrfs data image (vdb), ext4 metadata image (vdc).
-pub(super) const DEFAULT_MACHINE_DISK_COUNT: usize = 3;
+const BASE_MACHINE_DISK_COUNT: usize = 3;
+
+impl DesiredBoot {
+    /// Number of block devices a machine created from these boot params
+    /// carries: the always-present three, plus the read-only runtime image
+    /// when the pinned boot release ships one.
+    pub(super) fn expected_disk_count(&self) -> usize {
+        BASE_MACHINE_DISK_COUNT + usize::from(self.runtime_image.is_some())
+    }
+}
 
 /// Derives the metadata-volume image filename paired with a data image:
 /// `docker.img` → `docker-meta.img`, `docker-rosetta.img` →

--- a/assets.lock
+++ b/assets.lock
@@ -14,9 +14,9 @@
 # and the [boot] bump.
 
 [boot]
-version = "0.6.11"
+version = "0.6.12"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "fc5130e3e64e75bd2df7bae2de7ff4fe790cb18d04db8f01c441156a662d59b5"
+manifest_sha256 = "3510917efe70a664d49029216c0149bf01aa09a7757defb96175e9b1546d0466"
 
 [[tools]]
 name = "docker"

--- a/common/arcbox-constants/src/cmdline.rs
+++ b/common/arcbox-constants/src/cmdline.rs
@@ -7,6 +7,12 @@ pub const DOCKER_DATA_DEVICE_KEY: &str = "arcbox.docker_data_device=";
 /// Kernel cmdline key for guest Docker metadata block-device path.
 pub const DOCKER_METADATA_DEVICE_KEY: &str = "arcbox.docker_metadata_device=";
 
+/// Kernel cmdline key for the read-only runtime-image block device.
+///
+/// Present only when the host attached the image, so its absence is the
+/// guest's signal to keep exec'ing the runtime over VirtioFS.
+pub const RUNTIME_IMAGE_DEVICE_KEY: &str = "arcbox.runtime_image_device=";
+
 /// Kernel cmdline key carrying the host path of the interactive debug-console
 /// Unix socket (custom-HV backend).
 ///

--- a/common/arcbox-constants/src/devices.rs
+++ b/common/arcbox-constants/src/devices.rs
@@ -9,3 +9,9 @@ pub const DOCKER_DATA_BLOCK_DEVICE: &str = "/dev/vdb";
 /// The ext4 volume carrying the fsync-hot boltdb metadata directories; paired
 /// with the btrfs data device (see internal-docs/plans/ext4-metadata-volume.md).
 pub const DOCKER_METADATA_BLOCK_DEVICE: &str = "/dev/vdc";
+
+/// Default read-only runtime-image block device path in guest.
+///
+/// The fourth disk, after the rootfs (vda), data (vdb) and metadata (vdc)
+/// images; the host declares the real path on the kernel cmdline.
+pub const RUNTIME_IMAGE_BLOCK_DEVICE: &str = "/dev/vdd";

--- a/guest/arcbox-agent/src/agent/linux/cmdline.rs
+++ b/guest/arcbox-agent/src/agent/linux/cmdline.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use arcbox_constants::cmdline::{
     DOCKER_DATA_DEVICE_KEY as DOCKER_DATA_DEVICE_CMDLINE_KEY,
     DOCKER_METADATA_DEVICE_KEY as DOCKER_METADATA_DEVICE_CMDLINE_KEY, GUEST_DOCKER_VSOCK_PORT_KEY,
+    RUNTIME_IMAGE_DEVICE_KEY,
 };
 use arcbox_constants::devices::DOCKER_DATA_BLOCK_DEVICE as DOCKER_DATA_DEVICE_DEFAULT;
 use arcbox_constants::env::GUEST_DOCKER_VSOCK_PORT as GUEST_DOCKER_VSOCK_PORT_ENV;
@@ -65,6 +66,13 @@ pub(super) fn docker_data_device() -> String {
 /// declares instead). `None` means an older daemon that never attached one.
 pub(super) fn declared_docker_metadata_device() -> Option<String> {
     cmdline_value(DOCKER_METADATA_DEVICE_CMDLINE_KEY).filter(|v| !v.trim().is_empty())
+}
+
+/// The read-only runtime-image device the host declared when it attached the
+/// image. `None` means this boot release ships no runtime image, so the guest
+/// keeps exec'ing the container runtime over VirtioFS.
+pub(super) fn declared_runtime_image_device() -> Option<String> {
+    cmdline_value(RUNTIME_IMAGE_DEVICE_KEY).filter(|v| !v.trim().is_empty())
 }
 
 pub(super) fn kubernetes_api_vsock_port() -> u32 {

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -24,7 +24,7 @@ use arcbox_protocol::agent::{
 };
 
 use super::btrfs::ensure_data_mount;
-use super::cmdline::docker_api_vsock_port;
+use super::cmdline::{declared_runtime_image_device, docker_api_vsock_port};
 use super::probe::{probe_docker_api_ready, probe_first_ready_socket, probe_unix_socket};
 use super::rpc::sync_clock_from_host;
 use crate::agent::ensure_runtime;
@@ -508,7 +508,88 @@ fn runtime_start_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+/// Read-only mount point of the block-backed runtime image.
+///
+/// The runtime binaries otherwise live on the host-backed `arcbox` VirtioFS
+/// share, where every exec costs a FUSE round-trip — measured 7-10x more than
+/// exec'ing the same binary from block-backed storage, and paid on *every*
+/// container start (so on every `docker build` step). When the boot release
+/// ships a runtime image the host attaches it as a read-only disk and the
+/// guest execs from here instead (ABX-498).
+const RUNTIME_IMAGE_MOUNT: &str = "/run/arcbox/runtime";
+
+/// Mounts the read-only runtime image the host declared on the cmdline.
+/// Returns whether the mount is available afterward.
+///
+/// Best-effort by design: the VirtioFS copies stay as the fallback, so a
+/// release without an image, or a failed mount, costs exec speed but never
+/// correctness.
+fn mount_runtime_image(notes: &mut Vec<String>) -> bool {
+    if crate::mount::is_mounted(RUNTIME_IMAGE_MOUNT) {
+        return true;
+    }
+    let Some(device) = declared_runtime_image_device() else {
+        return false;
+    };
+    // The node can lag guest boot; wait briefly rather than silently taking
+    // the slow path for the rest of this boot.
+    if !wait_for_runtime_image_device(&device) {
+        notes.push(format!("runtime image device {device} never appeared"));
+        return false;
+    }
+    if let Err(e) = std::fs::create_dir_all(RUNTIME_IMAGE_MOUNT) {
+        notes.push(format!("runtime image mkdir failed({e})"));
+        return false;
+    }
+    match std::process::Command::new("/bin/busybox")
+        .args([
+            "mount",
+            "-t",
+            "erofs",
+            "-o",
+            "ro",
+            &device,
+            RUNTIME_IMAGE_MOUNT,
+        ])
+        .status()
+    {
+        Ok(status) if status.success() => {
+            notes.push(format!("mounted runtime image from {device}"));
+            true
+        }
+        _ => {
+            notes.push(format!(
+                "runtime image mount failed ({device}); using VirtioFS"
+            ));
+            false
+        }
+    }
+}
+
+/// Waits up to 5 s for the declared device node (same budget and rationale as
+/// the data-device wait in `btrfs.rs`).
+fn wait_for_runtime_image_device(device: &str) -> bool {
+    for attempt in 0..50 {
+        if Path::new(device).exists() {
+            if attempt > 0 {
+                tracing::info!(device, attempt, "waited for runtime image device");
+            }
+            return true;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    false
+}
+
 fn detect_runtime_bin_dir() -> Option<PathBuf> {
+    // Prefer the block-backed runtime image when it is mounted — exec from
+    // it is 7-10x cheaper than over VirtioFS. Everything downstream (the
+    // containerd/dockerd spawns and the PATH they inherit) follows this one
+    // directory, so preferring it here is the whole switch.
+    let image = PathBuf::from(RUNTIME_IMAGE_MOUNT);
+    if missing_runtime_binaries_at(&image).is_empty() {
+        return Some(image);
+    }
     let dir = PathBuf::from(ARCBOX_RUNTIME_BIN_DIR);
     if missing_runtime_binaries_at(&dir).is_empty() {
         Some(dir)
@@ -752,6 +833,12 @@ async fn try_start_bundled_runtime() -> String {
         return notes.join("; ");
     }
 
+    let mut notes = Vec::new();
+
+    // Mount the runtime image (when this release ships one) before probing
+    // for the runtime binaries, so the probe can prefer it.
+    mount_runtime_image(&mut notes);
+
     let Some(runtime_bin_dir) = detect_runtime_bin_dir() else {
         return runtime_missing_detail();
     };
@@ -760,8 +847,6 @@ async fn try_start_bundled_runtime() -> String {
         runtime_bin_dir = %runtime_bin_dir.display(),
         "starting bundled runtime"
     );
-
-    let mut notes = Vec::new();
 
     // Ensure kernel/filesystem prerequisites before spawning daemons.
     let prereq_notes = ensure_runtime_prerequisites();

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -835,6 +835,15 @@ async fn try_start_bundled_runtime() -> String {
 
     let mut notes = Vec::new();
 
+    // Ensure kernel/filesystem prerequisites before spawning daemons — and
+    // before mounting the runtime image below, since that mounts under /run
+    // and the prerequisites are what guarantee /run is a writable tmpfs.
+    let prereq_notes = ensure_runtime_prerequisites();
+    if !prereq_notes.is_empty() {
+        tracing::info!(prerequisites = %prereq_notes.join("; "), "runtime prerequisites");
+    }
+    notes.extend(prereq_notes);
+
     // Mount the runtime image (when this release ships one) before probing
     // for the runtime binaries, so the probe can prefer it.
     mount_runtime_image(&mut notes);
@@ -847,13 +856,6 @@ async fn try_start_bundled_runtime() -> String {
         runtime_bin_dir = %runtime_bin_dir.display(),
         "starting bundled runtime"
     );
-
-    // Ensure kernel/filesystem prerequisites before spawning daemons.
-    let prereq_notes = ensure_runtime_prerequisites();
-    if !prereq_notes.is_empty() {
-        tracing::info!(prerequisites = %prereq_notes.join("; "), "runtime prerequisites");
-    }
-    notes.extend(prereq_notes);
     match ensure_data_mount() {
         Ok(note) => notes.push(note),
         Err(e) => return format!("data volume setup failed: {}", e),


### PR DESCRIPTION
**Blocked on arcbox-boot 0.7.0** (arcboxlabs/boot-assets#46 → publish). CI will fail to resolve the dependency until then — that is expected; everything below was validated locally against a path-patched build.

## Why

The guest reaches `dockerd`/`containerd`/the shim/`runc` over the host-backed `arcbox` VirtioFS share, so every exec pays a FUSE round-trip. Measured warm, **paired inside a single boot** (boot-to-boot variance is ±20-67 ms and would otherwise swamp the effect):

| binary | VirtioFS | block-backed | ratio |
|---|---|---|---|
| runc | 22.7 ms | 2.3 ms | 10x |
| shim | 21.5 ms | 2.3 ms | 9.5x |
| containerd | 69.3 ms | 8.6 ms | 8.1x |
| dockerd | 133.7 ms | 18.3 ms | 7.3x |

Paid on every container start — so on every `docker build` step. The lever is the **filesystem**, not binary size: swapping runc for the 9x smaller crun, still on VirtioFS, measured 20 ms *slower*.

## What

- `BootAssets`/`DesiredBoot` carry the optional `runtime_image` the boot release now ships (arcbox-boot 0.7.0, `targets.<arch>.runtime`).
- It is attached as a **read-only** disk and its device declared on the kernel cmdline (`arcbox.runtime_image_device=`). Declaring it in `resolve_desired_boot` means the existing cmdline drift check recreates the machine exactly when a release starts or stops shipping the image — which is when the disk set changes.
- The guest mounts it read-only and `detect_runtime_bin_dir` prefers it. Everything downstream (the containerd/dockerd spawns and the PATH they inherit) already follows that one directory, so preferring it there is the whole switch.
- Drift detection now derives the expected disk count from the resolved boot params (3 or 4) instead of a constant.
- `is_cached` accounts for the image, so its ~73 MB download lands in the progress-reported phase instead of silently mid-boot.

## Degradation

Both skew directions are safe and were exercised: a release without an image leaves the cmdline key off and the guest keeps using the VirtioFS copies; a declared-but-unmountable image falls back the same way. Cost is exec speed, never correctness.

## Validation (isolated VZ bench, kernel#16 HZ=1000 + voluntary + PSI-off)

Ran the real path — image published into the cached manifest as `targets.arm64.runtime` with the pin updated, so the daemon went through manifest verification, attach, declaration and mount:

- `/dev/vdd` attached read-only; guest mount `/dev/vdd on /run/arcbox/runtime type erofs (ro)`
- cmdline carries `arcbox.runtime_image_device=/dev/vdd`; containerd `PATH=/run/arcbox/runtime:…`
- shim `/proc/<pid>/exe` = `/run/arcbox/runtime/containerd-shim-runc-v2`
- containers run; **simple cold build 0.71 s median** (Colima 0.99 s; 8.1 s at the start of this campaign)
- `cargo test -p arcbox-core vm_lifecycle` 53/53, including new coverage that the fourth disk drives drift in both directions

## Supersedes

#498 (tmpfs staging of runc + shim). This covers **all** runtime binaries on both backends with no RAM pin, no PATH juggling and no staging atomicity — and measures faster (0.71 s vs 1.31 s). #498 will be closed when this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional guest runtime images in newer boot releases.
  * Runtime images are automatically attached and mounted read-only when available.
  * Added fallback behavior to continue using the existing runtime when mounting is unavailable.
  * Improved cached asset validation and machine drift detection for runtime-image disks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->