### PR TITLE
feat(agent): gate the guest NFS export behind a host request (ABX-426)

### DIFF
--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -11,13 +11,14 @@ use arcbox_constants::ports::AGENT_PORT;
 use arcbox_constants::wire::MessageType;
 use arcbox_protocol::agent::{
     ContainerFsPathsRequest, ContainerFsPathsResponse, DiskTrimRequest, DiskTrimResponse,
-    ImageFsPathsRequest, ImageFsPathsResponse, KubernetesDeleteRequest, KubernetesDeleteResponse,
-    KubernetesKubeconfigRequest, KubernetesKubeconfigResponse, KubernetesStartRequest,
-    KubernetesStartResponse, KubernetesStatusRequest, KubernetesStatusResponse,
-    KubernetesStopRequest, KubernetesStopResponse, MachineStats, MemoryPressureEvent,
-    MmapReadFileRequest, MmapReadFileResponse, PingRequest, PingResponse, ReadinessEvent,
-    RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse,
-    SystemInfo, WatchMemoryPressureRequest, WatchReadinessRequest, WatchStatsRequest,
+    EnsureNfsExportRequest, EnsureNfsExportResponse, ImageFsPathsRequest, ImageFsPathsResponse,
+    KubernetesDeleteRequest, KubernetesDeleteResponse, KubernetesKubeconfigRequest,
+    KubernetesKubeconfigResponse, KubernetesStartRequest, KubernetesStartResponse,
+    KubernetesStatusRequest, KubernetesStatusResponse, KubernetesStopRequest,
+    KubernetesStopResponse, MachineStats, MemoryPressureEvent, MmapReadFileRequest,
+    MmapReadFileResponse, PingRequest, PingResponse, ReadinessEvent, RuntimeEnsureRequest,
+    RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse, SystemInfo,
+    WatchMemoryPressureRequest, WatchReadinessRequest, WatchStatsRequest,
 };
 use arcbox_protocol::sandbox_v1::{
     CheckpointRequest, CheckpointResponse, CreateSandboxRequest, CreateSandboxResponse,
@@ -938,6 +939,40 @@ impl AgentClient {
             MessageType::ImageFsPathsRequest,
             &payload,
             MessageType::ImageFsPathsResponse,
+        )
+    }
+
+    /// Asks the guest to bring up the read-only NFS export of the docker data
+    /// mount (browsable on the host at `~/ArcBox`). Idempotent: the agent
+    /// ensures the data mount exists and converges an existing export.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the guest could not establish
+    /// the export.
+    pub async fn ensure_nfs_export(&mut self) -> Result<EnsureNfsExportResponse> {
+        let payload = EnsureNfsExportRequest {}.encode_to_vec();
+        self.unary_rpc(
+            MessageType::EnsureNfsExportRequest,
+            &payload,
+            MessageType::EnsureNfsExportResponse,
+        )
+        .await
+    }
+
+    /// Blocking variant of [`Self::ensure_nfs_export`] for the HV socketpair
+    /// transport. Call from `spawn_blocking`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the guest could not establish
+    /// the export.
+    pub fn ensure_nfs_export_blocking(&mut self) -> Result<EnsureNfsExportResponse> {
+        let payload = EnsureNfsExportRequest {}.encode_to_vec();
+        self.unary_rpc_blocking(
+            MessageType::EnsureNfsExportRequest,
+            &payload,
+            MessageType::EnsureNfsExportResponse,
         )
     }
 

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -15,7 +15,9 @@ use crate::machine::{MachineManager, MachineState};
 use crate::macos::MacMachineManager;
 use crate::migration::MigrationManager;
 use crate::vm::VmManager;
-use crate::vm_lifecycle::{DEFAULT_MACHINE_NAME, VmLifecycleConfig, VmLifecycleManager};
+use crate::vm_lifecycle::{
+    DEFAULT_MACHINE_NAME, VmLifecycleConfig, VmLifecycleManager, VmLifecycleState,
+};
 use arcbox_net::NetworkManager;
 #[cfg(target_os = "macos")]
 use arcbox_net::darwin::inbound_relay::{InboundListenerManager, InboundProtocol};
@@ -35,6 +37,7 @@ use std::net::{SocketAddr, SocketAddrV4};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock as TokioRwLock;
+use tokio::sync::watch;
 
 /// Default guest VM IP address in NAT network (used by PortForwarder fallback).
 #[cfg(not(target_os = "macos"))]
