### PR TITLE
fix(core): disable the idle balloon — no macOS backend reclaims ballooned memory

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -118,16 +118,19 @@ Covers `arcbox-daemon` (startup/shutdown), `arcbox-core` (`vm_lifecycle`),
   + large `docker.img` mount under CPU/I/O pressure). A tight 30s budget
   raced the cold-boot path into "timeout waiting for agent" loops — do not
   tighten it toward the <1.5s cold-boot target.
-- **The idle balloon shrinks only on reclaim-capable backends** — on VZ it
-  is disabled by `BalloonDeps::reclaim_capable` (`balloon/controller.rs`),
-  and this gate is load-bearing: VZ inflation releases NOTHING host-side
-  (measured 2026-07-29, macOS 26.4 — 15.35 GB inflated, daemon
-  `phys_footprint` byte-identical, pages *compressed as live data* under
-  real host pressure; full evidence in `balloon/mod.rs` docs). VZ host
-  footprint ≈ configured `memory_mb` from boot; the only VZ memory levers
-  are `memory_mb` itself and the macOS compressor. Do not "re-enable VZ
-  ballooning" without first proving host-side reclaim on the target macOS.
-  Only HV reclaims (`arcbox-virtio-balloon` `MADV_DONTNEED`).
+- **The idle balloon never shrinks today: no macOS backend reclaims** —
+  the gate is `BalloonDeps::reclaim_capable` (`balloon/controller.rs`),
+  false on both backends, and it is load-bearing (measured 2026-07-29,
+  macOS 26.4; full evidence in `balloon/mod.rs` docs). VZ inflation
+  releases NOTHING host-side (15.35 GB inflated, daemon `phys_footprint`
+  byte-identical, pages *compressed as live data* under real host
+  pressure). HV inflates via `MADV_DONTNEED`, which Darwin treats as a
+  deactivation hint (calibrated footprint-inert; contents preserved).
+  Host footprint ≈ configured `memory_mb` from boot; the only macOS
+  memory levers are `memory_mb` itself and the macOS compressor. Do not
+  flip a backend to reclaim-capable without a measured host
+  `phys_footprint` drop on inflate (HV path: switch the device to
+  `MADV_FREE_REUSABLE` first).
 - `set_backend` only changes the backend used on the next (re)boot; it does
   NOT stop or restart a running VM. To apply immediately the caller forces a
   recreate via `Runtime::switch_system_vm_backend`. The backend is seeded

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -118,6 +118,16 @@ Covers `arcbox-daemon` (startup/shutdown), `arcbox-core` (`vm_lifecycle`),
   + large `docker.img` mount under CPU/I/O pressure). A tight 30s budget
   raced the cold-boot path into "timeout waiting for agent" loops — do not
   tighten it toward the <1.5s cold-boot target.
+- **The idle balloon shrinks only on reclaim-capable backends** — on VZ it
+  is disabled by `BalloonDeps::reclaim_capable` (`balloon/controller.rs`),
+  and this gate is load-bearing: VZ inflation releases NOTHING host-side
+  (measured 2026-07-29, macOS 26.4 — 15.35 GB inflated, daemon
+  `phys_footprint` byte-identical, pages *compressed as live data* under
+  real host pressure; full evidence in `balloon/mod.rs` docs). VZ host
+  footprint ≈ configured `memory_mb` from boot; the only VZ memory levers
+  are `memory_mb` itself and the macOS compressor. Do not "re-enable VZ
+  ballooning" without first proving host-side reclaim on the target macOS.
+  Only HV reclaims (`arcbox-virtio-balloon` `MADV_DONTNEED`).
 - `set_backend` only changes the backend used on the next (re)boot; it does
   NOT stop or restart a running VM. To apply immediately the caller forces a
   recreate via `Runtime::switch_system_vm_backend`. The backend is seeded

