### PR TITLE
docs: settled VirtioFS performance record (fs-perf-limits, CORE-48)

### DIFF
--- a/docs/fs-perf-limits.md
+++ b/docs/fs-perf-limits.md
@@ -1,0 +1,113 @@
+# VirtioFS datapath — measured performance and known limits
+
+As of boot assets **0.6.13** (kernel v0.0.22 with the `fuse-spin-wait` patch,
+2026-08-01). Backend: VZ (Apple's virtio-fs device — the custom VirtioFS
+serves only the HV backend and has **no** performance measurement yet).
+Host: Apple Silicon, macOS 26.4. Bench: `tests/bench-virtiofs` run inside the
+guest against the `/arcbox` share; driver: `tests/e2e/tests/bench_virtiofs.rs`
+(isolated daemon, results in `target/bench-virtiofs/`). Full investigation
+record: Linear CORE-48.
+
+## Headline: the fuse-spin-wait patch (kernel#17)
+
+Same-day, same-VM-shape A/B, container context, `--warmup 1 --iterations 3`:
+
+| bench | stock 6.18.38 | + spin-wait | Δ |
+|---|---|---|---|
+| metadata_stat | 31.8k ops/s | **50.3k** | **+58%** |
+| negative_lookup | 23.6k | **33.0k** | +40% |
+| create_delete | 4.6k | **5.9k** | +28% |
+| find_recursive | 18.3k | **21.6k** | +18% |
+| rm_rf | 2505 ms | **2380 ms** | −5% |
+| sequential_read | 3771 MB/s | 3637 MB/s | −3.5% (noise) |
+
+Mechanism: on virtualized ARM64 every synchronous FUSE op paid a cross-vCPU
+round trip — device-IRQ trap, then a reschedule-IPI trap (measured **1:1**
+with the request IRQ), then two context switches. Two architectural facts
+make this unfixable by scheduling policy: ARM64 has no `TIF_POLLING_NRFLAG`
+(every wakeup sends a physical IPI), and all vCPUs share one LLC domain
+(`wake_affine` never migrates the waiter onto the IRQ CPU — the bare-metal
+assumption that within-LLC IPIs are cheap breaks under virtualization).
+
+The fix (`kernel` repo, `patches/fuse-spin-wait.patch`): `request_wait_answer`
+polls `FR_FINISHED` for ≤40µs before sleeping — KVM halt polling applied at
+the FUSE wait point. Double-gated: only virtio-class transports
+(`fc->iq.ops != &fuse_dev_fiq_ops`; classic `/dev/fuse` daemons keep stock
+behavior) and only non-blocking opcodes (READ/WRITE/FLUSH/FSYNC/FSYNCDIR/
+COPY_FILE_RANGE/SETLKW excluded — an ungated spin cost **−54%** sequential
+read). Reference ceiling: `taskset` + IRQ-affinity pinning reaches 54.6k
+stat ops/s; the patch reaches ~97% of it with zero affinity management.
+
+## Competitor context (Colima, Apple virtio-fs, Ubuntu 6.8 guest)
+
+Both sides run **Apple's** virtio-fs device — this comparison isolates the
+guest kernel + context, not the FS server. Two same-day container-context
+pairs (same musl bench binary, same flags):
+
+| bench | ArcBox 0.6.13 | Colima | ratio |
+|---|---|---|---|
+| metadata_stat (2026-07-31) | 52.8k | 51.7k | 102% |
+| metadata_stat (2026-08-01) | 49.8k | 77.0k | 65% |
+| negative_lookup (08-01) | 34.5k | 36.8k | 94% |
+| create_delete (08-01) | 5.5k | 7.6k | 72% |
+| find_recursive (08-01) | 20.1k | 25.8k | 78% |
+| random_read_4k, buffered (08-01) | 21.9k | 37.0k | 59% |
+| rm_rf (08-01) | 2482 ms | 1732 ms | 1.43× slower |
+| sequential_read (08-01) | 3392 MB/s | 4160 MB/s | 82% |
+| sequential_write (08-01) | 1652 MB/s | 1964 MB/s | 84% |
+
+**Read the spread, not one cell**: Colima's own container-context stat swung
+51.7k → 77.0k across two days (its container tax also varied: −34% one day,
+≈0 the next), while ArcBox held 30–32k stock and 50–53k patched across ten
+boots. Pre-patch ArcBox lost every row at 39–84%; post-patch the hottest
+metadata ops sit at parity-to-65% depending on Colima's day. Unmeasured:
+OrbStack, Docker Desktop, and our own HV backend.
+
+## What we've ruled out (each with a same-VM A/B)
+
+- **Container / seccomp overhead (ours)**: ArcBox numbers are identical in
+  and out of containers, and `seccomp=unconfined` changes nothing — the
+  round-trip cost dominates. (Colima's container tax exists and varies.)
+- **`dax=always`**: never active on VZ. The pid-1 mount table shows
+  `rw,relatime` only — Apple's device exposes no DAX window, and the agent's
+  "remounted with dax=always" log records intent, not outcome.
+- **CPU mitigations / HZ / preemption**: identical between the two guests
+  (spectre_v2 `CSV2, but not BHB`; both HZ=1000 + voluntary preemption).
+- **Guest syscall/VFS path**: on tmpfs (no virtiofs) ArcBox is 6–28%
+  *faster* than Colima — the gap lived entirely in the FUSE round trip.
+- **Kernel-version regression**: inverted — 6.12.11 scored 12.6k stat
+  (2.4× worse); the 6.18 bump was a large improvement.
+- **Wake latency / placement knobs**: `idle=poll` ±0; `__wake_up_sync` +11%;
+  best sched-feature toggle (`NO_TTWU_QUEUE`) +12%; 2-vCPU boot ±0. None
+  approach the pinning ceiling (+82%) — hence the spin-wait design.
+- **`PARAVIRT_TIME_ACCOUNTING`**: inert — VZ offers no ARM PV_TIME, the
+  static key never enables.
+
+## Measurement discipline (violating these produced wrong conclusions)
+
+- **Same context**: container vs container, or shell vs shell — never mixed.
+  The original "39%" figure compared our container against Colima's shell.
+- **Same day, paired**: competitor numbers swing up to ~50% across days;
+  ours drift ≤9%. Cross-day ratios are noise.
+- **Native is not a denominator for metadata**: cache-hot APFS stat runs at
+  605k ops/s; no FUSE transport approaches it. Use competitor guests as the
+  bar. (The CLAUDE.md "File I/O >90% of native" target predates this.)
+- **Only the in-process trio is ratio-safe**: `metadata_stat`,
+  `create_delete`, `negative_lookup`. The others shell out to PATH tools,
+  call macOS-only `purge`, or depend on the I/O engine — see
+  `CONFOUNDED_RATIO_BENCHES` in the bench driver.
+- **Pin the random-read engine** (`--random-read-engine`); fio results
+  report under a different name so cross-engine joins are impossible.
+
+## Known gaps / next steps
+
+- `create_delete`, `rm_rf`, buffered `random_read_4k` still trail Colima —
+  the first two are unlink/fsync-class round trips the spin does not fully
+  cover; small buffered reads are `FUSE_READ` and deliberately excluded
+  from the spin (an ungated spin regressed bulk reads −54%).
+- Upstream track: adaptive grow/shrink budget (as in KVM halt polling)
+  instead of the fixed 40µs, with the LLC/IPI-under-virtualization story as
+  motivation. Reproducer material in CORE-48.
+- Extend the bench driver to `ARCBOX_VM_BACKEND=hv` to get the first
+  numbers for the custom VirtioFS (feeds RES-17 / Paper B).
+- Fix the agent's misleading dax log (records intent, not outcome).

--- a/docs/fs-perf-limits.md
+++ b/docs/fs-perf-limits.md
@@ -115,7 +115,9 @@ OrbStack, Docker Desktop, and our own HV backend.
   numbers for the custom VirtioFS (feeds RES-17 / Paper B).
 - Fix the agent's misleading dax log (records intent, not outcome).
 - The bench binary's own `TARGETS` table (`tests/bench-virtiofs/src/main.rs`)
-  still gates `metadata_stat`/`negative_lookup` as percent-of-native, so its
-  "Target Compliance" block prints a permanent FAIL for rows this doc rules
-  out as native-ratio'able. Known-stale, non-gating; the code fix lands with
-  the perf-target policy revision.
+  still frames `metadata_stat`/`negative_lookup` as percent-of-native, but
+  the gate is inert: nothing ever populates `percent_of_native`, so the
+  "Target Compliance" block can only print "no native baseline available"
+  (and the e2e driver runs `--format json`, which skips the block
+  entirely). Known-stale and never able to evaluate; the code fix lands
+  with the perf-target policy revision.

--- a/docs/fs-perf-limits.md
+++ b/docs/fs-perf-limits.md
@@ -36,7 +36,9 @@ the FUSE wait point. Double-gated: only virtio-class transports
 behavior) and only non-blocking opcodes (READ/WRITE/FLUSH/FSYNC/FSYNCDIR/
 COPY_FILE_RANGE/SETLKW excluded — an ungated spin cost **−54%** sequential
 read). Reference ceiling: `taskset` + IRQ-affinity pinning reaches 54.6k
