### PR TITLE
docs(cli): update stale `arcbox` invocations to `abctl`

### DIFF
--- a/.agents/skills/e2e-testing.md
+++ b/.agents/skills/e2e-testing.md
@@ -175,7 +175,7 @@ the helper is reachable, use the Rust client:
 make run-helper   # terminal 1
 make run-daemon   # terminal 2 — look for "configured" in logs
 
-# Or check via `arcbox doctor`:
+# Or check via `abctl doctor`:
 ./target/debug/abctl doctor   # "ArcBoxHelper" check
 ```
 

--- a/.agents/skills/feature-implementation-workflow.md
+++ b/.agents/skills/feature-implementation-workflow.md
@@ -164,7 +164,7 @@ jobs:
       - name: Cross-compile agent
         run: cargo build --release -p arcbox-agent --target aarch64-unknown-linux-musl
       - name: Sign binary
-        run: codesign --entitlements bundle/arcbox.entitlements --force -s - target/release/arcbox
+        run: codesign --entitlements bundle/arcbox.entitlements --force -s - target/release/abctl
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
 
@@ -201,10 +201,10 @@ Use this workflow when E2E traffic reaches remote services but TLS handshakes fa
 
 ```bash
 # Start daemon with debug logging
-RUST_LOG=debug ./target/debug/arcbox daemon start --foreground
+RUST_LOG=debug ./target/debug/abctl daemon start --foreground
 
 # Optional: include byte-level ingress->host write verification