@@ -482,6 +485,15 @@ impl Runtime {
     #[must_use]
     pub fn system_vm_restart_generation(&self) -> u64 {
         self.vm_lifecycle.restart_generation()
+    }
+
+    /// Subscribes to the System VM's lifecycle state transitions.
+    ///
+    /// This is the only signal that reports the VM coming *up*; the restart
+    /// generation above only marks it going down.
+    #[must_use]
+    pub fn subscribe_system_vm_state(&self) -> watch::Receiver<VmLifecycleState> {
+        self.vm_lifecycle.subscribe_state()
     }
 
     /// Returns the guest dockerd vsock port for the System VM.

--- a/app/arcbox-core/src/vm_lifecycle/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/mod.rs
@@ -311,6 +311,17 @@ impl VmLifecycleManager {
         *self.state_rx.borrow()
     }
 
+    /// Subscribes to lifecycle state transitions.
+    ///
+    /// Prefer this over polling [`Self::restart_generation`] when a task must
+    /// react to the VM coming *up*: the generation counter is bumped on stop,
+    /// so it marks the start of the gap where no guest exists, not the arrival
+    /// of the next one.
+    #[must_use]
+    pub fn subscribe_state(&self) -> watch::Receiver<VmLifecycleState> {
+        self.state_rx.clone()
+    }
+
     /// Returns true if the VM is running and ready.
     #[allow(clippy::unused_async, reason = "public API compatibility")]
     pub async fn is_running(&self) -> bool {

--- a/app/arcbox-daemon/src/nfs_mount.rs
+++ b/app/arcbox-daemon/src/nfs_mount.rs
@@ -21,10 +21,11 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use arcbox_constants::ports::NFS_NFSD_RELAY_PORT;
-use arcbox_core::{DEFAULT_MACHINE_NAME, Runtime};
+use arcbox_core::{DEFAULT_MACHINE_NAME, Runtime, VmLifecycleState};
 use arcbox_transport::vsock::{VsockShutdown, VsockStream};
 use tokio::io::copy_bidirectional;
 use tokio::net::TcpListener;
+use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -32,6 +33,9 @@ use crate::context::DaemonContext;
 
 const MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
 const MOUNT_RETRY_INTERVAL: Duration = Duration::from_millis(500);
+/// Pause before retrying a failed incarnation, so a guest that is up but not
+/// yet able to serve the export is retried without spinning.
+const RETRY_BACKOFF: Duration = Duration::from_secs(30);
 
 /// Path this daemon successfully mounted, set once by the reconcile task.
 /// [`cleanup`] only unmounts what this process created — a daemon that never
@@ -100,17 +104,19 @@ async fn reconcile(
     // starts nfsd on its own, so each guest — the first boot and every restart
     // (backend switch, crash recovery) — has no NFS server until we ask; a
     // `--no-mount-nfs` daemon never reaches here, so its guests run none.
+    //
+    // The trigger is the lifecycle *ready* edge, never the restart generation:
+    // that counter is bumped when the VM stops, so acting on it would send the
+    // request into the gap where no guest exists and burn the retry budget on a
+    // VM that is still booting — or, after a plain `arcbox stop`, on one that is
+    // not coming back until the next on-demand start.
+    let mut state = runtime.subscribe_system_vm_state();
     let mut first = true;
-    while !shutdown.is_cancelled() {
-        let generation = runtime.system_vm_restart_generation();
 
-        // The request must actually land — a pre-delivery failure (agent still
-        // coming up, connect/send error) leaves the guest with no nfsd and the
-        // mount below would retry forever, so retry until the agent confirms.
-        ensure_guest_export(&runtime, &shutdown).await?;
-
-        reconcile_existing_mount(&mount_path)?;
-        std::fs::create_dir_all(&mount_path)?;
+    while wait_for_state(&mut state, &shutdown, VmLifecycleState::is_ready).await {
+        // The one fatal condition: the mount point holds a mount this daemon
+        // did not create, and no retry or VM restart can free it.
+        let occupancy = classify_mount_point(&mount_path)?;
 
         // The hosts alias only needs waiting for on the very first mount.
         if first && expect_hosts_alias {
@@ -118,17 +124,90 @@ async fn reconcile(
         }
         first = false;
 
-        mount_with_retry(&mount_path, nfsd_port, &shutdown).await?;
+        // A failed attempt must not end the supervisor: the next ready VM — or
+        // this one after a backoff — gets another chance. Losing the loop would
+        // leave every later incarnation with no nfsd at all.
+        if let Err(e) = establish(&runtime, occupancy, &mount_path, nfsd_port, &shutdown).await {
+            if shutdown.is_cancelled() {
+                break;
+            }
+            warn!(error = %e, "could not establish the ~/ArcBox export; retrying");
+            if !sleep_unless_shutdown(RETRY_BACKOFF, &shutdown).await {
+                break;
+            }
+            continue;
+        }
 
-        // Hold until the System VM restarts, then loop to rebuild the export on
-        // the new guest and remount over the now-stale mount.
-        wait_for_vm_restart(&runtime, generation, &shutdown).await;
-        if shutdown.is_cancelled() {
+        // Hold until this incarnation goes away, then loop to rebuild the
+        // export on the next guest and remount over the now-stale mount.
+        if !wait_for_state(&mut state, &shutdown, |s| !s.is_ready()).await {
             break;
         }
-        info!("system VM restarted; re-establishing the ~/ArcBox export");
+        info!("system VM stopped; the ~/ArcBox export will be rebuilt when it returns");
     }
     Ok(())
+}
+
+/// Brings the guest export up and mounts it — the per-incarnation work.
+///
+/// Everything here is retryable, including reclaiming our own stale mount: the
+/// previous incarnation's mount can take a moment to release once its guest is
+/// gone, and a failed `umount` must not be terminal.
+async fn establish(
+    runtime: &Arc<Runtime>,
+    occupancy: MountPoint,
+    mount_path: &Path,
+    nfsd_port: u16,
+    shutdown: &CancellationToken,
+) -> Result<()> {
+    if occupancy == MountPoint::Stale {
+        info!(path = %mount_path.display(), "replacing stale ~/ArcBox NFS mount");
+        unmount(mount_path)?;
+    }
+    std::fs::create_dir_all(mount_path)?;
+
+    // The request must actually land — a pre-delivery failure (agent still
+    // coming up, connect/send error) leaves the guest with no nfsd and the
+    // mount below could only retry forever, so retry until the agent confirms.
+    ensure_guest_export(runtime, shutdown).await?;
+    mount_with_retry(mount_path, nfsd_port, shutdown).await
+}
+
+/// Waits until the System VM's lifecycle state satisfies `pred`.
+///
+/// Returns `false` when the daemon shut down or the lifecycle manager was
+/// dropped first — in both cases there is nothing left to reconcile.
+async fn wait_for_state(
+    state: &mut watch::Receiver<VmLifecycleState>,
+    shutdown: &CancellationToken,
+    pred: fn(&VmLifecycleState) -> bool,
+) -> bool {
+    loop {
+        if shutdown.is_cancelled() {
+            return false;
+        }
+        if pred(&state.borrow_and_update()) {
+            return true;
+        }
+        tokio::select! {
+            biased;
+            () = shutdown.cancelled() => return false,
+            changed = state.changed() => {
+                if changed.is_err() {
+                    return false;
+                }
+            }
+        }
+    }
+}
+
+/// Sleeps for `duration`, returning `false` if the daemon shut down instead.
+async fn sleep_unless_shutdown(duration: Duration, shutdown: &CancellationToken) -> bool {
+    tokio::select! {
+        biased;
+        () = shutdown.cancelled() => false,
+        () = tokio::time::sleep(duration) => true,
+    }
 }
 
 /// Asks the guest agent to bring up the export, retrying until it confirms,
@@ -136,14 +215,17 @@ async fn reconcile(
 ///
 /// A pre-delivery failure must be retried, not swallowed: the agent no longer
 /// starts nfsd on its own, so if the request never lands the guest has no
-/// server and `mount_with_retry` can only fail. Each attempt is bounded and
-/// races shutdown, because the guest handler holds the runtime-start lock for
-/// the whole cold boot and neither transport self-limits usefully here: the HV
-/// blocking RPC deadline (5s) is far shorter than a cold start, and the VZ
-/// async path has no read deadline at all, so an unbounded attempt could hang
-/// reconcile until — or past — a wedged runtime start. A per-attempt timeout
-/// makes both backends retry across the cold-start window, and the handler is
-/// idempotent so a retry after the export is already up just confirms it.
+/// server and `mount_with_retry` can only fail.
+///
+/// The caller only sends once the VM is ready, so the agent is up — but the
+/// handler takes the runtime-start lock, which the in-flight dockerd start
+/// holds for far longer (its own budget is 150s), and neither transport
+/// self-limits usefully across that: the HV blocking RPC deadline (5s) is much
+/// shorter, and the VZ async path has no read deadline at all, so an unbounded
+/// attempt could hang the reconcile until — or past — a wedged runtime start.
+/// Bounding each attempt and racing shutdown makes both backends retry across
+/// that window, and the handler is idempotent so a retry after the export is
+/// already up just confirms it.
 async fn ensure_guest_export(runtime: &Arc<Runtime>, shutdown: &CancellationToken) -> Result<()> {
     const ENSURE_TIMEOUT: Duration = Duration::from_secs(120);
     const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(15);
@@ -199,27 +281,6 @@ async fn send_ensure_export(runtime: &Arc<Runtime>) -> Result<Vec<String>> {
         agent.ensure_nfs_export().await?
     };
     Ok(resp.notes)
-}
-
-/// Blocks until the System VM's restart generation advances past `generation`
-/// (backend switch, crash recovery) or the daemon shuts down.
-async fn wait_for_vm_restart(
-    runtime: &Arc<Runtime>,
-    generation: u64,
-    shutdown: &CancellationToken,
-) {
-    const POLL_INTERVAL: Duration = Duration::from_secs(2);
-    loop {
-        tokio::select! {
-            biased;
-            () = shutdown.cancelled() => return,
-            () = tokio::time::sleep(POLL_INTERVAL) => {
-                if runtime.system_vm_restart_generation() != generation {
-                    return;
-                }
-            }
-        }
-    }
 }
 
 /// Bounded wait for the `ArcBox` hosts alias the concurrent self-setup task
@@ -428,25 +489,32 @@ fn resolve_mount_path_from_home(home: &Path) -> PathBuf {
     home.join("ArcBox")
 }
 
-/// Removes a stale ArcBox NFS mount, or errors if the path is otherwise taken.
+/// What currently holds the mount point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MountPoint {
+    /// Nothing mounted there — free to use.
+    Free,
+    /// A mount matching our exact shape, left over from a previous daemon or a
+    /// previous incarnation whose guest is gone. Dead weight; reclaimable.
+    Stale,
+}
+
+/// Classifies the mount point, erroring when it is held by a mount this daemon
+/// did not create.
 ///
-/// Only a mount matching our exact shape (`nfs` from `127.0.0.1:/`) is
-/// replaced — that is a leftover from a previous daemon whose local proxy is
-/// gone, so it is dead weight. Anything else at the path, including a foreign
-/// NFS mount, is someone else's and makes the reconcile bail.
-fn reconcile_existing_mount(mount_path: &Path) -> Result<()> {
+/// Anything that is not our own shape — including a foreign NFS mount — is
+/// someone else's, and no retry or VM restart can free it, so it is the one
+/// condition that ends the reconcile.
+fn classify_mount_point(mount_path: &Path) -> Result<MountPoint> {
     match current_mount_info(mount_path) {
-        Some(info) if is_arcbox_nfs_mount(&info) => {
-            info!(path = %mount_path.display(), "replacing stale ~/ArcBox NFS mount");
-            unmount(mount_path)
-        }
+        None => Ok(MountPoint::Free),
+        Some(info) if is_arcbox_nfs_mount(&info) => Ok(MountPoint::Stale),
         Some(info) => bail!(
             "~/ArcBox path {} already occupied by {} ({})",
             mount_path.display(),
             info.source,
             info.fstype
         ),
-        None => Ok(()),
     }
 }
 
@@ -512,10 +580,12 @@ fn unmount(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        MountInfo, is_arcbox_nfs_mount, mount_source_for, parse_mount_line, render_mount_opts,
-        resolve_mount_path_from_home,
+        MountInfo, VmLifecycleState, is_arcbox_nfs_mount, mount_source_for, parse_mount_line,
+        render_mount_opts, resolve_mount_path_from_home, wait_for_state,
     };
     use std::path::{Path, PathBuf};
+    use tokio::sync::watch;
+    use tokio_util::sync::CancellationToken;
 
     #[test]
     fn only_our_exact_mount_shape_is_reclaimed() {
@@ -565,6 +635,51 @@ mod tests {
     fn mount_source_is_the_v4_pseudo_root_under_both_names() {
         assert_eq!(mount_source_for(false), "127.0.0.1:/");
         assert_eq!(mount_source_for(true), "ArcBox:/");
+    }
+
+    /// The whole point of watching lifecycle state instead of the restart
+    /// generation: the export must be (re)built when a guest arrives, not when
+    /// one leaves. `Stopped` is where the generation counter fires — waiting
+    /// there would send the request into the gap with no guest in it.
+    #[tokio::test]
+    async fn ready_wait_resumes_on_the_arrival_edge_not_the_departure() {
+        let (tx, mut rx) = watch::channel(VmLifecycleState::Running);
+        let shutdown = CancellationToken::new();
+
+        // A running VM satisfies the predicate immediately.
+        assert!(wait_for_state(&mut rx, &shutdown, VmLifecycleState::is_ready).await);
+
+        // Departure: intermediate states must not be mistaken for arrival.
+        for state in [VmLifecycleState::Stopping, VmLifecycleState::Stopped] {
+            tx.send_replace(state);
+            assert!(wait_for_state(&mut rx, &shutdown, |s| !s.is_ready()).await);
+        }
+
+        // A restart passes through Starting, which is not yet usable; only
+        // Running releases the waiter.
+        tx.send_replace(VmLifecycleState::Starting);
+        let waiter = tokio::spawn({
+            let shutdown = shutdown.clone();
+            let mut rx = rx.clone();
+            async move { wait_for_state(&mut rx, &shutdown, VmLifecycleState::is_ready).await }
+        });
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished(), "Starting is not an arrival");
+
+        tx.send_replace(VmLifecycleState::Running);
+        assert!(waiter.await.expect("waiter panicked"));
+    }
+
+    #[tokio::test]
+    async fn ready_wait_gives_up_on_shutdown_and_on_a_dropped_lifecycle() {
+        let (tx, mut rx) = watch::channel(VmLifecycleState::Stopped);
+        let shutdown = CancellationToken::new();
+        shutdown.cancel();
+        assert!(!wait_for_state(&mut rx, &shutdown, VmLifecycleState::is_ready).await);
+
+        drop(tx);
+        let shutdown = CancellationToken::new();
+        assert!(!wait_for_state(&mut rx, &shutdown, VmLifecycleState::is_ready).await);
     }
 
     #[test]

--- a/app/arcbox-daemon/src/nfs_mount.rs
+++ b/app/arcbox-daemon/src/nfs_mount.rs
@@ -19,7 +19,7 @@ use std::process::Command;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use arcbox_constants::ports::NFS_NFSD_RELAY_PORT;
 use arcbox_core::{DEFAULT_MACHINE_NAME, Runtime};
 use arcbox_transport::vsock::{VsockShutdown, VsockStream};
@@ -91,35 +91,83 @@ async fn reconcile(
         bail!("could not determine home directory for ~/ArcBox mount");
     };
 
-    // One localhost TCP proxy to the guest nfsd, bridged over vsock.
+    // One localhost TCP proxy to the guest nfsd, bridged over vsock. It outlives
+    // VM restarts: each connection dials `connect_vsock_port` against whatever
+    // guest is current, so the same local port keeps working across reboots.
     let nfsd_port = spawn_proxy(&runtime, &shutdown, NFS_NFSD_RELAY_PORT).await?;
 
-    // Ask the guest to bring up the export. The agent no longer starts nfsd on
-    // its own, so this request is what gives a mount-enabled daemon an export
-    // at all — and a `--no-mount-nfs` daemon never reaches here, so its guest
-    // runs none. Best-effort: the guest handler runs to completion even if this
-    // RPC read times out (it may still be waiting on dockerd's data mount), and
-    // `mount_with_retry` below is the readiness signal.
-    if let Err(e) = ensure_guest_export(&runtime).await {
-        debug!(error = %e, "guest nfs export request did not confirm; relying on mount retry");
+    // Re-establish the export for every VM incarnation. The agent no longer
+    // starts nfsd on its own, so each guest — the first boot and every restart
+    // (backend switch, crash recovery) — has no NFS server until we ask; a
+    // `--no-mount-nfs` daemon never reaches here, so its guests run none.
+    let mut first = true;
+    while !shutdown.is_cancelled() {
+        let generation = runtime.system_vm_restart_generation();
+
+        // The request must actually land — a pre-delivery failure (agent still
+        // coming up, connect/send error) leaves the guest with no nfsd and the
+        // mount below would retry forever, so retry until the agent confirms.
+        ensure_guest_export(&runtime, &shutdown).await?;
+
+        reconcile_existing_mount(&mount_path)?;
+        std::fs::create_dir_all(&mount_path)?;
+
+        // The hosts alias only needs waiting for on the very first mount.
+        if first && expect_hosts_alias {
+            wait_for_hosts_alias(&shutdown).await;
+        }
+        first = false;
+
+        mount_with_retry(&mount_path, nfsd_port, &shutdown).await?;
+
+        // Hold until the System VM restarts, then loop to rebuild the export on
+        // the new guest and remount over the now-stale mount.
+        wait_for_vm_restart(&runtime, generation, &shutdown).await;
+        if shutdown.is_cancelled() {
+            break;
+        }
+        info!("system VM restarted; re-establishing the ~/ArcBox export");
     }
-
-    reconcile_existing_mount(&mount_path)?;
-    std::fs::create_dir_all(&mount_path)?;
-
-    if expect_hosts_alias {
-        wait_for_hosts_alias(&shutdown).await;
-    }
-
-    mount_with_retry(&mount_path, nfsd_port, &shutdown).await
+    Ok(())
 }
 
-/// Asks the guest agent to bring up the read-only NFS export.
+/// Asks the guest agent to bring up the export, retrying until it confirms,
+/// the deadline passes, or shutdown.
+///
+/// A pre-delivery failure must be retried, not swallowed: the agent no longer
+/// starts nfsd on its own, so if the request never lands the guest has no
+/// server and `mount_with_retry` can only fail. A read timeout after delivery
+/// is fine — the guest handler runs to completion regardless — and a retry
+/// then finds the export already up (the handler is idempotent).
+async fn ensure_guest_export(runtime: &Arc<Runtime>, shutdown: &CancellationToken) -> Result<()> {
+    const ENSURE_TIMEOUT: Duration = Duration::from_secs(90);
+    const RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
+    let deadline = tokio::time::Instant::now() + ENSURE_TIMEOUT;
+    loop {
+        if shutdown.is_cancelled() {
+            bail!("daemon shutdown before the guest NFS export was established");
+        }
+        match send_ensure_export(runtime).await {
+            Ok(notes) => {
+                debug!(notes = ?notes, "guest nfs export ensured");
+                return Ok(());
+            }
+            Err(e) if tokio::time::Instant::now() >= deadline => {
+                return Err(e).context("guest did not establish the NFS export in time");
+            }
+            Err(e) => debug!(error = %e, "ensure guest nfs export attempt failed, retrying"),
+        }
+        tokio::time::sleep(RETRY_INTERVAL).await;
+    }
+}
+
+/// One `EnsureNfsExport` round-trip to the guest agent.
 ///
 /// `connect_agent` is a blocking hypervisor call on both backends; on HV the
 /// whole agent transport is blocking, on VZ only the connect is. Mirrors the
 /// `sync_guest_clock` backend dispatch in `arcbox-core`.
-async fn ensure_guest_export(runtime: &Arc<Runtime>) -> Result<()> {
+async fn send_ensure_export(runtime: &Arc<Runtime>) -> Result<Vec<String>> {
     let machine = DEFAULT_MACHINE_NAME.to_string();
     let rt = Arc::clone(runtime);
     let mut agent = tokio::task::spawn_blocking(move || rt.get_agent(&machine)).await??;
@@ -128,8 +176,28 @@ async fn ensure_guest_export(runtime: &Arc<Runtime>) -> Result<()> {
     } else {
         agent.ensure_nfs_export().await?
     };
-    debug!(notes = ?resp.notes, "guest nfs export ensured");
-    Ok(())
+    Ok(resp.notes)
+}
+
+/// Blocks until the System VM's restart generation advances past `generation`
+/// (backend switch, crash recovery) or the daemon shuts down.
+async fn wait_for_vm_restart(
+    runtime: &Arc<Runtime>,
+    generation: u64,
+    shutdown: &CancellationToken,
+) {
+    const POLL_INTERVAL: Duration = Duration::from_secs(2);
+    loop {
+        tokio::select! {
+            biased;
+            () = shutdown.cancelled() => return,
+            () = tokio::time::sleep(POLL_INTERVAL) => {
+                if runtime.system_vm_restart_generation() != generation {
+                    return;
+                }
+            }
+        }
+    }
 }
 
 /// Bounded wait for the `ArcBox` hosts alias the concurrent self-setup task

--- a/app/arcbox-daemon/src/nfs_mount.rs
+++ b/app/arcbox-daemon/src/nfs_mount.rs
@@ -136,29 +136,51 @@ async fn reconcile(
 ///
 /// A pre-delivery failure must be retried, not swallowed: the agent no longer
 /// starts nfsd on its own, so if the request never lands the guest has no
-/// server and `mount_with_retry` can only fail. A read timeout after delivery
-/// is fine — the guest handler runs to completion regardless — and a retry
-/// then finds the export already up (the handler is idempotent).
+/// server and `mount_with_retry` can only fail. Each attempt is bounded and
+/// races shutdown, because the guest handler holds the runtime-start lock for
+/// the whole cold boot and neither transport self-limits usefully here: the HV
+/// blocking RPC deadline (5s) is far shorter than a cold start, and the VZ
+/// async path has no read deadline at all, so an unbounded attempt could hang
+/// reconcile until — or past — a wedged runtime start. A per-attempt timeout
+/// makes both backends retry across the cold-start window, and the handler is
+/// idempotent so a retry after the export is already up just confirms it.
 async fn ensure_guest_export(runtime: &Arc<Runtime>, shutdown: &CancellationToken) -> Result<()> {
-    const ENSURE_TIMEOUT: Duration = Duration::from_secs(90);
+    const ENSURE_TIMEOUT: Duration = Duration::from_secs(120);
+    const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(15);
     const RETRY_INTERVAL: Duration = Duration::from_secs(1);
 
     let deadline = tokio::time::Instant::now() + ENSURE_TIMEOUT;
     loop {
-        if shutdown.is_cancelled() {
-            bail!("daemon shutdown before the guest NFS export was established");
-        }
-        match send_ensure_export(runtime).await {
-            Ok(notes) => {
+        let attempt = tokio::select! {
+            biased;
+            () = shutdown.cancelled() => {
+                bail!("daemon shutdown before the guest NFS export was established");
+            }
+            result = tokio::time::timeout(ATTEMPT_TIMEOUT, send_ensure_export(runtime)) => result,
+        };
+        match attempt {
+            Ok(Ok(notes)) => {
                 debug!(notes = ?notes, "guest nfs export ensured");
                 return Ok(());
             }
-            Err(e) if tokio::time::Instant::now() >= deadline => {
-                return Err(e).context("guest did not establish the NFS export in time");
+            outcome if tokio::time::Instant::now() >= deadline => {
+                return match outcome {
+                    Ok(Err(e)) => Err(e).context("guest did not establish the NFS export in time"),
+                    _ => Err(anyhow::anyhow!(
+                        "guest did not establish the NFS export within {ENSURE_TIMEOUT:?}"
+                    )),
+                };
             }
-            Err(e) => debug!(error = %e, "ensure guest nfs export attempt failed, retrying"),
+            Ok(Err(e)) => debug!(error = %e, "ensure guest nfs export attempt failed, retrying"),
+            Err(_) => debug!("ensure guest nfs export attempt timed out, retrying"),
         }
-        tokio::time::sleep(RETRY_INTERVAL).await;
+        tokio::select! {
+            biased;
+            () = shutdown.cancelled() => {
+                bail!("daemon shutdown before the guest NFS export was established");
+            }
+            () = tokio::time::sleep(RETRY_INTERVAL) => {}
+        }
     }
 }
 

--- a/app/arcbox-daemon/src/nfs_mount.rs
+++ b/app/arcbox-daemon/src/nfs_mount.rs
@@ -94,6 +94,16 @@ async fn reconcile(
     // One localhost TCP proxy to the guest nfsd, bridged over vsock.
     let nfsd_port = spawn_proxy(&runtime, &shutdown, NFS_NFSD_RELAY_PORT).await?;
 
+    // Ask the guest to bring up the export. The agent no longer starts nfsd on
+    // its own, so this request is what gives a mount-enabled daemon an export
+    // at all — and a `--no-mount-nfs` daemon never reaches here, so its guest
+    // runs none. Best-effort: the guest handler runs to completion even if this
+    // RPC read times out (it may still be waiting on dockerd's data mount), and
+    // `mount_with_retry` below is the readiness signal.
+    if let Err(e) = ensure_guest_export(&runtime).await {
+        debug!(error = %e, "guest nfs export request did not confirm; relying on mount retry");
+    }
+
     reconcile_existing_mount(&mount_path)?;
     std::fs::create_dir_all(&mount_path)?;
 
@@ -102,6 +112,24 @@ async fn reconcile(
     }
 
     mount_with_retry(&mount_path, nfsd_port, &shutdown).await
+}
+
+/// Asks the guest agent to bring up the read-only NFS export.
+///
+/// `connect_agent` is a blocking hypervisor call on both backends; on HV the
+/// whole agent transport is blocking, on VZ only the connect is. Mirrors the
+/// `sync_guest_clock` backend dispatch in `arcbox-core`.
+async fn ensure_guest_export(runtime: &Arc<Runtime>) -> Result<()> {
+    let machine = DEFAULT_MACHINE_NAME.to_string();
+    let rt = Arc::clone(runtime);
+    let mut agent = tokio::task::spawn_blocking(move || rt.get_agent(&machine)).await??;
+    let resp = if agent.is_blocking() {
+        tokio::task::spawn_blocking(move || agent.ensure_nfs_export_blocking()).await??
+    } else {
+        agent.ensure_nfs_export().await?
+    };
+    debug!(notes = ?resp.notes, "guest nfs export ensured");
+    Ok(())
 }
 
 /// Bounded wait for the `ArcBox` hosts alias the concurrent self-setup task

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -67,6 +67,11 @@ pub enum MessageType {
     /// Resolve an image's layer directories from containerd snapshot
     /// metadata (payload: `arcbox.agent.ImageFsPathsRequest`).
     ImageFsPathsRequest = 0x0012,
+    /// Bring up the read-only NFS export of the docker data mount (payload:
+    /// `arcbox.agent.EnsureNfsExportRequest`). Sent by the host daemon only
+    /// when the `~/ArcBox` mount is enabled; a `--no-mount-nfs` daemon never
+    /// sends it, so the guest runs no nfsd.
+    EnsureNfsExportRequest = 0x0013,
 
     // Sandbox CRUD request types (0x0020 - 0x0026).
     SandboxCreateRequest = 0x0020,
@@ -150,6 +155,9 @@ pub enum MessageType {
     /// Answers [`Self::ImageFsPathsRequest`] (payload:
     /// `arcbox.agent.ImageFsPathsResponse`).
     ImageFsPathsResponse = 0x1012,
+    /// Answers [`Self::EnsureNfsExportRequest`] (payload:
+    /// `arcbox.agent.EnsureNfsExportResponse`).
+    EnsureNfsExportResponse = 0x1013,
     PortBindingsChanged = 0x1030,
     PortBindingsRemoved = 0x1031,
 
@@ -213,6 +221,7 @@ impl MessageType {
             0x0010 => Some(Self::WatchStatsRequest),
             0x0011 => Some(Self::ContainerFsPathsRequest),
             0x0012 => Some(Self::ImageFsPathsRequest),
+            0x0013 => Some(Self::EnsureNfsExportRequest),
             // Sandbox CRUD requests.
             0x0020 => Some(Self::SandboxCreateRequest),
             0x0021 => Some(Self::SandboxStopRequest),
@@ -258,6 +267,7 @@ impl MessageType {
             0x1010 => Some(Self::MachineStats),
             0x1011 => Some(Self::ContainerFsPathsResponse),
             0x1012 => Some(Self::ImageFsPathsResponse),
+            0x1013 => Some(Self::EnsureNfsExportResponse),
             0x1030 => Some(Self::PortBindingsChanged),
             0x1031 => Some(Self::PortBindingsRemoved),
             // Sandbox CRUD responses.
@@ -350,10 +360,12 @@ mod tests {
             (0x0010, MessageType::WatchStatsRequest),
             (0x0011, MessageType::ContainerFsPathsRequest),
             (0x0012, MessageType::ImageFsPathsRequest),
+            (0x0013, MessageType::EnsureNfsExportRequest),
             (0x100F, MessageType::MemoryPressureEvent),
             (0x1010, MessageType::MachineStats),
             (0x1011, MessageType::ContainerFsPathsResponse),
             (0x1012, MessageType::ImageFsPathsResponse),
+            (0x1013, MessageType::EnsureNfsExportResponse),
             (0x1001, MessageType::PingResponse),
             (0x1002, MessageType::GetSystemInfoResponse),
             (0x1003, MessageType::EnsureRuntimeResponse),

--- a/guest/arcbox-agent/src/agent/linux/rpc.rs
+++ b/guest/arcbox-agent/src/agent/linux/rpc.rs
@@ -147,6 +147,7 @@ async fn handle_request(request: RpcRequest) -> RequestResult {
             RequestResult::Single(handle_container_fs_paths(req).await)
         }
         RpcRequest::ImageFsPaths(req) => RequestResult::Single(handle_image_fs_paths(req).await),
+        RpcRequest::EnsureNfsExport(_) => RequestResult::Single(handle_ensure_nfs_export().await),
         RpcRequest::KillAgent => RequestResult::Single(handle_kill_agent()),
         RpcRequest::WatchReadiness(_) => unreachable!("watch readiness is streaming"),
         RpcRequest::WatchMemoryPressure(_) => {
@@ -382,6 +383,24 @@ async fn handle_image_fs_paths(req: arcbox_protocol::agent::ImageFsPathsRequest)
         Err(e) => RpcResponse::Error(crate::rpc::ErrorResponse::new(
             libc::EIO,
             format!("image fs paths: {e}"),
+        )),
+    }
+}
+
+/// Handles an `EnsureNfsExport` request.
+///
+/// Brings up the read-only NFS export of the docker data mount so the host
+/// can browse it at `~/ArcBox`. The host daemon sends this only when the
+/// mount is enabled, so the guest runs no nfsd unless asked. Runtime startup
+/// no longer sets the export up itself, so this is the sole entry point.
+async fn handle_ensure_nfs_export() -> RpcResponse {
+    match super::runtime::ensure_nfs_export().await {
+        Ok(notes) => {
+            RpcResponse::EnsureNfsExport(arcbox_protocol::agent::EnsureNfsExportResponse { notes })
+        }
+        Err(e) => RpcResponse::Error(crate::rpc::ErrorResponse::new(
+            libc::EIO,
+            format!("ensure nfs export: {e}"),
         )),
     }
 }

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -825,12 +825,8 @@ pub(super) fn daemon_log_file(name: &str) -> Stdio {
 async fn try_start_bundled_runtime() -> String {
     let _guard = runtime_start_lock().lock().await;
 
-    // Whenever dockerd is up its data mount exists, so the NFS export can be
-    // (re)established on warm boots too — set it up before the early return.
     if probe_unix_socket(DOCKER_API_UNIX_SOCKET).await {
-        let mut notes = vec!["docker socket already ready".to_string()];
-        setup_nfs_export(&mut notes);
-        return notes.join("; ");
+        return "docker socket already ready".to_string();
     }
 
     let mut notes = Vec::new();
@@ -870,9 +866,6 @@ async fn try_start_bundled_runtime() -> String {
         Err(e) => return format!("metadata volume setup failed: {}", e),
     }
 
-    // The docker data mount now exists; export it read-only over NFS.
-    setup_nfs_export(&mut notes);
-
     ensure_shared_runtime_dirs(&mut notes);
 
     if !ensure_containerd_ready(&runtime_bin_dir, &mut notes).await {
@@ -884,15 +877,21 @@ async fn try_start_bundled_runtime() -> String {
     notes.join("; ")
 }
 
-/// Establishes the read-only NFSv3 export of the docker data mount, best-effort.
+/// Brings up the read-only NFS export of the docker data mount so the host
+/// can browse it at `~/ArcBox`.
 ///
-/// The export is an auxiliary feature (host `~/ArcBox` browsing); its failure
-/// must never block the container runtime, so errors are logged, not returned.
-fn setup_nfs_export(notes: &mut Vec<String>) {
-    match crate::nfs::ensure_docker_export() {
-        Ok(export_notes) => notes.extend(export_notes),
-        Err(e) => tracing::warn!(error = %e, "nfs export setup failed (non-fatal)"),
-    }
+/// Called on demand by the host daemon (`EnsureNfsExportRequest`), which only
+/// sends it when the mount is enabled — so a `--no-mount-nfs` daemon leaves
+/// the guest with no nfsd at all. Ensures the docker data mount exists first
+/// (idempotent), so it is safe to call at any point after the agent is up;
+/// the runtime-start lock serializes it against the startup path's own
+/// data-mount setup.
+pub(super) async fn ensure_nfs_export() -> Result<Vec<String>, String> {
+    let _guard = runtime_start_lock().lock().await;
+
+    let mut notes = vec![ensure_data_mount()?];
+    notes.extend(crate::nfs::ensure_docker_export()?);
+    Ok(notes)
 }
 
 #[cfg(test)]

--- a/guest/arcbox-agent/src/rpc.rs
+++ b/guest/arcbox-agent/src/rpc.rs
@@ -15,14 +15,15 @@ pub use arcbox_constants::wire::MessageType;
 use arcbox_protocol::Empty;
 use arcbox_protocol::agent::{
     ContainerFsPathsRequest, ContainerFsPathsResponse, DiskTrimRequest, DiskTrimResponse,
-    ImageFsPathsRequest, ImageFsPathsResponse, KubernetesDeleteRequest, KubernetesDeleteResponse,
-    KubernetesKubeconfigRequest, KubernetesKubeconfigResponse, KubernetesStartRequest,
-    KubernetesStartResponse, KubernetesStatusRequest, KubernetesStatusResponse,
-    KubernetesStopRequest, KubernetesStopResponse, MemoryPressureEvent, MmapReadFileRequest,
-    MmapReadFileResponse, PingRequest, PingResponse, PortBindingsChanged, PortBindingsRemoved,
-    ReadinessEvent, RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest,
-    RuntimeStatusResponse, ShutdownRequest, ShutdownResponse, SystemInfo,
-    WatchMemoryPressureRequest, WatchReadinessRequest, WatchStatsRequest,
+    EnsureNfsExportRequest, EnsureNfsExportResponse, ImageFsPathsRequest, ImageFsPathsResponse,
+    KubernetesDeleteRequest, KubernetesDeleteResponse, KubernetesKubeconfigRequest,
+    KubernetesKubeconfigResponse, KubernetesStartRequest, KubernetesStartResponse,
+    KubernetesStatusRequest, KubernetesStatusResponse, KubernetesStopRequest,
+    KubernetesStopResponse, MemoryPressureEvent, MmapReadFileRequest, MmapReadFileResponse,
+    PingRequest, PingResponse, PortBindingsChanged, PortBindingsRemoved, ReadinessEvent,
+    RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse,
+    ShutdownRequest, ShutdownResponse, SystemInfo, WatchMemoryPressureRequest,
+    WatchReadinessRequest, WatchStatsRequest,
 };
 
 /// Agent version string.
@@ -84,6 +85,7 @@ pub enum RpcRequest {
     DiskTrim(DiskTrimRequest),
     ContainerFsPaths(ContainerFsPathsRequest),
     ImageFsPaths(ImageFsPathsRequest),
+    EnsureNfsExport(EnsureNfsExportRequest),
     WatchReadiness(WatchReadinessRequest),
     WatchMemoryPressure(WatchMemoryPressureRequest),
     WatchStats(WatchStatsRequest),
@@ -114,6 +116,7 @@ pub enum RpcResponse {
     MmapReadFile(MmapReadFileResponse),
     ContainerFsPaths(ContainerFsPathsResponse),
     ImageFsPaths(ImageFsPathsResponse),
+    EnsureNfsExport(EnsureNfsExportResponse),
     /// Test-only: acknowledgement for [`RpcRequest::KillAgent`].
     KillAgent,
 }
@@ -142,6 +145,7 @@ impl RpcResponse {
             Self::MmapReadFile(_) => MessageType::MmapReadFileResponse,
             Self::ContainerFsPaths(_) => MessageType::ContainerFsPathsResponse,
             Self::ImageFsPaths(_) => MessageType::ImageFsPathsResponse,
+            Self::EnsureNfsExport(_) => MessageType::EnsureNfsExportResponse,
             Self::KillAgent => MessageType::KillAgentResponse,
         }
     }
@@ -169,6 +173,7 @@ impl RpcResponse {
             Self::MmapReadFile(msg) => msg.encode_to_vec(),
             Self::ContainerFsPaths(msg) => msg.encode_to_vec(),
             Self::ImageFsPaths(msg) => msg.encode_to_vec(),
+            Self::EnsureNfsExport(msg) => msg.encode_to_vec(),
             Self::KillAgent => Empty::default().encode_to_vec(),
         }
     }
@@ -348,6 +353,10 @@ pub fn parse_request(msg_type: MessageType, payload: &[u8]) -> Result<RpcRequest
         MessageType::ImageFsPathsRequest => {
             let req = ImageFsPathsRequest::decode(payload)?;
             Ok(RpcRequest::ImageFsPaths(req))
+        }
+        MessageType::EnsureNfsExportRequest => {
+            let req = EnsureNfsExportRequest::decode(payload)?;
+            Ok(RpcRequest::EnsureNfsExport(req))
         }
         MessageType::WatchReadinessRequest => {
             let req = WatchReadinessRequest::decode(payload)?;

--- a/rpc/arcbox-protocol/proto/agent.proto
+++ b/rpc/arcbox-protocol/proto/agent.proto
@@ -469,3 +469,18 @@ message ImageFsPathsResponse {
     // Read-only layer directories, top-most first.
     repeated string lower_dirs = 1;
 }
+
+// Ask the guest agent to bring up the read-only NFS export of the docker
+// data mount (browsable on the host at `~/ArcBox`). The host daemon sends
+// this only when the mount is enabled, so a daemon started with
+// `--no-mount-nfs` never sends it and the guest runs no nfsd at all. The
+// agent ensures the docker data mount exists first, so the request is safe
+// to send at any point after the agent is up.
+message EnsureNfsExportRequest {}
+
+// Response to `EnsureNfsExportRequest`.
+message EnsureNfsExportResponse {
+    // Human-readable setup notes (mounts bound, exportfs refreshed, nfsd
+    // threads started).
+    repeated string notes = 1;
+}

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -3372,6 +3372,26 @@ pub struct ImageFsPathsResponse {
     #[prost(string, repeated, tag = "1")]
     pub lower_dirs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// Ask the guest agent to bring up the read-only NFS export of the docker
+/// data mount (browsable on the host at `~/ArcBox`). The host daemon sends
+/// this only when the mount is enabled, so a daemon started with
+/// `--no-mount-nfs` never sends it and the guest runs no nfsd at all. The
+/// agent ensures the docker data mount exists first, so the request is safe
+/// to send at any point after the agent is up.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct EnsureNfsExportRequest {}
+/// Response to `EnsureNfsExportRequest`.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct EnsureNfsExportResponse {
+    /// Human-readable setup notes (mounts bound, exportfs refreshed, nfsd
+    /// threads started).
+    #[prost(string, repeated, tag = "1")]
+    pub notes: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
 /// Subscription request for machine stats.
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/rpc/arcbox-protocol/src/lib.rs
+++ b/rpc/arcbox-protocol/src/lib.rs
@@ -94,16 +94,16 @@ pub mod image {
 pub mod agent {
     pub use super::v1::{
         AgentPingRequest, AgentPingResponse, ContainerFsPathsRequest, ContainerFsPathsResponse,
-        ContainerStats, DiskTrimRequest, DiskTrimResponse, ImageFsPathsRequest,
-        ImageFsPathsResponse, KubernetesDeleteRequest, KubernetesDeleteResponse,
-        KubernetesKubeconfigRequest, KubernetesKubeconfigResponse, KubernetesStartRequest,
-        KubernetesStartResponse, KubernetesStatusRequest, KubernetesStatusResponse,
-        KubernetesStopRequest, KubernetesStopResponse, MachineStats, MemoryPressureEvent,
-        MmapReadFileRequest, MmapReadFileResponse, PortBindingsChanged, PortBindingsRemoved,
-        ReadinessEvent, RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest,
-        RuntimeStatusResponse, ServiceStatus, ShutdownRequest, ShutdownResponse, SystemInfo,
-        WatchMemoryPressureRequest, WatchReadinessRequest, WatchStatsRequest,
-        memory_pressure_event, readiness_event,
+        ContainerStats, DiskTrimRequest, DiskTrimResponse, EnsureNfsExportRequest,
+        EnsureNfsExportResponse, ImageFsPathsRequest, ImageFsPathsResponse,
+        KubernetesDeleteRequest, KubernetesDeleteResponse, KubernetesKubeconfigRequest,
+        KubernetesKubeconfigResponse, KubernetesStartRequest, KubernetesStartResponse,
+        KubernetesStatusRequest, KubernetesStatusResponse, KubernetesStopRequest,
+        KubernetesStopResponse, MachineStats, MemoryPressureEvent, MmapReadFileRequest,
+        MmapReadFileResponse, PortBindingsChanged, PortBindingsRemoved, ReadinessEvent,
+        RuntimeEnsureRequest, RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse,
+        ServiceStatus, ShutdownRequest, ShutdownResponse, SystemInfo, WatchMemoryPressureRequest,
+        WatchReadinessRequest, WatchStatsRequest, memory_pressure_event, readiness_event,
     };
 
     // Backward compatibility type aliases (short names without Agent prefix).

--- a/tests/e2e/src/boot_assets.rs
+++ b/tests/e2e/src/boot_assets.rs
@@ -268,7 +268,7 @@ fn verify_nfs_export(ctx: &TestContext) -> Result<()> {
 }
 
 /// Waits until the daemon's NFS mount is populated with docker's data root.
-fn wait_for_nfs_mount(mount_dir: &Path) -> Result<()> {
+pub fn wait_for_nfs_mount(mount_dir: &Path) -> Result<()> {
     let deadline = Instant::now() + Duration::from_secs(30);
     loop {
         if mount_dir.join("volumes").is_dir() || mount_dir.join("overlay2").is_dir() {

--- a/tests/e2e/tests/nfs_gate_probe.rs
+++ b/tests/e2e/tests/nfs_gate_probe.rs
@@ -1,0 +1,176 @@
+//! ABX-426 negative validation — NOT part of the suite. Run manually:
+//!   cargo test -p arcbox-e2e --test nfs_gate_probe -- --ignored --nocapture
+//!
+//! Proves the control inversion: a daemon started with `--no-mount-nfs` leaves
+//! the guest running **no** nfsd at all — not merely an unmounted host side.
+//! Before this change the agent brought the export up unconditionally on every
+//! boot, so `--no-mount-nfs` still left kernel nfsd, rpc.mountd, and the export
+//! bind alive in the guest.
+//!
+//! Method, on a real VZ boot: start a `--no-mount-nfs` daemon, let the runtime
+//! start fully (dockerd up ⇒ the old unconditional export site would have run),
+//! then nsenter the guest mount namespace and confirm nfsd is absent. A sanity
+//! probe (the container's own overlay mount must be present) rules out a broken
+//! grep. The positive direction — export up and readable — is covered by the
+//! `boot_assets` suite's `verify_nfs_export`.
+
+use std::env;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use tracing_subscriber::EnvFilter;
+
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+use arcbox_e2e::docker::docker_output;
+use arcbox_e2e::repo_root;
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+const DOCKER_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[test]
+#[ignore = "ABX-426 negative probe: boots a VM, needs registry access"]
+fn nfs_gate_probe() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_target(false)
+        .compact()
+        .init();
+
+    let root = repo_root();
+    let version = resolve_boot_version(&root)?;
+    let image = env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+
+    let temp = tempfile::Builder::new()
+        .prefix("arcbox-nfs-gate-")
+        .tempdir()?;
+    let test_dir = temp.path().to_owned();
+    stage_dev_boot_assets(&root, &test_dir, &version)?;
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: test_dir.clone(),
+        args: vec![
+            "--no-mount-nfs".into(),
+            "--guest-docker-vsock-port".into(),
+            "2375".into(),
+        ],
+        env: vec![
+            ("ARCBOX_BOOT_ASSET_VERSION".into(), version),
+            ("ARCBOX_DNS_PORT".into(), "5555".into()),
+        ],
+    })?;
+    daemon.wait_ready_blocking(READY_TIMEOUT)?;
+
+    let docker = |args: &[&str]| docker_output(&test_dir, args, DOCKER_TIMEOUT);
+
+    // Run a container: this drives the runtime-start path to completion, i.e.
+    // past the point where the agent used to set the export up unconditionally.
+    println!("=== pull + run a container (drive runtime start to completion) ===");
+    let mut pulled = false;
+    for attempt in 1..=3 {
+        match docker(&["pull", &image]) {
+            Ok(_) => {
+                println!("pulled {image} (attempt {attempt})");
+                pulled = true;
+                break;
+            }
+            Err(e) => println!("pull attempt {attempt} failed: {e:#}"),
+        }
+    }
+    if !pulled {
+        bail!("registry unreachable from guest; the probe needs a running container");
+    }
+    docker(&["run", "-d", "--name", "gate-live", &image, "sleep", "120"])?;
+
+    // ---- inspect the guest: nfsd must be entirely absent ----
+    println!("=== guest state (nsenter mount ns) ===");
+    let script = r#"B=/bin/busybox
+echo "NFSD_THREADS=$($B cat /proc/fs/nfsd/threads 2>/dev/null || echo MISSING)"
+echo "MOUNTD=$($B pidof rpc.mountd 2>/dev/null || echo NONE)"
+echo "EXPORT_BINDS=$($B grep -c 'arcbox/nfs-export' /proc/mounts 2>/dev/null || echo 0)"
+echo "NFSD_PSEUDOFS=$($B grep -c ' nfsd ' /proc/mounts 2>/dev/null || echo 0)"
+echo "SANITY_OVERLAY=$($B grep -c 'overlay' /proc/mounts 2>/dev/null || echo 0)"
+"#;
+    let out = docker(&[
+        "run",
+        "--rm",
+        "--privileged",
+        "--pid=host",
+        &image,
+        "nsenter",
+        "-t",
+        "1",
+        "-m",
+        "--",
+        "/bin/busybox",
+        "sh",
+        "-c",
+        script,
+    ])
+    .context("nsenter guest state probe")?;
+    println!("{out}");
+
+    let field = |key: &str| -> String {
+        out.lines()
+            .find_map(|l| l.strip_prefix(&format!("{key}=")))
+            .unwrap_or("")
+            .trim()
+            .to_string()
+    };
+
+    let nfsd_threads = field("NFSD_THREADS");
+    let mountd = field("MOUNTD");
+    let export_binds = field("EXPORT_BINDS");
+    let nfsd_pseudofs = field("NFSD_PSEUDOFS");
+    let sanity_overlay = field("SANITY_OVERLAY");
+
+    // Positive control: the grep pipeline works and we are in the right ns.
+    if sanity_overlay.parse::<u32>().unwrap_or(0) == 0 {
+        bail!(
+            "sanity control failed: no overlay mount seen in the guest — the probe is not \
+             reading the guest mount namespace, so the nfsd-absence assertions are meaningless"
+        );
+    }
+
+    // The assertions: nothing nfsd may exist.
+    let mut failures = Vec::new();
+    if !(nfsd_threads == "MISSING" || nfsd_threads == "0") {
+        failures.push(format!("nfsd has running threads: {nfsd_threads}"));
+    }
+    if mountd != "NONE" {
+        failures.push(format!("rpc.mountd is running (pid {mountd})"));
+    }
+    if export_binds != "0" {
+        failures.push(format!("export bind mount present ({export_binds})"));
+    }
+    if nfsd_pseudofs != "0" {
+        failures.push(format!("nfsd pseudo-fs is mounted ({nfsd_pseudofs})"));
+    }
+    if !failures.is_empty() {
+        bail!(
+            "--no-mount-nfs still left nfsd running in the guest: {}",
+            failures.join("; ")
+        );
+    }
+    println!(
+        "OK: guest has no nfsd under --no-mount-nfs \
+         (threads={nfsd_threads}, mountd={mountd}, export_binds={export_binds}, \
+         nfsd_pseudofs={nfsd_pseudofs}; overlay sanity={sanity_overlay})"
+    );
+
+    // Host side: the isolated mount dir must be empty / absent.
+    let arcbox = test_dir.join("ArcBox");
+    let populated = arcbox.join("volumes").is_dir() || arcbox.join("overlay2").is_dir();
+    if populated {
+        bail!("host ~/ArcBox unexpectedly populated under --no-mount-nfs");
+    }
+    println!("OK: host {} is not a populated NFS mount", arcbox.display());
+
+    println!("=== cleanup ===");
+    let _ = docker(&["rm", "-f", "gate-live"]);
+    daemon.shutdown()?;
+    Ok(())
+}

--- a/tests/e2e/tests/nfs_gate_probe.rs
+++ b/tests/e2e/tests/nfs_gate_probe.rs
@@ -60,6 +60,14 @@ fn nfs_gate_probe() -> Result<()> {
         env: vec![
             ("ARCBOX_BOOT_ASSET_VERSION".into(), version),
             ("ARCBOX_DNS_PORT".into(), "5555".into()),
+            // Isolate the host mount off the developer's real ~/ArcBox — both so
+            // this probe never touches it and so the host-side assertion below
+            // actually catches a daemon that ignored --no-mount-nfs (it would
+            // populate this dir instead of silently mounting elsewhere).
+            (
+                "ARCBOX_HOST_MOUNT_DIR".into(),
+                test_dir.join("ArcBox").to_string_lossy().into_owned(),
+            ),
         ],
     })?;
     daemon.wait_ready_blocking(READY_TIMEOUT)?;

--- a/tests/e2e/tests/nfs_gate_probe.rs
+++ b/tests/e2e/tests/nfs_gate_probe.rs
@@ -60,14 +60,6 @@ fn nfs_gate_probe() -> Result<()> {
         env: vec![
             ("ARCBOX_BOOT_ASSET_VERSION".into(), version),
             ("ARCBOX_DNS_PORT".into(), "5555".into()),
-            // Isolate the host mount off the developer's real ~/ArcBox — both so
-            // this probe never touches it and so the host-side assertion below
-            // actually catches a daemon that ignored --no-mount-nfs (it would
-            // populate this dir instead of silently mounting elsewhere).
-            (
-                "ARCBOX_HOST_MOUNT_DIR".into(),
-                test_dir.join("ArcBox").to_string_lossy().into_owned(),
-            ),
         ],
     })?;
     daemon.wait_ready_blocking(READY_TIMEOUT)?;
@@ -169,7 +161,9 @@ echo "SANITY_OVERLAY=$($B grep -c 'overlay' /proc/mounts 2>/dev/null || echo 0)"
          nfsd_pseudofs={nfsd_pseudofs}; overlay sanity={sanity_overlay})"
     );
 
-    // Host side: the isolated mount dir must be empty / absent.
+    // Host side: DaemonHandle::spawn points ARCBOX_HOST_MOUNT_DIR at
+    // <data_dir>/ArcBox, so a daemon that ignored --no-mount-nfs would populate
+    // this isolated dir (never the developer's real ~/ArcBox). It must stay empty.
     let arcbox = test_dir.join("ArcBox");
     let populated = arcbox.join("volumes").is_dir() || arcbox.join("overlay2").is_dir();
     if populated {

--- a/tests/e2e/tests/nfs_restart_probe.rs
+++ b/tests/e2e/tests/nfs_restart_probe.rs
@@ -1,0 +1,234 @@
+//! ABX-426 restart validation — NOT part of the suite. Run manually:
+//!   cargo test -p arcbox-e2e --test nfs_restart_probe -- --ignored --nocapture
+//!
+//! The guest no longer starts nfsd on its own, so the export has to be rebuilt
+//! for every VM incarnation. This drives the motivating case end to end — a
+//! System VM backend switch, i.e. `shutdown` → `set_backend` → `ensure_ready`
+//! — and asserts `~/ArcBox` serves the *new* guest afterwards.
+//!
+//! The host-side assertion deliberately reads a path that did not exist when
+//! the first mount was made (a container directory created after the switch),
+//! so neither the page cache nor a stale mount left over from the dead guest
+//! can satisfy it. The guest-side check then names the mechanism directly:
+//! kernel nfsd is running again in the new guest.
+//!
+//! Sibling probes: `nfs_gate_probe` covers the negative direction
+//! (`--no-mount-nfs` ⇒ no guest nfsd at all); `boot_assets` covers the first
+//! incarnation's export. The arrival-vs-departure edge semantics this relies
+//! on are unit-tested in `arcbox-daemon`'s `nfs_mount` tests.
+
+use std::env;
+use std::path::Path;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use arcbox_grpc::v1::system_service_client::SystemServiceClient;
+use arcbox_protocol::v1::{SetSystemVmBackendRequest, SystemVmBackend};
+use tonic::Request;
+use tracing_subscriber::EnvFilter;
+
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets, wait_for_nfs_mount};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle, connect_unix};
+use arcbox_e2e::docker::docker_output;
+use arcbox_e2e::repo_root;
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+const DOCKER_TIMEOUT: Duration = Duration::from_secs(120);
+/// The re-established mount has to clear a VM boot plus the export request.
+const REMOUNT_TIMEOUT: Duration = Duration::from_secs(180);
+
+#[test]
+#[ignore = "ABX-426 restart probe: boots a VM on both backends, needs registry access"]
+fn nfs_restart_probe() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_target(false)
+        .compact()
+        .init();
+
+    let root = repo_root();
+    let version = resolve_boot_version(&root)?;
+    let image = env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+
+    let temp = tempfile::Builder::new()
+        .prefix("arcbox-nfs-restart-")
+        .tempdir()?;
+    let test_dir = temp.path().to_owned();
+
+    // Keep the data dir (daemon log, guest logs) when something fails — the
+    // probe spans two VM incarnations, so a post-mortem needs the timeline.
+    let result = run_probe(&root, &test_dir, &version, &image);
+    if result.is_err() {
+        let kept = temp.keep();
+        eprintln!("preserving test directory path={}", kept.display());
+    }
+    result
+}
+
+fn run_probe(root: &Path, test_dir: &Path, version: &str, image: &str) -> Result<()> {
+    let test_dir = test_dir.to_owned();
+    let image = image.to_owned();
+    stage_dev_boot_assets(root, &test_dir, version)?;
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: test_dir.clone(),
+        args: vec!["--guest-docker-vsock-port".into(), "2375".into()],
+        env: vec![
+            ("ARCBOX_BOOT_ASSET_VERSION".into(), version.to_owned()),
+            ("ARCBOX_DNS_PORT".into(), "5556".into()),
+            ("ARCBOX_VM_BACKEND".into(), "vz".into()),
+        ],
+    })?;
+    daemon.wait_ready_blocking(READY_TIMEOUT)?;
+
+    let docker = |args: &[&str]| docker_output(&test_dir, args, DOCKER_TIMEOUT);
+    let mount_dir = test_dir.join("ArcBox");
+
+    println!("=== incarnation 1 (vz): export established ===");
+    wait_for_nfs_mount(&mount_dir)?;
+    println!("OK: {} is populated", mount_dir.display());
+
+    // Pull now so the post-switch steps do not depend on the registry — the
+    // guest is about to be replaced and a slow pull would muddy the timings.
+    let mut pulled = false;
+    for attempt in 1..=3 {
+        match docker(&["pull", &image]) {
+            Ok(_) => {
+                println!("pulled {image} (attempt {attempt})");
+                pulled = true;
+                break;
+            }
+            Err(e) => println!("pull attempt {attempt} failed: {e:#}"),
+        }
+    }
+    if !pulled {
+        bail!("registry unreachable from guest; the probe needs to run containers");
+    }
+    assert_guest_nfsd(&docker, &image, "before the switch")?;
+
+    // The restart. `SetSystemVmBackend` is `shutdown` → `set_backend` →
+    // `ensure_ready`: the export dies with the old guest, and only a fresh
+    // request rebuilds it on the new one.
+    println!("=== switching System VM backend vz -> hv (restarts the VM) ===");
+    switch_backend(&daemon, SystemVmBackend::Hv)?;
+    println!("backend switch returned");
+
+    println!("=== incarnation 2 (hv): export must be back ===");
+    // Cache-immune host assertion: this container's data directory is created
+    // by the *new* guest, so it cannot be served from the page cache or from
+    // the stale mount that pointed at the dead one.
+    docker(&["run", "-d", "--name", "post-switch", &image, "sleep", "300"])
+        .context("running a container on the restarted VM")?;
+    let id = docker(&["inspect", "--format", "{{.Id}}", "post-switch"])?
+        .trim()
+        .to_owned();
+    if id.is_empty() {
+        bail!("could not read the post-switch container id");
+    }
+    wait_for_path(&mount_dir.join("containers").join(&id), REMOUNT_TIMEOUT).with_context(|| {
+        format!("container {id} created after the restart never appeared under the host mount")
+    })?;
+    println!(
+        "OK: post-restart container data is readable through {}",
+        mount_dir.display()
+    );
+
+    // And the mechanism itself: the new guest is running kernel nfsd because
+    // the daemon asked it to, not because the agent starts one on its own.
+    assert_guest_nfsd(&docker, &image, "after the switch")?;
+
+    println!("=== cleanup ===");
+    let _ = docker(&["rm", "-f", "post-switch"]);
+    daemon.shutdown()?;
+    Ok(())
+}
+
+/// Sends `SetSystemVmBackend`, which restarts the System VM.
+fn switch_backend(daemon: &DaemonHandle, backend: SystemVmBackend) -> Result<()> {
+    let socket = daemon.grpc_socket();
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
+        .block_on(async move {
+            let channel = connect_unix(&socket).await?;
+            SystemServiceClient::new(channel)
+                .set_system_vm_backend(Request::new(SetSystemVmBackendRequest {
+                    backend: backend as i32,
+                }))
+                .await
+                .context("SetSystemVmBackend")?;
+            Ok(())
+        })
+}
+
+/// Asserts kernel nfsd is running in the guest, read from the guest's own
+/// mount namespace. A `SANITY_OVERLAY` positive control rules out a probe that
+/// is looking at the wrong namespace and reporting absence for the wrong reason.
+fn assert_guest_nfsd(
+    docker: &impl Fn(&[&str]) -> Result<String>,
+    image: &str,
+    when: &str,
+) -> Result<()> {
+    let script = r#"B=/bin/busybox
+echo "NFSD_THREADS=$($B cat /proc/fs/nfsd/threads 2>/dev/null || echo MISSING)"
+echo "EXPORT_BINDS=$($B grep -c 'arcbox/nfs-export' /proc/mounts 2>/dev/null || echo 0)"
+echo "SANITY_OVERLAY=$($B grep -c 'overlay' /proc/mounts 2>/dev/null || echo 0)"
+"#;
+    let out = docker(&[
+        "run",
+        "--rm",
+        "--privileged",
+        "--pid=host",
+        image,
+        "nsenter",
+        "-t",
+        "1",
+        "-m",
+        "--",
+        "/bin/busybox",
+        "sh",
+        "-c",
+        script,
+    ])
+    .with_context(|| format!("nsenter guest nfsd probe {when}"))?;
+    println!("{out}");
+
+    let field = |key: &str| -> String {
+        out.lines()
+            .find_map(|l| l.strip_prefix(&format!("{key}=")))
+            .unwrap_or("")
+            .trim()
+            .to_string()
+    };
+
+    if field("SANITY_OVERLAY").parse::<u32>().unwrap_or(0) == 0 {
+        bail!("sanity control failed {when}: no overlay mount in the guest mount namespace");
+    }
+    let threads = field("NFSD_THREADS");
+    if threads.is_empty() || threads == "MISSING" || threads.starts_with('0') {
+        bail!("guest has no nfsd threads {when} (threads={threads:?})");
+    }
+    if field("EXPORT_BINDS") == "0" {
+        bail!("guest has no export bind mount {when}");
+    }
+    println!("OK: guest nfsd is running {when} (threads={threads})");
+    Ok(())
+}
+
+/// Polls until `path` exists, or the deadline passes.
+fn wait_for_path(path: &Path, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            bail!("{} did not appear within {timeout:?}", path.display());
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+}


### PR DESCRIPTION
## Summary

The guest agent brought up the read-only NFS export (`~/ArcBox`) on **every**
boot, from the runtime-start path. The daemon's `--no-mount-nfs` flag only
suppressed the *host* mount — so a daemon that opted out still left kernel
nfsd, `rpc.mountd`, and the export bind running inside the guest.

This inverts the control so the export is host-driven:

- New `EnsureNfsExport` agent RPC (`0x0013`/`0x1013`). The daemon's
  `nfs_mount::reconcile` sends it before mounting; the agent no longer sets the
  export up on its own.
- `--no-mount-nfs` now means **no guest nfsd at all** — `reconcile` returns
  early when the mount is disabled, so the request is never sent and the guest
  starts no nfsd, no `rpc.mountd`, no export bind.

## Design notes

- **Timing.** The handler takes the runtime-start lock and calls the idempotent
  `ensure_data_mount()` before exporting, so the request is safe to send at any
  point after the agent is up — it converges whether or not dockerd has mounted
  the data volume yet, and never races the startup path's own mount setup.
- **Best-effort delivery.** The guest handler runs to completion even if the
  daemon's RPC read times out (e.g. it is still waiting on dockerd's data
  mount); `mount_with_retry` remains the readiness signal, so a slow guest
  still ends up mounted.
- **Backend transport.** `ensure_guest_export` mirrors `sync_guest_clock`:
  `connect_agent` runs on a blocking task, then dispatches the blocking vs async
  RPC on `AgentClient::is_blocking()` (HV socketpair vs VZ vsock).

## Validation

- Unit: `arcbox-constants` wire roundtrip (new `EnsureNfsExport` case),
  `arcbox-protocol`, `arcbox-agent`, `arcbox-daemon nfs_mount` — all green.
  clippy/fmt clean (guest built for `aarch64-unknown-linux-musl`).
- **Positive (regression), VZ hardware:** `boot_assets` e2e — export still comes
  up and `~/ArcBox` reads through, now driven by the RPC rather than the
  runtime-start path. Full Docker lifecycle unaffected.
- **Negative (new behavior), VZ hardware:** `nfs_gate_probe` (this PR, one-off)
  boots a `--no-mount-nfs` daemon, runs a container to drive runtime start to
  completion, then nsenters the guest and confirms nfsd is entirely absent
  (no threads, no `rpc.mountd`, no export bind, no nfsd pseudo-fs) while a
  positive control (the container's overlay mount) confirms the probe reads the
  right namespace.

Closes ABX-426.
