### PR TITLE
fix(fleet): self-update on a version-refused control-plane enroll

### DIFF
--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -36,7 +36,7 @@ use crate::credentials::Credential;
 use crate::runner::RunnerSupervisor;
 use crate::settings::SettingsStore;
 use crate::state::AgentState;
-use crate::{attach, enroll};
+use crate::{attach, enroll, update};
 use image::ImageService;
 use lifecycle::LifecycleService;
 use settings::SettingsService;
@@ -398,9 +398,11 @@ impl AgentSupervisor {
 
         // The gateway round-trip must not hold `state` locked.
         let credential =
-            enroll::enroll(&self.config, token, self.backends.capabilities(), &gateway)
-                .await
-                .map_err(Internal)?;
+            match enroll::enroll(&self.config, token, self.backends.capabilities(), &gateway).await
+            {
+                Ok(credential) => credential,
+                Err(error) => return Err(self.refused_enrollment(error).await),
+            };
 
         let mut state = self.state.lock().await;
         // `check_enrollable` refuses `Enrolling`, so nothing else can
@@ -446,6 +448,43 @@ impl AgentSupervisor {
         let machine_id = credential.machine_id.clone();
         *state = State::Attached(self.attach(credential, gateway));
         Ok(machine_id)
+    }
+
+    /// Classify a failed enrollment round-trip, self-updating when it was
+    /// the gateway telling us which build to run. That refusal is the same
+    /// signal `attach` acts on (`AttachRejected`), arriving one step
+    /// earlier — so it gets the same treatment, or enrolling on a stale
+    /// binary would be a dead end that no later attach can rescue.
+    ///
+    /// Nothing to drain here: `check_enrollable` admitted this enroll only
+    /// from `Unenrolled`, so there is no attachment and no in-flight job to
+    /// protect. On success the process is replaced mid-RPC and the caller
+    /// re-issues `Enroll` against the new build; every path that returns
+    /// leaves the observable `Updating` for [`Self::enroll`]'s rollback to
+    /// reset.
+    async fn refused_enrollment(&self, error: anyhow::Error) -> Status {
+        let Some(payload) = enroll::update_payload(&error) else {
+            return Internal(error).into();
+        };
+        info!(
+            expected = %payload.expected_version,
+            current = env!("CARGO_PKG_VERSION"),
+            "gateway requires a different build; self-updating before enrolling"
+        );
+        self.agent_state.set_enrollment(Enrollment::Updating, "");
+        // Returns only on failure; success replaces this process.
+        let update_error = update::apply_and_exec(&self.config, &payload).await;
+        if update_error
+            .chain()
+            .any(|c| c.downcast_ref::<update::UnmanagedBinary>().is_some())
+        {
+            // Not our binary to manage: installing the expected build is the
+            // operator's job, not something to retry.
+            warn!(error = %update_error, "self-update declined");
+            return Status::failed_precondition(format!("{error}; {update_error}"));
+        }
+        warn!(error = %update_error, "self-update failed");
+        Internal(update_error).into()
     }
 
     /// Leave the fleet — terminal. Stops attaching, decommissions the
@@ -794,6 +833,101 @@ mod tests {
             }
         });
         (format!("http://{addr}"), task)