-RUST_LOG=debug ARCBOX_TCP_BYTE_TRACE=1 ./target/debug/arcbox daemon start --foreground
+RUST_LOG=debug ARCBOX_TCP_BYTE_TRACE=1 ./target/debug/abctl daemon start --foreground
 ```
 
 Run the failing E2E workload in another terminal (for example image pulls or repeated HTTPS requests).
@@ -348,10 +348,10 @@ cargo test -p arcbox-image -- test_name
 cargo test -p arcbox-e2e -- --ignored --nocapture
 
 # Start daemon with debug logging
-RUST_LOG=debug ./target/debug/arcbox daemon start --foreground
+RUST_LOG=debug ./target/debug/abctl daemon start --foreground
 
 # Start daemon with TCP byte-stream verification
-RUST_LOG=debug ARCBOX_TCP_BYTE_TRACE=1 ./target/debug/arcbox daemon start --foreground
+RUST_LOG=debug ARCBOX_TCP_BYTE_TRACE=1 ./target/debug/abctl daemon start --foreground
 
 # Focused TCP/TLS regression tests
 cargo test -p arcbox-net test_tcp_ack_padding_is_not_forwarded_as_payload -- --nocapture

--- a/.agents/skills/local-dev.md
+++ b/.agents/skills/local-dev.md
@@ -148,7 +148,7 @@ The daemon uses `flock(2)` on `~/.arcbox/run/daemon.lock` for exclusive
 ownership. Key behaviors:
 
 - **No stale PID issues**: lock auto-releases on process exit/crash
-- **CLI uses flock probe**: `arcbox daemon status` checks if lock is held,
+- **CLI uses flock probe**: `abctl daemon status` checks if lock is held,
   not whether a PID is alive
 - **Startup order**: `init_early` → `acquire_lock` → `start_grpc` →
   `wait_for_resources` → `init_runtime`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,18 +29,11 @@ The project is in **alpha**. Breaking changes (internal or user-facing) are acce
 - `virt/` — Virtualization.framework bindings, cross-platform hypervisor traits, VMM, VirtIO devices, VirtioFS, networking (NAT/DHCP/DNS)
 - `rpc/` — protobuf definitions, gRPC services, vsock/unix transport
 - `runtime/` — container state, OCI image/runtime
-- `app/` — core orchestration, API server, Docker Engine API compat, thin CLI (`abctl`), daemon binary (`arcbox-daemon`), facade crate
+- `app/` — core orchestration, API server, Docker Engine API compat, thin CLI (`abctl`, not `arcbox`), daemon binary (`arcbox-daemon`), facade crate
 - `guest/` — in-VM agent (cross-compiled for Linux)
 - `tests/` — test resources and fixture build scripts
 - `.agents/skills/` — shared Claude Code skills (symlinked from `.claude/skills/`)
 - `docs/` — supplementary documentation (boot assets, daemon lifecycle)
-
-- **CLI binary is `abctl`.** The `arcbox` binary is a deprecated compat shim
-  that `exec`s `abctl` and will be removed. Never write `arcbox <subcommand>`
-  in code, help text, docs, or scripts — use `abctl <subcommand>`. The name
-  `arcbox` remains correct for the project, crates, `arcbox-daemon`/
-  `arcbox-helper` binaries, `~/.arcbox`, the Docker context, and firewall
-  chain tags.
 
 ## Component Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,13 @@ The project is in **alpha**. Breaking changes (internal or user-facing) are acce
 - `.agents/skills/` — shared Claude Code skills (symlinked from `.claude/skills/`)
 - `docs/` — supplementary documentation (boot assets, daemon lifecycle)
 
+- **CLI binary is `abctl`.** The `arcbox` binary is a deprecated compat shim
+  that `exec`s `abctl` and will be removed. Never write `arcbox <subcommand>`
+  in code, help text, docs, or scripts — use `abctl <subcommand>`. The name
+  `arcbox` remains correct for the project, crates, `arcbox-daemon`/
+  `arcbox-helper` binaries, `~/.arcbox`, the Docker context, and firewall
+  chain tags.
+
 ## Component Rules
 
 Per-directory agent rules live in `AGENTS.md` files next to the code they

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ The project is in **alpha**. Breaking changes (internal or user-facing) are acce
 - `virt/` — Virtualization.framework bindings, cross-platform hypervisor traits, VMM, VirtIO devices, VirtioFS, networking (NAT/DHCP/DNS)
 - `rpc/` — protobuf definitions, gRPC services, vsock/unix transport
 - `runtime/` — container state, OCI image/runtime
-- `app/` — core orchestration, API server, Docker Engine API compat, thin CLI (`arcbox`), daemon binary (`arcbox-daemon`), facade crate
+- `app/` — core orchestration, API server, Docker Engine API compat, thin CLI (`abctl`), daemon binary (`arcbox-daemon`), facade crate
 - `guest/` — in-VM agent (cross-compiled for Linux)
 - `tests/` — test resources and fixture build scripts
 - `.agents/skills/` — shared Claude Code skills (symlinked from `.claude/skills/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ When asked to plan, the plan must be fully resolved before implementation begins
   ```
 - Requires Developer ID certificate (`.p12`) + provisioning profile (`.provisionprofile`). See `CONTRIBUTING.md` "Code Signing" section for setup.
 - Requires Xcode Command Line Tools
-- Some tasks require a running daemon. Start it in a background terminal: `arcbox daemon start`
+- Some tasks require a running daemon. Start it in a background terminal: `abctl daemon start`
 
 ## Guest Agent Cross-Compilation
 

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -6,6 +6,10 @@ Covers `arcbox-daemon` (startup/shutdown), `arcbox-core` (`vm_lifecycle`),
 `docs/daemon-lifecycle.md` (lock/handoff, residual-state tables) and
 `docs/data-directories.md` (filesystem paths) — point there, don't restate.
 
+`arcbox-cli` ships two binaries: `abctl` (the real CLI) and `arcbox` (a
+deprecated shim that `exec`s `abctl`, pending removal). User-facing strings
+must name `abctl`.
+
 ## Startup & readiness contract
 
 - Startup is a phased, typed pipeline and the order is load-bearing — see

--- a/app/arcbox-cli/src/commands/boot.rs
+++ b/app/arcbox-cli/src/commands/boot.rs
@@ -47,7 +47,7 @@ pub struct StatusArgs {
 // JSON output structures
 // =============================================================================
 
-/// JSON output for `arcbox boot status`.
+/// JSON output for `abctl boot status`.
 #[derive(Serialize)]
 struct StatusOutput {
     version: String,
@@ -81,7 +81,7 @@ struct ManifestInfo {
     source_sha: Option<String>,
 }
 
-/// NDJSON progress line for `arcbox boot prefetch`.
+/// NDJSON progress line for `abctl boot prefetch`.
 #[derive(Serialize, Default)]
 struct PrefetchProgress {
     phase: String,
@@ -101,13 +101,13 @@ struct PrefetchProgress {
     error: Option<String>,
 }
 
-/// JSON output for `arcbox boot list`.
+/// JSON output for `abctl boot list`.
 #[derive(Serialize)]
 struct ListOutput {
     versions: Vec<String>,
 }
 
-/// JSON output for `arcbox boot clear`.
+/// JSON output for `abctl boot clear`.
 #[derive(Serialize)]
 struct ClearOutput {
     cleared: bool,
@@ -243,7 +243,7 @@ async fn status(data_dir: PathBuf, args: StatusArgs, format: OutputFormat) -> an
                         println!("  Error:     {}", e);
                         println!();
                         println!("Boot will FAIL with the current assets.");
-                        println!("Run 'arcbox boot prefetch --force' to re-download.");
+                        println!("Run 'abctl boot prefetch --force' to re-download.");
                     }
                 }
             } else {
@@ -275,7 +275,7 @@ async fn status(data_dir: PathBuf, args: StatusArgs, format: OutputFormat) -> an
 
                 println!();
                 println!("Boot will FAIL without valid cached assets.");
-                println!("Run 'arcbox boot prefetch' to download boot assets.");
+                println!("Run 'abctl boot prefetch' to download boot assets.");
             }
         }
     }
@@ -535,7 +535,7 @@ async fn list(data_dir: PathBuf, format: OutputFormat) -> anyhow::Result<()> {
         OutputFormat::Table | OutputFormat::Quiet => {
             if versions.is_empty() {
                 println!("No cached versions found.");
-                println!("Run 'arcbox boot prefetch' to download boot assets.");
+                println!("Run 'abctl boot prefetch' to download boot assets.");
             } else {
                 println!("Cached versions:");
                 for version in versions {

--- a/app/arcbox-cli/src/commands/daemon.rs
+++ b/app/arcbox-cli/src/commands/daemon.rs
@@ -1,10 +1,10 @@
 //! Daemon command implementation.
 //!
 //! This command controls the lifecycle of the `arcbox-daemon` binary:
-//! - start in background (`arcbox daemon start`)
-//! - run in foreground (`arcbox daemon start -f`)
-//! - stop a running daemon (`arcbox daemon stop`)
-//! - inspect daemon status (`arcbox daemon status`)
+//! - start in background (`abctl daemon start`)
+//! - run in foreground (`abctl daemon start -f`)
+//! - stop a running daemon (`abctl daemon stop`)
+//! - inspect daemon status (`abctl daemon status`)
 
 use super::machine::UnixConnector;
 use anyhow::{Context, Result, bail};
@@ -233,7 +233,7 @@ fn spawn_background(args: &DaemonArgs) -> Result<()> {
     std::fs::create_dir_all(&layout.run_dir).context("Failed to create daemon run directory")?;
     std::fs::create_dir_all(&layout.log_dir).context("Failed to create daemon log directory")?;
 
-    // Serialize concurrent `arcbox daemon start` invocations. The alive
+    // Serialize concurrent `abctl daemon start` invocations. The alive
     // probe releases its flock immediately, so two racing starts could
     // both see "not running" and both spawn a daemon — the flock loser
     // then SIGTERMs the winner mid-boot via the stale-daemon takeover.
@@ -322,7 +322,7 @@ fn wait_for_lock_handoff(
     }
 }
 
-/// Exclusive lock serializing `arcbox daemon start` spawners.
+/// Exclusive lock serializing `abctl daemon start` spawners.
 ///
 /// Held via RAII; the flock is released when the value drops. A held
 /// lock means another start is mid-spawn: acquisition blocks (the
@@ -351,7 +351,7 @@ impl SpawnLock {
             if err.raw_os_error() == Some(libc::EWOULDBLOCK)
                 || err.raw_os_error() == Some(libc::EAGAIN)
             {
-                println!("Another `arcbox daemon start` is in progress, waiting...");
+                println!("Another `abctl daemon start` is in progress, waiting...");
                 // SAFETY: blocking flock on the same valid fd; bounded by
                 // the holder's spawn-handoff timeout.
                 let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };

--- a/app/arcbox-cli/src/commands/daemon.rs
+++ b/app/arcbox-cli/src/commands/daemon.rs
@@ -381,7 +381,7 @@ fn resolve_daemon_binary() -> Result<PathBuf> {
         return Ok(path);
     }
 
-    bail!("Failed to locate `arcbox-daemon` next to `arcbox` or in PATH");
+    bail!("Failed to locate `arcbox-daemon` next to `abctl` or in PATH");
 }
 
 fn find_in_path(binary: &str) -> Option<PathBuf> {

--- a/app/arcbox-cli/src/commands/dns.rs
+++ b/app/arcbox-cli/src/commands/dns.rs
@@ -4,9 +4,9 @@
 //! The resolver file points to `127.0.0.1:5553` where the ArcBox daemon
 //! provides DNS service.
 //!
-//! - `arcbox dns install`   — create resolver file (requires sudo)
-//! - `arcbox dns uninstall` — remove resolver file (requires sudo)
-//! - `arcbox dns status`    — check resolver file and DNS reachability
+//! - `abctl dns install`   — create resolver file (requires sudo)
+//! - `abctl dns uninstall` — remove resolver file (requires sudo)
+//! - `abctl dns status`    — check resolver file and DNS reachability
 
 use anyhow::{Context, Result};
 use clap::Subcommand;
@@ -83,7 +83,7 @@ async fn execute_install() -> Result<()> {
             eprintln!("Error: permission denied writing to /etc/resolver/");
             eprintln!();
             eprintln!("Run with sudo:");
-            eprintln!("  sudo arcbox dns install");
+            eprintln!("  sudo abctl dns install");
             std::process::exit(1);
         }
         Err(e) => Err(e).context("Failed to install DNS resolver"),
@@ -104,7 +104,7 @@ async fn execute_uninstall() -> Result<()> {
             eprintln!("Error: permission denied removing /etc/resolver/{domain}");
             eprintln!();
             eprintln!("Run with sudo:");
-            eprintln!("  sudo arcbox dns uninstall");
+            eprintln!("  sudo abctl dns uninstall");
             std::process::exit(1);
         }
         Err(e) => Err(e).context("Failed to uninstall DNS resolver"),
@@ -133,7 +133,7 @@ async fn execute_status() -> Result<()> {
 
     if !installed {
         println!();
-        println!("Run 'sudo arcbox dns install' to enable *.{domain} DNS resolution.");
+        println!("Run 'sudo abctl dns install' to enable *.{domain} DNS resolution.");
     }
     if !reachable {
         println!();

--- a/app/arcbox-cli/src/commands/docker.rs
+++ b/app/arcbox-cli/src/commands/docker.rs
@@ -75,7 +75,7 @@ pub(super) fn context_manager() -> Result<DockerContextManager> {
 // Setup — NDJSON progress
 // =============================================================================
 
-/// NDJSON progress line for `arcbox docker setup --format json`.
+/// NDJSON progress line for `abctl docker setup --format json`.
 #[derive(Serialize, Default)]
 struct SetupProgress {
     phase: String,
@@ -388,7 +388,7 @@ fn execute_enable(manager: &DockerContextManager) -> Result<()> {
     println!("  docker ps");
     println!("  docker run alpine echo hello");
     println!();
-    println!("To disable, run: arcbox docker disable");
+    println!("To disable, run: abctl docker disable");
 
     // Warn if socket doesn't exist.
     if !manager.socket_path().exists() {
@@ -449,9 +449,9 @@ fn execute_status(manager: &DockerContextManager) {
         println!("        Start the ArcBox daemon to use docker commands");
     } else if status.context_exists {
         println!("Status: Context exists but not default");
-        println!("        Run 'arcbox docker enable' to activate");
+        println!("        Run 'abctl docker enable' to activate");
     } else {
         println!("Status: Not configured");
-        println!("        Run 'arcbox docker enable' to set up");
+        println!("        Run 'abctl docker enable' to set up");
     }
 }

--- a/app/arcbox-cli/src/commands/machine.rs
+++ b/app/arcbox-cli/src/commands/machine.rs
@@ -290,7 +290,7 @@ async fn execute_create(args: CreateArgs) -> Result<()> {
     println!("  Disk:   {} GB", args.disk);
     println!();
     println!("To start the machine, run:");
-    println!("  arcbox machine start {}", args.name);
+    println!("  abctl machine start {}", args.name);
 
     Ok(())
 }
@@ -402,7 +402,7 @@ async fn execute_list(args: ListArgs) -> Result<()> {
         println!("No machines found.");
         println!();
         println!("To create a machine, run:");
-        println!("  arcbox machine create <name>");
+        println!("  abctl machine create <name>");
         return Ok(());
     }
 

--- a/app/arcbox-core/src/config.rs
+++ b/app/arcbox-core/src/config.rs
@@ -203,7 +203,7 @@ pub struct VmDefaults {
     /// macOS hypervisor backend for the System VM (`"vz"` or `"hv"`).
     ///
     /// First-boot default only: once the machine exists, its persisted
-    /// backend (as switched via `arcbox system backend`) wins. Settable
+    /// backend (as switched via `abctl system backend`) wins. Settable
     /// non-interactively via `ARCBOX_VM_BACKEND` or `config.toml` — the
     /// entry point for the dual-backend e2e matrix.
     pub backend: arcbox_vmm::VmBackend,

--- a/app/arcbox-core/src/runtime/assets.rs
+++ b/app/arcbox-core/src/runtime/assets.rs
@@ -34,7 +34,7 @@ pub(super) fn check_executable(path: &Path, context: &str) -> Result<()> {
 /// directories. Called before VM start. Fails fast if any binary is missing or
 /// not executable.
 ///
-/// These binaries are provisioned by `arcbox boot prefetch` (release builds) or
+/// These binaries are provisioned by `abctl boot prefetch` (release builds) or
 /// manually by developers (see `cargo xtask dev boot-assets`). This function
 /// only validates — it does not download or install anything.
 pub(super) fn ensure_guest_binaries(data_dir: &Path) -> Result<()> {

--- a/app/arcbox-daemon/src/startup/pipeline.rs
+++ b/app/arcbox-daemon/src/startup/pipeline.rs
@@ -182,7 +182,7 @@ impl RuntimeServicesStarted {
             println!("  Data:       {}", self.ctx.layout.data_dir.display());
             println!();
             if self.linux_vm {
-                println!("Use 'arcbox docker enable' to configure Docker CLI integration.");
+                println!("Use 'abctl docker enable' to configure Docker CLI integration.");
             } else {
                 println!(
                     "Running as a VM host only (--no-linux-vm): Docker and Kubernetes are disabled."
@@ -204,7 +204,7 @@ impl RuntimeServicesStarted {
 fn check_resolver_installed(domain: &str) {
     let resolver = FileResolver::new("arcbox");
     if !resolver.is_registered(domain) {
-        println!("Hint: Run 'sudo arcbox dns install' to enable *.{domain} DNS resolution.");
+        println!("Hint: Run 'sudo abctl dns install' to enable *.{domain} DNS resolution.");
     }
 }
 

--- a/docs/daemon-lifecycle.md
+++ b/docs/daemon-lifecycle.md
@@ -237,14 +237,14 @@ descriptor, not the PID. Even if the kernel reuses a PID for an unrelated
 process, the new daemon detects that the lock is not held (because the
 original holder's fd was closed on exit) and proceeds immediately.
 
-The CLI (`arcbox daemon status/stop/start`) also uses `flock` probing
+The CLI (`abctl daemon status/stop/start`) also uses `flock` probing
 (`LOCK_EX | LOCK_NB`) rather than `kill(pid, 0)` for liveness detection.
 PID is only read from the lock file for SIGTERM delivery and display.
 
 ### Spawn serialization (`daemon-spawn.lock`)
 
 The alive probe releases its flock immediately, so two racing
-`arcbox daemon start` invocations could both observe "not running" and
+`abctl daemon start` invocations could both observe "not running" and
 both spawn a daemon — the flock loser would then displace the winner
 mid-boot via the stale-daemon takeover. To close this TOCTOU, the CLI
 holds a separate `daemon-spawn.lock` (in the run directory) from the

--- a/docs/net-perf-limits.md
+++ b/docs/net-perf-limits.md
@@ -167,7 +167,7 @@ EVENT_IDX is the direct target of the signature and already scaffolded; it shoul
 
 ```bash
 # Start a clean daemon.
