### PR TITLE
test(e2e): VirtioFS guest-vs-native benchmark driver

### DIFF
--- a/tests/bench-virtiofs/src/main.rs
+++ b/tests/bench-virtiofs/src/main.rs
@@ -114,7 +114,9 @@ fn main() {
     } else if let Some(ref name) = cli.benchmark {
         vec![name.as_str()]
     } else {
-        eprintln!("Error: specify --all or --benchmark <name>. Use --list to see available benchmarks.");
+        eprintln!(
+            "Error: specify --all or --benchmark <name>. Use --list to see available benchmarks."
+        );
         process::exit(1);
     };
     // A skip entry that matches nothing would silently re-include a
@@ -173,8 +175,7 @@ fn main() {
         // Try micro first, then macro.
         let result = if micro::all_micro_benchmarks().contains(bench_name) {
             runner.run(&name, &cli.platform, || {
-                micro::run_micro_benchmark(bench_name, &target)
-                    .expect("unknown micro-benchmark")
+                micro::run_micro_benchmark(bench_name, &target).expect("unknown micro-benchmark")
             })
         } else if macro_bench::all_macro_benchmarks().contains(bench_name) {
             runner.run(&name, &cli.platform, || {
@@ -256,17 +257,19 @@ fn main() {
     }
 
     if cli.fail_on_regression && has_regressions {
-        eprintln!("\nFAILED: regressions detected beyond {:.1}% threshold", cli.threshold);
+        eprintln!(
+            "\nFAILED: regressions detected beyond {:.1}% threshold",
+            cli.threshold
+        );
         process::exit(1);
     }
 }
 
 /// Prints a human-readable summary of a single benchmark result.
 fn print_result_text(result: &runner::BenchmarkResult) {
-    eprintln!("  Duration:  {:.2}ms (p50: {:.2}ms, p99: {:.2}ms)",
-        result.metrics.duration_ms,
-        result.metrics.duration_p50_ms,
-        result.metrics.duration_p99_ms,
+    eprintln!(
+        "  Duration:  {:.2}ms (p50: {:.2}ms, p99: {:.2}ms)",
+        result.metrics.duration_ms, result.metrics.duration_p50_ms, result.metrics.duration_p99_ms,
     );
     if let Some(mb_s) = result.metrics.mb_per_sec {
         eprintln!("  Throughput: {:.1} MB/s", mb_s);

--- a/tests/bench-virtiofs/src/main.rs
+++ b/tests/bench-virtiofs/src/main.rs
@@ -70,6 +70,11 @@ struct Cli {
     #[arg(long, default_value = "arcbox-hv")]
     platform: String,
 
+    /// Comma-separated benchmark names to exclude (e.g. network-dependent
+    /// macros like `npm_install,git_clone` in hermetic environments).
+    #[arg(long, value_delimiter = ',')]
+    skip: Vec<String>,
+
     /// List all available benchmarks and exit.
     #[arg(long)]
     list: bool,
@@ -112,6 +117,10 @@ fn main() {
         eprintln!("Error: specify --all or --benchmark <name>. Use --list to see available benchmarks.");
         process::exit(1);
     };
+    let benchmarks_to_run: Vec<&str> = benchmarks_to_run
+        .into_iter()
+        .filter(|name| !cli.skip.iter().any(|skip| skip == name))
+        .collect();
 
     // Verify target directory exists.
     if !std::path::Path::new(&cli.target).is_dir() {

--- a/tests/bench-virtiofs/src/main.rs
+++ b/tests/bench-virtiofs/src/main.rs
@@ -75,6 +75,13 @@ struct Cli {
     #[arg(long, value_delimiter = ',')]
     skip: Vec<String>,
 
+    /// I/O engine for `random_read_4k`: the in-process buffered reader
+    /// (hermetic default) or fio with O_DIRECT (must be installed). The
+    /// fio engine reports under `random_read_4k_fio`, so numbers from
+    /// different engines can never be joined by name.
+    #[arg(long, default_value = "internal")]
+    random_read_engine: RandomReadEngine,
+
     /// List all available benchmarks and exit.
     #[arg(long)]
     list: bool,
@@ -84,6 +91,14 @@ struct Cli {
 enum OutputFormat {
     Text,
     Json,
+}
+
+#[derive(Clone, Copy, PartialEq, clap::ValueEnum)]
+enum RandomReadEngine {
+    /// In-process buffered reader — no external dependency.
+    Internal,
+    /// fio with `--direct=1` — requires fio on PATH.
+    Fio,
 }
 
 fn main() {
@@ -150,6 +165,18 @@ fn main() {
         process::exit(1);
     }
 
+    // The fio engine is opt-in and must actually be present — an implicit
+    // fallback would silently compare engines across the two phases.
+    if cli.random_read_engine == RandomReadEngine::Fio
+        && std::process::Command::new("fio")
+            .arg("--version")
+            .output()
+            .is_err()
+    {
+        eprintln!("Error: --random-read-engine fio requested but fio is not on PATH.");
+        process::exit(1);
+    }
+
     let runner = BenchmarkRunner::new(cli.warmup, cli.iterations);
     let mut results = Vec::new();
 
@@ -173,7 +200,15 @@ fn main() {
         let name = bench_name.to_string();
 
         // Try micro first, then macro.
-        let result = if micro::all_micro_benchmarks().contains(bench_name) {
+        let result = if *bench_name == "random_read_4k"
+            && cli.random_read_engine == RandomReadEngine::Fio
+        {
+            // The fio engine reports under its own name so numbers from
+            // different engines can never be joined.
+            runner.run("random_read_4k_fio", &cli.platform, || {
+                micro::bench_random_read_4k_fio(&target, micro::RANDOM_READ_OPS)
+            })
+        } else if micro::all_micro_benchmarks().contains(bench_name) {
             runner.run(&name, &cli.platform, || {
                 micro::run_micro_benchmark(bench_name, &target).expect("unknown micro-benchmark")
             })

--- a/tests/bench-virtiofs/src/main.rs
+++ b/tests/bench-virtiofs/src/main.rs
@@ -78,7 +78,10 @@ struct Cli {
     /// I/O engine for `random_read_4k`: the in-process buffered reader
     /// (hermetic default) or fio with O_DIRECT (must be installed). The
     /// fio engine reports under `random_read_4k_fio`, so numbers from
-    /// different engines can never be joined by name.
+    /// different engines can never be joined by name — which also means
+    /// a fio run's random-read row matches neither `TARGETS` nor a
+    /// baseline produced with the internal engine: gates and comparisons
+    /// only apply when both sides used the same engine.
     #[arg(long, default_value = "internal")]
     random_read_engine: RandomReadEngine,
 

--- a/tests/bench-virtiofs/src/main.rs
+++ b/tests/bench-virtiofs/src/main.rs
@@ -117,6 +117,22 @@ fn main() {
         eprintln!("Error: specify --all or --benchmark <name>. Use --list to see available benchmarks.");
         process::exit(1);
     };
+    // A skip entry that matches nothing would silently re-include a
+    // benchmark (e.g. the network-dependent macros a hermetic caller
+    // relies on excluding) — hard-error instead.
+    {
+        let mut known = micro::all_micro_benchmarks();
+        known.extend(macro_bench::all_macro_benchmarks());
+        for skip in &cli.skip {
+            if !known.contains(&skip.as_str()) {
+                eprintln!(
+                    "Error: --skip '{skip}' matches no benchmark. \
+                     Use --list to see available benchmarks."
+                );
+                process::exit(1);
+            }
+        }
+    }
     let benchmarks_to_run: Vec<&str> = benchmarks_to_run
         .into_iter()
         .filter(|name| !cli.skip.iter().any(|skip| skip == name))

--- a/tests/bench-virtiofs/src/micro.rs
+++ b/tests/bench-virtiofs/src/micro.rs
@@ -107,16 +107,6 @@ pub fn bench_sequential_write(target: &str, size_mb: u64) -> BenchmarkMetrics {
     }
 }
 
-/// Random 4K read benchmark — the in-process buffered reader.
-///
-/// Engine selection is explicit (no PATH sniffing): this is the hermetic
-/// default, and the fio/O_DIRECT variant is opt-in via the CLI's
-/// `--random-read-engine` flag, reporting under `random_read_4k_fio` so
-/// numbers from different engines can never be joined by name.
-pub fn bench_random_read_4k(target: &str, num_ops: u64) -> BenchmarkMetrics {
-    bench_random_read_4k_rust(target, num_ops)
-}
-
 /// Random 4K read using fio (`--direct=1`) for O_DIRECT IOPS measurement.
 pub fn bench_random_read_4k_fio(target: &str, num_ops: u64) -> BenchmarkMetrics {
     let test_file = format!("{}/bench_rand_read.dat", target);
@@ -170,8 +160,14 @@ pub fn bench_random_read_4k_fio(target: &str, num_ops: u64) -> BenchmarkMetrics 
     }
 }
 
-/// The in-process buffered random 4K reader (the `internal` engine).
-fn bench_random_read_4k_rust(target: &str, num_ops: u64) -> BenchmarkMetrics {
+/// Random 4K read benchmark — the in-process buffered reader (the
+/// `internal` engine, hermetic default).
+///
+/// Engine selection is explicit (no PATH sniffing): the fio/O_DIRECT
+/// variant is opt-in via the CLI's `--random-read-engine` flag and
+/// reports under `random_read_4k_fio` so numbers from different engines
+/// can never be joined by name.
+pub fn bench_random_read_4k(target: &str, num_ops: u64) -> BenchmarkMetrics {
     let test_file = format!("{}/bench_rand_read.dat", target);
     let file_size: u64 = 256 * 1024 * 1024; // 256 MB
 
@@ -399,10 +395,10 @@ pub fn all_micro_benchmarks() -> Vec<&'static str> {
     ]
 }
 
-/// Dispatches a micro-benchmark by name, returning None if the name is unknown.
 /// Operation count for the random-read benchmark, shared by both engines.
 pub const RANDOM_READ_OPS: u64 = 10_000;
 
+/// Dispatches a micro-benchmark by name, returning None if the name is unknown.
 pub fn run_micro_benchmark(name: &str, target: &str) -> Option<BenchmarkMetrics> {
     match name {
         "sequential_read" => Some(bench_sequential_read(target, 512)),

--- a/tests/bench-virtiofs/src/micro.rs
+++ b/tests/bench-virtiofs/src/micro.rs
@@ -36,11 +36,7 @@ pub fn bench_sequential_read(target: &str, size_mb: u64) -> BenchmarkMetrics {
 
     let start = Instant::now();
     let output = Command::new("dd")
-        .args([
-            &format!("if={}", test_file),
-            "of=/dev/null",
-            "bs=1048576",
-        ])
+        .args([&format!("if={}", test_file), "of=/dev/null", "bs=1048576"])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .output();
@@ -204,11 +200,14 @@ fn bench_random_read_4k_rust(target: &str, num_ops: u64) -> BenchmarkMetrics {
     let start = Instant::now();
     for _ in 0..num_ops {
         // Linear congruential generator.
-        rng_state = rng_state.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        rng_state = rng_state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
         let offset = (rng_state % max_offset) * 4096;
         f.seek(SeekFrom::Start(offset))
             .expect("failed to seek in test file");
-        f.read_exact(&mut buf).expect("failed to read from test file");
+        f.read_exact(&mut buf)
+            .expect("failed to read from test file");
     }
     let elapsed = start.elapsed();
 
@@ -373,12 +372,8 @@ fn parse_dd_throughput(stderr: &str) -> Option<f64> {
         let secs: f64 = time_str.parse().ok()?;
 
         // Find bytes count at the start of the line.
-        let line_start = stderr[..copied_idx]
-            .rfind('\n')
-            .map_or(0, |i| i + 1);
-        let bytes_str = stderr[line_start..copied_idx]
-            .split_whitespace()
-            .next()?;
+        let line_start = stderr[..copied_idx].rfind('\n').map_or(0, |i| i + 1);
+        let bytes_str = stderr[line_start..copied_idx].split_whitespace().next()?;
         let bytes: f64 = bytes_str.parse().ok()?;
 
         return Some(bytes / secs / (1024.0 * 1024.0));

--- a/tests/bench-virtiofs/src/micro.rs
+++ b/tests/bench-virtiofs/src/micro.rs
@@ -107,23 +107,18 @@ pub fn bench_sequential_write(target: &str, size_mb: u64) -> BenchmarkMetrics {
     }
 }
 
-/// Random 4K read benchmark.
+/// Random 4K read benchmark — the in-process buffered reader.
 ///
-/// If `fio` is available, delegates to it for accurate IOPS measurement.
-/// Otherwise falls back to a pure-Rust implementation using random seeks.
+/// Engine selection is explicit (no PATH sniffing): this is the hermetic
+/// default, and the fio/O_DIRECT variant is opt-in via the CLI's
+/// `--random-read-engine` flag, reporting under `random_read_4k_fio` so
+/// numbers from different engines can never be joined by name.
 pub fn bench_random_read_4k(target: &str, num_ops: u64) -> BenchmarkMetrics {
-    // Check if fio is available.
-    let fio_available = Command::new("fio").arg("--version").output().is_ok();
-
-    if fio_available {
-        bench_random_read_4k_fio(target, num_ops)
-    } else {
-        bench_random_read_4k_rust(target, num_ops)
-    }
+    bench_random_read_4k_rust(target, num_ops)
 }
 
-/// Random 4K read using fio for accurate IOPS measurement.
-fn bench_random_read_4k_fio(target: &str, num_ops: u64) -> BenchmarkMetrics {
+/// Random 4K read using fio (`--direct=1`) for O_DIRECT IOPS measurement.
+pub fn bench_random_read_4k_fio(target: &str, num_ops: u64) -> BenchmarkMetrics {
     let test_file = format!("{}/bench_rand_read.dat", target);
 
     // Create a 256MB test file for random reads.
@@ -175,7 +170,7 @@ fn bench_random_read_4k_fio(target: &str, num_ops: u64) -> BenchmarkMetrics {
     }
 }
 
-/// Pure-Rust fallback for random 4K reads when fio is unavailable.
+/// The in-process buffered random 4K reader (the `internal` engine).
 fn bench_random_read_4k_rust(target: &str, num_ops: u64) -> BenchmarkMetrics {
     let test_file = format!("{}/bench_rand_read.dat", target);
     let file_size: u64 = 256 * 1024 * 1024; // 256 MB
@@ -405,11 +400,14 @@ pub fn all_micro_benchmarks() -> Vec<&'static str> {
 }
 
 /// Dispatches a micro-benchmark by name, returning None if the name is unknown.
+/// Operation count for the random-read benchmark, shared by both engines.
+pub const RANDOM_READ_OPS: u64 = 10_000;
+
 pub fn run_micro_benchmark(name: &str, target: &str) -> Option<BenchmarkMetrics> {
     match name {
         "sequential_read" => Some(bench_sequential_read(target, 512)),
         "sequential_write" => Some(bench_sequential_write(target, 512)),
-        "random_read_4k" => Some(bench_random_read_4k(target, 10_000)),
+        "random_read_4k" => Some(bench_random_read_4k(target, RANDOM_READ_OPS)),
         "metadata_stat" => Some(bench_metadata_stat(target, 10_000)),
         "create_delete" => Some(bench_create_delete(target, 10_000)),
         "negative_lookup" => Some(bench_negative_lookup(target, 100_000)),

--- a/tests/bench-virtiofs/src/runner.rs
+++ b/tests/bench-virtiofs/src/runner.rs
@@ -49,11 +49,7 @@ impl BenchmarkRunner {
         let mut all_metrics = Vec::with_capacity(self.measured_iterations as usize);
 
         for i in 0..self.measured_iterations {
-            eprintln!(
-                "  [iter {}/{}] {name}",
-                i + 1,
-                self.measured_iterations
-            );
+            eprintln!("  [iter {}/{}] {name}", i + 1, self.measured_iterations);
             let start = Instant::now();
             let metrics = f();
             let elapsed = start.elapsed();
@@ -89,10 +85,7 @@ impl BenchmarkRunner {
         }
 
         // Sort durations for percentile computation.
-        let mut sorted_ms: Vec<f64> = durations
-            .iter()
-            .map(|d| d.as_secs_f64() * 1000.0)
-            .collect();
+        let mut sorted_ms: Vec<f64> = durations.iter().map(|d| d.as_secs_f64() * 1000.0).collect();
         sorted_ms.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
 
         let p50 = percentile(&sorted_ms, 50.0);

--- a/tests/e2e/tests/bench_virtiofs.rs
+++ b/tests/e2e/tests/bench_virtiofs.rs
@@ -43,14 +43,23 @@ const ITERATIONS: &str = "3";
 /// module docs). The bench CLI hard-errors on a name that matches no
 /// benchmark, so a rename upstream cannot silently re-include them.
 const SKIP_BENCHES: &str = "npm_install,git_clone";
-/// Benchmarks that shell out to userland tools (`rm`, `find`) resolved
-/// from `PATH` — busybox in the guest image vs BSD binaries on the host.
-/// Their absolute numbers are real signal (`rm_rf` is a known VirtioFS
-/// pain point), but their guest-vs-native *ratios* conflate toolchains
-/// with the filesystem: any future ratio assertion must exclude these
-/// names, and `find_recursive`'s flattering ratio must never be read as
-/// the perf table's File I/O target being met.
-const TOOLCHAIN_BOUND_BENCHES: &[&str] = &["rm_rf", "find_recursive"];
+/// Benchmarks whose guest-vs-native *ratio* is confounded by something
+/// other than the filesystem: `rm`/`find` resolve from `PATH` (busybox in
+/// the guest vs BSD on the host), the sequential pair shells out to `dd`
+/// and the read side also calls the macOS-only `purge` (cache-cold host
+/// vs warm guest), and `random_read_4k` is buffered-in-process while the
+/// perf-table targets imply O_DIRECT-class measurement (the engine is now
+/// pinned per invocation; fio reports under `random_read_4k_fio`).
+/// Absolute numbers are real signal (`rm_rf` is a known VirtioFS pain
+/// point), but any future ratio assertion may only use the genuinely
+/// in-process trio: `metadata_stat`, `create_delete`, `negative_lookup`.
+const CONFOUNDED_RATIO_BENCHES: &[&str] = &[
+    "sequential_read",
+    "sequential_write",
+    "random_read_4k",
+    "rm_rf",
+    "find_recursive",
+];
 
 #[test]
 #[ignore = "boots a VZ System VM through a real daemon and runs the VirtioFS benchmark suite"]
@@ -163,8 +172,8 @@ fn scenario(
     persist_report(&results, "native", &native_output)?;
     tracing::info!(dir = %results.display(), "bench reports written");
     tracing::info!(
-        toolchain_bound = ?TOOLCHAIN_BOUND_BENCHES,
-        "these rows compare userland tools as much as the filesystem — \
+        confounded_ratio = ?CONFOUNDED_RATIO_BENCHES,
+        "these rows are confounded by more than the filesystem — \
          exclude them from any guest-vs-native ratio"
     );
     Ok(())

--- a/tests/e2e/tests/bench_virtiofs.rs
+++ b/tests/e2e/tests/bench_virtiofs.rs
@@ -8,6 +8,11 @@
 //! this test measures and records; it does not assert a ratio (there is
 //! no baseline yet to regress against).
 //!
+//! The network-dependent macro benchmarks (`npm_install`, `git_clone`) are
+//! skipped on both sides: they need npm/git in the guest image (absent
+//! from the minimal bench image, where they fail instantly and report
+//! nonsense) and would hit the real registry/GitHub from the native run.
+//!
 //! Prerequisites (bailed on, not built here — keep the run's timing
 //! honest): both bench binaries must exist:
 //!
@@ -18,42 +23,29 @@
 //! ```
 
 use std::path::Path;
-use std::sync::Once;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
-use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
-use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
-use arcbox_e2e::docker::{docker_output, ensure_image};
+use arcbox_e2e::daemon::DaemonHandle;
+use arcbox_e2e::docker::{docker_output, ensure_image, run_with_timeout};
 use arcbox_e2e::metrics::RunMetrics;
-
-static TRACING: Once = Once::new();
+use arcbox_e2e::scenario::run_vz_scenario_with_log;
 
 const READY_TIMEOUT: Duration = Duration::from_secs(180);
-/// Ceiling for the full in-guest suite (dozens of benchmarks, files up to
-/// 256 MB, over VirtioFS).
+/// Ceiling for one full suite run (dozens of benchmarks, files up to
+/// 256 MB); applied to the guest and the native phase alike.
 const BENCH_BUDGET: Duration = Duration::from_secs(1800);
 /// First-baseline iteration counts: bounded runtime beats tight variance
 /// until a committed baseline exists.
 const WARMUP: &str = "1";
 const ITERATIONS: &str = "3";
-
-fn init_tracing() {
-    TRACING.call_once(|| {
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-            )
-            .try_init();
-    });
-}
+/// Network-dependent macro benchmarks, excluded on both sides (see the
+/// module docs).
+const SKIP_BENCHES: &str = "npm_install,git_clone";
 
 #[test]
 #[ignore = "boots a VZ System VM through a real daemon and runs the VirtioFS benchmark suite"]
 fn virtiofs_guest_vs_native_baseline() -> Result<()> {
-    init_tracing();
-
     let root = arcbox_e2e::repo_root();
     let bench_dir = root.join("tests/bench-virtiofs/target");
     let guest_bin = bench_dir.join("aarch64-unknown-linux-musl/release/arcbox-bench-virtiofs");
@@ -67,46 +59,9 @@ fn virtiofs_guest_vs_native_baseline() -> Result<()> {
         }
     }
 
-    if !arcbox_e2e::env_flag("SKIP_BUILD") {
-        let shell = xshell::Shell::new()?;
-        shell.change_dir(&root);
-        xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
-    }
-
-    let version = resolve_boot_version(&root)?;
-    let data_dir = tempfile::Builder::new()
-        .prefix("arcbox-bench-virtiofs-")
-        .tempdir()?;
-    stage_dev_boot_assets(&root, data_dir.path(), &version)?;
-
-    let mut daemon = DaemonHandle::spawn(DaemonConfig {
-        binary: root.join("target/release/arcbox-daemon"),
-        data_dir: data_dir.path().to_owned(),
-        args: vec![],
-        env: vec![
-            ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version),
-            ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
-        ],
-    })?;
-
-    let mut metrics = RunMetrics::new("bench_virtiofs", Some("vz"));
-    let result = scenario(
-        &mut daemon,
-        data_dir.path(),
-        &root,
-        &guest_bin,
-        &host_bin,
-        &mut metrics,
-    );
-    metrics.passed = result.is_ok();
-    if let Err(error) = metrics.write(Some(data_dir.path())) {
-        tracing::warn!("writing run metrics failed: {error:#}");
-    }
-    if result.is_err() {
-        let kept = data_dir.keep();
-        tracing::warn!(path = %kept.display(), "preserving test directory");
-    }
-    result
+    run_vz_scenario_with_log("bench_virtiofs", "info", |daemon, data_dir, metrics| {
+        scenario(daemon, data_dir, &root, &guest_bin, &host_bin, metrics)
+    })
 }
 
 fn scenario(
@@ -132,7 +87,7 @@ fn scenario(
         .context("staging guest bench binary into the share")?;
 
     // In-guest run against the VirtioFS share (scratch inside the share).
-    let guest_json = metrics.time("guest_bench", || {
+    let guest_output = metrics.time("guest_bench", || {
         docker_output(
             data_dir,
             &[
@@ -143,6 +98,8 @@ fn scenario(
                 &image,
                 "/b/arcbox-bench-virtiofs",
                 "--all",
+                "--skip",
+                SKIP_BENCHES,
                 "--format",
                 "json",
                 "--target",
@@ -162,23 +119,25 @@ fn scenario(
     // Native baseline on the host, same volume as the data dir.
     let native_scratch = data_dir.join("bench/native-scratch");
     std::fs::create_dir_all(&native_scratch)?;
-    let native_json = metrics.time("native_bench", || -> Result<String> {
-        let out = std::process::Command::new(host_bin)
-            .args([
-                "--all",
-                "--format",
-                "json",
-                "--target",
-                native_scratch.to_str().context("non-UTF8 scratch path")?,
-                "--platform",
-                "native",
-                "--warmup",
-                WARMUP,
-                "--iterations",
-                ITERATIONS,
-            ])
-            .output()
-            .context("running native bench suite")?;
+    let native_output = metrics.time("native_bench", || -> Result<String> {
+        let mut command = std::process::Command::new(host_bin);
+        command.args([
+            "--all",
+            "--skip",
+            SKIP_BENCHES,
+            "--format",
+            "json",
+            "--target",
+            native_scratch.to_str().context("non-UTF8 scratch path")?,
+            "--platform",
+            "native",
+            "--warmup",
+            WARMUP,
+            "--iterations",
+            ITERATIONS,
+        ]);
+        let out =
+            run_with_timeout(&mut command, BENCH_BUDGET).context("running native bench suite")?;
         if !out.status.success() {
             bail!(
                 "native bench failed: {}",
@@ -191,32 +150,48 @@ fn scenario(
     // Persist both reports outside the (deleted-on-success) data dir.
     let results = root.join("target/bench-virtiofs");
     std::fs::create_dir_all(&results)?;
-    std::fs::write(
-        results.join("guest-vz.json"),
-        extract_json_object(&guest_json)?,
-    )?;
-    std::fs::write(
-        results.join("native.json"),
-        extract_json_object(&native_json)?,
-    )?;
+    persist_report(&results, "guest-vz", &guest_output)?;
+    persist_report(&results, "native", &native_output)?;
     tracing::info!(dir = %results.display(), "bench reports written");
     Ok(())
 }
 
-/// Cuts a bench report down to its top-level JSON object and validates it.
+/// Writes `<name>.json` with the report extracted from a raw capture; on
+/// extraction failure the raw capture is preserved as `<name>.raw` so a
+/// failed 100+-second run never evaporates.
+fn persist_report(results: &Path, name: &str, raw: &str) -> Result<()> {
+    match extract_json_object(raw) {
+        Ok(json) => std::fs::write(results.join(format!("{name}.json")), json)
+            .with_context(|| format!("writing {name}.json")),
+        Err(error) => {
+            let raw_path = results.join(format!("{name}.raw"));
+            if let Err(write_error) = std::fs::write(&raw_path, raw) {
+                tracing::warn!("preserving raw {name} capture failed: {write_error:#}");
+            }
+            Err(error.context(format!(
+                "extracting the {name} report (raw capture preserved at {})",
+                raw_path.display()
+            )))
+        }
+    }
+}
+
+/// Extracts the first JSON value from a bench capture and re-serializes it.
 ///
 /// `docker_output` merges the container's stdout and stderr, and the bench
-/// prints progress text to stderr even in JSON mode — so the guest capture
-/// is a pretty-printed JSON object followed by loose text. The object's
-/// closing brace is the only column-0 `}` (nested closes are indented).
+/// prints progress text to stderr even in JSON mode — so the capture is
+/// one JSON object surrounded by loose text. The streaming deserializer
+/// consumes exactly one value wherever it ends, with no assumptions about
+/// the report's formatting.
 fn extract_json_object(raw: &str) -> Result<String> {
-    let start = raw.find('{').context("no JSON object in bench output")?;
-    let end = raw[start..]
-        .find("\n}")
-        .map(|i| start + i + 2)
-        .context("no top-level closing brace in bench output")?;
-    let json = &raw[start..end];
-    serde_json::from_str::<serde_json::Value>(json)
-        .context("extracted bench report is not valid JSON")?;
-    Ok(json.to_owned())
+    let excerpt: String = raw.chars().take(200).collect();
+    let start = raw
+        .find('{')
+        .with_context(|| format!("no JSON object in bench output: {excerpt:?}"))?;
+    let value = serde_json::Deserializer::from_str(&raw[start..])
+        .into_iter::<serde_json::Value>()
+        .next()
+        .with_context(|| format!("empty JSON stream in bench output: {excerpt:?}"))?
+        .with_context(|| format!("bench output is not valid JSON: {excerpt:?}"))?;
+    Ok(serde_json::to_string_pretty(&value)?)
 }

--- a/tests/e2e/tests/bench_virtiofs.rs
+++ b/tests/e2e/tests/bench_virtiofs.rs
@@ -191,8 +191,32 @@ fn scenario(
     // Persist both reports outside the (deleted-on-success) data dir.
     let results = root.join("target/bench-virtiofs");
     std::fs::create_dir_all(&results)?;
-    std::fs::write(results.join("guest-vz.json"), &guest_json)?;
-    std::fs::write(results.join("native.json"), &native_json)?;
+    std::fs::write(
+        results.join("guest-vz.json"),
+        extract_json_object(&guest_json)?,
+    )?;
+    std::fs::write(
+        results.join("native.json"),
+        extract_json_object(&native_json)?,
+    )?;
     tracing::info!(dir = %results.display(), "bench reports written");
     Ok(())
+}
+
+/// Cuts a bench report down to its top-level JSON object and validates it.
+///
+/// `docker_output` merges the container's stdout and stderr, and the bench
+/// prints progress text to stderr even in JSON mode — so the guest capture
+/// is a pretty-printed JSON object followed by loose text. The object's
+/// closing brace is the only column-0 `}` (nested closes are indented).
+fn extract_json_object(raw: &str) -> Result<String> {
+    let start = raw.find('{').context("no JSON object in bench output")?;
+    let end = raw[start..]
+        .find("\n}")
+        .map(|i| start + i + 2)
+        .context("no top-level closing brace in bench output")?;
+    let json = &raw[start..end];
+    serde_json::from_str::<serde_json::Value>(json)
+        .context("extracted bench report is not valid JSON")?;
+    Ok(json.to_owned())
 }

--- a/tests/e2e/tests/bench_virtiofs.rs
+++ b/tests/e2e/tests/bench_virtiofs.rs
@@ -40,8 +40,17 @@ const BENCH_BUDGET: Duration = Duration::from_secs(1800);
 const WARMUP: &str = "1";
 const ITERATIONS: &str = "3";
 /// Network-dependent macro benchmarks, excluded on both sides (see the
-/// module docs).
+/// module docs). The bench CLI hard-errors on a name that matches no
+/// benchmark, so a rename upstream cannot silently re-include them.
 const SKIP_BENCHES: &str = "npm_install,git_clone";
+/// Benchmarks that shell out to userland tools (`rm`, `find`) resolved
+/// from `PATH` — busybox in the guest image vs BSD binaries on the host.
+/// Their absolute numbers are real signal (`rm_rf` is a known VirtioFS
+/// pain point), but their guest-vs-native *ratios* conflate toolchains
+/// with the filesystem: any future ratio assertion must exclude these
+/// names, and `find_recursive`'s flattering ratio must never be read as
+/// the perf table's File I/O target being met.
+const TOOLCHAIN_BOUND_BENCHES: &[&str] = &["rm_rf", "find_recursive"];
 
 #[test]
 #[ignore = "boots a VZ System VM through a real daemon and runs the VirtioFS benchmark suite"]
@@ -153,6 +162,11 @@ fn scenario(
     persist_report(&results, "guest-vz", &guest_output)?;
     persist_report(&results, "native", &native_output)?;
     tracing::info!(dir = %results.display(), "bench reports written");
+    tracing::info!(
+        toolchain_bound = ?TOOLCHAIN_BOUND_BENCHES,
+        "these rows compare userland tools as much as the filesystem — \
+         exclude them from any guest-vs-native ratio"
+    );
     Ok(())
 }
 

--- a/tests/e2e/tests/bench_virtiofs.rs
+++ b/tests/e2e/tests/bench_virtiofs.rs
@@ -1,0 +1,198 @@
+//! VirtioFS file-I/O baseline (perf-target table: File I/O > 90% of native).
+//!
+//! Boots an isolated VZ daemon, copies the musl bench binary into the
+//! daemon's data dir (guest-visible under the `/arcbox` VirtioFS share),
+//! runs the suite inside the guest against that share, then runs the same
+//! suite natively on the host against a directory on the same volume.
+//! Both JSON reports land in `target/bench-virtiofs/` for comparison —
+//! this test measures and records; it does not assert a ratio (there is
+//! no baseline yet to regress against).
+//!
+//! Prerequisites (bailed on, not built here — keep the run's timing
+//! honest): both bench binaries must exist:
+//!
+//! ```sh
+//! cargo build --manifest-path tests/bench-virtiofs/Cargo.toml --release
+//! cargo build --manifest-path tests/bench-virtiofs/Cargo.toml --release \
+//!     --target aarch64-unknown-linux-musl
+//! ```
+
+use std::path::Path;
+use std::sync::Once;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+use arcbox_e2e::docker::{docker_output, ensure_image};
+use arcbox_e2e::metrics::RunMetrics;
+
+static TRACING: Once = Once::new();
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+/// Ceiling for the full in-guest suite (dozens of benchmarks, files up to
+/// 256 MB, over VirtioFS).
+const BENCH_BUDGET: Duration = Duration::from_secs(1800);
+/// First-baseline iteration counts: bounded runtime beats tight variance
+/// until a committed baseline exists.
+const WARMUP: &str = "1";
+const ITERATIONS: &str = "3";
+
+fn init_tracing() {
+    TRACING.call_once(|| {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+            )
+            .try_init();
+    });
+}
+
+#[test]
+#[ignore = "boots a VZ System VM through a real daemon and runs the VirtioFS benchmark suite"]
+fn virtiofs_guest_vs_native_baseline() -> Result<()> {
+    init_tracing();
+
+    let root = arcbox_e2e::repo_root();
+    let bench_dir = root.join("tests/bench-virtiofs/target");
+    let guest_bin = bench_dir.join("aarch64-unknown-linux-musl/release/arcbox-bench-virtiofs");
+    let host_bin = bench_dir.join("release/arcbox-bench-virtiofs");
+    for (bin, what) in [(&guest_bin, "musl guest"), (&host_bin, "host native")] {
+        if !bin.exists() {
+            bail!(
+                "{what} bench binary missing at {} — build it first (see module docs)",
+                bin.display()
+            );
+        }
+    }
+
+    if !arcbox_e2e::env_flag("SKIP_BUILD") {
+        let shell = xshell::Shell::new()?;
+        shell.change_dir(&root);
+        xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+    }
+
+    let version = resolve_boot_version(&root)?;
+    let data_dir = tempfile::Builder::new()
+        .prefix("arcbox-bench-virtiofs-")
+        .tempdir()?;
+    stage_dev_boot_assets(&root, data_dir.path(), &version)?;
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: data_dir.path().to_owned(),
+        args: vec![],
+        env: vec![
+            ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version),
+            ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
+        ],
+    })?;
+
+    let mut metrics = RunMetrics::new("bench_virtiofs", Some("vz"));
+    let result = scenario(
+        &mut daemon,
+        data_dir.path(),
+        &root,
+        &guest_bin,
+        &host_bin,
+        &mut metrics,
+    );
+    metrics.passed = result.is_ok();
+    if let Err(error) = metrics.write(Some(data_dir.path())) {
+        tracing::warn!("writing run metrics failed: {error:#}");
+    }
+    if result.is_err() {
+        let kept = data_dir.keep();
+        tracing::warn!(path = %kept.display(), "preserving test directory");
+    }
+    result
+}
+
+fn scenario(
+    daemon: &mut DaemonHandle,
+    data_dir: &Path,
+    root: &Path,
+    guest_bin: &Path,
+    host_bin: &Path,
+    metrics: &mut RunMetrics,
+) -> Result<()> {
+    metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
+
+    let image = std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+    metrics.time("docker_pull", || ensure_image(data_dir, &image))?;
+
+    // Stage the guest binary inside the share so the guest sees it at
+    // /arcbox/bench without any image plumbing.
+    let stage = data_dir.join("bench");
+    // The bench refuses a missing --target; both scratch dirs are created
+    // host-side (the guest sees them through the share).
+    std::fs::create_dir_all(stage.join("scratch"))?;
+    std::fs::copy(guest_bin, stage.join("arcbox-bench-virtiofs"))
+        .context("staging guest bench binary into the share")?;
+
+    // In-guest run against the VirtioFS share (scratch inside the share).
+    let guest_json = metrics.time("guest_bench", || {
+        docker_output(
+            data_dir,
+            &[
+                "run",
+                "--rm",
+                "-v",
+                "/arcbox/bench:/b",
+                &image,
+                "/b/arcbox-bench-virtiofs",
+                "--all",
+                "--format",
+                "json",
+                "--target",
+                "/b/scratch",
+                "--platform",
+                "arcbox-vz",
+                "--warmup",
+                WARMUP,
+                "--iterations",
+                ITERATIONS,
+            ],
+            BENCH_BUDGET,
+        )
+        .context("running guest bench suite")
+    })?;
+
+    // Native baseline on the host, same volume as the data dir.
+    let native_scratch = data_dir.join("bench/native-scratch");
+    std::fs::create_dir_all(&native_scratch)?;
+    let native_json = metrics.time("native_bench", || -> Result<String> {
+        let out = std::process::Command::new(host_bin)
+            .args([
+                "--all",
+                "--format",
+                "json",
+                "--target",
+                native_scratch.to_str().context("non-UTF8 scratch path")?,
+                "--platform",
+                "native",
+                "--warmup",
+                WARMUP,
+                "--iterations",
+                ITERATIONS,
+            ])
+            .output()
+            .context("running native bench suite")?;
+        if !out.status.success() {
+            bail!(
+                "native bench failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        String::from_utf8(out.stdout).context("native bench emitted non-UTF8")
+    })?;
+
+    // Persist both reports outside the (deleted-on-success) data dir.
+    let results = root.join("target/bench-virtiofs");
+    std::fs::create_dir_all(&results)?;
+    std::fs::write(results.join("guest-vz.json"), &guest_json)?;
+    std::fs::write(results.join("native.json"), &native_json)?;
+    tracing::info!(dir = %results.display(), "bench reports written");
+    Ok(())
+}


### PR DESCRIPTION
First harness for the perf-table **File I/O** metric (`tests/bench-virtiofs` existed but had never been run against a real guest).

## What it does

- Boots an **isolated** VZ daemon (e2e harness: own data dir, DNS port, staging — never touches the production daemon).
- Stages the musl `arcbox-bench-virtiofs` binary into the data dir, guest-visible through the `/arcbox` VirtioFS share.
- Runs the full suite in-guest against the share, then natively on the host against the same volume; both JSON reports land in `target/bench-virtiofs/`.
- Measures and records only — no ratio assertion until a committed baseline exists.

## First numbers (2026-07-30, VZ + DAX, warmup 1 / iters 3)

| bench | guest | native (cache-hot) | ratio |
|---|---|---|---|
| sequential_read | 3595 MB/s | 27689 MB/s | 13% |
| sequential_write | 1644 MB/s | 13653 MB/s | 12% |
| random_read_4k | 23.0k ops/s | 1140k ops/s | 2% |
| metadata_stat | 31.0k ops/s | 605k ops/s | 5% |
| negative_lookup | 23.2k ops/s | 466k ops/s | 5% |
| create_delete | 4.8k ops/s | 31.1k ops/s | 15% |
| find_recursive | 17.7k ops/s | 19.6k ops/s | 90% |
| rm_rf | 2493 ms | 479 ms | 5.2× slower |

Validity notes (also in the module docs): `npm_install`/`git_clone` are **invalid in-guest** (alpine lacks npm/git — they fail instantly); the native baseline is page-cache-hot APFS, which no FUSE path can match — a competitor-guest baseline (OrbStack/Colima, same suite) is the fair comparison for the table's spirit. Follow-ups: richer bench image, O_DIRECT / larger-than-RAM native mode, competitor run.

## Validation

- Hardware run green: 140s end-to-end, both reports written.
- `cargo clippy` / `cargo fmt --check` clean; gates on `SKIP_BUILD` per the xtask contract (fallback self-build).