### PR TITLE
feat(daemon): show ~/ArcBox files as owned by the browsing user (ABX-427)

### DIFF
--- a/app/arcbox-daemon/src/nfs_mount.rs
+++ b/app/arcbox-daemon/src/nfs_mount.rs
@@ -472,8 +472,17 @@ fn mount_source_for(alias_installed: bool) -> String {
 ///   of hanging Finder forever (macOS rejects `soft` with `vers=4`).
 /// - `rdirplus`: fetch attributes with directory entries — fewer round trips.
 /// - `actimeo=10`: modest attribute cache for a browse mount.
+/// - `noowners`: display-only owner mapping (ABX-427). The guest's uids are
+///   meaningless on the host, so the export otherwise lists as `root` and bare
+///   numbers. This is `MNT_IGNORE_OWNERSHIP` — Finder's "Ignore ownership on
+///   this volume" — under which every object reports uid 99, which the VFS
+///   renders as the *current* user. Presentational only, and safe precisely
+///   because it is: the server stays the sole authority (`ro` export,
+///   `all_squash,anonuid=0`, so it already evaluates ACCESS as root), and the
+///   mount is `ro` besides. The local check it drops was only ever able to
+///   refuse reads the server would have granted.
 fn render_mount_opts(nfsd_port: u16) -> String {
-    format!("ro,vers=4,rdirplus,actimeo=10,deadtimeout=60,port={nfsd_port}")
+    format!("ro,noowners,vers=4,rdirplus,actimeo=10,deadtimeout=60,port={nfsd_port}")
 }
 
 /// Host mount point: `$ARCBOX_HOST_MOUNT_DIR` when set (so a test daemon stays
@@ -629,6 +638,8 @@ mod tests {
         assert!(opts.contains("port=51000"));
         // Must never request write access to a read-only export.
         assert!(!opts.contains("rw"));
+        // Guest uids mean nothing on the host; show the browsing user instead.
+        assert!(opts.contains("noowners"));
     }
 
     #[test]

--- a/tests/e2e/src/boot_assets.rs
+++ b/tests/e2e/src/boot_assets.rs
@@ -287,7 +287,7 @@ pub fn wait_for_nfs_mount(mount_dir: &Path) -> Result<()> {
 
 /// Reads `path`, retrying briefly while the just-written file propagates
 /// through the NFS attribute cache.
-fn read_file_with_retry(path: &Path, timeout: Duration) -> Result<String> {
+pub fn read_file_with_retry(path: &Path, timeout: Duration) -> Result<String> {
     let deadline = Instant::now() + timeout;
     loop {
         match fs::read_to_string(path) {

--- a/tests/e2e/tests/nfs_gate_probe.rs
+++ b/tests/e2e/tests/nfs_gate_probe.rs
@@ -57,10 +57,7 @@ fn nfs_gate_probe() -> Result<()> {
             "--guest-docker-vsock-port".into(),
             "2375".into(),
         ],
-        env: vec![
-            ("ARCBOX_BOOT_ASSET_VERSION".into(), version),
-            ("ARCBOX_DNS_PORT".into(), "5555".into()),
-        ],
+        env: vec![("ARCBOX_BOOT_ASSET_VERSION".into(), version)],
     })?;
     daemon.wait_ready_blocking(READY_TIMEOUT)?;
 

--- a/tests/e2e/tests/nfs_owner_probe.rs
+++ b/tests/e2e/tests/nfs_owner_probe.rs
@@ -1,0 +1,142 @@
+//! ABX-427 ownership display — NOT part of the suite. Run manually:
+//!   cargo test -p arcbox-e2e --test nfs_owner_probe -- --ignored --nocapture
+//!
+//! The guest's uids mean nothing on the host, so `~/ArcBox` used to list as
+//! `root` and bare numbers. The mount now carries `noowners`
+//! (`MNT_IGNORE_OWNERSHIP`), under which every object reports uid 99 and the
+//! VFS renders that as the current user.
+//!
+//! Asserting "uid 99" would test the constant, not the behaviour, so the
+//! comparison is against a file this process created in the same run: the
+//! export must report the same owner as something we own. That is exactly the
+//! property a user checks in Finder, and it holds whoever runs the test.
+//!
+//! Access was never the problem — the export is `all_squash,anonuid=0`, so the
+//! server evaluates ACCESS as root and root-0600 files already read fine
+//! (probed 2026-07-16). This probe therefore also reads a file through the
+//! mount, to catch a regression where the display fix broke reads.
+
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use tracing_subscriber::EnvFilter;
+
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets, wait_for_nfs_mount};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+use arcbox_e2e::repo_root;
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+
+#[test]
+#[ignore = "ABX-427 ownership probe: boots a VM"]
+fn nfs_owner_probe() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_target(false)
+        .compact()
+        .init();
+
+    let root = repo_root();
+    let version = resolve_boot_version(&root)?;
+
+    let temp = tempfile::Builder::new()
+        .prefix("arcbox-nfs-owner-")
+        .tempdir()?;
+    let test_dir = temp.path().to_owned();
+
+    let result = run_probe(&root, &test_dir, &version);
+    if result.is_err() {
+        let kept = temp.keep();
+        eprintln!("preserving test directory path={}", kept.display());
+    }
+    result
+}
+
+fn run_probe(root: &Path, test_dir: &Path, version: &str) -> Result<()> {
+    stage_dev_boot_assets(root, test_dir, version)?;
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: test_dir.to_owned(),
+        args: vec!["--guest-docker-vsock-port".into(), "2375".into()],
+        env: vec![
+            ("ARCBOX_BOOT_ASSET_VERSION".into(), version.to_owned()),
+            ("ARCBOX_DNS_PORT".into(), "5557".into()),
+        ],
+    })?;
+    daemon.wait_ready_blocking(READY_TIMEOUT)?;
+
+    let mount_dir = test_dir.join("ArcBox");
+    wait_for_nfs_mount(&mount_dir)?;
+
+    // The reference: a directory this process created, on local disk.
+    let expected_uid = fs::metadata(test_dir)
+        .context("stat of the test dir")?
+        .uid();
+    println!("browsing user uid={expected_uid}");
+
+    let mut checked = Vec::new();
+    let mut wrong = Vec::new();
+
+    let mut record = |label: String, path: &Path| -> Result<()> {
+        let meta = fs::symlink_metadata(path).with_context(|| format!("stat of {label}"))?;
+        let (uid, gid) = (meta.uid(), meta.gid());
+        println!("{label}: uid={uid} gid={gid}");
+        if uid == expected_uid {
+            checked.push(label);
+        } else {
+            wrong.push(format!("{label} reports uid {uid}"));
+        }
+        Ok(())
+    };
+
+    record("mount root".to_string(), &mount_dir)?;
+
+    // Guest-owned entries: dockerd writes these as root, which is precisely
+    // what used to surface. Cover a few rather than trusting one.
+    let entries: Vec<_> = fs::read_dir(&mount_dir)
+        .with_context(|| format!("reading {}", mount_dir.display()))?
+        .filter_map(Result::ok)
+        .take(5)
+        .collect();
+    if entries.is_empty() {
+        bail!("export listed no entries; the probe has nothing to check");
+    }
+    for entry in &entries {
+        record(
+            format!("entry {}", entry.file_name().to_string_lossy()),
+            &entry.path(),
+        )?;
+    }
+
+    if !wrong.is_empty() {
+        bail!(
+            "~/ArcBox still reports guest ownership ({}); expected uid {expected_uid} everywhere",
+            wrong.join("; ")
+        );
+    }
+    println!(
+        "OK: all {} checked paths report the browsing user (uid {expected_uid})",
+        checked.len()
+    );
+
+    // The display fix must not have cost us read access.
+    let engine_id = mount_dir.join("engine-id");
+    if engine_id.is_file() {
+        let content = fs::read_to_string(&engine_id).context("reading engine-id through NFS")?;
+        if content.trim().is_empty() {
+            bail!("engine-id read through the mount was empty");
+        }
+        println!("OK: engine-id still readable through the mount");
+    } else {
+        println!("note: engine-id absent; skipped the read-through check");
+    }
+
+    daemon.shutdown()?;
+    Ok(())
+}