-arcbox daemon start
+abctl daemon start
 
 # Run an iperf3 server in a guest container.
 docker run -d --rm --name iperf3-srv -p 5201:5201 networkstatic/iperf3 -s

--- a/docs/sandbox-api.md
+++ b/docs/sandbox-api.md
@@ -121,8 +121,8 @@ File transfer with a 256 MiB per-file cap, usable while the sandbox is
 - `WriteFile` starts with `WriteFileRequest{open: {id, path, mode}}`
   (mode 0 → 0644), followed by `chunk` payloads, last one `done == true`.
 
-CLI: `arcbox sandbox cp ./local <id>:/path` and
-`arcbox sandbox cp <id>:/path ./local`.
+CLI: `abctl sandbox cp ./local <id>:/path` and
+`abctl sandbox cp <id>:/path ./local`.
 
 ### ExposePort / UnexposePort
 
@@ -140,7 +140,7 @@ host listener :H → inbound relay → guest :G (reserved 40000-49999)
 
 `host_port: 0` reuses the allocated guest relay port for a stable
 mapping. Mappings are removed automatically on Stop/Remove/TTL. CLI:
-`arcbox sandbox expose <id> <port>` / `unexpose`.
+`abctl sandbox expose <id> <port>` / `unexpose`.
 
 ### Stop / Remove
 

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -115,7 +115,7 @@ impl SandboxService {
         if !spec.mounts.is_empty() {
             return Err(SandboxError::Unsupported(
                 "mounts are not supported in Sandbox V1; copy files in with \
-                 WriteFile (`arcbox sandbox cp`) instead"
+                 WriteFile (`abctl sandbox cp`) instead"
                     .into(),
             ));
         }
@@ -129,7 +129,7 @@ impl SandboxService {
         if !spec.image.is_empty() {
             return Err(SandboxError::Unsupported(
                 "registry image pull is not supported in Sandbox V1; build the \
-                 rootfs from a local Docker image with `arcbox sandbox create \
+                 rootfs from a local Docker image with `abctl sandbox create \
                  --from-image` instead"
                     .into(),
             ));

--- a/tests/fex/README.md
+++ b/tests/fex/README.md
@@ -67,7 +67,7 @@ interpreter at registration time so containers inherit it across mount
 namespaces. (This registration lives in the `boot-assets` rootfs init, not the
 ArcBox guest agent.)
 
-Manual guest-side confirmation (until `arcbox exec` diag is wired):
+Manual guest-side confirmation (until `abctl exec` diag is wired):
 
 ```bash
 # inside the HV guest:

--- a/tests/fex/validate-fex.sh
+++ b/tests/fex/validate-fex.sh
@@ -3,7 +3,7 @@
 #
 # Reproducible spike for "FEX as the default linux/amd64 runtime inside the
 # single HV utility VM". Run this on Apple Silicon macOS with a running,
-# Developer-ID-signed `arcbox daemon` and the `arcbox` Docker context active.
+# Developer-ID-signed `abctl daemon` and the `arcbox` Docker context active.
 #
 # It exercises PLAN.md Decision Gates A/B/C and records an environment header
 # so results are reproducible. Every check prints exactly one tagged line:
@@ -53,12 +53,12 @@ printf 'docker context    %s\n' "$CONTEXT"
   | sed 's/^/server version    /' || tag INFRA "daemon not reachable on context '$CONTEXT'"
 
 # Guest-side facts (best effort; require the daemon to expose an exec/diag path).
-# These mirror PLAN.md Observability. If `arcbox` CLI exposes a guest exec, wire
+# These mirror PLAN.md Observability. If the `abctl` CLI exposes a guest exec, wire
 # it here; otherwise these are documented manual checks in README.md.
-if command -v arcbox >/dev/null 2>&1; then
-  printf 'guest kernel      %s\n' "$(arcbox exec -- uname -r 2>/dev/null || echo '? (run manually in guest)')"
-  printf 'fex version       %s\n' "$(arcbox exec -- /arcbox/runtime/bin/FEX --version 2>/dev/null || echo '? (run manually in guest)')"
-  printf 'binfmt x86_64     %s\n' "$(arcbox exec -- sh -c 'cat /proc/sys/fs/binfmt_misc/FEX-x86_64 2>/dev/null | head -1' 2>/dev/null || echo '? (run manually in guest)')"
+if command -v abctl >/dev/null 2>&1; then
+  printf 'guest kernel      %s\n' "$(abctl exec -- uname -r 2>/dev/null || echo '? (run manually in guest)')"
+  printf 'fex version       %s\n' "$(abctl exec -- /arcbox/runtime/bin/FEX --version 2>/dev/null || echo '? (run manually in guest)')"
+  printf 'binfmt x86_64     %s\n' "$(abctl exec -- sh -c 'cat /proc/sys/fs/binfmt_misc/FEX-x86_64 2>/dev/null | head -1' 2>/dev/null || echo '? (run manually in guest)')"
 fi
 
 if [ "$infra" -gt 0 ]; then
@@ -99,9 +99,9 @@ fi
 
 # No VZ runtime VM may be started for default amd64 runtime. The daemon should
 # expose this; until a diag endpoint exists, README.md documents the manual
-# `arcbox info` / process check.
-if command -v arcbox >/dev/null 2>&1; then
-  if arcbox info 2>/dev/null | grep -qi 'rosetta.*running\|vz.*runtime.*running'; then
+# `abctl info` / process check.
+if command -v abctl >/dev/null 2>&1; then
+  if abctl info 2>/dev/null | grep -qi 'rosetta.*running\|vz.*runtime.*running'; then
     tag FAIL "a VZ/Rosetta runtime VM is running for default amd64 (PLAN forbids)"
   else
     tag PASS "no VZ/Rosetta runtime VM active for default amd64 runtime"


### PR DESCRIPTION
The CLI binary was renamed `arcbox` → `abctl`, but a lot of user-facing text still tells people to run `arcbox ...`. Since the `arcbox` shim is slated for removal, every such hint would become a dead end. This updates them all.

## Changed

- **CLI hints** (`app/arcbox-cli`): `abctl boot prefetch [--force]`, `sudo abctl dns install/uninstall`, `abctl docker enable/disable`, `abctl machine start/create`, and the concurrent-start message in `daemon.rs`.
- **Daemon output** (`app/arcbox-daemon/src/startup/pipeline.rs`): the Docker-integration and DNS-resolver hints printed on startup.
- **Guest agent errors** (`guest/arcbox-agent/src/sandbox.rs`): `abctl sandbox cp`, `abctl sandbox create --from-image`.
- **Doc comments**: `boot.rs`, `dns.rs`, `docker.rs`, `daemon.rs`, `arcbox-core/src/config.rs` (`abctl system backend`), `arcbox-core/src/runtime/assets.rs`.
- **Docs**: `docs/sandbox-api.md`, `docs/daemon-lifecycle.md`, `docs/net-perf-limits.md`, `tests/fex/README.md`.
- **Agent guidance**: `CLAUDE.md`/`AGENTS.md` daemon-start hint, plus `.agents/skills/{e2e-testing,local-dev,feature-implementation-workflow}.md` (including `target/debug/arcbox` → `target/debug/abctl`).
- **Scripts**: `tests/fex/validate-fex.sh` (`command -v abctl`, `abctl exec`, `abctl info`).

## Deliberately unchanged

- The `arcbox` compat shim: `arcbox_placeholder.rs`, the `[[bin]] name = "arcbox"` entry, the `bin/arcbox` symlink created by `abctl setup install`, and its row in `docs/data-directories.md`. Removing the shim is a separate PR with its own deprecation window.
- Non-CLI uses of the name: `arcbox-daemon`/`arcbox-helper` binaries, crate names, `~/.arcbox` paths, the `arcbox` Docker context, and the `arcbox` nft/iptables chain and rule tags.
- `CHANGELOG.md` and `internal-docs/plans/*`, which are historical records.

## Verification

`cargo fmt --check` passes. The change is comments, strings, and Markdown only — no code paths touched.