+    }
+
+    /// A gateway that refuses every enrollment with `UpdateRequired`, the
+    /// way a real one meets an agent whose build is not the pinned one,
+    /// pushing `binary_url` as the download to converge on.
+    struct PinnedGateway {
+        binary_url: String,
+    }
+
+    #[tonic::async_trait]
+    impl arcbox_fleet_proto::v1::fleet_gateway_service_server::FleetGatewayService for PinnedGateway {
+        async fn enroll(
+            &self,
+            _: tonic::Request<arcbox_fleet_proto::v1::EnrollRequest>,
+        ) -> Result<tonic::Response<arcbox_fleet_proto::v1::EnrollResponse>, Status> {
+            Ok(tonic::Response::new(
+                arcbox_fleet_proto::v1::EnrollResponse {
+                    result: Some(
+                        arcbox_fleet_proto::v1::enroll_response::Result::UpdateRequired(
+                            arcbox_fleet_proto::v1::AgentUpdate {
+                                expected_version: "9.9.9".to_owned(),
+                                binary_url: self.binary_url.clone(),
+                                binary_sha256: "0".repeat(64),
+                            },
+                        ),
+                    ),
+                },
+            ))
+        }
+
+        type AttachStream = tokio_stream::wrappers::ReceiverStream<
+            Result<arcbox_fleet_proto::v1::AttachResponse, Status>,
+        >;
+
+        async fn attach(
+            &self,
+            _: tonic::Request<tonic::Streaming<arcbox_fleet_proto::v1::AttachRequest>>,
+        ) -> Result<tonic::Response<Self::AttachStream>, Status> {
+            Err(Status::unimplemented("enrollment-only test gateway"))
+        }
+
+        async fn unenroll(
+            &self,
+            _: tonic::Request<arcbox_fleet_proto::v1::UnenrollRequest>,
+        ) -> Result<tonic::Response<arcbox_fleet_proto::v1::UnenrollResponse>, Status> {
+            Err(Status::unimplemented("enrollment-only test gateway"))
+        }
+    }
+
+    /// Serve [`PinnedGateway`] on a scratch port and return its URL.
+    async fn pinned_gateway(binary_url: &str) -> String {
+        use arcbox_fleet_proto::v1::fleet_gateway_service_server::FleetGatewayServiceServer;
+
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind pinned gateway listener");
+        let addr = listener.local_addr().expect("pinned gateway addr");
+        tokio::spawn(
+            tonic::transport::Server::builder()
+                .add_service(FleetGatewayServiceServer::new(PinnedGateway {
+                    binary_url: binary_url.to_owned(),
+                }))
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener)),
+        );
+        format!("http://{addr}")
+    }
+
+    /// A refusal that does carry a download enters the self-update path —
+    /// which stops at the managed-path check here, because the test binary is
+    /// not the binary the agent owns. Proves the enrollment path reaches the
+    /// updater (nothing is downloaded: `ensure_managed` runs first) and that
+    /// declining still rolls the enrollment back.
+    #[tokio::test]
+    async fn enroll_declines_to_self_update_an_unmanaged_binary() {
+        let dir =
+            std::env::temp_dir().join(format!("fleet-enroll-unmanaged-{}", std::process::id()));
+        let agent_state = AgentState::new(&seed());
+        let supervisor = test_supervisor(&dir, agent_state.clone()).await;
+        // Never fetched — the managed-path refusal precedes the download.
+        let gateway = pinned_gateway("http://127.0.0.1:1/arcbox-fleet-agent").await;
+
+        let err = supervisor
+            .enroll("flt_join_test".to_owned(), Some(&gateway))
+            .await
+            .expect_err("a version-refused enrollment cannot succeed");
+
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(err.message().contains("is not the managed"), "{err}");
+        assert!(matches!(*supervisor.state.lock().await, State::Unenrolled));
+        assert_eq!(
+            agent_state.current().enrollment,
+            Enrollment::Unenrolled as i32
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     /// Poll until the observable enrollment reaches `Attaching`, bounded so a

--- a/fleet/arcbox-fleet-agent/src/enroll.rs
+++ b/fleet/arcbox-fleet-agent/src/enroll.rs
@@ -16,8 +16,8 @@ use crate::host;
 use crate::update::UpdatePayload;
 
 /// Enrollment refused because the gateway pins a different build. Carries
-/// the pushed download (when the gateway had one for this platform) so the
-/// CLI enroll path can self-update and re-exec into a retry.
+/// the pushed download (when the gateway had one for this platform) so both
+/// enroll paths can self-update and re-exec into a retry.
 #[derive(Debug, thiserror::Error)]
 #[error(
     "enrollment refused: gateway expects agent version {expected_version}, \
@@ -54,8 +54,10 @@ const GATEWAY_UNENROLL_TIMEOUT: Duration = Duration::from_secs(10);
 ///
 /// A gateway that expects a different agent build refuses enrollment with
 /// `EnrollResponse::update_required`, surfaced as [`EnrollUpdateRequired`]:
-/// the CLI enroll path self-updates and retries when the refusal carries a
-/// download, and otherwise shows the operator the expected version.
+/// both enroll paths self-update and re-exec when the refusal carries a
+/// download, and otherwise show the operator the expected version. `quick
+/// enroll` re-execs into a retry of itself; the control-plane RPC re-execs
+/// `serve`, and its caller re-issues `Enroll` against the new build.
 pub async fn enroll(
     config: &AgentConfig,
     token: String,

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -48,6 +48,7 @@ mod vm;
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use arcbox_fleet_control_proto::v1 as control_proto;
@@ -242,15 +243,28 @@ async fn run(command: Command, config: AgentConfig) -> Result<()> {
             let token = resolve_enrollment_token(token_file, token)?;
             let channel = control::client::connect_default(&config).await?;
             let mut client = FleetLifecycleServiceClient::new(channel);
-            let response = client
-                .enroll(control_proto::EnrollRequest {
-                    enrollment_token: token,
-                    control_plane: String::new(),
-                })
-                .await
-                .context("Enroll RPC failed")?
-                .into_inner();
-            println!("enrolled (machine_id={})", response.machine_id);
+            let request = control_proto::EnrollRequest {
+                enrollment_token: token,
+                control_plane: String::new(),
+            };
+            let machine_id = match client.enroll(request.clone()).await {
+                Ok(response) => response.into_inner().machine_id,
+                // A gateway that pins a different build refuses the
+                // enrollment, and the agent self-updates and re-execs on the
+                // spot — so a connection that drops mid-call is the expected
+                // shape of "it updated", not a failure to report.
+                Err(status) if is_connection_lost(&status) => {
+                    println!(
+                        "agent restarted mid-enroll (a version refusal self-updates in place); \
+                         waiting for it to come back"
+                    );
+                    resume_enroll_after_restart(&config, request).await?
+                }
+                Err(status) => {
+                    return Err(anyhow::Error::new(status).context("Enroll RPC failed"));
+                }
+            };
+            println!("enrolled (machine_id={machine_id})");
             Ok(())
         }
         Command::Quick(QuickCommand::Enroll(EnrollArgs { token_file, token })) => {
@@ -647,6 +661,82 @@ fn resolve_enrollment_token(token_file: Option<PathBuf>, token: Option<String>) 
         anyhow::bail!("enrollment token is empty");
     }
     Ok(token)
+}
+
+/// How long `enroll` waits for the agent to come back after it self-updates
+/// and re-execs mid-call. The download and its checksum verification both
+/// finish before the exec, so this only has to cover process restart and the
+/// control socket rebind.
+const RESTART_WAIT: Duration = Duration::from_secs(30);
+/// Gap between reconnect attempts inside [`RESTART_WAIT`].
+const RESTART_POLL: Duration = Duration::from_millis(250);
+
+/// Whether the RPC failed because the connection went away rather than
+/// because the agent chose to answer that way. `Enroll`'s own refusals all
+/// carry a specific code (`InvalidArgument` for an empty token,
+/// `FailedPrecondition` for a state or operator-action refusal, `Internal`
+/// for a fault), so only transport-level codes reach the resume path.
+fn is_connection_lost(status: &tonic::Status) -> bool {
+    matches!(
+        status.code(),
+        tonic::Code::Unknown | tonic::Code::Unavailable | tonic::Code::Cancelled
+    )
+}
+
+/// Finish an `Enroll` whose connection dropped because the agent
+/// self-updated and re-exec'd. Waits for the replacement process to rebind
+/// the control socket, then replays the enrollment — the join token is
+/// multi-use, so replaying it is safe. Guarded by `GetStatus`: the replay
+/// only happens while the agent reports itself unenrolled, so an enrollment
+/// that did land and whose response we merely lost can never enroll the
+/// machine a second time.
+async fn resume_enroll_after_restart(
+    config: &AgentConfig,
+    request: control_proto::EnrollRequest,
+) -> Result<String> {
+    let deadline = tokio::time::Instant::now() + RESTART_WAIT;
+    let mut client = loop {
+        match control::client::connect_default(config).await {
+            Ok(channel) => break FleetLifecycleServiceClient::new(channel),
+            Err(error) if tokio::time::Instant::now() >= deadline => {
+                return Err(error.context("the agent went away mid-enroll and never came back"));
+            }
+            Err(_) => tokio::time::sleep(RESTART_POLL).await,
+        }
+    };
+
+    let info = client
+        .get_agent_info(control_proto::GetAgentInfoRequest {})
+        .await
+        .context("GetAgentInfo RPC failed after the agent restarted")?
+        .into_inner();
+    let status = client
+        .get_status(control_proto::GetStatusRequest {})
+        .await
+        .context("GetStatus RPC failed after the agent restarted")?
+        .into_inner();
+    match control_proto::ConnectionState::try_from(status.state)
+        .unwrap_or(control_proto::ConnectionState::Unspecified)
+    {
+        control_proto::ConnectionState::Unenrolled => {}
+        control_proto::ConnectionState::Unspecified => {
+            anyhow::bail!("agent reported an unknown state after restarting");
+        }
+        // Enrolled after all: the pre-restart attempt persisted its
+        // credential and only the response was lost with the connection.
+        _ => return Ok(status.machine_id),
+    }
+
+    println!(
+        "agent is back on {}; finishing enrollment",
+        info.agent_version
+    );
+    Ok(client
+        .enroll(request)
+        .await
+        .context("Enroll RPC failed after the agent self-updated")?
+        .into_inner()
+        .machine_id)
 }
 
 /// Run the startup probes and assemble the backend registry: any

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -683,26 +683,91 @@ fn is_connection_lost(status: &tonic::Status) -> bool {
     )
 }
 
+/// What a post-restart `GetStatus` says to do about the enrollment this CLI
+/// still owes its caller.
+#[derive(Debug, PartialEq, Eq)]
+enum PostRestart {
+    /// Definitively not enrolled — replay the enrollment.
+    Replay,
+    /// Enrolled, with the id to report.
+    Enrolled(String),
+    /// Enrolled-ish but no machine id yet: `AgentSupervisor::enroll`
+    /// publishes `Attaching` with an empty id for the whole of its gateway
+    /// round-trip, and `status` reports that as `Enrolled`. So this is
+    /// somebody else's `Enroll` still in flight — it may yet fail and leave
+    /// the agent unenrolled. Neither answer is known; look again.
+    InProgress,
+    /// A state this build does not model.
+    Unknown,
+}
+
+/// Classify a post-restart status. Split out as a pure function because it
+/// carries the whole double-enroll argument: `Replay` may only be returned
+/// when the agent is *definitively* unenrolled, never while an enrollment is
+/// merely unresolved.
+fn post_restart(state: control_proto::ConnectionState, machine_id: &str) -> PostRestart {
+    use control_proto::ConnectionState;
+    match state {
+        ConnectionState::Unenrolled => PostRestart::Replay,
+        ConnectionState::Unspecified => PostRestart::Unknown,
+        _ if machine_id.is_empty() => PostRestart::InProgress,
+        _ => PostRestart::Enrolled(machine_id.to_owned()),
+    }
+}
+
+/// One attempt at reading the restarting agent's enrollment. `Err` is a
+/// retryable "not back yet": no socket, or a socket whose server is still
+/// coming up.
+async fn poll_post_restart(
+    config: &AgentConfig,
+) -> Result<(
+    FleetLifecycleServiceClient<tonic::transport::Channel>,
+    PostRestart,
+)> {
+    let mut client =
+        FleetLifecycleServiceClient::new(control::client::connect_default(config).await?);
+    let status = client
+        .get_status(control_proto::GetStatusRequest {})
+        .await
+        .context("GetStatus RPC failed after the agent restarted")?
+        .into_inner();
+    let state = control_proto::ConnectionState::try_from(status.state)
+        .unwrap_or(control_proto::ConnectionState::Unspecified);
+    Ok((client, post_restart(state, &status.machine_id)))
+}
+
 /// Finish an `Enroll` whose connection dropped because the agent
-/// self-updated and re-exec'd. Waits for the replacement process to rebind
-/// the control socket, then replays the enrollment — the join token is
-/// multi-use, so replaying it is safe. Guarded by `GetStatus`: the replay
-/// only happens while the agent reports itself unenrolled, so an enrollment
-/// that did land and whose response we merely lost can never enroll the
-/// machine a second time.
+/// self-updated and re-exec'd. Polls until the replacement process has
+/// rebound the control socket *and* reports a settled enrollment, then
+/// replays the enrollment — the join token is multi-use, so replaying it is
+/// safe. Guarded by [`post_restart`]: the replay happens only while the
+/// agent is definitively unenrolled, so an enrollment that did land — or one
+/// another caller is still driving — can never enroll the machine twice.
 async fn resume_enroll_after_restart(
     config: &AgentConfig,
     request: control_proto::EnrollRequest,
 ) -> Result<String> {
     let deadline = tokio::time::Instant::now() + RESTART_WAIT;
     let mut client = loop {
-        match control::client::connect_default(config).await {
-            Ok(channel) => break FleetLifecycleServiceClient::new(channel),
-            Err(error) if tokio::time::Instant::now() >= deadline => {
-                return Err(error.context("the agent went away mid-enroll and never came back"));
+        // Every arm that doesn't resolve the enrollment yields the reason to
+        // report if the deadline expires while we keep waiting on it.
+        let waiting_on = match poll_post_restart(config).await {
+            Ok((client, PostRestart::Replay)) => break client,
+            Ok((_, PostRestart::Enrolled(machine_id))) => return Ok(machine_id),
+            Ok((_, PostRestart::Unknown)) => {
+                anyhow::bail!("agent reported an unknown state after restarting")
             }
-            Err(_) => tokio::time::sleep(RESTART_POLL).await,
+            Ok((_, PostRestart::InProgress)) => {
+                anyhow::anyhow!("another enrollment is still in progress")
+            }
+            Err(error) => error,
+        };
+        if tokio::time::Instant::now() >= deadline {
+            return Err(
+                waiting_on.context("the agent never came back ready to enroll after restarting")
+            );
         }
+        tokio::time::sleep(RESTART_POLL).await;
     };
 
     let info = client
@@ -710,23 +775,6 @@ async fn resume_enroll_after_restart(
         .await
         .context("GetAgentInfo RPC failed after the agent restarted")?
         .into_inner();
-    let status = client
-        .get_status(control_proto::GetStatusRequest {})
-        .await
-        .context("GetStatus RPC failed after the agent restarted")?
-        .into_inner();
-    match control_proto::ConnectionState::try_from(status.state)
-        .unwrap_or(control_proto::ConnectionState::Unspecified)
-    {
-        control_proto::ConnectionState::Unenrolled => {}
-        control_proto::ConnectionState::Unspecified => {
-            anyhow::bail!("agent reported an unknown state after restarting");
-        }
-        // Enrolled after all: the pre-restart attempt persisted its
-        // credential and only the response was lost with the connection.
-        _ => return Ok(status.machine_id),
-    }
-
     println!(
         "agent is back on {}; finishing enrollment",
         info.agent_version
@@ -1015,5 +1063,71 @@ mod tests {
             resolve_enrollment_token(Some(path.clone()), Some("ignored".to_owned())).unwrap();
         assert_eq!(token, "flt_from_file");
         let _ = std::fs::remove_file(path);
+    }
+
+    /// Only a lost connection may trigger the resume path. A deliberate
+    /// refusal reaching it would replay an enrollment the agent already
+    /// answered.
+    #[test]
+    fn only_transport_failures_count_as_a_lost_connection() {
+        for code in [
+            tonic::Code::Unknown,
+            tonic::Code::Unavailable,
+            tonic::Code::Cancelled,
+        ] {
+            assert!(
+                is_connection_lost(&tonic::Status::new(code, "")),
+                "{code:?}"
+            );
+        }
+        for code in [
+            tonic::Code::FailedPrecondition,
+            tonic::Code::InvalidArgument,
+            tonic::Code::Internal,
+        ] {
+            assert!(
+                !is_connection_lost(&tonic::Status::new(code, "")),
+                "{code:?}"
+            );
+        }
+    }
+
+    /// The double-enroll guard. `Replay` is only ever correct when the agent
+    /// is definitively unenrolled — an enrolled state reports its id, and an
+    /// enrollment still in flight (`Attaching`, which `status` reports as
+    /// `Enrolled` with no id yet) is unresolved, not a licence to replay.
+    #[test]
+    fn post_restart_replays_only_a_definitely_unenrolled_agent() {
+        use control_proto::ConnectionState;
+
+        assert_eq!(
+            post_restart(ConnectionState::Unenrolled, ""),
+            PostRestart::Replay
+        );
+        assert_eq!(
+            post_restart(ConnectionState::Enrolled, "fltm_test"),
+            PostRestart::Enrolled("fltm_test".to_owned())
+        );
+        // Another caller's Enroll is mid-round-trip: no id published yet.
+        assert_eq!(
+            post_restart(ConnectionState::Enrolled, ""),
+            PostRestart::InProgress
+        );
+        assert_eq!(
+            post_restart(ConnectionState::Unspecified, ""),
+            PostRestart::Unknown
+        );
+        // Every other enrolled-ish state reports its machine, never replays.
+        for state in [
+            ConnectionState::Draining,
+            ConnectionState::Detached,
+            ConnectionState::CredentialRejected,
+        ] {
+            assert_eq!(
+                post_restart(state, "fltm_test"),
+                PostRestart::Enrolled("fltm_test".to_owned()),
+                "{state:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

A gateway that pins a different `agent_version` refuses enrollment with `EnrollResponse::update_required`, carrying the expected version and (for a pinned platform) a download. `quick enroll` acts on that — self-updates and re-execs into a retry. The control-plane `Enroll` RPC did not: `AgentSupervisor::finish_enroll` mapped the refusal to a raw `INTERNAL` and rolled back to `Unenrolled`.

That made a stale binary enrolling through the control socket a dead end. Because it never enrolls, the attach path that *would* have updated it (`AttachRejected` → drain → swap → re-exec) never runs, and the operator sees only an opaque internal error.

## Change

- `finish_enroll` routes a failed round-trip through a new `AgentSupervisor::refused_enrollment`: a refusal carrying a download logs, sets the observable `Enrollment::Updating`, and hands off to `update::apply_and_exec`, replacing the process on the pinned build. A binary the agent doesn't own returns `FAILED_PRECONDITION` with the `UnmanagedBinary` reason; anything else stays `INTERNAL`.
- No drain here: `check_enrollable` admits an enroll only from `Unenrolled`, so there is no attachment and no in-flight job to protect.
- The re-exec kills the in-flight RPC, so `arcbox-fleet-agent enroll` now resumes across it: reconnect-poll for up to 30s, `GetAgentInfo` for the version it came back on, then **`GetStatus` as a guard** — the enrollment is replayed only while the agent reports itself `Unenrolled`, so an enrollment that landed and whose response was merely lost cannot enroll the machine twice. The join token is multi-use, so the replay itself is safe.

## Verification

`cargo test -p arcbox-fleet-agent` (108 unit + 1 integration), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — all clean.

New test `enroll_declines_to_self_update_an_unmanaged_binary` drives a mock gateway that answers every enroll with `UpdateRequired` and asserts the enrollment reaches the updater, declines on the managed-path check, and rolls the gate back to `Unenrolled`. Nothing is downloaded: `ensure_managed` runs before the fetch.

**Draft because the runtime path is not yet exercised end-to-end.** Unit tests necessarily stop at `ensure_managed` — the download → verify → probe → swap → re-exec → reconnect → replay sequence has not been run against a live gateway on a mismatched pin. Worth doing on the dev box (gateway pinned to a published version, agent built at a lower one, running from the managed path) before this is marked ready.