--- a/tests/e2e/tests/nfs_owner_probe.rs
+++ b/tests/e2e/tests/nfs_owner_probe.rs
@@ -130,26 +130,36 @@ fn run_probe(root: &Path, test_dir: &Path, version: &str) -> Result<()> {
     // ready and the export is populated, so a file that will not read is a
     // failure, not an absence. The retry covers the `actimeo=10` attribute
     // cache a freshly mounted export sits behind.
-    read_through_check(&mount_dir, &entries)?;
+    read_through_check(&mount_dir)?;
 
     daemon.shutdown()?;
     Ok(())
 }
 
 /// Reads a real guest file through the mount, preferring dockerd's `engine-id`
-/// and falling back to any regular file at the export root.
-fn read_through_check(mount_dir: &Path, entries: &[fs::DirEntry]) -> Result<()> {
+/// and otherwise scanning the export root for the first regular file.
+///
+/// The scan is this function's own `read_dir`, not the uid loop's sample: that
+/// one is an arbitrary five entries, and dockerd's data root is nearly all
+/// directories at the top level, so a sample can legitimately contain no
+/// regular file at all. Absence of a candidate and failure to read one are
+/// reported as the different things they are.
+fn read_through_check(mount_dir: &Path) -> Result<()> {
     const READ_RETRY: Duration = Duration::from_secs(20);
 
+    // `symlink_metadata`, so a symlink is not mistaken for its target.
+    let is_regular_file = |path: &Path| fs::symlink_metadata(path).is_ok_and(|meta| meta.is_file());
+
     let engine_id = mount_dir.join("engine-id");
-    let candidates = std::iter::once(engine_id).chain(entries.iter().filter_map(|entry| {
-        let path = entry.path();
-        // `symlink_metadata`, so a symlink is not mistaken for its target.
-        fs::symlink_metadata(&path)
-            .ok()
-            .filter(std::fs::Metadata::is_file)
-            .map(|_| path)
-    }));
+    let candidates = std::iter::once(engine_id)
+        .filter(|path| is_regular_file(path))
+        .chain(
+            fs::read_dir(mount_dir)
+                .with_context(|| format!("scanning {} for a file", mount_dir.display()))?
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .filter(|path| is_regular_file(path)),
+        );
 
     let mut attempts = Vec::new();
     for path in candidates {
@@ -163,12 +173,14 @@ fn read_through_check(mount_dir: &Path, entries: &[fs::DirEntry]) -> Result<()> 
         }
     }
 
+    if attempts.is_empty() {
+        bail!(
+            "the export root {} holds no regular file, so the read-through check had no candidate",
+            mount_dir.display()
+        );
+    }
     bail!(
-        "no file could be read through the mount, so the read-through check never ran ({})",
-        if attempts.is_empty() {
-            "no regular file at the export root".to_owned()
-        } else {
-            attempts.join("; ")
-        }
+        "no file could be read through the mount: {}",
+        attempts.join("; ")
     )
 }