-stat ops/s; the patch reaches ~97% of it with zero affinity management.
+stat ops/s (+82% over that run's same-boot 29.9k stock baseline); the
+headline patched cell reaches 92% of that ceiling — 50.3k, with zero
+affinity management.
 
 ## Competitor context (Colima, Apple virtio-fs, Ubuntu 6.8 guest)
 
@@ -79,7 +81,8 @@ OrbStack, Docker Desktop, and our own HV backend.
   (2.4× worse); the 6.18 bump was a large improvement.
 - **Wake latency / placement knobs**: `idle=poll` ±0; `__wake_up_sync` +11%;
   best sched-feature toggle (`NO_TTWU_QUEUE`) +12%; 2-vCPU boot ±0. None
-  approach the pinning ceiling (+82%) — hence the spin-wait design.
+  approach the pinning ceiling (+82% in its same-boot pair, 29.9k → 54.6k)
+  — hence the spin-wait design.
 - **`PARAVIRT_TIME_ACCOUNTING`**: inert — VZ offers no ARM PV_TIME, the
   static key never enables.
 
@@ -111,3 +114,8 @@ OrbStack, Docker Desktop, and our own HV backend.
 - Extend the bench driver to `ARCBOX_VM_BACKEND=hv` to get the first
   numbers for the custom VirtioFS (feeds RES-17 / Paper B).
 - Fix the agent's misleading dax log (records intent, not outcome).
+- The bench binary's own `TARGETS` table (`tests/bench-virtiofs/src/main.rs`)
+  still gates `metadata_stat`/`negative_lookup` as percent-of-native, so its
+  "Target Compliance" block prints a permanent FAIL for rows this doc rules
+  out as native-ratio'able. Known-stale, non-gating; the code fix lands with
+  the perf-target policy revision.

--- a/tests/bench-virtiofs/README.md
+++ b/tests/bench-virtiofs/README.md
@@ -81,8 +81,8 @@ same-context rule, and current numbers) lives in `docs/fs-perf-limits.md`.
 ## Performance Targets (legacy — do not gate on these)
 
 > **Superseded by `docs/fs-perf-limits.md`.** These percent-of-native