--- a/app/arcbox-core/src/vm_lifecycle/actor.rs
+++ b/app/arcbox-core/src/vm_lifecycle/actor.rs
@@ -178,14 +178,20 @@ impl RealBalloonDeps {
 impl BalloonDeps for RealBalloonDeps {
     type Watch = AgentPressureWatch;
 
-    /// Only the custom HV backend reclaims: its balloon device
-    /// `madvise(MADV_DONTNEED)`s inflated pages (`arcbox-virtio-balloon`).
-    /// VZ inflation is a host-side no-op — measured 2026-07-29 on macOS
-    /// 26.4: guest gave up 15.35 GB, daemon `phys_footprint` never moved,
-    /// and under real host memory pressure the kernel *compressed* the
-    /// ballooned pages as live data instead of discarding them.
+    /// No macOS backend reclaims ballooned memory today (measured and
+    /// calibrated 2026-07-29 on macOS 26.4):
+    /// - VZ: Apple applies neither `vm_deallocate` nor any `madvise` to
+    ///   inflated pages — a 15.35 GB inflation left the daemon's
+    ///   `phys_footprint` byte-identical, and real host pressure
+    ///   *compressed* the pages as live data.
+    /// - HV: `arcbox-virtio-balloon` inflates with `MADV_DONTNEED`, which
+    ///   Darwin treats as a deactivation hint — calibrated
+    ///   footprint-inert, contents preserved (compressed, not discarded,
+    ///   under pressure). Flip HV to `true` only after the device switches
+    ///   to `MADV_FREE_REUSABLE` and a real HV boot shows the host
+    ///   footprint dropping on inflate.
     fn reclaim_capable(&self) -> bool {
-        matches!(self.shared.backend(), arcbox_vmm::VmBackend::Hv)
+        false
     }
 
     fn full_memory_bytes(&self) -> Option<u64> {

--- a/app/arcbox-core/src/vm_lifecycle/actor.rs
+++ b/app/arcbox-core/src/vm_lifecycle/actor.rs
@@ -178,6 +178,16 @@ impl RealBalloonDeps {
 impl BalloonDeps for RealBalloonDeps {
     type Watch = AgentPressureWatch;
 
+    /// Only the custom HV backend reclaims: its balloon device
+    /// `madvise(MADV_DONTNEED)`s inflated pages (`arcbox-virtio-balloon`).
+    /// VZ inflation is a host-side no-op — measured 2026-07-29 on macOS
+    /// 26.4: guest gave up 15.35 GB, daemon `phys_footprint` never moved,
+    /// and under real host memory pressure the kernel *compressed* the
+    /// ballooned pages as live data instead of discarding them.
+    fn reclaim_capable(&self) -> bool {
+        matches!(self.shared.backend(), arcbox_vmm::VmBackend::Hv)
+    }
+
     fn full_memory_bytes(&self) -> Option<u64> {
         self.shared
             .machine_manager

--- a/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
@@ -79,6 +79,13 @@ pub(in crate::vm_lifecycle) trait BalloonDeps:
     /// The watch type produced by [`Self::open_pressure_watch`].
     type Watch: PressureWatch;
 
+    /// Whether inflating the balloon actually releases host memory on the
+    /// current backend. When `false`, idle shrinking is pure cost (guest
+    /// scarcity + reclaim CPU) with zero host-side benefit, and the
+    /// controller must not shrink at all. See the module docs for the VZ
+    /// measurement behind this.
+    fn reclaim_capable(&self) -> bool;
+
     /// Configured full memory of the machine, if the machine record exists.
     fn full_memory_bytes(&self) -> Option<u64>;
 
@@ -318,6 +325,15 @@ impl<D: BalloonDeps> BalloonController<D> {
 
     /// Entry probe: size the balloon from clean (balloon-empty) stats.
     async fn enter_idle(&mut self) -> Mode<D::Watch> {
+        if !self.deps.reclaim_capable() {
+            // No retry timer: the answer is a property of the backend, not
+            // a transient. The next real idle entry re-asks (the backend
+            // can change across a VM recreate).
+            tracing::info!(
+                "idle balloon disabled: backend does not release ballooned memory to the host"
+            );
+            return Mode::Active;
+        }
         let Some(full) = self.deps.full_memory_bytes() else {
             return Mode::IdleUnshrunk;
         };
@@ -473,6 +489,9 @@ mod tests {
 
     /// Test double with scripted stats/watch behavior and recorded targets.
     struct FakeDeps {
+        /// Backend reclaim capability (default `true`: the shrink paths
+        /// under test assume an HV-class backend).
+        reclaim_capable: bool,
         full: Option<u64>,
         stats: Mutex<Vec<Option<GuestStats>>>,
         /// Injected latency for `guest_stats` (probe-race tests).
@@ -490,6 +509,7 @@ mod tests {
     impl FakeDeps {
         fn new(full: Option<u64>) -> Self {
             Self {
+                reclaim_capable: true,
                 full,
                 stats: Mutex::new(Vec::new()),
                 stats_delay: Duration::ZERO,
@@ -520,6 +540,10 @@ mod tests {
 
     impl BalloonDeps for Arc<FakeDeps> {
         type Watch = FakeWatch;
+
+        fn reclaim_capable(&self) -> bool {
+            self.reclaim_capable
+        }
 
         fn full_memory_bytes(&self) -> Option<u64> {
             self.full
@@ -639,6 +663,37 @@ mod tests {
     const FINAL_TARGET: u64 = 4 * GIB + super::super::IDLE_BALLOON_HEADROOM;
     /// First staged step from 16 GiB full memory.
     const FIRST_STEP: u64 = FULL - super::super::SHRINK_STEP;
+
+    /// A reclaim-incapable backend (VZ) must make idle entry fully inert:
+    /// no stats probe, no shrink, no retry timer — and the controller stays
+    /// responsive to later cycles.
+    #[tokio::test(start_paused = true)]
+    async fn reclaim_incapable_backend_never_shrinks() {
+        let mut deps = FakeDeps::new(Some(FULL));
+        deps.reclaim_capable = false;
+        deps.push_stats(Some(idle_stats()));
+        let h = Harness::spawn(deps);
+
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+        // Well past IDLE_ENTRY_RETRY: no timer may have re-entered.
+        tokio::time::advance(Duration::from_secs(120)).await;
+        h.settle().await;
+
+        assert_eq!(h.targets(), Vec::<u64>::new());
+        assert_eq!(h.deps.set_attempts.load(Ordering::SeqCst), 0);
+        // The gate fires before the stats probe: the scripted reply is
+        // still queued.
+        assert_eq!(h.deps.stats.lock().unwrap().len(), 1);
+        assert_eq!(h.deps.watches_opened.load(Ordering::SeqCst), 0);
+
+        // Still alive for the next cycle.
+        h.commands.send(BalloonCommand::ExitIdle).unwrap();
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+        assert_eq!(h.deps.set_attempts.load(Ordering::SeqCst), 0);
+        assert_eq!(h.activity_count(), 0);
+    }
 
     #[tokio::test(start_paused = true)]
     async fn enter_idle_takes_first_staged_step_and_watches() {

--- a/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
@@ -82,8 +82,10 @@ pub(in crate::vm_lifecycle) trait BalloonDeps:
     /// Whether inflating the balloon actually releases host memory on the
     /// current backend. When `false`, idle shrinking is pure cost (guest
     /// scarcity + reclaim CPU) with zero host-side benefit, and the
-    /// controller must not shrink at all. See the module docs for the VZ
-    /// measurement behind this.
+    /// controller must not shrink at all. No macOS backend qualifies
+    /// today — see the module docs for the per-backend measurements (VZ:
+    /// Apple no-op; HV: Darwin-inert `MADV_DONTNEED`) and what flipping a
+    /// backend requires.
     fn reclaim_capable(&self) -> bool;
 
     /// Configured full memory of the machine, if the machine record exists.
@@ -664,9 +666,9 @@ mod tests {
     /// First staged step from 16 GiB full memory.
     const FIRST_STEP: u64 = FULL - super::super::SHRINK_STEP;
 
-    /// A reclaim-incapable backend (VZ) must make idle entry fully inert:
-    /// no stats probe, no shrink, no retry timer — and the controller stays
-    /// responsive to later cycles.
+    /// A reclaim-incapable backend (today: every macOS backend) must make
+    /// idle entry fully inert: no stats probe, no shrink, no retry timer —
+    /// and the controller stays responsive to later cycles.
     #[tokio::test(start_paused = true)]
     async fn reclaim_incapable_backend_never_shrinks() {
         let mut deps = FakeDeps::new(Some(FULL));

--- a/app/arcbox-core/src/vm_lifecycle/balloon/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/mod.rs
@@ -18,6 +18,17 @@
 //!   very numbers a host-side re-computation would need, so pressure
 //!   detection is delegated to the guest (see `WatchMemoryPressure`)
 //!   and the only moves are "keep" or "give it all back".
+//! - **Idle shrinking runs only on reclaim-capable backends** (2026-07-29
+//!   measurement). On VZ, inflation is a host-side no-op: Apple neither
+//!   deallocates nor `madvise`s the pages the guest gives up — a 15.35 GB
+//!   inflation left the daemon's `phys_footprint` byte-identical, and under
+//!   real host memory pressure the kernel *compressed* the ballooned pages
+//!   as live data (calibrated against `MADV_FREE`/`MADV_FREE_REUSABLE`
+//!   probes, which are discarded within seconds under the same pressure).
+//!   VZ host footprint is pinned at the configured `memory_mb` from boot,
+//!   so shrinking there is guest starvation with zero host benefit. Only
+//!   the HV backend reclaims (`arcbox-virtio-balloon` MADV_DONTNEED); see
+//!   [`controller::BalloonDeps::reclaim_capable`].
 
 pub(super) mod controller;
 

--- a/app/arcbox-core/src/vm_lifecycle/balloon/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/mod.rs
@@ -18,17 +18,21 @@
 //!   very numbers a host-side re-computation would need, so pressure
 //!   detection is delegated to the guest (see `WatchMemoryPressure`)
 //!   and the only moves are "keep" or "give it all back".
-//! - **Idle shrinking runs only on reclaim-capable backends** (2026-07-29
-//!   measurement). On VZ, inflation is a host-side no-op: Apple neither
-//!   deallocates nor `madvise`s the pages the guest gives up — a 15.35 GB
-//!   inflation left the daemon's `phys_footprint` byte-identical, and under
-//!   real host memory pressure the kernel *compressed* the ballooned pages
-//!   as live data (calibrated against `MADV_FREE`/`MADV_FREE_REUSABLE`
-//!   probes, which are discarded within seconds under the same pressure).
-//!   VZ host footprint is pinned at the configured `memory_mb` from boot,
-//!   so shrinking there is guest starvation with zero host benefit. Only
-//!   the HV backend reclaims (`arcbox-virtio-balloon` MADV_DONTNEED); see
-//!   [`controller::BalloonDeps::reclaim_capable`].
+//! - **Idle shrinking runs only on reclaim-capable backends — and no macOS
+//!   backend is one today** (2026-07-29 measurements, macOS 26.4). VZ:
+//!   Apple neither deallocates nor `madvise`s the pages the guest gives up
+//!   — a 15.35 GB inflation left the daemon's `phys_footprint`
+//!   byte-identical, and under real host memory pressure the kernel
+//!   *compressed* the ballooned pages as live data (calibrated against a
+//!   `MADV_FREE` probe, which the same pressure discards within seconds).
+//!   HV: its device inflates with `MADV_DONTNEED`, which Darwin treats as
+//!   a deactivation hint — calibrated footprint-inert, contents preserved
+//!   (compressed, never discarded, under pressure); real Darwin reclaim
+//!   needs `MADV_FREE_REUSABLE` (calibrated: footprint drops instantly).
+//!   Host footprint stays pinned at the configured `memory_mb`, so
+//!   shrinking is guest starvation with zero host benefit on either
+//!   backend. See [`controller::BalloonDeps::reclaim_capable`]; flip a
+//!   backend only with a measured host footprint drop on inflate.
 
 pub(super) mod controller;
 

--- a/tests/e2e/tests/idle_balloon.rs
+++ b/tests/e2e/tests/idle_balloon.rs
@@ -1,20 +1,23 @@
-//! Idle-balloon regression e2e (2026-07-15 incident).
+//! Idle-balloon regression e2e (2026-07-15 incident → 2026-07-29 verdict).
 //!
-//! The incident: a VM running containers idled after 5 quiet minutes, the
-//! balloon was shrunk to an unconditional 128 MB, and nothing could ever
-//! restore it — 18 hours of reclaim thrash with dockerd and the agent
-//! starved unresponsive.
+//! History: the 2026-07-15 incident (an unconditional shrink to 128 MB
+//! starved a running compose stack for 18 hours) led to the usage-aware
+//! staged-descent redesign this test originally exercised. The 2026-07-29
+//! measurements then showed no macOS backend actually reclaims ballooned
+//! memory (VZ: Apple applies no madvise at all; HV: `MADV_DONTNEED` is a
+//! Darwin deactivation hint) — shrinking was guest starvation with zero
+//! host benefit, so the idle balloon is disabled on macOS entirely. See
+//! `app/arcbox-core/src/vm_lifecycle/balloon/mod.rs` for the evidence.
 //!
-//! This scenario replays the shape on a real VZ daemon with a short idle
-//! timeout: hold a memory workload, let the VM idle-shrink, then grow the
-//! workload *inside the guest* (no host API traffic, exactly like the
-//! incident) and require the guest-driven pressure exit: balloon restored,
-//! Docker responsive, no reclaim storm.
+//! This scenario pins the new contract on a real VZ daemon with a short
+//! idle timeout, while a container runs in the guest and a persistent
+//! `docker events` subscription is held open (the desktop-UI shape that
+//! once pinned `active_ops` and disabled idle handling outright):
 //!
-//! The whole cycle runs under a persistent `docker events` subscription —
-//! the desktop UI holds one for its entire lifetime, and counting that
-//! passive stream as VM activity once pinned `active_ops` and disabled
-//! idle reclaim outright on desktop installs.
+//! - idle must still ENGAGE (the disabled-balloon line is the witness);
+//! - the balloon must never shrink or restore — no descent, no
+//!   `Out of puff` reclaim storm, no 8.5-minute shrink/restore cycle;
+//! - Docker must be responsive afterwards.
 //!
 //! Balloon moves have no RPC surface; the daemon log is the only oracle
 //! for them. That is an explicit exception to the "readiness only via
@@ -34,21 +37,16 @@ static TRACING: Once = Once::new();
 
 const READY_TIMEOUT: Duration = Duration::from_secs(180);
 /// Idle timeout under test (knob). The actor's idle ticker runs every 10s,
-/// so the shrink lands within ~30s of the last docker call.
+/// so idle entry lands within ~30s of the last docker call.
 const IDLE_TIMEOUT_SECS: u64 = 20;
-/// Budget for observing the idle shrink in the daemon log.
-const SHRINK_BUDGET: Duration = Duration::from_secs(120);
-/// Budget from ballast growth until the balloon must be restored. Covers
-/// the slow path where growth lands while the guest is still settling and
-/// the agent's never-settled cap (180 samples) has to fire.
-const RESTORE_BUDGET: Duration = Duration::from_secs(150);
+/// Budget for observing the disabled-balloon line in the daemon log.
+const IDLE_BUDGET: Duration = Duration::from_secs(120);
+/// Quiet window after idle entry in which no shrink may appear. Longer
+/// than `IDLE_ENTRY_RETRY` (30s), so a regression that arms the retry
+/// timer instead of staying inert is caught too.
+const QUIET_WINDOW: Duration = Duration::from_secs(90);
 /// Ceiling for one docker CLI invocation.
 const DOCKER_ATTEMPT: Duration = Duration::from_secs(30);
-/// Delay inside the ballast container before it grows its memory. Sized
-/// past the idle timeout (~20s) + ticker (10s) + the full staged descent
-/// (~7 steps × 15s dwell) + the final step's settle, so growth hits a
-/// shrunk, settled, armed guest and exercises the fast pressure path.
-const BALLAST_GROW_DELAY_SECS: u64 = 180;
 
 fn init_tracing() {
     TRACING.call_once(|| {
@@ -62,8 +60,8 @@ fn init_tracing() {
 }
 
 #[test]
-#[ignore = "boots a VZ System VM through a real daemon and drives an idle-shrink/pressure-restore cycle"]
-fn idle_shrink_is_usage_aware_and_pressure_restores() -> Result<()> {
+#[ignore = "boots a VZ System VM through a real daemon and verifies idle entry never shrinks the balloon"]
+fn idle_entry_never_shrinks_on_macos() -> Result<()> {
     init_tracing();
 
     let root = arcbox_e2e::repo_root();
@@ -112,129 +110,61 @@ fn scenario(daemon: &mut DaemonHandle, data_dir: &Path, metrics: &mut RunMetrics
     let image = std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
     metrics.time("docker_pull", || ensure_image(data_dir, &image))?;
 
-    // Persistent observer, held open for the whole cycle: the idle shrink
-    // below must engage despite this live `/events` subscription.
+    // Persistent observer, held open for the whole cycle: idle entry below
+    // must engage despite this live `/events` subscription.
     let mut events = docker_stream(data_dir, &["events"]).context("subscribing to events")?;
 
-    // The ballast: hold ~256 MB immediately (tmpfs pages persist regardless
-    // of process lifetime), then grow by 2 GiB after the VM has idled and
-    // shrunk. The growth happens entirely inside the guest — no host API
-    // traffic — exactly the incident shape. `--shm-size` matters: Docker's
-    // default /dev/shm is 64 MB, which silently neuters the ballast.
-    let ballast_script = format!(
-        "dd if=/dev/zero of=/dev/shm/hold bs=1M count=256 && sleep {BALLAST_GROW_DELAY_SECS} && \
-         dd if=/dev/zero of=/dev/shm/grow bs=1M count=2048; sleep 900"
-    );
-    metrics.time("ballast_start", || {
+    // An in-guest workload: container load never counts as host activity
+    // (the incident shape), so it must not block idle entry either.
+    metrics.time("workload_start", || {
         docker_output(
             data_dir,
-            &[
-                "run",
-                "-d",
-                "--shm-size=3g",
-                "--name",
-                "ballast",
-                &image,
-                "sh",
-                "-c",
-                &ballast_script,
-            ],
+            &["run", "-d", "--name", "workload", &image, "sleep", "900"],
             DOCKER_ATTEMPT,
         )
-        .context("starting ballast container")
+        .context("starting workload container")
     })?;
-    let ballast_started = Instant::now();
 
-    // Phase 1 — the idle shrink must be usage-aware.
-    let shrink = metrics.time("idle_shrink", || {
-        wait_for_log(
-            data_dir,
-            "idle balloon shrunk to guest usage + headroom",
-            SHRINK_BUDGET,
-        )
+    // Phase 1 — idle must engage, and the balloon gate must answer it with
+    // the disabled line (not a shrink).
+    let disabled = metrics.time("idle_disabled", || {
+        wait_for_log(data_dir, "idle balloon disabled", IDLE_BUDGET)
     })?;
-    let target_mb =
-        extract_u64_field(&shrink, "target_mb").context("shrink log line carries no target_mb")?;
-    let final_mb =
-        extract_u64_field(&shrink, "final_mb").context("shrink log line carries no final_mb")?;
-    tracing::info!(target_mb, final_mb, "idle balloon descent started");
-    if final_mb < 384 {
-        bail!("final target {final_mb}MB below the 384MB floor (incident-style blind shrink?)");
-    }
-    if final_mb >= 16384 {
-        bail!("final target {final_mb}MB is not usage-aware (no reclaim planned)");
-    }
+    tracing::info!(line = %disabled, "idle entry answered by the disabled gate");
 
-    // The staged dev agent must support the pressure watch; a fallback to
-    // polling means a stale agent and would validate the wrong path.
-    if log_contains(data_dir, "pressure watch unavailable")? {
-        bail!("controller degraded to polling — staged agent lacks WatchMemoryPressure");
-    }
-
-    // Phase 2 — the shrink must survive the post-inflation transient.
-    // Hardware regression guard: inflating the balloon evicts the page
-    // cache, and the resulting refault burst once tripped a restore one
-    // second after the shrink.
-    let grow_at = ballast_started + Duration::from_secs(BALLAST_GROW_DELAY_SECS);
-    let quiet_until = grow_at
-        .checked_sub(Duration::from_secs(5))
-        .unwrap_or(grow_at);
-    metrics.time("shrink_survives_transient", || -> Result<()> {
-        while Instant::now() < quiet_until {
-            if log_contains(data_dir, "balloon restored to full memory")? {
-                bail!("balloon restored before the in-guest growth");
+    // Phase 2 — the quiet window: nothing balloon-shaped may happen. This
+    // is the anti-regression for both the descent (would log a shrink) and
+    // the thrash cycle (would log a restore + Out-of-puff storm).
+    metrics.time("quiet_window", || -> Result<()> {
+        let deadline = Instant::now() + QUIET_WINDOW;
+        while Instant::now() < deadline {
+            for forbidden in ["idle balloon shrunk", "balloon restored to full memory"] {
+                if log_contains(data_dir, forbidden)? {
+                    bail!("daemon log contains {forbidden:?} — the reclaim gate did not hold");
+                }
             }
             std::thread::sleep(Duration::from_millis(500));
         }
         Ok(())
     })?;
-
-    // Phase 3 — in-guest growth must be answered by a guest-driven restore.
-    let restore_deadline = grow_at + RESTORE_BUDGET;
-    let restored = wait_for_log_until(
-        data_dir,
-        "balloon restored to full memory",
-        restore_deadline,
-    )?;
-    let restore_latency = Instant::now().saturating_duration_since(grow_at);
-    tracing::info!(line = %restored, latency_secs = restore_latency.as_secs(), "balloon restored");
-    metrics.record("pressure_restore_latency", restore_latency.as_secs_f64());
-
-    // The fast (armed) pressure path must have answered — not the bounded
-    // never-settled cap. The staged descent exists precisely so the guest
-    // settles and arms before real pressure can arrive.
-    if !agent_log_contains(data_dir, "memory pressure detector armed")? {
-        bail!("guest never armed — staged descent did not settle before growth");
-    }
-    if restore_latency > Duration::from_secs(30) {
-        bail!(
-            "restore took {}s — cap path, not the armed fast path",
-            restore_latency.as_secs()
-        );
-    }
-
-    // Phase 4 — the incident signature must be absent and Docker must be
-    // responsive right after the restore.
     let storm_lines = count_log_matches(data_dir, "Out of puff")?;
-    if storm_lines > 20 {
-        bail!("guest logged {storm_lines} 'Out of puff' lines — reclaim storm not prevented");
+    if storm_lines > 0 {
+        bail!("guest logged {storm_lines} 'Out of puff' lines with the balloon disabled");
     }
-    metrics.time("docker_after_restore", || {
-        docker_output(data_dir, &["ps"], Duration::from_secs(10)).context("docker ps after restore")
+
+    // Phase 3 — Docker responsive after the idle window (this call also
+    // exits idle, which must work without any balloon bookkeeping).
+    metrics.time("docker_after_idle", || {
+        docker_output(data_dir, &["ps"], Duration::from_secs(10)).context("docker ps after idle")
     })?;
 
-    // The exit must have gone through the state machine (idle → running).
-    if !log_contains(data_dir, r#""from":"idle","to":"running""#)? {
-        bail!("balloon restore did not ride the lifecycle state machine");
-    }
-
     // The whole cycle ran under a live events subscription — prove the
-    // observer survived, so the shrink above really happened despite it.
+    // observer survived, so idle entry above really engaged despite it.
     events
         .assert_alive()
         .context("events subscription died mid-scenario")?;
 
-    docker_output(data_dir, &["rm", "-f", "ballast"], DOCKER_ATTEMPT).ok();
+    docker_output(data_dir, &["rm", "-f", "workload"], DOCKER_ATTEMPT).ok();
     Ok(())
 }
 
@@ -255,27 +185,13 @@ fn log_contains(data_dir: &Path, needle: &str) -> Result<bool> {
     Ok(read_log(data_dir)?.contains(needle))
 }
 
-/// The guest agent's log, exported to the host via VirtioFS.
-fn agent_log_contains(data_dir: &Path, needle: &str) -> Result<bool> {
-    let path = data_dir.join("log/agent.log");
-    if !path.exists() {
-        return Ok(false);
-    }
-    Ok(std::fs::read_to_string(&path)
-        .with_context(|| format!("reading {}", path.display()))?
-        .contains(needle))
-}
-
 fn count_log_matches(data_dir: &Path, needle: &str) -> Result<usize> {
     Ok(read_log(data_dir)?.matches(needle).count())
 }
 
 /// Polls the daemon log for a line containing `needle`, returning that line.
 fn wait_for_log(data_dir: &Path, needle: &str, budget: Duration) -> Result<String> {
-    wait_for_log_until(data_dir, needle, Instant::now() + budget)
-}
-
-fn wait_for_log_until(data_dir: &Path, needle: &str, deadline: Instant) -> Result<String> {
+    let deadline = Instant::now() + budget;
     loop {
         if let Some(line) = read_log(data_dir)?.lines().find(|l| l.contains(needle)) {
             return Ok(line.to_owned());
@@ -285,12 +201,4 @@ fn wait_for_log_until(data_dir: &Path, needle: &str, deadline: Instant) -> Resul
         }
         std::thread::sleep(Duration::from_millis(500));
     }
-}
-
-/// Extracts a numeric field (`"name":123`) from a structured log line.
-fn extract_u64_field(line: &str, name: &str) -> Option<u64> {
-    let key = format!("\"{name}\":");
-    let rest = &line[line.find(&key)? + key.len()..];
-    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
-    digits.parse().ok()
 }

--- a/virt/arcbox-virtio-balloon/src/lib.rs
+++ b/virt/arcbox-virtio-balloon/src/lib.rs
@@ -6,8 +6,9 @@
 //! - Feature bit `VIRTIO_BALLOON_F_DEFLATE_ON_OOM` (bit 2) — the guest may
 //!   reclaim balloon pages on OOM without host permission. Safe for us
 //!   because we use `madvise(MADV_DONTNEED)` which does not unmap the
-//!   guest-visible region; reclaimed pages simply re-fault zero-filled,
-//!   matching the balloon contract.
+//!   guest-visible region; reclaimed pages stay accessible (on Linux they
+//!   re-fault zero-filled, on Darwin the original contents survive — see
+//!   the inflate section), matching the balloon contract either way.
 //! - Two config-space fields: `num_pages` (host → guest target, read-only
 //!   from the guest) and `actual` (guest → host current, written by the
 //!   guest as pages are inflated/deflated).
@@ -17,9 +18,11 @@
 //!   on `reporting_vq` (transport index computed from the negotiated
 //!   feature set — see [`reporting_queue_index`]); the host
 //!   `madvise(MADV_DONTNEED)`s the ranges and completes the buffers.
-//!   Combined with
-//!   `DEFLATE_ON_OOM` this lets the guest kernel self-manage: idle memory
-//!   drains back to the host with no balloon-target policy at all.
+//!   Combined with `DEFLATE_ON_OOM` this is designed to let the guest
+//!   kernel self-manage — idle memory draining back to the host with no
+//!   balloon-target policy at all — but that drain is real only where
+//!   `MADV_DONTNEED` reclaims (Linux hosts); on Darwin it is a
+//!   deactivation hint and nothing is released (see the inflate section).
 //!
 //! Not implemented (all optional per spec):
 //! - Stats virtqueue (`VIRTIO_BALLOON_F_STATS_VQ`)
@@ -364,10 +367,11 @@ fn handle_pfn_list(buf: &[u8], ram_base: *mut u8, ram_len: usize, gpa_base: usiz
     handled
 }
 
-/// Releases one guest-reported free range via `madvise(MADV_DONTNEED)`,
-/// returning the number of 4 KiB pages released. The range is
-/// guest-controlled: it must be page-aligned, non-empty, and fully inside
-/// the guest RAM mapping, or it is logged and skipped.
+/// `madvise(MADV_DONTNEED)`s one guest-reported free range, returning the
+/// number of 4 KiB pages madvised (released on Linux; deactivation hint
+/// only on Darwin — see the module docs). The range is guest-controlled:
+/// it must be page-aligned, non-empty, and fully inside the guest RAM
+/// mapping, or it is logged and skipped.
 fn handle_reported_range(
     addr: u64,
     len: u32,
@@ -397,10 +401,12 @@ fn handle_reported_range(
     }
     // SAFETY: ram_base points to a live host mapping of the guest RAM
     // region, valid for ram_len bytes; offset..end was bounds-checked
-    // above. MADV_DONTNEED releases the physical backing without
-    // invalidating the mapping; the guest re-faults zero pages, which is
-    // the free-page-reporting contract (the pages are free right now and
-    // the guest keeps them off-limits until the buffer completes).
+    // above. MADV_DONTNEED never invalidates the mapping, so later guest
+    // access stays valid: on Linux it re-faults a zero page (real
+    // reclaim), on Darwin the original contents survive (deactivation
+    // hint only — see the module docs). Either way the reporting contract
+    // holds: the pages are free right now and the guest keeps them
+    // off-limits until the buffer completes.
     let ret = unsafe { libc::madvise(ram_base.add(offset).cast(), len, libc::MADV_DONTNEED) };
     if ret != 0 {
         tracing::warn!(

--- a/virt/arcbox-virtio-balloon/src/lib.rs
+++ b/virt/arcbox-virtio-balloon/src/lib.rs
@@ -32,11 +32,17 @@
 //! When the guest inflates the balloon, it writes a descriptor chain
 //! containing `u32` PFNs (4 KiB granularity) into the inflate queue.
 //! For each PFN, the host calls `madvise(MADV_DONTNEED)` on the
-//! corresponding page of the guest RAM mapping. The physical page is
-//! released back to the kernel's free pool. A subsequent access from
-//! the guest will re-fault a zero page — acceptable per §5.5.1: the
-//! guest has promised not to use the page until it tells the host via
-//! the deflate queue.
+//! corresponding page of the guest RAM mapping. On Linux hosts this
+//! releases the physical page back to the kernel's free pool and a
+//! subsequent guest access re-faults a zero page — acceptable per
+//! §5.5.1: the guest has promised not to use the page until it tells
+//! the host via the deflate queue. On Darwin, `MADV_DONTNEED` is only
+//! a deactivation hint: page contents are preserved (compressed, not
+//! discarded, under host pressure) and `phys_footprint` never drops
+//! (calibrated 2026-07-29 on macOS 26.4). Real Darwin reclaim needs
+//! `MADV_FREE_REUSABLE`, so macOS HV ballooning reclaims nothing yet
+//! and `vm_lifecycle` keeps its idle balloon disabled there
+//! (`BalloonDeps::reclaim_capable`).
 //!
 //! ## Deflate semantics
 //!
@@ -337,11 +343,12 @@ fn handle_pfn_list(buf: &[u8], ram_base: *mut u8, ram_len: usize, gpa_base: usiz
         }
         // SAFETY: ram_base points to a live host mapping of the guest
         // RAM region, valid for ram_len bytes. offset..offset+page_size
-        // was bounds-checked above. madvise on a host mapping with
-        // MADV_DONTNEED is documented to release physical backing
-        // without invalidating the virtual mapping; subsequent access
-        // re-faults zero-filled pages — which is exactly the balloon
-        // contract (§5.5.1).
+        // was bounds-checked above. MADV_DONTNEED never invalidates the
+        // virtual mapping, so later guest access stays valid: on Linux
+        // it re-faults a zero page (real reclaim); on Darwin the
+        // original contents survive (deactivation hint only — see the
+        // module docs). Either way the balloon contract (§5.5.1) holds:
+        // the guest promised not to read the page while ballooned.
         let ret =
             unsafe { libc::madvise(ram_base.add(offset).cast(), page_size, libc::MADV_DONTNEED) };
         if ret != 0 {

--- a/virt/arcbox-vz/AGENTS.md
+++ b/virt/arcbox-vz/AGENTS.md
@@ -71,6 +71,12 @@ the ABI.
 
 - Lifecycle ops resolve on VZ completion handlers — there is no state
   polling; do not reintroduce it.
+- **Balloon inflation is a host-side no-op** (measured 2026-07-29, macOS
+  26.4): Apple neither deallocates nor `madvise`s pages the guest gives up
+  — host `phys_footprint` stays at the configured memory size from boot,
+  and under host memory pressure the kernel compresses ballooned pages as
+  live data. `set_target_memory_size` only resizes what the *guest* may
+  use. This is why the idle balloon is HV-only (`app/AGENTS.md`).
 - `VZLinuxRosettaAvailability` raw values are notSupported=0, notInstalled=1,
   installed=2 (a hand-written mapping once had 1 and 2 swapped; the shim now
   returns raw values and Rust maps them — keep them aligned with the SDK).

--- a/virt/arcbox-vz/AGENTS.md
+++ b/virt/arcbox-vz/AGENTS.md
@@ -76,7 +76,8 @@ the ABI.
   — host `phys_footprint` stays at the configured memory size from boot,
   and under host memory pressure the kernel compresses ballooned pages as
   live data. `set_target_memory_size` only resizes what the *guest* may
-  use. This is why the idle balloon is HV-only (`app/AGENTS.md`).
+  use. This is one half of why the idle balloon never engages on macOS
+  (the other is HV's Darwin-inert `MADV_DONTNEED` — see `app/AGENTS.md`).
 - `VZLinuxRosettaAvailability` raw values are notSupported=0, notInstalled=1,
   installed=2 (a hand-written mapping once had 1 and 2 swapped; the shim now
   returns raw values and Rust maps them — keep them aligned with the SDK).


### PR DESCRIPTION
## Problem

The idle balloon assumed inflation returns memory to the host. On macOS that premise is false on **both** backends, so the mechanism was pure cost:

- Every ~8.5 min while idle (VZ, production shape): descent to `used + 256 MB` → guest `MemAvailable` literally **0** for ~100 s → `Out of puff` reclaim spin at ~14 cores → pressure restore → repeat. Average ≈ **2.8 cores while "idle"**.
- Host memory returned across all of it: **zero bytes**.

## Evidence (macOS 26.4 / 25E246)

1. **VZ inflation is invisible host-side.** In-guest probe confirmed the balloon inflating to 15.35 GB (`MemAvailable` → 0) while the daemon's `phys_footprint` stayed byte-identical at 16.4 GB, region `Dirty 16 GB / Clean 0 / Reclaimable 0` — replicated across two instrumented descents, one sampled mid-inflation with no restore in the window.
2. **Not lazy reclaim either.** Calibration probes on the same build: `MADV_FREE_REUSABLE` drops `phys_footprint` instantly; plain `MADV_FREE` is footprint-invisible but harvested within ~5 s under real pressure. Under a 44 GiB ballast (+10.3 M compressions) the kernel left the "returned" 15 GB untouched — then compressed **all 16 GB of guest RAM as live data** (daemon RSS 16.4 GB → 22 MB, footprint unchanged). Apple applies neither `vm_deallocate` nor any `madvise` to inflated pages.
3. **HV's primitive is Darwin-inert (review round, credit: pullfrog).** The HV device inflates with `MADV_DONTNEED`. Calibrated identically: footprint stays pinned after `MADV_DONTNEED`, and under the same 44 GiB pressure the pages are **compressed with contents preserved** (`internal` 4 GiB → 0, footprint unchanged) — Darwin treats it as a deactivation hint, not reclaim. The original HV `true` branch was carried from the device crate's doc comments, which asserted Linux semantics; those comments are corrected in this PR too.
4. **VZ footprint is pinned from boot.** On a freshly recreated machine the daemon hit full-configured-size RSS within 5 minutes of boot, before the first balloon cycle, while the guest had touched ~400 MB. Host cost ≈ `memory_mb`, period; the only levers are `memory_mb` itself and the macOS compressor.

Aggravating regression: the 1.30.0 kernel ships `CONFIG_PSI_DEFAULT_DISABLED` and nothing sets `psi=1`, so the agent's PSI trigger (1.3 s pressure reaction) silently degraded to sampling (~98 s blind window at `MemAvailable` 0). With the balloon disabled, that consumer is gone and PSI-off becomes a pure build-latency win.

## Change

- `BalloonDeps::reclaim_capable()` — new capability probe; `RealBalloonDeps` returns `false` (no macOS backend reclaims today, per-backend evidence in the impl comment).
- Controller: idle entry short-circuits to `Mode::Active` when the backend cannot reclaim — before the stats RPC, arming no retry timer. Re-checked on every idle entry.
- Regression test `reclaim_incapable_backend_never_shrinks` (no shrink, no stats probe, no timers, controller stays responsive).
- Docs: measurements + invariant recorded in `balloon/mod.rs`, `app/AGENTS.md`, `virt/arcbox-vz/AGENTS.md`; `arcbox-virtio-balloon`'s module/SAFETY comments corrected to per-OS `MADV_DONTNEED` semantics.

The shrink machinery stays fully tested — re-enabling HV is a one-line flip once its reclaim is real.

## Follow-ups (not in this PR)

- HV reclaim done right: switch `arcbox-virtio-balloon` inflate to `MADV_FREE_REUSABLE` (+ `MADV_FREE_REUSE` on deflate/re-touch), verify `phys_footprint` drops on a real HV boot (incl. the `hv_vm_map` interaction), then flip `reclaim_capable()` for HV.
- Idle-target formula hardening before any re-enable: `(total − MemAvailable) + 256 MB` degenerates to the floor for an idle guest and drives `MemAvailable` to 0; keep a 1–2 GB guest floor.
- If HV idle ballooning returns, boot HV guests with `psi=1` (the PSI-off kernel leaves only the ~98 s sampling window).

## Validation

- `cargo test -p arcbox-core --lib` — 168 passed (27 balloon); `cargo test -p arcbox-virtio-balloon` — 16 passed.
- `cargo clippy` / `cargo fmt --check` — clean.