--- a/tests/e2e/tests/nfs_owner_probe.rs
+++ b/tests/e2e/tests/nfs_owner_probe.rs
@@ -24,7 +24,9 @@ use std::time::Duration;
 use anyhow::{Context, Result, bail};
 use tracing_subscriber::EnvFilter;
 
-use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets, wait_for_nfs_mount};
+use arcbox_e2e::boot_assets::{
+    read_file_with_retry, resolve_boot_version, stage_dev_boot_assets, wait_for_nfs_mount,
+};
 use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
 use arcbox_e2e::repo_root;
 
@@ -64,10 +66,7 @@ fn run_probe(root: &Path, test_dir: &Path, version: &str) -> Result<()> {
         binary: root.join("target/release/arcbox-daemon"),
         data_dir: test_dir.to_owned(),
         args: vec!["--guest-docker-vsock-port".into(), "2375".into()],
-        env: vec![
-            ("ARCBOX_BOOT_ASSET_VERSION".into(), version.to_owned()),
-            ("ARCBOX_DNS_PORT".into(), "5557".into()),
-        ],
+        env: vec![("ARCBOX_BOOT_ASSET_VERSION".into(), version.to_owned())],
     })?;
     daemon.wait_ready_blocking(READY_TIMEOUT)?;
 
@@ -125,18 +124,51 @@ fn run_probe(root: &Path, test_dir: &Path, version: &str) -> Result<()> {
         checked.len()
     );
 
-    // The display fix must not have cost us read access.
-    let engine_id = mount_dir.join("engine-id");
-    if engine_id.is_file() {
-        let content = fs::read_to_string(&engine_id).context("reading engine-id through NFS")?;
-        if content.trim().is_empty() {
-            bail!("engine-id read through the mount was empty");
-        }
-        println!("OK: engine-id still readable through the mount");
-    } else {
-        println!("note: engine-id absent; skipped the read-through check");
-    }
+    // The display fix must not have cost us read access. This is the only
+    // check here that reads *content* — the loop above exercises getattr and
+    // readdir only — so it must never degrade into a skip: the daemon is
+    // ready and the export is populated, so a file that will not read is a
+    // failure, not an absence. The retry covers the `actimeo=10` attribute
+    // cache a freshly mounted export sits behind.
+    read_through_check(&mount_dir, &entries)?;
 
     daemon.shutdown()?;
     Ok(())