-> targets (and the same table printed by `--list` / checked by the
-> binary) predate the CORE-48 methodology work, which showed that
+> targets (and the same table printed by `--list`; the binary's runtime
+> check is inert — nothing populates `percent_of_native`) predate the CORE-48 methodology work, which showed that
 > cache-hot native is not a valid denominator for FUSE metadata and that
 > only the in-process trio (`metadata_stat`, `create_delete`,
 > `negative_lookup`) is ratio-safe at all. The table is kept verbatim

--- a/tests/bench-virtiofs/README.md
+++ b/tests/bench-virtiofs/README.md
@@ -82,7 +82,8 @@ same-context rule, and current numbers) lives in `docs/fs-perf-limits.md`.
 
 > **Superseded by `docs/fs-perf-limits.md`.** These percent-of-native
 > targets (and the same table printed by `--list`; the binary's runtime
-> check is inert — nothing populates `percent_of_native`) predate the CORE-48 methodology work, which showed that
+> check is inert — nothing populates `percent_of_native`) predate the
+> CORE-48 methodology work, which showed that
 > cache-hot native is not a valid denominator for FUSE metadata and that
 > only the in-process trio (`metadata_stat`, `create_delete`,
 > `negative_lookup`) is ratio-safe at all. The table is kept verbatim

--- a/tests/bench-virtiofs/README.md
+++ b/tests/bench-virtiofs/README.md
@@ -78,10 +78,17 @@ same-context rule, and current numbers) lives in `docs/fs-perf-limits.md`.
 | `rm_rf` | `rm -rf` of a 5000-file directory tree | wall time |
 | `find_recursive` | `find -name "*.ts"` over 2000 files | wall time |
 
-## Performance Targets
+## Performance Targets (legacy — do not gate on these)
 
-These are the minimum acceptable performance levels as a percentage of
-native macOS filesystem performance:
+> **Superseded by `docs/fs-perf-limits.md`.** These percent-of-native
+> targets (and the same table printed by `--list` / checked by the
+> binary) predate the CORE-48 methodology work, which showed that
+> cache-hot native is not a valid denominator for FUSE metadata and that
+> only the in-process trio (`metadata_stat`, `create_delete`,
+> `negative_lookup`) is ratio-safe at all. The table is kept verbatim
+> until the perf-target policy revision (proposed alongside
+> fs-perf-limits.md) is approved; until then, treat competitor-guest
+> same-context comparisons as the bar and never use these rows as gates.
 
 | Benchmark | Target |
 |-----------|--------|

