### PR TITLE
chore(assets): bump boot assets to 0.6.13 (fuse spin-wait, CORE-48)

### DIFF
--- a/assets.lock
+++ b/assets.lock
@@ -14,9 +14,9 @@
 # and the [boot] bump.
 
 [boot]
-version = "0.6.12"
+version = "0.6.13"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "3510917efe70a664d49029216c0149bf01aa09a7757defb96175e9b1546d0466"
+manifest_sha256 = "7bff7252fa38a74fd1a513baffeceb80eaddb556b11eec55438503ac7e9ec6c0"
 
 [[tools]]
 name = "docker"


### PR DESCRIPTION
Bundle **v0.6.13** ships kernel **v0.0.22** with the FUSE bounded spin-wait ([kernel#17](https://github.com/arcboxlabs/kernel/pull/17)) — the CORE-48 fix for VirtioFS metadata round-trip cost.

## What users get

Bind-mounted host volumes (`docker run -v`) — stat/lookup storms on source trees, node_modules, etc:

| bench (VirtioFS share) | 0.6.12 | 0.6.13 | Δ |
|---|---|---|---|
| metadata_stat | 32.1k ops/s | **52.8k** | **+64%** |
| negative_lookup | 23.9k | **34.3k** | +44% |
| create_delete | 4.9k | **6.0k** | +22% |
| find_recursive | 18.3k | **21.6k** | +18% |
| rm_rf | 2505 ms | **2380 ms** | −5% |
| sequential_read | 3771 MB/s | 3720 MB/s | ±0 |

The spin is double-gated (virtio-class transports only; blocking opcodes excluded) after kernel#17's review round — full investigation record in Linear **CORE-48**.

## Validation

- `boot_assets` e2e green on the new bundle (full Docker lifecycle, 116s; CDN download path exercised).
- Per-file hashes verified against the published manifest before staging.
- Daemon rebuilt with the embedded pin (compile-time `assets.lock`).