+}
+
+/// Reads a real guest file through the mount, preferring dockerd's `engine-id`
+/// and falling back to any regular file at the export root.
+fn read_through_check(mount_dir: &Path, entries: &[fs::DirEntry]) -> Result<()> {
+    const READ_RETRY: Duration = Duration::from_secs(20);
+
+    let engine_id = mount_dir.join("engine-id");
+    let candidates = std::iter::once(engine_id).chain(entries.iter().filter_map(|entry| {
+        let path = entry.path();
+        // `symlink_metadata`, so a symlink is not mistaken for its target.
+        fs::symlink_metadata(&path)
+            .ok()
+            .filter(std::fs::Metadata::is_file)
+            .map(|_| path)
+    }));
+
+    let mut attempts = Vec::new();
+    for path in candidates {
+        match read_file_with_retry(&path, READ_RETRY) {
+            Ok(content) if !content.trim().is_empty() => {
+                println!("OK: {} still readable through the mount", path.display());
+                return Ok(());
+            }
+            Ok(_) => attempts.push(format!("{} read empty", path.display())),
+            Err(e) => attempts.push(format!("{} failed: {e:#}", path.display())),
+        }
+    }
+
+    bail!(
+        "no file could be read through the mount, so the read-through check never ran ({})",
+        if attempts.is_empty() {
+            "no regular file at the export root".to_owned()
+        } else {
+            attempts.join("; ")
+        }
+    )
 }

--- a/tests/e2e/tests/nfs_restart_probe.rs
+++ b/tests/e2e/tests/nfs_restart_probe.rs
@@ -79,7 +79,6 @@ fn run_probe(root: &Path, test_dir: &Path, version: &str, image: &str) -> Result
         args: vec!["--guest-docker-vsock-port".into(), "2375".into()],
         env: vec![
             ("ARCBOX_BOOT_ASSET_VERSION".into(), version.to_owned()),
-            ("ARCBOX_DNS_PORT".into(), "5556".into()),
             ("ARCBOX_VM_BACKEND".into(), "vz".into()),
         ],
     })?;


### PR DESCRIPTION
Closes ABX-427.

## What

One mount option: `noowners`.

`~/ArcBox` listed as `root` and bare numeric guest uids, which reads oddly next to OrbStack where everything appears owned by the Mac user. **Access was never the problem** — the export is `all_squash,anonuid=0`, so the server evaluates ACCESS as root and root-`0600` files already read fine (probed 2026-07-16). This was always display-only.

macOS ships the mechanism: `noowners` sets `MNT_IGNORE_OWNERSHIP` — the same flag as Finder's "Ignore ownership on this volume" — under which every object reports uid 99, which the VFS renders as the current user. Host-side, nothing in the guest, nothing in the kernel.

## Why not the two mechanisms the issue proposed

| | Cost |
|---|---|
| NFSv4 idmapping | `nfsidmap`/idmapd into the guest rootfs (cross-repo boot-assets change) **plus** the host's `vfs.generic.nfs.client.default_nfs4domain` sysctl — host-global, reshaping every NFSv4 mount on the user's machine |
| nfsd GETATTR squash | a kernel patch carried forever in arcbox-kernel |

Neither buys anything extra: we are the only client of this export. `noowners` also survives whatever ABX-424 does to the export layout, since it is a property of our mount rather than of the served attributes.

## Safety

Presentational by construction. The server remains the sole authority (`ro` export, `all_squash`) and the mount is `ro` besides, so the local ownership check this drops could only ever have *refused* reads the server would have granted — it cannot grant anything new. The desktop Files tabs read no ownership, so nothing downstream changes.

## Validation

New `tests/e2e/tests/nfs_owner_probe.rs`, run A/B against the same live export on hardware:

| | mount root + 5 guest entries | `engine-id` read-through |
|---|---|---|
| **with** `noowners` | `uid=501 gid=20` (the browsing user's own ids) | OK |
| **without** (control) | `uid=0 gid=0` throughout | — |

The control run makes the probe a real regression test rather than one that passes either way. It compares against a file the test itself created instead of asserting the literal uid 99, so it tests the behaviour and holds whoever runs it.

Also green: `cargo test -p arcbox-daemon nfs_mount` (7/7), clippy `-D warnings`, fmt.