--- a/tests/bench-virtiofs/README.md
+++ b/tests/bench-virtiofs/README.md
@@ -38,7 +38,23 @@ cargo run --manifest-path tests/bench-virtiofs/Cargo.toml --release -- \
 # Native baseline (run against a local directory)
 cargo run --manifest-path tests/bench-virtiofs/Cargo.toml --release -- \
     --all --platform native --target /tmp/bench --format json > native.json
+
+# Hermetic run: exclude the network-dependent macros (npm/git). An entry
+# that matches no benchmark is a hard error, so a rename cannot silently
+# re-include them.
+cargo run --manifest-path tests/bench-virtiofs/Cargo.toml --release -- \
+    --all --skip npm_install,git_clone --target /arcbox
+
+# random_read_4k engine is explicit (default: the in-process buffered
+# reader). The fio/O_DIRECT engine is opt-in, errors when fio is absent,
+# and reports under `random_read_4k_fio` so numbers from different
+# engines can never be joined by name.
+cargo run --manifest-path tests/bench-virtiofs/Cargo.toml --release -- \
+    --benchmark random_read_4k --random-read-engine fio --target /arcbox
 ```
+
+Guest-vs-native comparison methodology (which ratios are meaningful, the
+same-context rule, and current numbers) lives in `docs/fs-perf-limits.md`.
 
 ## Benchmarks
 

--- a/virt/AGENTS.md
+++ b/virt/AGENTS.md
@@ -187,6 +187,14 @@ Counters") or it falsifies the metrics.
   build.rs landmines. VZ has no Rust-side ObjC interop anymore; fix VZ bugs
   there.
 
+- `docs/fs-perf-limits.md` — the settled VirtioFS story: the per-op
+  cross-vCPU IPI mechanism, the kernel `fuse-spin-wait` fix (+58%
+  metadata_stat), everything ruled out en route (dax was never active on
+  VZ; idle=poll, sched features, kernel version all measured), and the
+  measurement discipline (same-context/same-day pairing; only the
+  in-process trio is ratio-safe). Read this before any "make file I/O
+  faster" work. VZ runs Apple's virtio-fs device — the custom VirtioFS
+  is HV-only and still unmeasured.
 - `docs/net-perf-limits.md` — the settled multi-flow Host→VM ceiling
   (~10–12 Gbps combined vs ~22–29 Gbps single-flow) and its root cause
   (per-IRQ host-side cost: `hv_vcpus_exit` / `hv_gic_set_spi` /


### PR DESCRIPTION
The CORE-48 investigation produced numbers, a mechanism, a shipped kernel fix, and — most valuably — a list of dead ends that cost a hardware round each. This PR gives them the same in-repo home the network story has (`docs/net-perf-limits.md`), so none of it has to be re-derived.

## Contents

- **`docs/fs-perf-limits.md`** (new): fuse-spin-wait headline A/B (+58% metadata_stat, bulk unchanged), the per-op cross-vCPU IPI mechanism and why no scheduler policy could fix it, competitor context with the observed ~50% day-to-day variance on Colima's side (same-day pairing discipline), the ruled-out list (dax **never active** on VZ, idle=poll, sched features ≤+12%, kernel-version inverted, PVTIME inert), and the measurement rules that kept the investigation honest.
- **`virt/AGENTS.md`**: pointer next to the net-perf doc — "read before any make-file-I/O-faster work". *(AGENTS.md edit pre-approved by the repo owner in-session, 2026-08-01.)*
- **`tests/bench-virtiofs/README.md`**: documents the `--skip` and `--random-read-engine` flags from #507's review cycle, plus a pointer to the methodology doc.

## Proposal (NOT applied — root CLAUDE.md changes need explicit approval)

The perf-target table has two cells this investigation falsified:

1. **`File I/O (vs native) >90%`** — cache-hot native APFS metadata runs 605k stat ops/s; no FUSE transport can approach it. Proposed replacement: *"File I/O ≥100% of the best competitor guest, same-context"* (currently at parity-to-65% on metadata depending on Colima's day, 82–84% sequential).
2. **`Idle memory <150MB`** — physically unreachable on VZ: host footprint pins at configured `memory_mb` from boot and no balloon can return it (#504's evidence). Proposed: mark the target HV-only, and track VZ via `memory_mb` right-sizing (CORE-46).

Say the word and I'll fold the CLAUDE.md revision into this PR or a follow-up.

Data provenance: same-day paired runs via `tests/e2e/tests/bench_virtiofs.rs` + a colima container run of the identical binary; raw JSONs regenerable, full record in Linear CORE-48.