### PR TITLE
feat(cli): abctl claude — coding-agent TUI in a sandbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tar",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,7 +265,7 @@ arcbox-api = { version = "0.5.3", path = "app/arcbox-api" } # x-release-please-v
 arcbox-migration = { version = "0.5.3", path = "app/arcbox-migration" } # x-release-please-version
 arcbox-logging = { version = "0.5.3", path = "common/arcbox-logging", default-features = false } # x-release-please-version
 
-# Test infrastructure
+# Temporary files and directories (tests, staging paths)
 tempfile = "3"
 
 [workspace.lints.clippy]

--- a/app/arcbox-cli/Cargo.toml
+++ b/app/arcbox-cli/Cargo.toml
@@ -49,6 +49,7 @@ hex = "0.4"
 tokio-stream.workspace = true
 arcbox-helper.workspace = true
 chrono.workspace = true
+tar = "0.4.46"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 macos-resolver = { workspace = true }

--- a/app/arcbox-cli/Cargo.toml
+++ b/app/arcbox-cli/Cargo.toml
@@ -50,7 +50,7 @@ tokio-stream.workspace = true
 arcbox-helper.workspace = true
 chrono.workspace = true
 tar = "0.4.46"
-tempfile = "3.14"
+tempfile = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 macos-resolver = { workspace = true }
@@ -59,7 +59,6 @@ macos-resolver = { workspace = true }
 default = []
 
 [dev-dependencies]
-tempfile = "3.14"
 tokio = { workspace = true, features = [
     "rt-multi-thread",
     "macros",

--- a/app/arcbox-cli/Cargo.toml
+++ b/app/arcbox-cli/Cargo.toml
@@ -50,6 +50,7 @@ tokio-stream.workspace = true
 arcbox-helper.workspace = true
 chrono.workspace = true
 tar = "0.4.46"
+tempfile = "3.14"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 macos-resolver = { workspace = true }

--- a/app/arcbox-cli/assets/templates/claude.Dockerfile
+++ b/app/arcbox-cli/assets/templates/claude.Dockerfile
@@ -1,0 +1,36 @@
+# Sandbox image for Claude Code.
+#
+# Pinned deliberately: the image tag is a hash of this file, so bumping the
+# version below is what invalidates both the Docker build cache and the
+# exported image layout.
+#
+# Debian rather than Alpine: the npm package resolves a per-platform native
+# binary through optional dependencies, and the musl variants additionally
+# need libgcc/libstdc++/ripgrep wired up by hand.
+FROM node:22-slim
+
+# git is what the agent uses to get code in and out of the sandbox; ripgrep is
+# what it searches with; ca-certificates is required for TLS to the API.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        less \
+        procps \
+        ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# Optional dependencies must stay enabled: this package ships the CLI as a
+# per-platform native binary (…-linux-arm64) resolved that way, with no
+# JavaScript fallback if it is skipped.
+RUN npm install -g @anthropic-ai/claude-code@2.1.220
+
+# Claude Code refuses to skip permission prompts while running as root, and
+# skipping them is the point of running inside a microVM.
+RUN useradd --create-home --uid 1000 --shell /bin/bash agent \
+    && mkdir -p /workspace \
+    && chown agent:agent /workspace
+
+USER agent
+WORKDIR /workspace

--- a/app/arcbox-cli/assets/templates/claude.Dockerfile
+++ b/app/arcbox-cli/assets/templates/claude.Dockerfile
@@ -27,10 +27,14 @@ RUN apt-get update \
 RUN npm install -g @anthropic-ai/claude-code@2.1.220
 
 # Claude Code refuses to skip permission prompts while running as root, and
-# skipping them is the point of running inside a microVM.
-RUN useradd --create-home --uid 1000 --shell /bin/bash agent \
-    && mkdir -p /workspace \
-    && chown agent:agent /workspace
+# skipping them is the point of running inside a microVM. The node images
+# already ship a uid-1000 `node` user, so reuse it rather than adding a second
+# one (useradd --uid 1000 would fail with "UID already in use").
+RUN mkdir -p /workspace && chown node:node /workspace
 
-USER agent
+# Only the filesystem is converted into the sandbox rootfs — image config is
+# not carried over, so USER/WORKDIR/ENV here document intent and keep
+# `docker run` on this image usable. The sandbox identity, working directory
+# and environment are set per session by the caller.
+USER node
 WORKDIR /workspace

--- a/app/arcbox-cli/src/commands/agent.rs
+++ b/app/arcbox-cli/src/commands/agent.rs
@@ -54,6 +54,16 @@ pub struct AgentDef {
     pub user: &'static str,
     /// Working directory for the session.
     pub workdir: &'static str,
+    /// Environment the session cannot do without.
+    ///
+    /// Only the image's filesystem is converted into the sandbox rootfs, so
+    /// its `ENV` never reaches the process: `vm-agent` runs as PID 1 with the
+    /// kernel's environment (`HOME=/`, `TERM=linux`) plus whatever the caller
+    /// sends. That makes `PATH` and `HOME` this layer's responsibility —
+    /// without `PATH`, `execvp` falls back to `/bin:/usr/bin` and cannot find
+    /// an npm-installed CLI in `/usr/local/bin`; without a writable `HOME`,
+    /// the agent cannot store its own state.
+    pub base_env: &'static [(&'static str, &'static str)],
 }
 
 /// Claude Code.
@@ -65,8 +75,17 @@ pub const CLAUDE: AgentDef = AgentDef {
     bypass_flag: "--dangerously-skip-permissions",
     env_prefixes: &["ANTHROPIC_", "CLAUDE_"],
     required_env: &["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"],
-    user: "agent",
+    // The node images ship this uid-1000 user; the template gives it
+    // /workspace.
+    user: "node",
     workdir: "/workspace",
+    base_env: &[
+        (
+            "PATH",
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        ),
+        ("HOME", "/home/node"),
+    ],
 };
 
 #[derive(Args)]
@@ -126,7 +145,12 @@ fn collect_env<I>(def: &AgentDef, host_vars: I) -> Result<HashMap<String, String
 where
     I: IntoIterator<Item = (String, String)>,
 {
-    let mut env = HashMap::new();
+    let mut env: HashMap<String, String> = def
+        .base_env
+        .iter()
+        .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+        .collect();
+
     for (key, value) in host_vars {
         let forward = PASSTHROUGH_ENV.contains(&key.as_str())
             || def
@@ -324,9 +348,15 @@ mod tests {
         assert_eq!(env.get("ANTHROPIC_API_KEY").unwrap(), "key");
         assert_eq!(env.get("CLAUDE_CODE_EXTRA").unwrap(), "1");
         assert_eq!(env.get("TERM").unwrap(), "xterm-256color");
+        // Without these the session cannot start at all: execvp would miss
+        // /usr/local/bin, and HOME would be the unwritable kernel default.
+        assert!(env.get("PATH").unwrap().contains("/usr/local/bin"));
+        assert_eq!(env.get("HOME").unwrap(), "/home/node");
         // Unrelated host secrets must not leak into the sandbox.
         assert!(!env.contains_key("AWS_SECRET_ACCESS_KEY"));
-        assert!(!env.contains_key("PATH"));
+        // The host's own PATH is a macOS path list and must not win over the
+        // sandbox one.
+        assert_ne!(env.get("PATH").unwrap(), "/usr/bin");
     }
 
     #[test]

--- a/app/arcbox-cli/src/commands/agent.rs
+++ b/app/arcbox-cli/src/commands/agent.rs
@@ -1,0 +1,361 @@
+//! Coding-agent sessions inside a sandbox.
+//!
+//! `abctl claude` builds (or reuses) a sandbox from a built-in template and
+//! attaches the terminal to the agent's TUI, so the agent runs with its
+//! permission prompts switched off and the microVM is the isolation boundary.
+//!
+//! `/workspace` starts empty: the agent brings code in itself (`git clone`)
+//! and results come back out with `abctl sandbox cp`. Nothing on the host is
+//! mounted into the sandbox.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use arcbox_grpc::SandboxServiceClient;
+use arcbox_protocol::sandbox_v1::{
+    CreateSandboxRequest, ExecRequest, InspectSandboxRequest, RemoveSandboxRequest, ResourceLimits,
+    SandboxInfo,
+};
+use clap::Args;
+use tonic::transport::Channel;
+
+use super::sandbox::{attach_machine, current_tty_size, exec_session, sandbox_channel};
+
+/// How long to wait for a freshly created sandbox to become ready.
+///
+/// Boot itself is about a second; the ceiling covers the guest-side ext4
+/// conversion on first use of a new image.
+const READY_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Poll interval while waiting for readiness.
+const READY_POLL: Duration = Duration::from_millis(250);
+
+/// Host environment variables always forwarded, regardless of agent.
+const PASSTHROUGH_ENV: &[&str] = &["TERM", "LANG"];
+
+/// A coding agent that can be run in a sandbox.
+pub struct AgentDef {
+    /// Display name, also used as the `arcbox.agent` label value.
+    pub name: &'static str,
+    /// Default sandbox id, reused across invocations.
+    pub sandbox_id: &'static str,
+    /// Built-in template providing the image.
+    pub template: &'static str,
+    /// Executable to run inside the sandbox.
+    pub command: &'static str,
+    /// Argument that turns off the agent's own permission prompting.
+    pub bypass_flag: &'static str,
+    /// Host env vars with these prefixes are forwarded into the session.
+    pub env_prefixes: &'static [&'static str],
+    /// At least one of these must be set, or there is no point starting.
+    pub required_env: &'static [&'static str],
+    /// Non-root user inside the image.
+    pub user: &'static str,
+    /// Working directory for the session.
+    pub workdir: &'static str,
+}
+
+/// Claude Code.
+pub const CLAUDE: AgentDef = AgentDef {
+    name: "claude",
+    sandbox_id: "agent-claude",
+    template: "claude",
+    command: "claude",
+    bypass_flag: "--dangerously-skip-permissions",
+    env_prefixes: &["ANTHROPIC_", "CLAUDE_"],
+    required_env: &["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"],
+    user: "agent",
+    workdir: "/workspace",
+};
+
+#[derive(Args)]
+pub struct AgentArgs {
+    /// Sandbox ID to use (default: one shared sandbox per agent)
+    #[arg(long)]
+    pub id: Option<String>,
+    /// Number of vCPUs
+    #[arg(long, default_value = "2")]
+    pub cpus: u32,
+    /// Memory in MiB
+    #[arg(long, default_value = "2048")]
+    pub memory: u64,
+    /// Keep the agent's permission prompts instead of skipping them
+    #[arg(long)]
+    pub no_bypass: bool,
+    /// Extra arguments passed through to the agent
+    #[arg(trailing_var_arg = true)]
+    pub args: Vec<String>,
+}
+
+/// What to do with a sandbox before attaching to it.
+#[derive(Debug, PartialEq, Eq)]
+enum Action {
+    /// No sandbox yet.
+    Create,
+    /// Ready and idle — attach directly.
+    Attach,
+    /// Booting; wait for it.
+    WaitReady,
+    /// Dead or half-dead; its `/workspace` is already gone, so start over.
+    Recreate,
+    /// In use or in a state we should not silently destroy.
+    Refuse,
+}
+
+/// Decide how to reach a usable sandbox from its current state.
+fn plan_action(state: Option<&str>) -> Action {
+    match state {
+        None => Action::Create,
+        Some("ready") => Action::Attach,
+        Some("starting") => Action::WaitReady,
+        // `Stop` tears down the CoW overlay, so a stopped sandbox has lost
+        // everything under /workspace and is only a name.
+        Some("stopped" | "failed") => Action::Recreate,
+        // "running" means a workload already holds the sandbox; anything else
+        // is a state this build does not know about.
+        Some(_) => Action::Refuse,
+    }
+}
+
+/// Collect the environment to forward into the session.
+///
+/// Credentials are passed per-session rather than written into the image or
+/// the sandbox record, so nothing persists them.
+fn collect_env<I>(def: &AgentDef, host_vars: I) -> Result<HashMap<String, String>>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut env = HashMap::new();
+    for (key, value) in host_vars {
+        let forward = PASSTHROUGH_ENV.contains(&key.as_str())
+            || def
+                .env_prefixes
+                .iter()
+                .any(|prefix| key.starts_with(prefix));
+        if forward && !value.is_empty() {
+            env.insert(key, value);
+        }
+    }
+
+    if !def.required_env.iter().any(|key| env.contains_key(*key)) {
+        bail!(
+            "no credentials for {}: set {} in your shell first — it is forwarded \
+             into the sandbox for this session only",
+            def.name,
+            def.required_env.join(" or ")
+        );
+    }
+
+    Ok(env)
+}
+
+/// Run an agent session, creating or reusing its sandbox as needed.
+pub async fn execute(def: &AgentDef, args: AgentArgs) -> Result<()> {
+    let id = args.id.unwrap_or_else(|| def.sandbox_id.to_string());
+    // Fail before any image work if the credentials are not there.
+    let env = collect_env(def, std::env::vars())?;
+
+    let channel = sandbox_channel().await?;
+    let mut client = SandboxServiceClient::new(channel);
+
+    let existing = inspect(&mut client, &id).await?;
+    match plan_action(existing.as_ref().map(|info| info.state.as_str())) {
+        Action::Attach => {}
+        Action::WaitReady => wait_ready(&mut client, &id).await?,
+        Action::Refuse => {
+            let state = existing.map(|info| info.state).unwrap_or_default();
+            bail!(
+                "sandbox '{id}' is {state} — a session may already be active. \
+                 Use --id <name> for a second one, or remove it with \
+                 `abctl sandbox rm {id}`"
+            );
+        }
+        Action::Recreate => {
+            remove(&mut client, &id).await?;
+            create(&mut client, def, &id, args.cpus, args.memory).await?;
+            wait_ready(&mut client, &id).await?;
+        }
+        Action::Create => {
+            create(&mut client, def, &id, args.cpus, args.memory).await?;
+            wait_ready(&mut client, &id).await?;
+        }
+    }
+
+    let mut cmd = vec![def.command.to_string()];
+    if !args.no_bypass {
+        cmd.push(def.bypass_flag.to_string());
+    }
+    cmd.extend(args.args);
+
+    let init = ExecRequest {
+        id: id.clone(),
+        cmd,
+        env,
+        working_dir: def.workdir.to_string(),
+        user: def.user.to_string(),
+        tty: true,
+        tty_size: current_tty_size(true),
+        ..Default::default()
+    };
+
+    let exit_code = exec_session(&mut client, init).await?;
+
+    eprintln!(
+        "\nSandbox '{id}' is still running: reopen with `abctl {}`, copy work out with \
+         `abctl sandbox cp {id}:{}/<file> .`, or discard it with `abctl sandbox rm {id}`.\n\
+         Removing or stopping the sandbox destroys everything in {}.",
+        def.name, def.workdir, def.workdir
+    );
+
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+    Ok(())
+}
+
+/// Fetch a sandbox, or `None` when it does not exist.
+async fn inspect(
+    client: &mut SandboxServiceClient<Channel>,
+    id: &str,
+) -> Result<Option<SandboxInfo>> {
+    let request = attach_machine(tonic::Request::new(InspectSandboxRequest {
+        id: id.to_string(),
+    }));
+    match client.inspect(request).await {
+        Ok(response) => Ok(Some(response.into_inner())),
+        Err(status) if status.code() == tonic::Code::NotFound => Ok(None),
+        Err(status) => Err(status).context("Failed to inspect sandbox")?,
+    }
+}
+
+/// Remove a sandbox that cannot be reused.
+async fn remove(client: &mut SandboxServiceClient<Channel>, id: &str) -> Result<()> {
+    let request = attach_machine(tonic::Request::new(RemoveSandboxRequest {
+        id: id.to_string(),
+        force: true,
+    }));
+    client
+        .remove(request)
+        .await
+        .context("Failed to remove the previous sandbox")?;
+    Ok(())
+}
+
+/// Build the agent image if needed and create the sandbox.
+async fn create(
+    client: &mut SandboxServiceClient<Channel>,
+    def: &AgentDef,
+    id: &str,
+    vcpus: u32,
+    memory_mib: u64,
+) -> Result<()> {
+    let rootfs = super::sandbox::resolve_template_rootfs(def.template).await?;
+
+    let request = attach_machine(tonic::Request::new(CreateSandboxRequest {
+        id: id.to_string(),
+        labels: HashMap::from([("arcbox.agent".to_string(), def.name.to_string())]),
+        rootfs,
+        limits: Some(ResourceLimits { vcpus, memory_mib }),
+        // No TTL: expiry would take /workspace with it mid-session.
+        ttl_seconds: 0,
+        ..Default::default()
+    }));
+    client
+        .create(request)
+        .await
+        .context("Failed to create the agent sandbox")?;
+    Ok(())
+}
+
+/// Block until the sandbox reports `ready`.
+async fn wait_ready(client: &mut SandboxServiceClient<Channel>, id: &str) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + READY_TIMEOUT;
+    loop {
+        match inspect(client, id).await? {
+            Some(info) if info.state == "ready" => return Ok(()),
+            Some(info) if info.state == "failed" => {
+                let detail = if info.error.is_empty() {
+                    "no reason reported".to_string()
+                } else {
+                    info.error
+                };
+                bail!("sandbox '{id}' failed to start: {detail}");
+            }
+            Some(_) => {}
+            None => bail!("sandbox '{id}' disappeared while starting"),
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            bail!(
+                "sandbox '{id}' was not ready within {}s",
+                READY_TIMEOUT.as_secs()
+            );
+        }
+        tokio::time::sleep(READY_POLL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vars(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn collect_env_forwards_prefixed_and_passthrough_vars() {
+        let env = collect_env(
+            &CLAUDE,
+            vars(&[
+                ("ANTHROPIC_API_KEY", "key"),
+                ("CLAUDE_CODE_EXTRA", "1"),
+                ("TERM", "xterm-256color"),
+                ("AWS_SECRET_ACCESS_KEY", "nope"),
+                ("PATH", "/usr/bin"),
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(env.get("ANTHROPIC_API_KEY").unwrap(), "key");
+        assert_eq!(env.get("CLAUDE_CODE_EXTRA").unwrap(), "1");
+        assert_eq!(env.get("TERM").unwrap(), "xterm-256color");
+        // Unrelated host secrets must not leak into the sandbox.
+        assert!(!env.contains_key("AWS_SECRET_ACCESS_KEY"));
+        assert!(!env.contains_key("PATH"));
+    }
+
+    #[test]
+    fn collect_env_accepts_any_required_key() {
+        let env = collect_env(&CLAUDE, vars(&[("ANTHROPIC_AUTH_TOKEN", "token")])).unwrap();
+        assert_eq!(env.get("ANTHROPIC_AUTH_TOKEN").unwrap(), "token");
+    }
+
+    #[test]
+    fn collect_env_requires_credentials() {
+        // Nothing set at all.
+        let error = collect_env(&CLAUDE, vars(&[("TERM", "xterm")])).unwrap_err();
+        assert!(error.to_string().contains("ANTHROPIC_API_KEY"));
+
+        // Set but empty is the same as unset — a common shell footgun.
+        let error = collect_env(&CLAUDE, vars(&[("ANTHROPIC_API_KEY", "")])).unwrap_err();
+        assert!(error.to_string().contains("no credentials"));
+    }
+
+    #[test]
+    fn plan_action_maps_every_sandbox_state() {
+        assert_eq!(plan_action(None), Action::Create);
+        assert_eq!(plan_action(Some("ready")), Action::Attach);
+        assert_eq!(plan_action(Some("starting")), Action::WaitReady);
+        assert_eq!(plan_action(Some("stopped")), Action::Recreate);
+        assert_eq!(plan_action(Some("failed")), Action::Recreate);
+        // A live workload holds the sandbox; never destroy it from under one.
+        assert_eq!(plan_action(Some("running")), Action::Refuse);
+        assert_eq!(plan_action(Some("stopping")), Action::Refuse);
+        assert_eq!(plan_action(Some("something-new")), Action::Refuse);
+    }
+}

--- a/app/arcbox-cli/src/commands/mod.rs
+++ b/app/arcbox-cli/src/commands/mod.rs
@@ -42,6 +42,7 @@ pub fn resolve_grpc_socket_path() -> PathBuf {
     arcbox_constants::paths::HostLayout::from_env_or_default().grpc_socket
 }
 
+pub mod agent;
 pub mod boot;
 pub mod cli_plugins;
 pub mod daemon;
@@ -129,6 +130,9 @@ pub enum Commands {
     /// Manage sandboxes inside a machine
     #[command(subcommand)]
     Sandbox(sandbox::SandboxCommands),
+
+    /// Open Claude Code in a dedicated sandbox
+    Claude(agent::AgentArgs),
 
     /// Manage Docker CLI integration
     #[command(subcommand)]

--- a/app/arcbox-cli/src/commands/sandbox.rs
+++ b/app/arcbox-cli/src/commands/sandbox.rs
@@ -682,8 +682,16 @@ pub(super) async fn exec_session(
             }
         }
         if output.done {
+            // `done` carries the exit status and is the last frame of the
+            // session, so stop here instead of waiting for the server to close
+            // the stream: it will not while our request stream is still open
+            // (the stdin pump keeps it alive for the whole session), which hung
+            // the client after the workload had already exited — including
+            // after a Ctrl-C the remote handled correctly. Returning drops the
+            // request stream, which the guest treats as a disconnect.
             exit_code = output.exit_code;
             received_done = true;
+            break;
         }
     }
 

--- a/app/arcbox-cli/src/commands/sandbox.rs
+++ b/app/arcbox-cli/src/commands/sandbox.rs
@@ -24,7 +24,7 @@ use tonic::transport::Channel;
 use super::machine::UnixConnector;
 use arcbox_cli::terminal::{RawModeGuard, TerminalSize};
 
-async fn sandbox_channel() -> Result<Channel> {
+pub(super) async fn sandbox_channel() -> Result<Channel> {
     let socket_path = super::resolve_grpc_socket_path();
     tonic::transport::Endpoint::from_static("http://[::]:50051")
         .connect_with_connector(UnixConnector::new(socket_path.clone()))
@@ -39,7 +39,7 @@ async fn sandbox_channel() -> Result<Channel> {
 
 /// Attaches the default `x-machine` metadata header to a tonic request for
 /// daemon-side routing to the guest VM agent.
-fn attach_machine<T>(mut request: tonic::Request<T>) -> tonic::Request<T> {
+pub(super) fn attach_machine<T>(mut request: tonic::Request<T>) -> tonic::Request<T> {
     // SAFETY: DEFAULT_MACHINE_NAME is a valid ASCII string.
     let val = MetadataValue::from_static(DEFAULT_MACHINE_NAME);
     request.metadata_mut().insert("x-machine", val);
@@ -551,42 +551,62 @@ async fn execute_exec(args: ExecArgs) -> Result<()> {
     let channel = sandbox_channel().await?;
     let mut client = SandboxServiceClient::new(channel);
 
-    let (msg_tx, msg_rx) = tokio::sync::mpsc::channel::<ExecInput>(16);
-
-    // Detect initial terminal size when TTY is requested.
-    let tty_size = if args.tty {
-        TerminalSize::current().ok().map(|s| ProtoTerminalSize {
-            width: u32::from(s.cols),
-            height: u32::from(s.rows),
-        })
-    } else {
-        None
+    let init = ExecRequest {
+        id: args.id,
+        cmd: args.cmd,
+        tty: args.tty,
+        tty_size: current_tty_size(args.tty),
+        timeout_seconds: args.timeout,
+        ..Default::default()
     };
+
+    let exit_code = exec_session(&mut client, init).await?;
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+    Ok(())
+}
+
+/// Initial terminal size to report, when a TTY was requested.
+pub(super) fn current_tty_size(tty: bool) -> Option<ProtoTerminalSize> {
+    if !tty {
+        return None;
+    }
+    TerminalSize::current().ok().map(|s| ProtoTerminalSize {
+        width: u32::from(s.cols),
+        height: u32::from(s.rows),
+    })
+}
+
+/// Run one interactive exec session and return the command's exit code.
+///
+/// Owns the whole bidirectional stream: the init frame, raw terminal mode,
+/// SIGWINCH forwarding, the stdin pump, and copying output back out. Callers
+/// decide what an exit code means — nothing here terminates the process.
+pub(super) async fn exec_session(
+    client: &mut SandboxServiceClient<Channel>,
+    init: ExecRequest,
+) -> Result<i32> {
+    let tty = init.tty;
+    let (msg_tx, msg_rx) = tokio::sync::mpsc::channel::<ExecInput>(16);
 
     // The first message in the stream must be the Init payload.
     msg_tx
         .send(ExecInput {
-            payload: Some(exec_input::Payload::Init(ExecRequest {
-                id: args.id,
-                cmd: args.cmd,
-                tty: args.tty,
-                tty_size,
-                timeout_seconds: args.timeout,
-                ..Default::default()
-            })),
+            payload: Some(exec_input::Payload::Init(init)),
         })
         .await
         .context("Failed to send exec init")?;
 
     // Enable raw terminal mode when TTY is requested.
-    let raw_guard = if args.tty {
+    let raw_guard = if tty {
         Some(RawModeGuard::new()?)
     } else {
         None
     };
 
     // Resize pump: SIGWINCH → gRPC resize frames (TTY sessions only).
-    if args.tty {
+    if tty {
         let resize_tx = msg_tx.clone();
         match arcbox_cli::terminal::ResizeWatcher::new() {
             Ok(mut watcher) => {
@@ -667,17 +687,14 @@ async fn execute_exec(args: ExecArgs) -> Result<()> {
         }
     }
 
-    // Drop the raw mode guard before exiting so the terminal is restored.
+    // Drop the raw mode guard before returning so the terminal is restored.
     drop(raw_guard);
 
     if !received_done {
         anyhow::bail!("exec stream closed without a terminal status frame");
     }
 
-    if exit_code != 0 {
-        std::process::exit(exit_code);
-    }
-    Ok(())
+    Ok(exit_code)
 }
 
 async fn execute_events(args: EventsArgs) -> Result<()> {

--- a/app/arcbox-cli/src/commands/sandbox.rs
+++ b/app/arcbox-cli/src/commands/sandbox.rs
@@ -83,6 +83,8 @@ pub enum SandboxCommands {
     /// Delete a snapshot
     #[command(name = "snapshot-rm")]
     DeleteSnapshot(DeleteSnapshotArgs),
+    /// List built-in rootfs templates
+    Templates(TemplatesArgs),
 }
 
 #[derive(Args)]
@@ -94,14 +96,17 @@ pub struct CreateArgs {
     #[arg(long)]
     pub kernel: Option<String>,
     /// Root filesystem ext4 image path (empty = daemon default)
-    #[arg(long, conflicts_with_all = ["from_dockerfile", "from_image"])]
+    #[arg(long, conflicts_with_all = ["from_dockerfile", "from_image", "from_template"])]
     pub rootfs: Option<String>,
     /// Build sandbox rootfs from a Dockerfile
-    #[arg(long, conflicts_with_all = ["rootfs", "from_image"])]
+    #[arg(long, conflicts_with_all = ["rootfs", "from_image", "from_template"])]
     pub from_dockerfile: Option<String>,
     /// Build sandbox rootfs from an existing Docker image
-    #[arg(long, conflicts_with_all = ["rootfs", "from_dockerfile"])]
+    #[arg(long, conflicts_with_all = ["rootfs", "from_dockerfile", "from_template"])]
     pub from_image: Option<String>,
+    /// Build sandbox rootfs from a built-in template (see `sandbox templates`)
+    #[arg(long, conflicts_with_all = ["rootfs", "from_dockerfile", "from_image"])]
+    pub from_template: Option<String>,
     /// Number of vCPUs (0 = daemon default)
     #[arg(long, default_value = "0")]
     pub cpus: u32,
@@ -257,6 +262,16 @@ pub struct DeleteSnapshotArgs {
     pub snapshot_id: String,
 }
 
+#[derive(Args)]
+pub struct TemplatesArgs {
+    /// Print a template's Dockerfile instead of listing names
+    ///
+    /// Redirect it to a file to customize a template, then build the result
+    /// with `--from-dockerfile`.
+    #[arg(long, value_name = "NAME")]
+    pub show: Option<String>,
+}
+
 /// Executes a sandbox subcommand.
 pub async fn execute(cmd: SandboxCommands) -> Result<()> {
     match cmd {
@@ -275,7 +290,42 @@ pub async fn execute(cmd: SandboxCommands) -> Result<()> {
         SandboxCommands::Restore(args) => execute_restore(args).await,
         SandboxCommands::ListSnapshots(args) => execute_list_snapshots(args).await,
         SandboxCommands::DeleteSnapshot(args) => execute_delete_snapshot(args).await,
+        SandboxCommands::Templates(args) => execute_templates(args),
     }
+}
+
+/// Build a built-in template and return the guest-visible rootfs path.
+///
+/// Shared with the agent-session commands (`abctl claude`), which select their
+/// image by template name.
+pub(super) async fn resolve_template_rootfs(name: &str) -> Result<String> {
+    let template = arcbox_cli::templates::find(name).with_context(|| {
+        format!(
+            "unknown template '{name}' (available: {})",
+            arcbox_cli::templates::names()
+        )
+    })?;
+    arcbox_cli::rootfs_builder::resolve_from_dockerfile_contents(template.dockerfile.as_bytes())
+        .await
+        .with_context(|| format!("Failed to build the '{name}' template image"))
+}
+
+fn execute_templates(args: TemplatesArgs) -> Result<()> {
+    if let Some(name) = args.show {
+        let template = arcbox_cli::templates::find(&name).with_context(|| {
+            format!(
+                "unknown template '{name}' (available: {})",
+                arcbox_cli::templates::names()
+            )
+        })?;
+        print!("{}", template.dockerfile);
+        return Ok(());
+    }
+
+    for template in arcbox_cli::templates::TEMPLATES {
+        println!("{:<10} {}", template.name, template.description);
+    }
+    Ok(())
 }
 
 fn parse_labels(raw: &[String]) -> Result<HashMap<String, String>> {
@@ -307,6 +357,8 @@ async fn execute_create(args: CreateArgs) -> Result<()> {
         arcbox_cli::rootfs_builder::resolve_from_image(image_ref)
             .await
             .context("Failed to resolve Docker image")?
+    } else if let Some(name) = &args.from_template {
+        resolve_template_rootfs(name).await?
     } else {
         args.rootfs.clone().unwrap_or_default()
     };

--- a/app/arcbox-cli/src/lib.rs
+++ b/app/arcbox-cli/src/lib.rs
@@ -3,4 +3,5 @@
 //! This module exposes shared CLI utilities.
 
 pub mod rootfs_builder;
+pub mod templates;
 pub mod terminal;

--- a/app/arcbox-cli/src/main.rs
+++ b/app/arcbox-cli/src/main.rs
@@ -71,6 +71,9 @@ fn main() -> Result<()> {
                 Commands::Macos(cmd) => commands::macos::execute(cmd).await,
                 Commands::Migrate(cmd) => commands::migrate::execute(cmd).await,
                 Commands::Sandbox(cmd) => commands::sandbox::execute(cmd).await,
+                Commands::Claude(args) => {
+                    commands::agent::execute(&commands::agent::CLAUDE, args).await
+                }
                 Commands::Docker(cmd) => commands::docker::execute(cmd, cli.format).await,
                 Commands::Kubernetes(cmd) => commands::kubernetes::execute(cmd).await,
                 Commands::System(cmd) => commands::system::execute(cmd).await,

--- a/app/arcbox-cli/src/main.rs
+++ b/app/arcbox-cli/src/main.rs
@@ -60,42 +60,52 @@ fn main() -> Result<()> {
         .with(tracing_subscriber::fmt::layer().with_target(false))
         .init();
 
-    tokio::runtime::Builder::new_multi_thread()
+    let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
-        .expect("Failed to build tokio runtime")
-        .block_on(async {
-            match cli.command {
-                Commands::Machine(cmd) => commands::machine::execute(cmd).await,
-                #[cfg(target_os = "macos")]
-                Commands::Macos(cmd) => commands::macos::execute(cmd).await,
-                Commands::Migrate(cmd) => commands::migrate::execute(cmd).await,
-                Commands::Sandbox(cmd) => commands::sandbox::execute(cmd).await,
-                Commands::Claude(args) => {
-                    commands::agent::execute(&commands::agent::CLAUDE, args).await
-                }
-                Commands::Docker(cmd) => commands::docker::execute(cmd, cli.format).await,
-                Commands::Kubernetes(cmd) => commands::kubernetes::execute(cmd).await,
-                Commands::System(cmd) => commands::system::execute(cmd).await,
-                Commands::Boot(cmd) => commands::boot::execute(cmd, cli.format).await,
-                Commands::Disk(cmd) => commands::disk::execute(cmd).await,
-                #[cfg(target_os = "macos")]
-                Commands::Dns(cmd) => commands::dns::execute(cmd).await,
-                Commands::Daemon(args) => commands::daemon::execute(args).await,
-                Commands::Logs(args) => commands::logs::execute(args).await,
-                Commands::Setup(cmd) => commands::setup::execute(cmd, cli.format).await,
-                Commands::Doctor => commands::doctor::execute().await,
-                Commands::Top(args) => commands::top::execute(args, cli.format).await,
-                #[cfg(target_os = "macos")]
-                Commands::Install(args) => commands::install::execute(args).await,
-                #[cfg(target_os = "macos")]
-                Commands::Uninstall(args) => commands::uninstall::execute(args).await,
-                #[cfg(target_os = "macos")]
-                Commands::Internal(cmd) => commands::internal::execute(cmd).await,
-                Commands::Info => execute_info().await,
-                Commands::Version => commands::version::execute().await,
+        .expect("Failed to build tokio runtime");
+
+    let result = runtime.block_on(async {
+        match cli.command {
+            Commands::Machine(cmd) => commands::machine::execute(cmd).await,
+            #[cfg(target_os = "macos")]
+            Commands::Macos(cmd) => commands::macos::execute(cmd).await,
+            Commands::Migrate(cmd) => commands::migrate::execute(cmd).await,
+            Commands::Sandbox(cmd) => commands::sandbox::execute(cmd).await,
+            Commands::Claude(args) => {
+                commands::agent::execute(&commands::agent::CLAUDE, args).await
             }
-        })
+            Commands::Docker(cmd) => commands::docker::execute(cmd, cli.format).await,
+            Commands::Kubernetes(cmd) => commands::kubernetes::execute(cmd).await,
+            Commands::System(cmd) => commands::system::execute(cmd).await,
+            Commands::Boot(cmd) => commands::boot::execute(cmd, cli.format).await,
+            Commands::Disk(cmd) => commands::disk::execute(cmd).await,
+            #[cfg(target_os = "macos")]
+            Commands::Dns(cmd) => commands::dns::execute(cmd).await,
+            Commands::Daemon(args) => commands::daemon::execute(args).await,
+            Commands::Logs(args) => commands::logs::execute(args).await,
+            Commands::Setup(cmd) => commands::setup::execute(cmd, cli.format).await,
+            Commands::Doctor => commands::doctor::execute().await,
+            Commands::Top(args) => commands::top::execute(args, cli.format).await,
+            #[cfg(target_os = "macos")]
+            Commands::Install(args) => commands::install::execute(args).await,
+            #[cfg(target_os = "macos")]
+            Commands::Uninstall(args) => commands::uninstall::execute(args).await,
+            #[cfg(target_os = "macos")]
+            Commands::Internal(cmd) => commands::internal::execute(cmd).await,
+            Commands::Info => execute_info().await,
+            Commands::Version => commands::version::execute().await,
+        }
+    });
+
+    // Interactive sessions leave a `tokio::io::stdin()` read parked on a
+    // blocking thread, and that read cannot be cancelled — dropping the runtime
+    // would wait for it, so a clean exit would not return the shell until the
+    // user pressed Enter. Detaching those threads lets `main` return normally
+    // and still runs the sentry guard's flush on the way out.
+    runtime.shutdown_background();
+
+    result
 }
 
 /// Display system-wide information.

--- a/app/arcbox-cli/src/rootfs_builder.rs
+++ b/app/arcbox-cli/src/rootfs_builder.rs
@@ -75,28 +75,45 @@ pub async fn resolve_from_dockerfile(dockerfile_path: &str) -> Result<String> {
     let content = tokio::fs::read(dockerfile)
         .await
         .context("failed to read Dockerfile")?;
-    let hash = cache_key(&content);
-    let tag = format!("arcbox-sandbox:{hash}");
+    let context_dir = dockerfile.parent().unwrap_or_else(|| Path::new("."));
 
-    let context_dir = dockerfile
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .to_string_lossy()
-        .to_string();
+    build_and_resolve(&content, dockerfile, context_dir).await
+}
 
-    // docker build
+/// Build an in-memory Dockerfile and return the guest-visible path of its
+/// exported OCI image layout.
+///
+/// Used for the built-in templates ([`crate::templates`]), which have no file
+/// on disk. The Dockerfile is written into a private temp directory that also
+/// serves as the (empty) build context, so a template must not `COPY` local
+/// paths.
+pub async fn resolve_from_dockerfile_contents(contents: &[u8]) -> Result<String> {
+    let context = tempfile::TempDir::new().context("failed to create image build directory")?;
+    let dockerfile = context.path().join("Dockerfile");
+    tokio::fs::write(&dockerfile, contents)
+        .await
+        .context("failed to stage Dockerfile")?;
+
+    build_and_resolve(contents, &dockerfile, context.path()).await
+}
+
+/// Shared `docker build` step: tag by content hash, then export the layout.
+///
+/// The tag is derived from the Dockerfile contents, so an unchanged
+/// Dockerfile resolves to the same image (and therefore the same exported
+/// layout and guest-side ext4) on every run.
+async fn build_and_resolve(
+    contents: &[u8],
+    dockerfile: &Path,
+    context_dir: &Path,
+) -> Result<String> {
+    let tag = format!("arcbox-sandbox:{}", cache_key(contents));
+
     eprintln!("Building Docker image...");
     let output = Command::new("docker")
-        .args([
-            "--context",
-            docker_context(),
-            "build",
-            "-t",
-            &tag,
-            "-f",
-            dockerfile_path,
-            &context_dir,
-        ])
+        .args(["--context", docker_context(), "build", "-t", &tag, "-f"])
+        .arg(dockerfile)
+        .arg(context_dir)
         .output()
         .await
         .context("failed to spawn docker build")?;

--- a/app/arcbox-cli/src/rootfs_builder.rs
+++ b/app/arcbox-cli/src/rootfs_builder.rs
@@ -1,21 +1,36 @@
-//! Resolve Docker images to guest-visible overlay2 layer paths.
+//! Resolve Docker images to guest-visible OCI image layout directories.
 //!
 //! For `--from-dockerfile`, runs `docker build` via the ArcBox Docker context
-//! (proxied to guest dockerd), then inspects the image to get the overlay2
-//! layer directory. For `--from-image`, inspects an existing image directly.
+//! (proxied to guest dockerd); for `--from-image`, an existing image is used
+//! as-is. Either way the image is exported with `docker save` into an OCI
+//! image layout directory, which the guest agent feeds to `oci2rootfs` for
+//! ext4 conversion.
 //!
-//! The returned path is a guest-internal filesystem path (under Docker's
-//! overlay2 storage) that the guest agent passes to `oci2rootfs` for ext4
-//! conversion.
+//! There is deliberately no overlay2 layer path here: guest dockerd uses the
+//! containerd snapshotter image store, so `docker inspect` reports no
+//! `GraphDriver` and there is no `UpperDir` to point at.
+//!
+//! The export is staged where the guest can read it back over VirtioFS —
+//! `~/Library/Caches/arcbox/sandbox-oci/<digest>` when the user's cache
+//! directory is under `/Users`, since the `users` share maps it to the
+//! identical guest path and macOS reclaims `Library/Caches` on its own.
+//! Otherwise it falls back to `<data_dir>/cache/sandbox-oci/<digest>`, which
+//! the guest sees below `/arcbox`. Staging in `$TMPDIR` would be preferable
+//! but the `/private` share never mounts in the guest (CORE-41).
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result, bail};
+use arcbox_constants::paths::{ArcboxProfile, HostLayout, guest};
 use sha2::{Digest, Sha256};
 use tokio::process::Command;
 
-/// Docker context name used for ArcBox Docker API.
-const DOCKER_CONTEXT: &str = "arcbox";
+/// Directory holding exported image layouts, under the staging root.
+const OCI_STAGING_DIR: &str = "sandbox-oci";
+
+/// Marker file that identifies an OCI image layout directory.
+const OCI_LAYOUT_MARKER: &str = "oci-layout";
 
 /// Check if a file has a valid ext4 superblock magic.
 pub fn has_ext4_magic(path: &Path) -> bool {
@@ -43,8 +58,8 @@ pub fn looks_like_dockerfile(path: &Path) -> bool {
         .is_some_and(|line| line.trim().to_ascii_uppercase().starts_with("FROM "))
 }
 
-/// Build a Docker image from a Dockerfile and return its guest-visible
-/// overlay2 layer directory path.
+/// Build a Docker image from a Dockerfile and return the guest-visible path
+/// of its exported OCI image layout.
 pub async fn resolve_from_dockerfile(dockerfile_path: &str) -> Result<String> {
     let dockerfile = Path::new(dockerfile_path);
     if !dockerfile.exists() {
@@ -74,7 +89,7 @@ pub async fn resolve_from_dockerfile(dockerfile_path: &str) -> Result<String> {
     let output = Command::new("docker")
         .args([
             "--context",
-            DOCKER_CONTEXT,
+            docker_context(),
             "build",
             "-t",
             &tag,
@@ -90,53 +105,224 @@ pub async fn resolve_from_dockerfile(dockerfile_path: &str) -> Result<String> {
         bail!("docker build failed:\n{stderr}");
     }
 
-    inspect_layer_path(&tag).await
+    resolve_layout(&tag).await
 }
 
-/// Get the guest-visible overlay2 layer directory for an existing Docker image.
+/// Export an existing Docker image and return the guest-visible path of its
+/// OCI image layout.
 pub async fn resolve_from_image(image_ref: &str) -> Result<String> {
-    inspect_layer_path(image_ref).await
+    resolve_layout(image_ref).await
 }
 
-/// Query the overlay2 layer directory for an image via `docker inspect`.
+/// Docker context for the active runtime profile.
 ///
-/// Returns the chain-id directory (parent of UpperDir) so that `oci2rootfs`
-/// can resolve the full layer chain.
-async fn inspect_layer_path(image_ref: &str) -> Result<String> {
+/// `main` mirrors `--profile` into `ARCBOX_PROFILE`, so this follows the flag
+/// as well as the environment.
+fn docker_context() -> &'static str {
+    ArcboxProfile::from_env_or_default().docker_context_name()
+}
+
+/// Platform selector for `docker save`, pinning a single manifest so the
+/// exported layout is unambiguous for the converter.
+fn docker_platform() -> Result<&'static str> {
+    match std::env::consts::ARCH {
+        "aarch64" => Ok("linux/arm64"),
+        "x86_64" => Ok("linux/amd64"),
+        other => bail!("unsupported host architecture for sandbox images: {other}"),
+    }
+}
+
+/// Export `image_ref` to an OCI image layout and return its guest-visible path.
+///
+/// Reuses an existing export for the same image digest, so repeat runs skip
+/// both the `docker save` and the guest-side ext4 conversion (the guest keys
+/// its rootfs cache off this path, which is digest-derived and therefore
+/// stable).
+async fn resolve_layout(image_ref: &str) -> Result<String> {
+    let digest = image_digest(image_ref).await?;
+    let dir_name = digest_dir_name(&digest)?;
+    let (host_root, guest_root) = staging_paths(dirs::cache_dir().as_deref(), &data_dir());
+    let host_dir = host_root.join(&dir_name);
+    let guest_path = format!("{guest_root}/{dir_name}");
+
+    if host_dir.join(OCI_LAYOUT_MARKER).is_file() {
+        return Ok(guest_path);
+    }
+
+    export_oci_layout(image_ref, &host_root, &host_dir).await?;
+    Ok(guest_path)
+}
+
+/// Root data directory for the active profile.
+fn data_dir() -> PathBuf {
+    HostLayout::from_env_or_default().data_dir
+}
+
+/// Pick the staging root, returning the host directory and the path the guest
+/// sees it at.
+///
+/// The guest mounts the host's `/Users` at the identical path, so a cache
+/// directory below it needs no translation and macOS is free to reclaim it.
+/// Anything else falls back to the data directory, which the guest always has
+/// mounted at [`guest::MOUNT`].
+fn staging_paths(cache_dir: Option<&Path>, data_dir: &Path) -> (PathBuf, String) {
+    if let Some(cache) = cache_dir
+        && cache.starts_with("/Users/")
+    {
+        let root = cache.join("arcbox").join(OCI_STAGING_DIR);
+        let guest = root.to_string_lossy().into_owned();
+        return (root, guest);
+    }
+
+    (
+        data_dir.join(guest::CACHE).join(OCI_STAGING_DIR),
+        format!("{}/{}/{OCI_STAGING_DIR}", guest::MOUNT, guest::CACHE),
+    )
+}
+
+/// Resolve an image reference to its content digest.
+async fn image_digest(image_ref: &str) -> Result<String> {
     let output = Command::new("docker")
         .args([
             "--context",
-            DOCKER_CONTEXT,
+            docker_context(),
+            "image",
             "inspect",
             "--format",
-            "{{.GraphDriver.Data.UpperDir}}",
+            "{{.Id}}",
             image_ref,
         ])
         .output()
         .await
-        .context("failed to spawn docker inspect")?;
+        .context("failed to spawn docker image inspect")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!("docker inspect failed (is the image present?):\n{stderr}");
+        bail!("docker image inspect failed (is the image present?):\n{stderr}");
     }
 
-    let upper_dir = String::from_utf8(output.stdout)
-        .context("docker inspect returned non-UTF-8 output")?
+    let digest = String::from_utf8(output.stdout)
+        .context("docker image inspect returned non-UTF-8 output")?
         .trim()
         .to_string();
+    if digest.is_empty() {
+        bail!("docker image inspect returned an empty digest for {image_ref}");
+    }
+    Ok(digest)
+}
 
-    if upper_dir.is_empty() {
-        bail!("docker inspect returned empty UpperDir for {image_ref}");
+/// Convert an image digest into a single path component (`sha256:ab…` →
+/// `sha256-ab…`).
+///
+/// The digest reaches us from `docker image inspect` and becomes a directory
+/// name that the guest later opens, so the character set is checked rather
+/// than assumed.
+fn digest_dir_name(digest: &str) -> Result<String> {
+    let (algorithm, hex) = digest.split_once(':').with_context(|| {
+        format!("malformed image digest {digest:?}: expected <algorithm>:<hex>")
+    })?;
+    let valid = !algorithm.is_empty()
+        && !hex.is_empty()
+        && algorithm.bytes().all(|b| b.is_ascii_alphanumeric())
+        && hex.bytes().all(|b| b.is_ascii_hexdigit());
+    if !valid {
+        bail!("malformed image digest {digest:?}: expected <algorithm>:<hex>");
+    }
+    Ok(format!("{algorithm}-{hex}"))
+}
+
+/// Export an image into `dest` as an OCI image layout.
+///
+/// Streams `docker save` to a private temp file, unpacks it into a private
+/// temp directory, and only then renames into place, so a concurrent or
+/// crashed export can never be observed as a complete layout.
+async fn export_oci_layout(image_ref: &str, root: &Path, dest: &Path) -> Result<()> {
+    let platform = docker_platform()?;
+    tokio::fs::create_dir_all(root)
+        .await
+        .with_context(|| format!("failed to create image staging dir {}", root.display()))?;
+
+    let archive = unique_temp_path(root, "save");
+    let staged = unique_temp_path(root, "layout");
+
+    eprintln!("Exporting {image_ref} for the sandbox...");
+    let saved = Command::new("docker")
+        .args([
+            "--context",
+            docker_context(),
+            "save",
+            "--platform",
+            platform,
+            "-o",
+        ])
+        .arg(&archive)
+        .arg(image_ref)
+        .output()
+        .await
+        .context("failed to spawn docker save");
+
+    let result = async {
+        let output = saved?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("docker save failed for {image_ref}:\n{stderr}");
+        }
+
+        let (from, into) = (archive.clone(), staged.clone());
+        tokio::task::spawn_blocking(move || unpack_archive(&from, &into))
+            .await
+            .context("image unpack task panicked")??;
+
+        if !staged.join(OCI_LAYOUT_MARKER).is_file() {
+            bail!(
+                "docker save produced no OCI image layout for {image_ref} \
+                 (missing {OCI_LAYOUT_MARKER})"
+            );
+        }
+        Ok(())
+    }
+    .await;
+
+    let _ = tokio::fs::remove_file(&archive).await;
+
+    if let Err(error) = result {
+        let _ = tokio::fs::remove_dir_all(&staged).await;
+        return Err(error);
     }
 
-    // oci2rootfs expects the chain-id directory (contains diff/, link, lower),
-    // not the diff/ subdirectory itself.
-    let layer_dir = upper_dir
-        .strip_suffix("/diff")
-        .unwrap_or(&upper_dir)
-        .to_string();
+    // A concurrent export may have published the same digest first; its
+    // contents are equivalent, so keep the winner and drop our copy.
+    if dest.exists() {
+        let _ = tokio::fs::remove_dir_all(&staged).await;
+        return Ok(());
+    }
+    if let Err(error) = tokio::fs::rename(&staged, dest).await {
+        let _ = tokio::fs::remove_dir_all(&staged).await;
+        return Err(error)
+            .with_context(|| format!("failed to publish image layout at {}", dest.display()));
+    }
+    Ok(())
+}
 
-    Ok(layer_dir)
+/// Unpack a `docker save` archive into `dest`.
+fn unpack_archive(archive: &Path, dest: &Path) -> Result<()> {
+    let file = std::fs::File::open(archive)
+        .with_context(|| format!("failed to open {}", archive.display()))?;
+    // Blob permissions are irrelevant to the converter, and preserving them
+    // would need ownership the CLI does not have.
+    let mut tar = tar::Archive::new(file);
+    tar.set_preserve_permissions(false);
+    tar.unpack(dest)
+        .with_context(|| format!("failed to unpack image archive into {}", dest.display()))
+}
+
+/// Build a private temp path inside `root`.
+///
+/// Per-process unique so concurrent exports never share a partially written
+/// file — the same rule `arcbox-asset` follows for downloads.
+fn unique_temp_path(root: &Path, kind: &str) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    root.join(format!(".{kind}.{}.{seq}.tmp", std::process::id()))
 }
 
 /// Full SHA-256 hex digest of content.
@@ -185,5 +371,62 @@ mod tests {
     #[test]
     fn test_has_ext4_magic_nonexistent() {
         assert!(!has_ext4_magic(Path::new("/nonexistent")));
+    }
+
+    #[test]
+    fn digest_dir_name_replaces_the_algorithm_separator() {
+        let hex = "a".repeat(64);
+        assert_eq!(
+            digest_dir_name(&format!("sha256:{hex}")).unwrap(),
+            format!("sha256-{hex}")
+        );
+    }
+
+    #[test]
+    fn digest_dir_name_rejects_values_that_are_not_a_digest() {
+        // Each of these would otherwise become a directory name the guest opens.
+        for bad in [
+            "sha256:../../etc/passwd",
+            "sha256:abc/def",
+            "sha256:",
+            ":abcdef",
+            "abcdef",
+            "sha256:not-hex",
+        ] {
+            assert!(
+                digest_dir_name(bad).is_err(),
+                "{bad} should be rejected as a digest"
+            );
+        }
+    }
+
+    #[test]
+    fn staging_paths_uses_the_user_cache_dir_verbatim() {
+        // A cache dir under /Users is visible to the guest at the same path,
+        // so host and guest paths must match exactly.
+        let (host, guest) = staging_paths(
+            Some(Path::new("/Users/someone/Library/Caches")),
+            Path::new("/Users/someone/.arcbox"),
+        );
+        assert_eq!(
+            host,
+            PathBuf::from("/Users/someone/Library/Caches/arcbox/sandbox-oci")
+        );
+        assert_eq!(guest, "/Users/someone/Library/Caches/arcbox/sandbox-oci");
+    }
+
+    #[test]
+    fn staging_paths_falls_back_to_the_data_dir_off_users() {
+        // Off /Users the only guaranteed share is the data dir at /arcbox.
+        let (host, guest) = staging_paths(
+            Some(Path::new("/home/someone/.cache")),
+            Path::new("/srv/arcbox"),
+        );
+        assert_eq!(host, PathBuf::from("/srv/arcbox/cache/sandbox-oci"));
+        assert_eq!(guest, "/arcbox/cache/sandbox-oci");
+
+        let (host, guest) = staging_paths(None, Path::new("/srv/arcbox"));
+        assert_eq!(host, PathBuf::from("/srv/arcbox/cache/sandbox-oci"));
+        assert_eq!(guest, "/arcbox/cache/sandbox-oci");
     }
 }

--- a/app/arcbox-cli/src/rootfs_builder.rs
+++ b/app/arcbox-cli/src/rootfs_builder.rs
@@ -11,10 +11,10 @@
 //! `GraphDriver` and there is no `UpperDir` to point at.
 //!
 //! The export is staged where the guest can read it back over VirtioFS —
-//! `~/Library/Caches/arcbox/sandbox-oci/<digest>` when the user's cache
+//! `~/Library/Caches/arcbox/sandbox-oci/<content-key>` when the user's cache
 //! directory is under `/Users`, since the `users` share maps it to the
 //! identical guest path and macOS reclaims `Library/Caches` on its own.
-//! Otherwise it falls back to `<data_dir>/cache/sandbox-oci/<digest>`, which
+//! Otherwise it falls back to `<data_dir>/cache/sandbox-oci/<content-key>`, which
 //! the guest sees below `/arcbox`. Staging in `$TMPDIR` would be preferable
 //! but the `/private` share never mounts in the guest (CORE-41).
 
@@ -151,13 +151,12 @@ fn docker_platform() -> Result<&'static str> {
 
 /// Export `image_ref` to an OCI image layout and return its guest-visible path.
 ///
-/// Reuses an existing export for the same image digest, so repeat runs skip
+/// Reuses an existing export for the same filesystem content, so repeat runs skip
 /// both the `docker save` and the guest-side ext4 conversion (the guest keys
-/// its rootfs cache off this path, which is digest-derived and therefore
-/// stable).
+/// its rootfs cache off this path, which is content-derived and therefore
+/// stable across rebuilds).
 async fn resolve_layout(image_ref: &str) -> Result<String> {
-    let digest = image_digest(image_ref).await?;
-    let dir_name = digest_dir_name(&digest)?;
+    let dir_name = format!("layers-{}", image_fs_key(image_ref).await?);
     let (host_root, guest_root) = staging_paths(dirs::cache_dir().as_deref(), &data_dir());
     let host_dir = host_root.join(&dir_name);
     let guest_path = format!("{guest_root}/{dir_name}");
@@ -197,8 +196,20 @@ fn staging_paths(cache_dir: Option<&Path>, data_dir: &Path) -> (PathBuf, String)
     )
 }
 
-/// Resolve an image reference to its content digest.
-async fn image_digest(image_ref: &str) -> Result<String> {
+/// Identify an image by the content of its filesystem.
+///
+/// Deliberately NOT `.Id`: the config digest changes on every `docker build`
+/// even when the result is byte-identical, because BuildKit stamps fresh
+/// metadata into the config. Keying the export on it meant every create
+/// re-ran `docker save` and re-converted the image to ext4 in the guest —
+/// minutes of work per sandbox. The layer diff IDs are stable across such
+/// rebuilds and change exactly when the filesystem changes, which is both
+/// what the converter consumes and what the guest's rootfs cache keys on
+/// (by path).
+///
+/// Hashing the list also makes the key safe as a path component whatever
+/// `docker` reported.
+async fn image_fs_key(image_ref: &str) -> Result<String> {
     let output = Command::new("docker")
         .args([
             "--context",
@@ -206,7 +217,7 @@ async fn image_digest(image_ref: &str) -> Result<String> {
             "image",
             "inspect",
             "--format",
-            "{{.Id}}",
+            "{{join .RootFS.Layers \",\"}}",
             image_ref,
         ])
         .output()
@@ -217,34 +228,14 @@ async fn image_digest(image_ref: &str) -> Result<String> {
         bail!("docker image inspect failed (is the image present?):\n{stderr}");
     }
 
-    let digest = String::from_utf8(output.stdout)
+    let layers = String::from_utf8(output.stdout)
         .context("docker image inspect returned non-UTF-8 output")?
         .trim()
         .to_string();
-    if digest.is_empty() {
-        bail!("docker image inspect returned an empty digest for {image_ref}");
+    if layers.is_empty() {
+        bail!("docker image inspect reported no layers for {image_ref}");
     }
-    Ok(digest)
-}
-
-/// Convert an image digest into a single path component (`sha256:ab…` →
-/// `sha256-ab…`).
-///
-/// The digest reaches us from `docker image inspect` and becomes a directory
-/// name that the guest later opens, so the character set is checked rather
-/// than assumed.
-fn digest_dir_name(digest: &str) -> Result<String> {
-    let (algorithm, hex) = digest.split_once(':').with_context(|| {
-        format!("malformed image digest {digest:?}: expected <algorithm>:<hex>")
-    })?;
-    let valid = !algorithm.is_empty()
-        && !hex.is_empty()
-        && algorithm.bytes().all(|b| b.is_ascii_alphanumeric())
-        && hex.bytes().all(|b| b.is_ascii_hexdigit());
-    if !valid {
-        bail!("malformed image digest {digest:?}: expected <algorithm>:<hex>");
-    }
-    Ok(format!("{algorithm}-{hex}"))
+    Ok(cache_key(layers.as_bytes()))
 }
 
 /// Export an image into `dest` as an OCI image layout.
@@ -388,33 +379,6 @@ mod tests {
     #[test]
     fn test_has_ext4_magic_nonexistent() {
         assert!(!has_ext4_magic(Path::new("/nonexistent")));
-    }
-
-    #[test]
-    fn digest_dir_name_replaces_the_algorithm_separator() {
-        let hex = "a".repeat(64);
-        assert_eq!(
-            digest_dir_name(&format!("sha256:{hex}")).unwrap(),
-            format!("sha256-{hex}")
-        );
-    }
-
-    #[test]
-    fn digest_dir_name_rejects_values_that_are_not_a_digest() {
-        // Each of these would otherwise become a directory name the guest opens.
-        for bad in [
-            "sha256:../../etc/passwd",
-            "sha256:abc/def",
-            "sha256:",
-            ":abcdef",
-            "abcdef",
-            "sha256:not-hex",
-        ] {
-            assert!(
-                digest_dir_name(bad).is_err(),
-                "{bad} should be rejected as a digest"
-            );
-        }
     }
 
     #[test]

--- a/app/arcbox-cli/src/templates.rs
+++ b/app/arcbox-cli/src/templates.rs
@@ -1,0 +1,98 @@
+//! Built-in sandbox image templates.
+//!
+//! A template is a Dockerfile shipped inside the CLI, so a sandbox image for a
+//! known workload can be built without the user writing or hosting anything.
+//! Templates go through the same `docker build` path as `--from-dockerfile`
+//! (see [`crate::rootfs_builder`]) — they are an input to it, not a parallel
+//! mechanism.
+
+/// A Dockerfile embedded in the binary.
+pub struct Template {
+    /// Name used by `--from-template` and `sandbox templates`.
+    pub name: &'static str,
+    /// One-line summary shown when listing.
+    pub description: &'static str,
+    /// Dockerfile contents. Needs no build context: templates must not
+    /// reference local files with `COPY`/`ADD`.
+    pub dockerfile: &'static str,
+}
+
+/// Every template the CLI ships.
+pub const TEMPLATES: &[Template] = &[Template {
+    name: "claude",
+    description: "Claude Code on Node.js 22 with git, running as a non-root user",
+    dockerfile: include_str!("../assets/templates/claude.Dockerfile"),
+}];
+
+/// Look up a template by name.
+#[must_use]
+pub fn find(name: &str) -> Option<&'static Template> {
+    TEMPLATES.iter().find(|template| template.name == name)
+}
+
+/// Comma-separated template names, for error messages and help text.
+#[must_use]
+pub fn names() -> String {
+    TEMPLATES
+        .iter()
+        .map(|template| template.name)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_resolves_known_names_only() {
+        assert_eq!(find("claude").map(|t| t.name), Some("claude"));
+        assert!(find("nope").is_none());
+        assert!(find("").is_none());
+    }
+
+    #[test]
+    fn template_names_are_unique() {
+        let mut names: Vec<_> = TEMPLATES.iter().map(|t| t.name).collect();
+        let total = names.len();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), total, "template names must be unique");
+    }
+
+    #[test]
+    fn every_template_is_a_buildable_dockerfile() {
+        // Catches a template that would only fail once `docker build` runs.
+        for template in TEMPLATES {
+            let dir = tempfile::TempDir::new().unwrap();
+            let path = dir.path().join("Dockerfile");
+            std::fs::write(&path, template.dockerfile).unwrap();
+            assert!(
+                crate::rootfs_builder::looks_like_dockerfile(&path),
+                "template {} is not a Dockerfile",
+                template.name
+            );
+            assert!(
+                !template.description.is_empty(),
+                "template {} needs a description",
+                template.name
+            );
+        }
+    }
+
+    #[test]
+    fn templates_do_not_need_a_build_context() {
+        // Templates are written to an empty temp dir, so a COPY/ADD of a local
+        // path could never resolve.
+        for template in TEMPLATES {
+            for line in template.dockerfile.lines() {
+                let directive = line.trim().to_ascii_uppercase();
+                assert!(
+                    !directive.starts_with("COPY ") && !directive.starts_with("ADD "),
+                    "template {} uses a build context: {line}",
+                    template.name
+                );
+            }
+        }
+    }
+}

--- a/common/arcbox-constants/src/paths.rs
+++ b/common/arcbox-constants/src/paths.rs
@@ -358,8 +358,18 @@ pub mod privileged_log {
 
 /// Guest-side subdirectory names within `/arcbox/`.
 pub mod guest {
+    /// Mount point of the host data directory inside the guest.
+    ///
+    /// The `arcbox` VirtioFS tag is mounted here, so a host path under the
+    /// data directory is visible to the guest at the same relative path
+    /// below this prefix.
+    pub const MOUNT: &str = "/arcbox";
+
     /// Log directory inside the VirtioFS mount.
     pub const LOG: &str = "log";
+
+    /// Host-built artifacts the guest reads back (e.g. exported OCI layouts).
+    pub const CACHE: &str = "cache";
 }
 
 #[cfg(all(test, feature = "std"))]

--- a/docs/agent-sandbox.md
+++ b/docs/agent-sandbox.md
@@ -85,5 +85,12 @@ A template can also be used directly, without the `claude` wrapper:
 $ abctl sandbox create --id t1 --from-template claude --memory 2048
 ```
 
-Keep in mind Claude Code refuses to skip permission prompts as root, which is
-why the template creates a non-root `agent` user that owns `/workspace`.
+Two things to keep in mind when writing your own image:
+
+- Claude Code refuses to skip permission prompts as root, so the session runs
+  as the image's non-root `node` user (uid 1000), which owns `/workspace`.
+- Only the image's **filesystem** is converted into the sandbox rootfs — its
+  `ENV`, `USER`, `WORKDIR` and `ENTRYPOINT` are not carried over. `abctl claude`
+  therefore supplies `PATH`, `HOME`, the working directory and the user itself;
+  a hand-built image driven through `abctl sandbox exec` has to do the same
+  (`--user`, absolute paths, or an explicit `PATH`).

--- a/docs/agent-sandbox.md
+++ b/docs/agent-sandbox.md
@@ -1,0 +1,89 @@
+# Coding agents in a sandbox
+
+`abctl claude` opens Claude Code inside a dedicated ArcBox sandbox (a
+Firecracker microVM). The agent runs with its permission prompts switched off,
+because the microVM — not the prompt — is the isolation boundary.
+
+```console
+$ export ANTHROPIC_API_KEY=sk-...
+$ abctl claude
+```
+
+The first run builds the agent image (a couple of minutes); later runs reuse it
+and start in about a second.
+
+## Requirements
+
+Sandboxes need nested virtualization: the VZ backend on Apple Silicon M3 or
+newer with macOS 15+. Elsewhere every sandbox RPC fails with
+`FAILED_PRECONDITION`. See [sandbox-api.md](sandbox-api.md).
+
+## Getting code in and out
+
+`/workspace` starts **empty**. Nothing on the host is mounted into the sandbox,
+so the agent brings code in itself:
+
+```
+> clone https://github.com/some/repo into /workspace and fix the failing test
+```
+
+Results come back out through the sandbox file API. It transfers one file at a
+time (256 MiB limit), so archive a tree first:
+
+```console
+$ abctl sandbox run agent-claude -- tar -czf /tmp/out.tgz -C /workspace .
+$ abctl sandbox cp agent-claude:/tmp/out.tgz .
+```
+
+**Everything in `/workspace` is destroyed when the sandbox is stopped or
+removed** — stopping tears down the sandbox's copy-on-write layer. Copy out what
+you want to keep before running `abctl sandbox rm`.
+
+## Sessions
+
+One sandbox is reused per agent (`agent-claude`), so exiting the TUI leaves it
+running and reopening continues where you left off — including `claude
+--continue`, since the agent's own state lives in the sandbox.
+
+```console
+$ abctl claude                      # reuse or create
+$ abctl claude --id review          # a second, independent session
+$ abctl claude -- --model opus      # everything after -- goes to the agent
+$ abctl claude --no-bypass          # keep the agent's permission prompts
+$ abctl sandbox ls                  # see agent sandboxes
+$ abctl sandbox rm agent-claude     # discard one (destroys /workspace)
+```
+
+Resources default to 2 vCPUs and 2048 MiB; override with `--cpus` / `--memory`.
+
+## Credentials
+
+`ANTHROPIC_API_KEY` (or `ANTHROPIC_AUTH_TOKEN`) must be set in your shell, and
+is forwarded for that session only — never written into the image or the
+sandbox record. `ANTHROPIC_*` and `CLAUDE_*` variables are forwarded too; other
+host environment variables are not, so unrelated credentials stay out of the
+sandbox. OAuth credentials from `~/.claude` are deliberately not copied in.
+
+## Customizing the image
+
+The image comes from a built-in template. Inspect it, edit it, and build your
+version:
+
+```console
+$ abctl sandbox templates
+claude     Claude Code on Node.js 22 with git, running as a non-root user
+
+$ abctl sandbox templates --show claude > Dockerfile
+$ # edit Dockerfile, then:
+$ abctl sandbox create --id mine --from-dockerfile ./Dockerfile --memory 2048
+$ abctl sandbox exec -t mine -- claude
+```
+
+A template can also be used directly, without the `claude` wrapper:
+
+```console
+$ abctl sandbox create --id t1 --from-template claude --memory 2048
+```
+
+Keep in mind Claude Code refuses to skip permission prompts as root, which is
+why the template creates a non-root `agent` user that owns `/workspace`.

--- a/docs/data-directories.md
+++ b/docs/data-directories.md
@@ -252,7 +252,7 @@ Tags defined in `common/arcbox-constants/src/virtiofs.rs`.
 | `/run/arcbox/vmm.sock` | Guest VMM gRPC socket | agent |
 | `/var/lib/arcbox/sandboxes` | Firecracker sandbox data | agent |
 | `/var/lib/arcbox/sandbox/rootfs.ext4` | Default sandbox rootfs (busybox + vm-agent, auto-built) | agent |
-| `/var/lib/arcbox/sandbox/rootfs-<hash>.ext4` | Converted overlay2 rootfs cache | agent |
+| `/var/lib/arcbox/sandbox/rootfs-<layer>-<agent>.ext4` | Converted image rootfs cache, keyed on the source layer and the injected `vm-agent`; superseded entries are swept on the next conversion unless a snapshot still needs them as its dm-snapshot origin | agent |
 | `/var/lib/arcbox/jailer` | Firecracker jailer chroots | agent |
 | `/arcbox/runtime/bin/{firecracker,jailer}` | Firecracker binaries (boot manifest, via VirtioFS) | host daemon |
 | `/arcbox/runtime/kernel/vmlinux` | Sandbox guest kernel (boot manifest, via VirtioFS) | host daemon |

--- a/docs/sandbox-api.md
+++ b/docs/sandbox-api.md
@@ -10,6 +10,9 @@ Proto source of truth: `rpc/arcbox-protocol/proto/sandbox.proto`
 (package `sandbox.v1`). Server implementation:
 `app/arcbox-api/src/grpc/{sandbox,snapshot}.rs`.
 
+For the end-user CLI feature built on this API — running a coding agent in a
+sandbox — see [agent-sandbox.md](agent-sandbox.md).
+
 ## Requirements
 
 Sandboxes need **nested virtualization**: the VZ backend on Apple Silicon

--- a/guest/arcbox-agent/src/rootfs_builder.rs
+++ b/guest/arcbox-agent/src/rootfs_builder.rs
@@ -12,8 +12,9 @@
 //!   used when `CreateSandboxRequest` supplies no rootfs. Rebuilt when the
 //!   source binaries are newer than the cached image.
 
+use std::collections::BTreeSet;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use arcbox_ext4::constants::file_mode;
@@ -65,8 +66,16 @@ fn is_oci_layout(dir: &Path) -> bool {
 /// staged by the host CLI (the `--from-image` / `--from-dockerfile` path) or a
 /// Docker overlay2 chain-id directory (e.g.
 /// `/var/lib/docker/overlay2/<chain-id>`).
+///
+/// `pinned` are images that must survive the superseded-image sweep because a
+/// snapshot still needs them as its dm-snapshot origin
+/// (`SandboxManager::pinned_rootfs_paths`).
+///
 /// Returns the path to the generated (or cached) ext4 image.
-pub async fn convert_layer_to_rootfs(layer_path: &str) -> Result<String> {
+pub async fn convert_layer_to_rootfs(
+    layer_path: &str,
+    pinned: &BTreeSet<PathBuf>,
+) -> Result<String> {
     if !Path::new(layer_path).exists() {
         bail!("layer path not found: {layer_path}");
     }
@@ -132,7 +141,7 @@ pub async fn convert_layer_to_rootfs(layer_path: &str) -> Result<String> {
         .await
         .context("failed to rename ext4 into cache")?;
 
-    sweep_superseded(&layer_key, &agent_key).await;
+    sweep_superseded(Path::new(ROOTFS_CACHE_DIR), &layer_key, &agent_key, pinned).await;
 
     tracing::info!(path = %ext4_path, "rootfs ready");
     Ok(ext4_path)
@@ -156,18 +165,39 @@ async fn vm_agent_key() -> Result<String> {
 /// Delete images for `layer_key` built against a different `vm-agent`.
 ///
 /// Bounds the cache at one image per layer instead of accumulating one per
-/// agent version. Best-effort: an image a live sandbox still has open unlinks
-/// fine on Linux and frees its space when the last reference closes.
-async fn sweep_superseded(layer_key: &str, agent_key: &str) {
-    let Ok(mut entries) = tokio::fs::read_dir(ROOTFS_CACHE_DIR).await else {
+/// agent version.
+///
+/// Two kinds of reference survive this:
+///
+/// - a live sandbox's open image, which unlinks fine on Linux and frees its
+///   space when the last reference closes;
+/// - anything in `pinned`, i.e. an image a snapshot records as its
+///   dm-snapshot origin. That reference is durable (it lives in the snapshot
+///   catalog's `meta.json`, so it outlasts reboots) and unrepairable:
+///   re-converting the layer with a different `vm-agent` yields different bytes
+///   than the snapshot's guest memory was captured against, so a regenerated
+///   image is worse than none.
+async fn sweep_superseded(
+    cache_dir: &Path,
+    layer_key: &str,
+    agent_key: &str,
+    pinned: &BTreeSet<PathBuf>,
+) {
+    let Ok(mut entries) = tokio::fs::read_dir(cache_dir).await else {
         return;
     };
     let mut removed = 0usize;
     while let Ok(Some(entry)) = entries.next_entry().await {
         let name = entry.file_name().to_string_lossy().into_owned();
-        if is_superseded_image(&name, layer_key, agent_key)
-            && tokio::fs::remove_file(entry.path()).await.is_ok()
-        {
+        if !is_superseded_image(&name, layer_key, agent_key) {
+            continue;
+        }
+        let path = entry.path();
+        if pinned.contains(&path) {
+            tracing::debug!(path = %path.display(), "keeping superseded rootfs: pinned by a snapshot");
+            continue;
+        }
+        if tokio::fs::remove_file(&path).await.is_ok() {
             removed += 1;
         }
     }
@@ -557,6 +587,32 @@ mod tests {
         )
         .unwrap();
         assert!(is_oci_layout(dir.path()));
+    }
+
+    #[tokio::test]
+    async fn sweep_superseded_keeps_images_a_snapshot_still_needs() {
+        let dir = tempfile::tempdir().unwrap();
+        let image = |name: &str| dir.path().join(name);
+        for name in [
+            "rootfs-aaaa-0000.ext4",
+            "rootfs-aaaa.ext4",
+            "rootfs-aaaa-1111.ext4",
+            "rootfs-bbbb-0000.ext4",
+        ] {
+            std::fs::write(image(name), b"x").unwrap();
+        }
+        let pinned = BTreeSet::from([image("rootfs-aaaa.ext4")]);
+
+        sweep_superseded(dir.path(), "aaaa", "1111", &pinned).await;
+
+        // Superseded and unreferenced: gone.
+        assert!(!image("rootfs-aaaa-0000.ext4").exists());
+        // Superseded but a snapshot records it as its dm-snapshot origin, and a
+        // re-conversion would not reproduce those bytes.
+        assert!(image("rootfs-aaaa.ext4").exists());
+        // Current image and other layers are untouched.
+        assert!(image("rootfs-aaaa-1111.ext4").exists());
+        assert!(image("rootfs-bbbb-0000.ext4").exists());
     }
 
     #[test]

--- a/guest/arcbox-agent/src/rootfs_builder.rs
+++ b/guest/arcbox-agent/src/rootfs_builder.rs
@@ -71,10 +71,15 @@ pub async fn convert_layer_to_rootfs(layer_path: &str) -> Result<String> {
         bail!("layer path not found: {layer_path}");
     }
 
-    // Cache key derived from the layer path. Both source kinds carry the image
-    // digest in the directory name, so the path is a stable identifier.
-    let hash = path_hash(layer_path);
-    let ext4_path = format!("{ROOTFS_CACHE_DIR}/rootfs-{hash}.ext4");
+    // The cached image has two ingredients, so the key names both: the layer
+    // (whose directory name carries the image digest for either source kind,
+    // making the path a stable identifier) and the `vm-agent` binary injected
+    // below. Keying on the layer alone meant a newer agent never reached an
+    // already-converted image — the sandbox kept booting the old init with no
+    // sign anything was stale.
+    let layer_key = path_hash(layer_path);
+    let agent_key = vm_agent_key().await?;
+    let ext4_path = format!("{ROOTFS_CACHE_DIR}/rootfs-{layer_key}-{agent_key}.ext4");
 
     // Check cache.
     if Path::new(&ext4_path).exists() && has_ext4_magic(Path::new(&ext4_path)) {
@@ -127,8 +132,65 @@ pub async fn convert_layer_to_rootfs(layer_path: &str) -> Result<String> {
         .await
         .context("failed to rename ext4 into cache")?;
 
+    sweep_superseded(&layer_key, &agent_key).await;
+
     tracing::info!(path = %ext4_path, "rootfs ready");
     Ok(ext4_path)
+}
+
+/// Content key for the `vm-agent` binary that gets injected into every image.
+///
+/// Content rather than mtime: this binary is copied into place by installers and
+/// by hand during development, so an older build can easily carry a newer
+/// timestamp — which an mtime check would read as fresh and then bake in.
+async fn vm_agent_key() -> Result<String> {
+    use std::hash::Hasher;
+    let bytes = tokio::fs::read(VM_AGENT_BIN)
+        .await
+        .with_context(|| format!("failed to read {VM_AGENT_BIN}"))?;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    hasher.write(&bytes);
+    Ok(format!("{:016x}", hasher.finish()))
+}
+
+/// Delete images for `layer_key` built against a different `vm-agent`.
+///
+/// Bounds the cache at one image per layer instead of accumulating one per
+/// agent version. Best-effort: an image a live sandbox still has open unlinks
+/// fine on Linux and frees its space when the last reference closes.
+async fn sweep_superseded(layer_key: &str, agent_key: &str) {
+    let Ok(mut entries) = tokio::fs::read_dir(ROOTFS_CACHE_DIR).await else {
+        return;
+    };
+    let mut removed = 0usize;
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if is_superseded_image(&name, layer_key, agent_key)
+            && tokio::fs::remove_file(entry.path()).await.is_ok()
+        {
+            removed += 1;
+        }
+    }
+    if removed > 0 {
+        tracing::info!(removed, layer = %layer_key, "removed superseded rootfs images");
+    }
+}
+
+/// True when `name` is a cached image for `layer_key` built against some other
+/// `vm-agent` than `agent_key`.
+fn is_superseded_image(name: &str, layer_key: &str, agent_key: &str) -> bool {
+    let Some(keys) = name
+        .strip_prefix("rootfs-")
+        .and_then(|rest| rest.strip_suffix(".ext4"))
+    else {
+        return false;
+    };
+    let Some((layer, agent)) = keys.split_once('-') else {
+        // Pre-`agent_key` naming (`rootfs-<layer>.ext4`): its injected agent is
+        // unknown, so treat it as superseded rather than keep it forever.
+        return keys == layer_key;
+    };
+    layer == layer_key && agent != agent_key
 }
 
 /// Ensure the default busybox + vm-agent rootfs exists at `path` and is
@@ -441,6 +503,42 @@ mod tests {
     #[test]
     fn test_has_ext4_magic_nonexistent() {
         assert!(!has_ext4_magic(Path::new("/nonexistent")));
+    }
+
+    #[test]
+    fn is_superseded_image_matches_only_the_same_layer_with_another_agent() {
+        // Same layer, older agent build: must go, or the sandbox keeps booting
+        // the stale init.
+        assert!(is_superseded_image("rootfs-aaaa-0000.ext4", "aaaa", "1111"));
+        // The image we just published.
+        assert!(!is_superseded_image(
+            "rootfs-aaaa-1111.ext4",
+            "aaaa",
+            "1111"
+        ));
+        // A different layer is a different image, not a superseded one.
+        assert!(!is_superseded_image(
+            "rootfs-bbbb-0000.ext4",
+            "aaaa",
+            "1111"
+        ));
+        // Legacy name from before the agent key existed: same layer, unknown
+        // agent, so treat as superseded; other layers stay.
+        assert!(is_superseded_image("rootfs-aaaa.ext4", "aaaa", "1111"));
+        assert!(!is_superseded_image("rootfs-bbbb.ext4", "aaaa", "1111"));
+        // Anything that is not a published image is left alone, including the
+        // in-progress temp files sweep_stale_tmp owns.
+        assert!(!is_superseded_image(
+            ".rootfs-aaaa-1111.ext4.tmp",
+            "aaaa",
+            "1111"
+        ));
+        assert!(!is_superseded_image("default.ext4", "aaaa", "1111"));
+        assert!(!is_superseded_image(
+            "rootfs-aaaa-1111.ext4.bak",
+            "aaaa",
+            "1111"
+        ));
     }
 
     #[test]

--- a/guest/arcbox-agent/src/rootfs_builder.rs
+++ b/guest/arcbox-agent/src/rootfs_builder.rs
@@ -4,9 +4,10 @@
 //! `arcbox-ext4` stack (no external binary, no mount, no root required for
 //! the ext4 write itself):
 //!
-//! - [`convert_layer_to_rootfs`] — convert a Docker overlay2 layer directory
-//!   to ext4, then inject `/sbin/vm-agent` via loop mount. Cached ext4
-//!   images are reused to avoid redundant conversions.
+//! - [`convert_layer_to_rootfs`] — convert a host-staged OCI image layout (or
+//!   a Docker overlay2 layer directory) to ext4, then inject `/sbin/vm-agent`
+//!   via loop mount. Cached ext4 images are reused to avoid redundant
+//!   conversions.
 //! - [`ensure_default_rootfs`] — build the default busybox + vm-agent image
 //!   used when `CreateSandboxRequest` supplies no rootfs. Rebuilt when the
 //!   source binaries are newer than the cached image.
@@ -46,18 +47,32 @@ pub fn has_ext4_magic(path: &Path) -> bool {
         && magic == [0x53, 0xEF]
 }
 
-/// Convert an overlay2 layer directory to a bootable ext4 rootfs.
+/// Marker file that identifies an OCI image layout directory.
+const OCI_LAYOUT_MARKER: &str = "oci-layout";
+
+/// True when `dir` is an OCI image layout rather than an overlay2 layer.
 ///
-/// `layer_path` is a guest-visible overlay2 chain-id directory
-/// (e.g. `/var/lib/docker/overlay2/<chain-id>`).
+/// Dispatching on the marker keeps the choice explicit: a `docker save`
+/// layout also carries a legacy `manifest.json`, so leaning on the
+/// `oci2rootfs` autodetect heuristics would be guesswork.
+fn is_oci_layout(dir: &Path) -> bool {
+    dir.join(OCI_LAYOUT_MARKER).is_file()
+}
+
+/// Convert an image source directory to a bootable ext4 rootfs.
+///
+/// `layer_path` is a guest-visible directory: either an OCI image layout
+/// staged by the host CLI (the `--from-image` / `--from-dockerfile` path) or a
+/// Docker overlay2 chain-id directory (e.g.
+/// `/var/lib/docker/overlay2/<chain-id>`).
 /// Returns the path to the generated (or cached) ext4 image.
 pub async fn convert_layer_to_rootfs(layer_path: &str) -> Result<String> {
     if !Path::new(layer_path).exists() {
         bail!("layer path not found: {layer_path}");
     }
 
-    // Cache key derived from the layer path (overlay2 chain-id directories
-    // are content-addressed, so the path is a stable identifier).
+    // Cache key derived from the layer path. Both source kinds carry the image
+    // digest in the directory name, so the path is a stable identifier.
     let hash = path_hash(layer_path);
     let ext4_path = format!("{ROOTFS_CACHE_DIR}/rootfs-{hash}.ext4");
 
@@ -75,16 +90,25 @@ pub async fn convert_layer_to_rootfs(layer_path: &str) -> Result<String> {
     let ext4_tmp = format!("{ROOTFS_CACHE_DIR}/.rootfs-{req_id}.ext4.tmp");
 
     // Convert via the oci2rootfs library (blocking CPU/IO work).
-    tracing::info!(layer = %layer_path, ext4 = %ext4_path, "converting overlay2 layer to ext4");
+    tracing::info!(layer = %layer_path, ext4 = %ext4_path, "converting image layer to ext4");
     {
         let layer = layer_path.to_owned();
         let out = ext4_tmp.clone();
         tokio::task::spawn_blocking(move || -> Result<()> {
-            let source = oci2rootfs::Overlay2Source::open(&layer)
-                .context("failed to open overlay2 layer")?;
-            oci2rootfs::Converter::new(&out)
-                .convert(source)
-                .context("overlay2 → ext4 conversion failed")?;
+            let converter = oci2rootfs::Converter::new(&out);
+            if is_oci_layout(Path::new(&layer)) {
+                let source = oci2rootfs::OciLayoutSource::open(&layer)
+                    .context("failed to open OCI image layout")?;
+                converter
+                    .convert(source)
+                    .context("OCI layout → ext4 conversion failed")?;
+            } else {
+                let source = oci2rootfs::Overlay2Source::open(&layer)
+                    .context("failed to open overlay2 layer")?;
+                converter
+                    .convert(source)
+                    .context("overlay2 → ext4 conversion failed")?;
+            }
             Ok(())
         })
         .await
@@ -417,6 +441,24 @@ mod tests {
     #[test]
     fn test_has_ext4_magic_nonexistent() {
         assert!(!has_ext4_magic(Path::new("/nonexistent")));
+    }
+
+    #[test]
+    fn is_oci_layout_detects_the_layout_marker() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // An overlay2 chain-id directory has no marker.
+        std::fs::create_dir(dir.path().join("diff")).unwrap();
+        assert!(!is_oci_layout(dir.path()));
+
+        // A `docker save` export does, alongside a legacy manifest.json.
+        std::fs::write(dir.path().join("manifest.json"), "[]").unwrap();
+        std::fs::write(
+            dir.path().join(OCI_LAYOUT_MARKER),
+            r#"{"imageLayoutVersion":"1.0.0"}"#,
+        )
+        .unwrap();
+        assert!(is_oci_layout(dir.path()));
     }
 
     #[test]

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -143,8 +143,14 @@ impl SandboxService {
                 .map_err(|e| SandboxError::Internal(format!("default rootfs: {e}")))?;
             spec.rootfs.clone_from(&self.default_rootfs);
         } else if std::path::Path::new(&spec.rootfs).is_dir() {
-            // Directory → overlay2 layer needing conversion.
-            let ext4_path = crate::rootfs_builder::convert_layer_to_rootfs(&spec.rootfs)
+            // Directory → overlay2 layer needing conversion. Pass the images
+            // snapshots depend on so the conversion's cache sweep leaves them
+            // alone — a restore has no way to rebuild its dm-snapshot origin.
+            let pinned = self
+                .manager
+                .pinned_rootfs_paths()
+                .map_err(SandboxError::from)?;
+            let ext4_path = crate::rootfs_builder::convert_layer_to_rootfs(&spec.rootfs, &pinned)
                 .await
                 .map_err(|e| SandboxError::Internal(format!("rootfs build failed: {e}")))?;
             spec.rootfs = ext4_path;

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -932,6 +932,9 @@ mod agent {
                 drop(slave);
                 let writer: Arc<Mutex<VsockStream>> = Arc::new(Mutex::new(conn));
 
+                let read_fd = unsafe { libc::dup(writer.lock().unwrap().fd) };
+                let mut reader = unsafe { VsockStream::from_raw_fd(read_fd) };
+
                 let w_read = Arc::clone(&writer);
                 let t_pty = thread::spawn(move || {
                     let mut buf = [0u8; 4096];
@@ -949,10 +952,29 @@ mod agent {
                             }
                         }
                     }
-                });
 
-                let read_fd = unsafe { libc::dup(writer.lock().unwrap().fd) };
-                let mut reader = unsafe { VsockStream::from_raw_fd(read_fd) };
+                    // The master read only ends when every slave fd is closed,
+                    // i.e. the session's processes are gone. Report the status
+                    // here rather than after the input loop: that loop is parked
+                    // in read_frame waiting for host frames, and the host is
+                    // waiting for this status, so leaving it until then
+                    // deadlocked every interactive session that exited on its
+                    // own (^D at a shell, an agent quitting on ^C) until the
+                    // client gave up or was killed.
+                    let exit_code = exit_rx.recv().unwrap_or(-1);
+                    let _ = write_frame(
+                        &mut *w_read.lock().unwrap(),
+                        MSG_EXIT,
+                        &exit_code.to_le_bytes(),
+                    );
+
+                    // Unblock the input loop so the session tears down without
+                    // depending on the client noticing first.
+                    // SAFETY: read_fd is a live dup of the connection owned by
+                    // the input loop; shutting down its read half makes a
+                    // blocked read return instead of waiting for host input.
+                    unsafe { libc::shutdown(read_fd, libc::SHUT_RD) };
+                });
                 // SAFETY: master_fd is valid; File takes ownership for writes.
                 let mut master_writer = unsafe { std::fs::File::from_raw_fd(master_fd) };
 
@@ -982,15 +1004,9 @@ mod agent {
                     }
                 }
 
+                // The PTY thread owns reporting the exit status (see above), so
+                // joining it is all that is left.
                 let _ = t_pty.join();
-
-                // The reaper owns waitpid; block on the routed exit code.
-                let exit_code = exit_rx.recv().unwrap_or(-1);
-                let _ = write_frame(
-                    &mut *writer.lock().unwrap(),
-                    MSG_EXIT,
-                    &exit_code.to_le_bytes(),
-                );
             }
         }
     }

--- a/virt/arcbox-vm/src/manager.rs
+++ b/virt/arcbox-vm/src/manager.rs
@@ -15,7 +15,7 @@ use crate::config::{RateLimitSpec, RestoreSpec, SnapshotRequest, SnapshotType, V
 use crate::error::{Result, VmmError};
 use crate::instance::{VmId, VmInfo, VmInstance, VmMetrics, VmState, VmSummary};
 use crate::network::NetworkManager;
-use crate::snapshot::{SnapshotCatalog, SnapshotInfo};
+use crate::snapshot::{SnapshotCatalog, SnapshotDraft, SnapshotInfo};
 use crate::spawn::{spawn_direct, spawn_jailer};
 use crate::store::VmStore;
 
@@ -427,8 +427,8 @@ impl VmmManager {
             self.pause_vm(id).await?;
         }
 
-        let snapshot_id = Uuid::new_v4().to_string();
-        let snap_dir = self.snapshots.prepare_dir(id, &snapshot_id)?;
+        let pending = self.snapshots.begin(id)?;
+        let snap_dir = pending.dir();
         let vmstate_path = snap_dir.join("vmstate");
         let mem_path = snap_dir.join("mem");
 
@@ -446,16 +446,13 @@ impl VmmManager {
             }
         }
 
-        let meta = self.snapshots.register(
-            id,
-            req.name,
-            req.snapshot_type,
-            vmstate_path,
-            Some(mem_path),
-            None,
-            None,
-            None,
-        )?;
+        let meta = pending.commit(SnapshotDraft {
+            name: req.name,
+            snapshot_type: req.snapshot_type,
+            parent_id: None,
+            kernel_path: None,
+            rootfs_path: None,
+        })?;
 
         if was_running {
             self.resume_vm(id).await?;

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -26,7 +26,7 @@ use crate::boot_proto::KernelIpParam;
 use crate::config::VmmConfig;
 use crate::error::{Result, VmmError};
 use crate::network::{NetworkAllocation, NetworkManager};
-use crate::snapshot::SnapshotCatalog;
+use crate::snapshot::{SnapshotCatalog, SnapshotDraft};
 use crate::snapshot_cow::{CowHandle, CowManager};
 use crate::spawn::{spawn_direct, spawn_jailer};
 use crate::vsock::{self, ExecInputMsg, OutputChunk, StartCommand};
@@ -98,8 +98,9 @@ impl SandboxManager {
             let config = Arc::clone(&config);
             let network = Arc::clone(&network);
             let cow_manager = Arc::clone(&cow_manager);
+            let snapshots = Arc::clone(&snapshots);
             tokio::spawn(async move {
-                reconcile::sweep_orphans(&config, &network, &cow_manager).await;
+                reconcile::sweep_orphans(&config, &network, &cow_manager, &snapshots).await;
                 let _ = reconcile_tx.send(true);
             });
         } else {

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -24,6 +24,14 @@ async fn move_file(from: &Path, to: &Path) -> std::io::Result<()> {
 }
 
 impl SandboxManager {
+    /// Rootfs images that existing snapshots need to stay restorable.
+    ///
+    /// Exposed so whoever owns the converted-rootfs cache can pin them; see
+    /// [`SnapshotCatalog::referenced_rootfs_paths`].
+    pub fn pinned_rootfs_paths(&self) -> Result<std::collections::BTreeSet<PathBuf>> {
+        self.snapshots.referenced_rootfs_paths()
+    }
+
     pub async fn checkpoint_sandbox(
         &self,
         sandbox_id: &SandboxId,

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -53,20 +53,26 @@ impl SandboxManager {
         };
 
         let vm = self.get_vm_handle(sandbox_id)?;
-        let snapshot_id = Uuid::new_v4().to_string();
+
+        // Staging directory outside the catalog: the snapshot becomes visible
+        // only on commit, and dropping `pending` on any error below takes the
+        // directory and whatever partial vmstate/mem it holds with it.
+        let pending = self.snapshots.begin(sandbox_id)?;
+        let snapshot_id = pending.id().to_owned();
+        let staging_dir = pending.dir();
 
         // Pause before snapshotting.
         vm.pause().await.map_err(VmmError::from)?;
 
         // Everything between pause and resume is fallible (chroot dir setup,
-        // chown, catalog dir prep, the snapshot RPC). Run it in a block whose
-        // result is handled only AFTER an unconditional resume — a bare `?`
-        // here previously left the guest paused forever, wedging every later
-        // RPC. Returns the chroot snapshot dir (jailer mode) to move afterward.
+        // chown, the snapshot RPC). Run it in a block whose result is handled
+        // only AFTER an unconditional resume — a bare `?` here previously left
+        // the guest paused forever, wedging every later RPC. Returns the chroot
+        // snapshot dir (jailer mode) to move afterward.
         //
         // In jailer mode FC runs inside a chroot and can only write to paths
         // within it, so the snapshot is written to a chroot-local dir and moved
-        // to the catalog after resume.
+        // into staging after resume.
         let paused: Result<Option<PathBuf>> = async {
             let (fc_vmstate_path, fc_mem_path, chroot_snap_dir_opt) =
                 if let Some(ref jc) = self.config.firecracker.jailer {
@@ -85,10 +91,9 @@ impl SandboxManager {
                     let fc_mem = format!("/snapshots/{snapshot_id}/mem");
                     (fc_vmstate, fc_mem, Some(chroot_snap))
                 } else {
-                    let snap_dir = self.snapshots.prepare_dir(sandbox_id, &snapshot_id)?;
                     (
-                        snap_dir.join("vmstate").to_str().unwrap().to_owned(),
-                        snap_dir.join("mem").to_str().unwrap().to_owned(),
+                        staging_dir.join("vmstate").to_str().unwrap().to_owned(),
+                        staging_dir.join("mem").to_str().unwrap().to_owned(),
                         None,
                     )
                 };
@@ -105,40 +110,30 @@ impl SandboxManager {
 
         let chroot_snap_dir_opt = paused?;
 
-        // If jailer mode, move snapshot files from chroot to the catalog dir.
-        let (vmstate_path, mem_path) = if let Some(chroot_snap) = chroot_snap_dir_opt {
-            let catalog_dir = self.snapshots.prepare_dir(sandbox_id, &snapshot_id)?;
-            let dst_vmstate = catalog_dir.join("vmstate");
-            let dst_mem = catalog_dir.join("mem");
-            move_file(&chroot_snap.join("vmstate"), &dst_vmstate)
+        // If jailer mode, move snapshot files from the chroot into staging.
+        if let Some(chroot_snap) = chroot_snap_dir_opt {
+            move_file(&chroot_snap.join("vmstate"), &staging_dir.join("vmstate"))
                 .await
                 .map_err(VmmError::Io)?;
             if chroot_snap.join("mem").exists() {
-                move_file(&chroot_snap.join("mem"), &dst_mem)
+                move_file(&chroot_snap.join("mem"), &staging_dir.join("mem"))
                     .await
                     .map_err(VmmError::Io)?;
             }
             let _ = tokio::fs::remove_dir_all(&chroot_snap).await;
-            (dst_vmstate, dst_mem)
-        } else {
-            let snap_dir = self.snapshots.prepare_dir(sandbox_id, &snapshot_id)?;
-            (snap_dir.join("vmstate"), snap_dir.join("mem"))
-        };
+        }
 
         // Store kernel/rootfs template paths so restore can re-derive them.
         // Jailer mode needs them for chroot staging; direct mode needs the
         // rootfs path to set up a fresh dm-snapshot and retarget the
         // vmstate-recorded symlink.
-        let meta = self.snapshots.register(
-            sandbox_id,
-            Some(name),
-            crate::config::SnapshotType::Full,
-            vmstate_path,
-            Some(mem_path),
-            None,
-            Some(kernel_path),
-            Some(rootfs_path),
-        )?;
+        let meta = pending.commit(SnapshotDraft {
+            name: Some(name),
+            snapshot_type: crate::config::SnapshotType::Full,
+            parent_id: None,
+            kernel_path: Some(kernel_path),
+            rootfs_path: Some(rootfs_path),
+        })?;
 
         let snap_dir_path = meta
             .vmstate_path

--- a/virt/arcbox-vm/src/sandbox/reconcile.rs
+++ b/virt/arcbox-vm/src/sandbox/reconcile.rs
@@ -126,7 +126,8 @@ pub(super) fn clear_state_record(vm_dir: &Path) {
     let _ = std::fs::remove_file(vm_dir.join(STATE_FILE));
 }
 
-/// Sweep `<data_dir>/sandboxes/*/state.json` and tear down every leftover.
+/// Sweep `<data_dir>/sandboxes/*/state.json` and tear down every leftover,
+/// plus snapshots a checkpoint never finished writing.
 ///
 /// Runs once per manager construction, in the background. Ordering per
 /// sandbox mirrors live teardown: kill Firecracker → wait for exit → dm
@@ -135,7 +136,12 @@ pub(super) async fn sweep_orphans(
     config: &VmmConfig,
     network: &NetworkManager,
     cow_manager: &CowManager,
+    snapshots: &crate::snapshot::SnapshotCatalog,
 ) {
+    // Snapshots staged by a checkpoint that died mid-flight: unfinished by
+    // definition, and each can hold a full memory dump.
+    snapshots.sweep_incomplete();
+
     let sandboxes_dir = PathBuf::from(&config.firecracker.data_dir).join("sandboxes");
     let Ok(entries) = std::fs::read_dir(&sandboxes_dir) else {
         return;

--- a/virt/arcbox-vm/src/snapshot.rs
+++ b/virt/arcbox-vm/src/snapshot.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use tracing::info;
+use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::config::SnapshotType;
@@ -61,6 +61,128 @@ impl From<&SnapshotMeta> for SnapshotInfo {
     }
 }
 
+/// Name of the VM-state file inside a snapshot directory.
+const VMSTATE_FILE: &str = "vmstate";
+
+/// Name of the memory file inside a snapshot directory.
+const MEM_FILE: &str = "mem";
+
+/// Suffix marking a staging directory, i.e. a snapshot still being written.
+///
+/// The leading dot keeps it out of the catalog's `{snapshot_id}` namespace:
+/// snapshot IDs are UUIDs, so no published entry can collide with one.
+const STAGING_SUFFIX: &str = ".partial";
+
+/// True when `path` is a published snapshot directory.
+///
+/// Staging directories are named `.{snapshot_id}.partial` and are not catalog
+/// members until [`PendingSnapshot::commit`] renames them.
+fn is_catalog_entry(path: &Path) -> bool {
+    path.is_dir()
+        && path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|name| !name.starts_with('.'))
+}
+
+/// What a caller knows about a snapshot before it is published.
+///
+/// The file layout (`vmstate`, `mem`) is the catalog's business, so it is not
+/// part of this: [`PendingSnapshot::commit`] fills those paths in.
+#[derive(Debug)]
+pub struct SnapshotDraft {
+    /// Optional human-readable label.
+    pub name: Option<String>,
+    pub snapshot_type: SnapshotType,
+    /// Parent snapshot ID (diff chain).
+    pub parent_id: Option<String>,
+    /// Host-absolute kernel path (required for jailer-mode restore staging).
+    pub kernel_path: Option<String>,
+    /// Host-absolute rootfs path (required for restore to rebuild the
+    /// dm-snapshot origin).
+    pub rootfs_path: Option<String>,
+}
+
+/// A snapshot being written, not yet part of the catalog.
+///
+/// Firecracker writes into [`Self::dir`], a staging directory that is
+/// deliberately outside the catalog's namespace, and [`Self::commit`] writes
+/// `meta.json` there and renames the whole directory into place. That single
+/// atomic publish is what lets every reader assume a catalogued directory has
+/// a readable record: a snapshot is either complete or not there at all.
+///
+/// Dropping without committing removes the staging directory, so a failed
+/// checkpoint leaves neither a record-less entry nor a partial `vmstate`/`mem`
+/// behind. A crash leaves the staging directory, which
+/// [`SnapshotCatalog::sweep_incomplete`] reclaims on the next start.
+pub struct PendingSnapshot<'a> {
+    catalog: &'a SnapshotCatalog,
+    vm_id: String,
+    id: String,
+    published: bool,
+}
+
+impl PendingSnapshot<'_> {
+    /// Identifier the snapshot will carry once published.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Staging directory to write `vmstate` and `mem` into.
+    pub fn dir(&self) -> PathBuf {
+        self.catalog.staging_dir(&self.vm_id, &self.id)
+    }
+
+    /// Publish the snapshot: write the record, then rename it into the catalog.
+    ///
+    /// The `mem` file is recorded when the staging directory actually holds one
+    /// (diff snapshots and jailer moves may not produce it).
+    pub fn commit(mut self, draft: SnapshotDraft) -> Result<SnapshotMeta> {
+        let staging = self.dir();
+        let published = self.catalog.snapshot_dir(&self.vm_id, &self.id);
+        let has_mem = staging.join(MEM_FILE).exists();
+
+        let meta = SnapshotMeta {
+            id: self.id.clone(),
+            vm_id: self.vm_id.clone(),
+            name: draft.name,
+            snapshot_type: draft.snapshot_type,
+            vmstate_path: published.join(VMSTATE_FILE),
+            mem_path: has_mem.then(|| published.join(MEM_FILE)),
+            created_at: Utc::now(),
+            parent_id: draft.parent_id,
+            kernel_path: draft.kernel_path,
+            rootfs_path: draft.rootfs_path,
+        };
+
+        let json = serde_json::to_string_pretty(&meta)?;
+        std::fs::write(SnapshotCatalog::meta_path(&staging), json).map_err(VmmError::Io)?;
+        std::fs::rename(&staging, &published).map_err(VmmError::Io)?;
+        self.published = true;
+
+        info!(snapshot_id = %meta.id, vm_id = %meta.vm_id, "snapshot registered");
+        Ok(meta)
+    }
+}
+
+impl Drop for PendingSnapshot<'_> {
+    fn drop(&mut self) {
+        if self.published {
+            return;
+        }
+        let dir = self.dir();
+        match std::fs::remove_dir_all(&dir) {
+            Ok(()) => {
+                info!(snapshot_id = %self.id, vm_id = %self.vm_id, "discarded incomplete snapshot");
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                warn!(path = %dir.display(), error = %e, "failed to discard incomplete snapshot");
+            }
+        }
+    }
+}
+
 /// Manages the on-disk snapshot catalog for all VMs.
 ///
 /// Layout:
@@ -69,7 +191,13 @@ impl From<&SnapshotMeta> for SnapshotInfo {
 ///     vmstate
 ///     mem          (full only)
 ///     meta.json
+/// {data_dir}/snapshots/{vm_id}/.{snapshot_id}.partial/   (being written)
 /// ```
+///
+/// Every catalogued directory carries a readable `meta.json`, because a
+/// snapshot is written into a `.partial` staging directory and renamed in as a
+/// whole (see [`PendingSnapshot`]). Readers therefore treat a missing or
+/// unparseable record as corruption rather than as a normal lifecycle state.
 pub struct SnapshotCatalog {
     root: PathBuf,
 }
@@ -82,35 +210,19 @@ impl SnapshotCatalog {
         }
     }
 
-    /// Register a freshly-created snapshot.
-    #[allow(clippy::too_many_arguments)]
-    pub fn register(
-        &self,
-        vm_id: &str,
-        name: Option<String>,
-        snapshot_type: SnapshotType,
-        vmstate_path: PathBuf,
-        mem_path: Option<PathBuf>,
-        parent_id: Option<String>,
-        kernel_path: Option<String>,
-        rootfs_path: Option<String>,
-    ) -> Result<SnapshotMeta> {
-        let id = Uuid::new_v4().to_string();
-        let meta = SnapshotMeta {
-            id: id.clone(),
+    /// Start a new snapshot for `vm_id`.
+    ///
+    /// Creates the staging directory; the snapshot enters the catalog only on
+    /// [`PendingSnapshot::commit`].
+    pub fn begin(&self, vm_id: &str) -> Result<PendingSnapshot<'_>> {
+        let pending = PendingSnapshot {
+            catalog: self,
             vm_id: vm_id.to_owned(),
-            name,
-            snapshot_type,
-            vmstate_path,
-            mem_path,
-            created_at: Utc::now(),
-            parent_id,
-            kernel_path,
-            rootfs_path,
+            id: Uuid::new_v4().to_string(),
+            published: false,
         };
-        self.write_meta(&meta)?;
-        info!(snapshot_id = %id, vm_id, "snapshot registered");
-        Ok(meta)
+        std::fs::create_dir_all(pending.dir()).map_err(VmmError::Io)?;
+        Ok(pending)
     }
 
     /// List all snapshots for a VM, sorted by creation time (oldest first).
@@ -122,9 +234,9 @@ impl SnapshotCatalog {
         let mut entries: Vec<SnapshotMeta> = std::fs::read_dir(&dir)
             .map_err(VmmError::Io)?
             .filter_map(|e| e.ok())
-            .filter(|e| e.path().is_dir())
-            .filter_map(|e| self.read_meta(&e.path()).ok())
-            .collect();
+            .filter(|e| is_catalog_entry(&e.path()))
+            .map(|e| self.read_meta(&e.path()))
+            .collect::<Result<_>>()?;
         entries.sort_by_key(|m| m.created_at);
         Ok(entries.iter().map(SnapshotInfo::from).collect())
     }
@@ -148,11 +260,35 @@ impl SnapshotCatalog {
         Ok(())
     }
 
-    /// Return the canonical directory for a new snapshot (creates it).
-    pub fn prepare_dir(&self, vm_id: &str, snapshot_id: &str) -> Result<PathBuf> {
-        let dir = self.snapshot_dir(vm_id, snapshot_id);
-        std::fs::create_dir_all(&dir).map_err(VmmError::Io)?;
-        Ok(dir)
+    /// Remove staging directories left behind by a crash mid-checkpoint.
+    ///
+    /// A committed snapshot is renamed into place atomically, so anything still
+    /// staged when the process died is unfinished by definition — and can be
+    /// holding a full memory dump.
+    pub fn sweep_incomplete(&self) {
+        let Ok(vms) = std::fs::read_dir(&self.root) else {
+            return;
+        };
+        for vm in vms.flatten() {
+            let Ok(entries) = std::fs::read_dir(vm.path()) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let staged = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|name| name.starts_with('.') && name.ends_with(STAGING_SUFFIX));
+                if staged && path.is_dir() {
+                    match std::fs::remove_dir_all(&path) {
+                        Ok(()) => info!(path = %path.display(), "removed incomplete snapshot"),
+                        Err(e) => {
+                            warn!(path = %path.display(), error = %e, "failed to remove incomplete snapshot");
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// Find a snapshot by ID alone, searching across all owner directories.
@@ -166,10 +302,8 @@ impl SnapshotCatalog {
             let entry = entry.map_err(VmmError::Io)?;
             if entry.path().is_dir() {
                 let snap_path = entry.path().join(snapshot_id);
-                if snap_path.is_dir()
-                    && let Ok(meta) = self.read_meta(&snap_path)
-                {
-                    return Ok(meta);
+                if is_catalog_entry(&snap_path) {
+                    return self.read_meta(&snap_path);
                 }
             }
         }
@@ -215,12 +349,13 @@ impl SnapshotCatalog {
             }
             for snapshot in std::fs::read_dir(&vm_dir).map_err(VmmError::Io)? {
                 let snapshot_dir = snapshot.map_err(VmmError::Io)?.path();
-                if !snapshot_dir.is_dir() {
+                if !is_catalog_entry(&snapshot_dir) {
                     continue;
                 }
-                // Deliberately strict: an unreadable meta.json means unknown
-                // references, and guessing there would delete an image a
-                // restore still needs.
+                // Strict by design: a catalogued directory always carries a
+                // readable record (see [`PendingSnapshot`]), so a failure here
+                // is real corruption — and treating unknown references as "none"
+                // is what would delete an image a restore still needs.
                 if let Some(rootfs) = self.read_meta(&snapshot_dir)?.rootfs_path {
                     pinned.insert(PathBuf::from(rootfs));
                 }
@@ -247,21 +382,13 @@ impl SnapshotCatalog {
         self.vm_dir(vm_id).join(snapshot_id)
     }
 
-    fn meta_path(dir: &Path) -> PathBuf {
-        dir.join("meta.json")
+    fn staging_dir(&self, vm_id: &str, snapshot_id: &str) -> PathBuf {
+        self.vm_dir(vm_id)
+            .join(format!(".{snapshot_id}{STAGING_SUFFIX}"))
     }
 
-    fn write_meta(&self, meta: &SnapshotMeta) -> Result<()> {
-        let dir = self.snapshot_dir(&meta.vm_id, &meta.id);
-        std::fs::create_dir_all(&dir).map_err(VmmError::Io)?;
-        let json = serde_json::to_string_pretty(meta)?;
-        // Write-and-rename: a meta.json torn by a crash mid-write would be an
-        // unreadable snapshot record, and readers treat that as an error rather
-        // than as "no references".
-        let tmp = dir.join("meta.json.tmp");
-        std::fs::write(&tmp, json).map_err(VmmError::Io)?;
-        std::fs::rename(&tmp, Self::meta_path(&dir)).map_err(VmmError::Io)?;
-        Ok(())
+    fn meta_path(dir: &Path) -> PathBuf {
+        dir.join("meta.json")
     }
 
     fn read_meta(&self, dir: &Path) -> Result<SnapshotMeta> {
@@ -276,19 +403,93 @@ mod tests {
     use super::*;
     use crate::config::SnapshotType;
 
+    /// Publish a snapshot the way a producer does: stage, write a `vmstate`,
+    /// then commit.
+    fn publish(catalog: &SnapshotCatalog, vm_id: &str, draft: SnapshotDraft) -> SnapshotMeta {
+        let pending = catalog.begin(vm_id).unwrap();
+        std::fs::write(pending.dir().join(VMSTATE_FILE), b"vmstate").unwrap();
+        pending.commit(draft).unwrap()
+    }
+
+    fn draft() -> SnapshotDraft {
+        SnapshotDraft {
+            name: None,
+            snapshot_type: SnapshotType::Full,
+            parent_id: None,
+            kernel_path: None,
+            rootfs_path: None,
+        }
+    }
+
     fn register_one(catalog: &SnapshotCatalog, vm_id: &str) -> SnapshotMeta {
-        catalog
-            .register(
-                vm_id,
-                None,
-                SnapshotType::Full,
-                PathBuf::from("/tmp/vmstate"),
-                None,
-                None,
-                None,
-                None,
-            )
-            .unwrap()
+        publish(catalog, vm_id, draft())
+    }
+
+    #[test]
+    fn commit_publishes_atomically_and_records_catalog_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
+
+        let pending = catalog.begin("vm-1").unwrap();
+        let staging = pending.dir();
+        let id = pending.id().to_owned();
+        std::fs::write(staging.join(VMSTATE_FILE), b"vmstate").unwrap();
+        std::fs::write(staging.join(MEM_FILE), b"mem").unwrap();
+        // Nothing is catalogued while the snapshot is still being written.
+        assert!(catalog.list("vm-1").unwrap().is_empty());
+
+        let meta = pending.commit(draft()).unwrap();
+
+        assert!(!staging.exists());
+        let published = catalog.snapshot_dir("vm-1", &id);
+        assert_eq!(meta.vmstate_path, published.join(VMSTATE_FILE));
+        assert_eq!(meta.mem_path, Some(published.join(MEM_FILE)));
+        assert_eq!(catalog.list("vm-1").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn commit_records_no_mem_when_the_snapshot_has_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
+        let meta = register_one(&catalog, "vm-1");
+        assert_eq!(meta.mem_path, None);
+    }
+
+    #[test]
+    fn dropping_without_commit_leaves_no_trace() {
+        let dir = tempfile::tempdir().unwrap();
+        let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
+
+        let staging = {
+            let pending = catalog.begin("vm-1").unwrap();
+            let staging = pending.dir();
+            // A failed checkpoint can leave a partial memory dump behind.
+            std::fs::write(staging.join(MEM_FILE), b"partial").unwrap();
+            staging
+        };
+
+        assert!(!staging.exists());
+        assert!(catalog.list("vm-1").unwrap().is_empty());
+        // No record-less directory to trip readers up.
+        assert!(catalog.referenced_rootfs_paths().unwrap().is_empty());
+    }
+
+    #[test]
+    fn sweep_incomplete_reclaims_staging_left_by_a_crash() {
+        let dir = tempfile::tempdir().unwrap();
+        let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
+        let kept = register_one(&catalog, "vm-1");
+
+        // Simulate a process death between `begin` and `commit`: the staging
+        // directory survives because `Drop` never ran.
+        let orphan = catalog.staging_dir("vm-1", "22222222-dead-beef");
+        std::fs::create_dir_all(&orphan).unwrap();
+        std::fs::write(orphan.join(MEM_FILE), b"partial").unwrap();
+
+        catalog.sweep_incomplete();
+
+        assert!(!orphan.exists());
+        assert!(catalog.get("vm-1", &kept.id).is_ok());
     }
 
     #[test]
@@ -297,23 +498,19 @@ mod tests {
         let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
         assert!(catalog.referenced_rootfs_paths().unwrap().is_empty());
 
-        let register_with_rootfs = |vm_id: &str, rootfs: Option<String>| {
-            catalog
-                .register(
-                    vm_id,
-                    None,
-                    SnapshotType::Full,
-                    PathBuf::from("/tmp/vmstate"),
-                    None,
-                    None,
-                    None,
-                    rootfs,
-                )
-                .unwrap()
+        let with_rootfs = |vm_id: &str, rootfs: Option<String>| {
+            publish(
+                &catalog,
+                vm_id,
+                SnapshotDraft {
+                    rootfs_path: rootfs,
+                    ..draft()
+                },
+            )
         };
-        register_with_rootfs("vm-1", Some("/var/lib/arcbox/sandbox/rootfs-a.ext4".into()));
-        register_with_rootfs("vm-2", Some("/var/lib/arcbox/sandbox/rootfs-b.ext4".into()));
-        register_with_rootfs("vm-2", None);
+        with_rootfs("vm-1", Some("/var/lib/arcbox/sandbox/rootfs-a.ext4".into()));
+        with_rootfs("vm-2", Some("/var/lib/arcbox/sandbox/rootfs-b.ext4".into()));
+        with_rootfs("vm-2", None);
 
         assert_eq!(
             catalog.referenced_rootfs_paths().unwrap(),
@@ -361,18 +558,15 @@ mod tests {
     fn test_register_and_get() {
         let dir = tempfile::tempdir().unwrap();
         let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
-        let meta = catalog
-            .register(
-                "vm-2",
-                Some("my-snap".into()),
-                SnapshotType::Diff,
-                PathBuf::from("/tmp/vmstate"),
-                None,
-                None,
-                None,
-                None,
-            )
-            .unwrap();
+        let meta = publish(
+            &catalog,
+            "vm-2",
+            SnapshotDraft {
+                name: Some("my-snap".into()),
+                snapshot_type: SnapshotType::Diff,
+                ..draft()
+            },
+        );
         let loaded = catalog.get("vm-2", &meta.id).unwrap();
         assert_eq!(loaded.id, meta.id);
         assert_eq!(loaded.snapshot_type, SnapshotType::Diff);

--- a/virt/arcbox-vm/src/snapshot.rs
+++ b/virt/arcbox-vm/src/snapshot.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
@@ -195,6 +196,39 @@ impl SnapshotCatalog {
         Ok(all)
     }
 
+    /// Rootfs images that catalogued snapshots depend on.
+    ///
+    /// Restore rebuilds the dm-snapshot origin from
+    /// [`SnapshotMeta::rootfs_path`], and the guest memory in the snapshot was
+    /// captured against those exact bytes — re-converting the same image with a
+    /// different `vm-agent` produces a different file and is not a substitute.
+    /// Anything that garbage-collects rootfs images must treat these as pinned.
+    pub fn referenced_rootfs_paths(&self) -> Result<BTreeSet<PathBuf>> {
+        if !self.root.exists() {
+            return Ok(BTreeSet::new());
+        }
+        let mut pinned = BTreeSet::new();
+        for vm in std::fs::read_dir(&self.root).map_err(VmmError::Io)? {
+            let vm_dir = vm.map_err(VmmError::Io)?.path();
+            if !vm_dir.is_dir() {
+                continue;
+            }
+            for snapshot in std::fs::read_dir(&vm_dir).map_err(VmmError::Io)? {
+                let snapshot_dir = snapshot.map_err(VmmError::Io)?.path();
+                if !snapshot_dir.is_dir() {
+                    continue;
+                }
+                // Deliberately strict: an unreadable meta.json means unknown
+                // references, and guessing there would delete an image a
+                // restore still needs.
+                if let Some(rootfs) = self.read_meta(&snapshot_dir)?.rootfs_path {
+                    pinned.insert(PathBuf::from(rootfs));
+                }
+            }
+        }
+        Ok(pinned)
+    }
+
     /// Delete a snapshot knowing only its ID (searches across all owner directories).
     pub fn delete_by_id(&self, snapshot_id: &str) -> Result<()> {
         let meta = self.find_by_id(snapshot_id)?;
@@ -221,7 +255,12 @@ impl SnapshotCatalog {
         let dir = self.snapshot_dir(&meta.vm_id, &meta.id);
         std::fs::create_dir_all(&dir).map_err(VmmError::Io)?;
         let json = serde_json::to_string_pretty(meta)?;
-        std::fs::write(Self::meta_path(&dir), json).map_err(VmmError::Io)?;
+        // Write-and-rename: a meta.json torn by a crash mid-write would be an
+        // unreadable snapshot record, and readers treat that as an error rather
+        // than as "no references".
+        let tmp = dir.join("meta.json.tmp");
+        std::fs::write(&tmp, json).map_err(VmmError::Io)?;
+        std::fs::rename(&tmp, Self::meta_path(&dir)).map_err(VmmError::Io)?;
         Ok(())
     }
 
@@ -250,6 +289,53 @@ mod tests {
                 None,
             )
             .unwrap()
+    }
+
+    #[test]
+    fn referenced_rootfs_paths_spans_every_vm_and_skips_snapshots_without_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
+        assert!(catalog.referenced_rootfs_paths().unwrap().is_empty());
+
+        let register_with_rootfs = |vm_id: &str, rootfs: Option<String>| {
+            catalog
+                .register(
+                    vm_id,
+                    None,
+                    SnapshotType::Full,
+                    PathBuf::from("/tmp/vmstate"),
+                    None,
+                    None,
+                    None,
+                    rootfs,
+                )
+                .unwrap()
+        };
+        register_with_rootfs("vm-1", Some("/var/lib/arcbox/sandbox/rootfs-a.ext4".into()));
+        register_with_rootfs("vm-2", Some("/var/lib/arcbox/sandbox/rootfs-b.ext4".into()));
+        register_with_rootfs("vm-2", None);
+
+        assert_eq!(
+            catalog.referenced_rootfs_paths().unwrap(),
+            BTreeSet::from([
+                PathBuf::from("/var/lib/arcbox/sandbox/rootfs-a.ext4"),
+                PathBuf::from("/var/lib/arcbox/sandbox/rootfs-b.ext4"),
+            ])
+        );
+    }
+
+    #[test]
+    fn referenced_rootfs_paths_fails_on_an_unreadable_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
+        let meta = register_one(&catalog, "vm-1");
+        std::fs::write(
+            SnapshotCatalog::meta_path(&catalog.snapshot_dir("vm-1", &meta.id)),
+            "{ truncated",
+        )
+        .unwrap();
+        // Guessing "no references" here would delete an image a restore needs.
+        assert!(catalog.referenced_rootfs_paths().is_err());
     }
 
     #[test]

--- a/virt/arcbox-vm/tests/integration.rs
+++ b/virt/arcbox-vm/tests/integration.rs
@@ -1,11 +1,9 @@
 mod common;
 
-use std::path::PathBuf;
-
 use arcbox_vm::config::SnapshotType;
 #[cfg(target_os = "linux")]
 use arcbox_vm::network::{NetworkAllocation, NetworkManager};
-use arcbox_vm::snapshot::SnapshotCatalog;
+use arcbox_vm::snapshot::{SnapshotCatalog, SnapshotDraft};
 
 // ---------------------------------------------------------------------------
 // Snapshot persistence
@@ -20,17 +18,16 @@ fn snapshot_catalog_persists_across_instances() {
 
     let id = {
         let catalog = SnapshotCatalog::new(data_dir);
-        catalog
-            .register(
-                "vm-persist",
-                Some("checkpoint-1".into()),
-                SnapshotType::Full,
-                PathBuf::from("/tmp/vmstate"),
-                None,
-                None,
-                None,
-                None,
-            )
+        let pending = catalog.begin("vm-persist").unwrap();
+        std::fs::write(pending.dir().join("vmstate"), b"vmstate").unwrap();
+        pending
+            .commit(SnapshotDraft {
+                name: Some("checkpoint-1".into()),
+                snapshot_type: SnapshotType::Full,
+                parent_id: None,
+                kernel_path: None,
+                rootfs_path: None,
+            })
             .unwrap()
             .id
     }; // catalog is dropped; all state must come from disk

--- a/virt/arcbox-vz/build.rs
+++ b/virt/arcbox-vz/build.rs
@@ -57,6 +57,14 @@ fn main() {
     let scratch = PathBuf::from(env::var("OUT_DIR").unwrap()).join("swiftpm-scratch");
 
     // Shared by `build` and `--show-bin-path` so both resolve the same layout.
+    //
+    // `--build-system native` is load-bearing on a Command-Line-Tools-only
+    // host, which is the setup CONTRIBUTING.md asks for: SwiftPM's newer
+    // default (swiftbuild/XCBuild) needs a full Xcode.app and otherwise dies
+    // with `SessionFailedError(... "Unknown error parsing property list")`
+    // before compiling anything. CI runners ship full Xcode, so dropping this
+    // breaks contributors without breaking CI. The flag is deprecated
+    // upstream — revisit when SwiftPM removes it.
     let common = [
         "--package-path",
         pkg.to_str().unwrap(),
@@ -68,6 +76,8 @@ fn main() {
         triple,
         "--product",
         "ArcBoxVZShim",
+        "--build-system",
+        "native",
     ];
 
     let out = xcrun()


### PR DESCRIPTION
Implements CORE-40: `abctl claude` drops you into Claude Code running inside a
dedicated sandbox (Firecracker microVM), with permission prompts off because
the microVM is the isolation boundary rather than the prompt.

`/workspace` starts empty and nothing from the host is mounted — the agent
clones its own code and results come back out with `abctl sandbox cp`. That is
the deliberately small cut of CORE-38: no workspace base-image builder, no
in-sandbox overlayfs, no whiteout sync-back.

## What is here

* **`abctl claude`** — reuses or creates `agent-claude`, waits for ready, and
  attaches the terminal. Exiting leaves the sandbox `ready` (stopping would tear
  down the CoW layer and take `/workspace` with it), so reopening continues the
  session, `claude --continue` included. Credentials come from
  `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN` and are forwarded per session
  only, never written into the image or the sandbox record.
* **Embedded image templates** — Dockerfiles shipped in the binary, built
  through the existing `--from-dockerfile` path rather than beside it. Also
  usable directly: `sandbox create --from-template claude`, and
  `sandbox templates --show claude > Dockerfile` to fork one.
* **Docs** — `docs/agent-sandbox.md`, linked from `docs/sandbox-api.md`.

## Bugs found and fixed along the way

Each of these was hit while getting the feature to work, and each is
independently reviewable:

1. **`--from-image`/`--from-dockerfile` were completely broken.** Guest dockerd
   uses the containerd snapshotter image store, so `docker inspect` reports
   `GraphDriver: null` and there is no overlay2 `UpperDir` — every custom
   sandbox rootfs failed with `map has no entry for key "GraphDriver"`. Now the
   image is exported with `docker save --platform` into an OCI layout, staged
   where the guest can read it back, and the guest converter dispatches on the
   `oci-layout` marker.
2. **The export cache never hit.** It was keyed on the image config digest,
   which BuildKit stamps afresh on every build, so each create re-ran
   `docker save` and re-converted to ext4 in the guest. Keyed on a hash of
   `RootFS.Layers` now — stable across identical rebuilds, changes exactly when
   the filesystem does. Repeat create 6.5s -> 0.64s.
3. **Interactive sessions hung after their workload exited.** `vm-agent` sent
   the exit status only after its input loop returned, but that loop blocks
   waiting for host frames while the host waits for the status — a deadlock that
   made `^D` at a shell or an agent quitting on `^C` look like a stuck session,
   and left the sandbox in `running` with its workload slot claimed. The PTY
   thread now reports the status when the session's last slave fd closes and
   unblocks the input loop. The client side stops at the terminal `done` frame
   instead of waiting for a stream close that will not come.
4. **The workspace CLI could not build on a Command-Line-Tools-only host**
   (CORE-42), which is the toolchain `CONTRIBUTING.md` asks for. SwiftPM's
   default build system needs a full Xcode; `--build-system native` does not.
   CI runners have Xcode, so this had no gate.

## Verification

Unit tests cover the pure logic: staging-path selection, template registry
(including that every embedded Dockerfile parses and needs no build context),
credential collection, and sandbox-state reconciliation.

The live path was exercised by hand on an M4 Pro / macOS 27: template build ->
sandbox create -> TUI session as the non-root `node` user with bypass active ->
`git clone` into `/workspace` -> `tar` + `cp` the result out -> reopen the
session. `node -e "fetch('https://api.anthropic.com/v1/models')"` from inside a
sandbox returns HTTP 401, which confirms full TLS with certificate validation
through the sandbox datapath.

## Known follow-ups (filed, not in this PR)

* CORE-41 — the `/private` VirtioFS share never mounts in the guest, so
  `docker -v /tmp/...` fails and `$TMPDIR` cannot be used for host->guest
  staging (which is why the OCI export stages under `~/Library/Caches`).
* CORE-43 — sandbox runtime is ~7x slower on CPU and ~35-45x slower on process
  startup than the host; that is what makes an agent TUI feel laggy.
* CORE-42 — `--build-system native` is deprecated upstream; the supported macOS
  toolchain needs a decision.
(A fifth bug — a newer `vm-agent` never reaching an already-converted template
rootfs — is fixed in this PR rather than deferred: the converted-image cache is
now keyed on both the layer and the injected agent's content, and supersedes its
own older images so the cache holds one per layer rather than one per agent
version.)

