### PR TITLE
fix(balloon): keep a guest reserve in the idle target instead of the floor (CORE-45)

### DIFF
--- a/app/arcbox-core/src/vm_lifecycle/actor.rs
+++ b/app/arcbox-core/src/vm_lifecycle/actor.rs
@@ -194,10 +194,15 @@ impl BalloonDeps for RealBalloonDeps {
         false
     }
 
+    /// Gated on the machine actually running: `VmManager::set_balloon_target`
+    /// rejects any VM that is not `Running`, and a stopped machine keeps its
+    /// record, so reporting its size here would leave the controller retrying
+    /// a call that can never succeed.
     fn full_memory_bytes(&self) -> Option<u64> {
         self.shared
             .machine_manager
             .get(&self.shared.machine_name)
+            .filter(|info| info.state == crate::machine::MachineState::Running)
             .map(|info| info.memory_mb * 1024 * 1024)
     }
 

--- a/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
@@ -106,6 +106,10 @@ pub(in crate::vm_lifecycle) trait BalloonDeps:
 /// Retry cadence while idle but not (yet) shrunk.
 const IDLE_ENTRY_RETRY: Duration = Duration::from_secs(30);
 
+/// Retry cadence for a shrink whose restore exhausted its attempts. Applies
+/// while the VM is active, where nothing else would re-attempt it.
+const STRANDED_RESTORE_RETRY: Duration = Duration::from_secs(30);
+
 /// Minimum dwell at each descent step before taking the next one.
 ///
 /// The guest's `SETTLED` frame proves the guest is healthy at the current
@@ -207,11 +211,32 @@ impl<D: BalloonDeps> BalloonController<D> {
         let mut mode = Mode::Active;
         loop {
             mode = match mode {
-                Mode::Active => match self.commands.recv().await {
-                    Some(BalloonCommand::EnterIdle) => self.enter_idle().await,
-                    Some(BalloonCommand::ExitIdle) => Mode::Active,
-                    None => return,
-                },
+                Mode::Active => {
+                    // A restore that exhausted its retries leaves the guest
+                    // squeezed with `applied` still set. Active is when it can
+                    // least afford that — the guest is working, and a
+                    // fail-open restore usually follows guest memory pressure
+                    // — and an active VM may never go idle again, so waiting
+                    // for the next idle entry is not a retry at all.
+                    let stranded = self.applied.is_some();
+                    tokio::select! {
+                        cmd = self.commands.recv() => match cmd {
+                            Some(BalloonCommand::EnterIdle) => self.enter_idle().await,
+                            Some(BalloonCommand::ExitIdle) => Mode::Active,
+                            None => return,
+                        },
+                        () = async {
+                            if stranded {
+                                tokio::time::sleep(STRANDED_RESTORE_RETRY).await;
+                            } else {
+                                std::future::pending::<()>().await;
+                            }
+                        } => {
+                            self.restore("retrying a stranded shrink");
+                            Mode::Active
+                        }
+                    }
+                }
                 Mode::IdleUnshrunk => {
                     tokio::select! {
                         cmd = self.commands.recv() => match cmd {
@@ -1041,6 +1066,41 @@ mod tests {
             h.activity_count(),
             1,
             "idle exit still rides the state machine"
+        );
+    }
+
+    /// Review finding (greptile P1, round 2): a fail-open restore that
+    /// exhausts its attempts lands in `Active` with the shrink still applied.
+    /// An active VM may never go idle again, so retrying only on idle entry
+    /// leaves a *working* guest squeezed indefinitely — the worst case, since
+    /// fail-open usually follows guest memory pressure.
+    #[tokio::test(start_paused = true)]
+    async fn stranded_shrink_is_retried_while_active() {
+        let deps = FakeDeps::new(Some(FULL));
+        deps.push_stats(Some(idle_stats()));
+        let watch = deps.push_watch();
+        let h = Harness::spawn(deps);
+
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+        assert_eq!(h.targets(), vec![FIRST_STEP]);
+
+        // Pressure fails open, but every restore attempt fails: the
+        // controller returns to Active with the guest still shrunk.
+        h.deps.fail_set_target.store(true, Ordering::SeqCst);
+        watch.send(WatchFrame::Pressure).unwrap();
+        h.settle().await;
+        assert_eq!(h.targets(), vec![FIRST_STEP], "restore did not land");
+
+        // The backend recovers. No idle entry ever happens.
+        h.deps.fail_set_target.store(false, Ordering::SeqCst);
+        tokio::time::advance(STRANDED_RESTORE_RETRY + Duration::from_secs(1)).await;
+        h.settle().await;
+
+        assert_eq!(
+            h.targets(),
+            vec![FIRST_STEP, FULL],
+            "an active guest must not stay squeezed waiting for idle"
         );
     }
 

--- a/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
@@ -661,8 +661,11 @@ mod tests {
         }
     }
 
-    /// Final descent target for `idle_stats` (usage + headroom).
-    const FINAL_TARGET: u64 = 4 * GIB + super::super::IDLE_BALLOON_HEADROOM;
+    /// Final descent target for `idle_stats`. Derived from the policy rather
+    /// than restated, so a policy change cannot silently desync this test.
+    fn final_target() -> u64 {
+        super::super::idle_target(idle_stats(), FULL)
+    }
     /// First staged step from 16 GiB full memory.
     const FIRST_STEP: u64 = FULL - super::super::SHRINK_STEP;
 
@@ -717,23 +720,21 @@ mod tests {
     /// fresh watch (fresh settling detector).
     #[tokio::test(start_paused = true)]
     async fn staged_descent_steps_on_settled_frames() {
-        const STEP: u64 = super::super::SHRINK_STEP;
+        // Derive the whole descent from the policy: SHRINK_STEP increments
+        // from full down to the target, the last one clamping.
+        let expected: Vec<u64> = std::iter::successors(Some(FULL), |&cur| {
+            (cur > final_target()).then(|| super::super::next_step(cur, final_target()))
+        })
+        .skip(1)
+        .collect();
+
         let deps = FakeDeps::new(Some(FULL));
         deps.push_stats(Some(idle_stats()));
-        let watches: Vec<_> = (0..6).map(|_| deps.push_watch()).collect();
+        let watches: Vec<_> = (0..expected.len()).map(|_| deps.push_watch()).collect();
         let h = Harness::spawn(deps);
 
         h.commands.send(BalloonCommand::EnterIdle).unwrap();
         h.settle().await;
-
-        let expected = [
-            FULL - STEP,     // 14 GiB
-            FULL - 2 * STEP, // 12 GiB
-            FULL - 3 * STEP, // 10 GiB
-            FULL - 4 * STEP, // 8 GiB
-            FULL - 5 * STEP, // 6 GiB
-            FINAL_TARGET,    // clamp
-        ];
         for (i, watch) in watches.iter().enumerate().take(expected.len() - 1) {
             watch.send(WatchFrame::Settled).unwrap();
             h.settle().await;
@@ -754,9 +755,11 @@ mod tests {
         assert_eq!(h.activity_count(), 0, "descent is not activity");
 
         // At the final target, further Settled frames change nothing.
-        watches[5].send(WatchFrame::Settled).unwrap();
+        watches[expected.len() - 1]
+            .send(WatchFrame::Settled)
+            .unwrap();
         h.settle().await;
-        assert_eq!(h.targets(), expected.to_vec());
+        assert_eq!(h.targets(), expected);
     }
 
     #[tokio::test(start_paused = true)]

--- a/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
@@ -128,7 +128,9 @@ const WATCH_SILENCE_DEADLINE: Duration = Duration::from_secs(25);
 const DEGRADED_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 /// `MemAvailable` floor for pressure, both as the watch request threshold
-/// and the degraded-poll check. Safely below the entry headroom (256 MiB).
+/// and the degraded-poll check. Safely below the reserve the entry policy
+/// leaves the guest ([`super::IDLE_MIN_RESERVE`], 1 GiB), so tripping it
+/// means the guest went past what the policy planned for.
 pub(in crate::vm_lifecycle) const PRESSURE_MIN_AVAILABLE: u64 = 128 * 1024 * 1024;
 
 /// Refault-rate threshold (pages/second) for the watch request. Disabled:
@@ -154,6 +156,23 @@ pub(in crate::vm_lifecycle) const WATCH_KEEPALIVE: Duration = Duration::from_sec
 /// Budget for the entry-time guest stats probe.
 const GUEST_STATS_TIMEOUT: Duration = Duration::from_secs(super::GUEST_STATS_TIMEOUT_SECS);
 
+/// An in-effect shrink. Present exactly while the guest is squeezed —
+/// including after a restore exhausted its attempts, which is what makes
+/// `Some` mean "the guest is owed memory" at every read site.
+///
+/// The three fields only ever move together, so they are one value rather
+/// than three parallel `Option`s: the old shape let a caller consult
+/// `applied` alone and miss that a restore had failed.
+#[derive(Debug, Clone, Copy)]
+struct ShrinkState {
+    /// Currently applied balloon target.
+    applied: u64,
+    /// Final descent target; `applied > final_target` means steps pending.
+    final_target: u64,
+    /// When the current step was applied (dwell pacing).
+    step_applied_at: tokio::time::Instant,
+}
+
 /// The controller task. Owns all balloon state; communicates with the world
 /// only through [`BalloonDeps`] (in) and the activity callback (out).
 pub(in crate::vm_lifecycle) struct BalloonController<D: BalloonDeps> {
@@ -161,12 +180,8 @@ pub(in crate::vm_lifecycle) struct BalloonController<D: BalloonDeps> {
     deps: D,
     /// Notes lifecycle activity: resets the idle clock and exits `Idle`.
     activity: Arc<dyn Fn() + Send + Sync>,
-    /// Currently applied balloon target while shrunk.
-    applied: Option<u64>,
-    /// Final descent target; `applied > final` means more steps pending.
-    final_target: Option<u64>,
-    /// When the current step was applied (dwell pacing).
-    step_applied_at: Option<tokio::time::Instant>,
+    /// The shrink currently owed back to the guest, if any.
+    shrink: Option<ShrinkState>,
 }
 
 /// Controller mode; holds the open watch so drops cancel it naturally.
@@ -200,9 +215,7 @@ impl<D: BalloonDeps> BalloonController<D> {
             commands,
             deps,
             activity,
-            applied: None,
-            final_target: None,
-            step_applied_at: None,
+            shrink: None,
         }
     }
 
@@ -212,25 +225,17 @@ impl<D: BalloonDeps> BalloonController<D> {
         loop {
             mode = match mode {
                 Mode::Active => {
-                    // A restore that exhausted its retries leaves the guest
-                    // squeezed with `applied` still set. Active is when it can
-                    // least afford that — the guest is working, and a
-                    // fail-open restore usually follows guest memory pressure
-                    // — and an active VM may never go idle again, so waiting
-                    // for the next idle entry is not a retry at all.
-                    let stranded = self.applied.is_some();
+                    // A restore that exhausted its attempts leaves the guest
+                    // squeezed. Active is when it can least afford that — the
+                    // guest is working, and a fail-open restore usually
+                    // follows guest memory pressure — and an active VM may
+                    // never go idle again, so waiting for the next idle entry
+                    // is not a retry at all.
+                    let stranded = self.shrink.is_some();
                     tokio::select! {
                         cmd = self.commands.recv() => match cmd {
                             Some(BalloonCommand::EnterIdle) => self.enter_idle().await,
-                            Some(BalloonCommand::ExitIdle) => {
-                                // `fail_open` notes activity, so this edge
-                                // arrives right after a failed restore: retry
-                                // here rather than wait out the timer.
-                                if stranded {
-                                    self.restore("stale shrink on activity");
-                                }
-                                Mode::Active
-                            }
+                            Some(BalloonCommand::ExitIdle) => self.exit_idle(),
                             None => return,
                         },
                         () = async {
@@ -240,7 +245,9 @@ impl<D: BalloonDeps> BalloonController<D> {
                                 std::future::pending::<()>().await;
                             }
                         } => {
-                            self.restore("retrying a stranded shrink");
+                            // Failure is fine here: staying in Active re-arms
+                            // this same timer.
+                            let _ = self.restore("retrying a stranded shrink");
                             Mode::Active
                         }
                     }
@@ -248,8 +255,7 @@ impl<D: BalloonDeps> BalloonController<D> {
                 Mode::IdleUnshrunk => {
                     tokio::select! {
                         cmd = self.commands.recv() => match cmd {
-                            // Nothing was shrunk; nothing to restore.
-                            Some(BalloonCommand::ExitIdle) => Mode::Active,
+                            Some(BalloonCommand::ExitIdle) => self.exit_idle(),
                             Some(BalloonCommand::EnterIdle) => Mode::IdleUnshrunk,
                             None => return,
                         },
@@ -259,10 +265,7 @@ impl<D: BalloonDeps> BalloonController<D> {
                 Mode::Watching(mut watch) => {
                     tokio::select! {
                         cmd = self.commands.recv() => match cmd {
-                            Some(BalloonCommand::ExitIdle) => {
-                                self.restore("idle exit");
-                                Mode::Active
-                            }
+                            Some(BalloonCommand::ExitIdle) => self.exit_idle(),
                             Some(BalloonCommand::EnterIdle) => Mode::Watching(watch),
                             None => return,
                         },
@@ -278,8 +281,10 @@ impl<D: BalloonDeps> BalloonController<D> {
                                     // remaining dwell (still watching for
                                     // pressure) before the next step.
                                     let applied_at = self
-                                        .step_applied_at
-                                        .unwrap_or_else(tokio::time::Instant::now);
+                                        .shrink
+                                        .map_or_else(tokio::time::Instant::now, |s| {
+                                            s.step_applied_at
+                                        });
                                     Mode::Dwelling {
                                         watch,
                                         until: applied_at + STEP_DWELL,
@@ -297,10 +302,7 @@ impl<D: BalloonDeps> BalloonController<D> {
                 Mode::Dwelling { mut watch, until } => {
                     tokio::select! {
                         cmd = self.commands.recv() => match cmd {
-                            Some(BalloonCommand::ExitIdle) => {
-                                self.restore("idle exit");
-                                Mode::Active
-                            }
+                            Some(BalloonCommand::ExitIdle) => self.exit_idle(),
                             Some(BalloonCommand::EnterIdle) => Mode::Dwelling { watch, until },
                             None => return,
                         },
@@ -328,10 +330,7 @@ impl<D: BalloonDeps> BalloonController<D> {
                 Mode::Polling => {
                     tokio::select! {
                         cmd = self.commands.recv() => match cmd {
-                            Some(BalloonCommand::ExitIdle) => {
-                                self.restore("idle exit");
-                                Mode::Active
-                            }
+                            Some(BalloonCommand::ExitIdle) => self.exit_idle(),
                             Some(BalloonCommand::EnterIdle) => Mode::Polling,
                             None => return,
                         },
@@ -369,17 +368,11 @@ impl<D: BalloonDeps> BalloonController<D> {
             );
             return Mode::Active;
         }
-        // A restore that exhausted its retries deliberately leaves `applied`
-        // set. Nothing else reads it, so without this the guest stays squeezed
-        // indefinitely — and any decision made now would violate the sizing
-        // invariant anyway, since the stats would be taken while the balloon
-        // is still inflated. Give the memory back first; if that still fails,
-        // retry later rather than size from perturbed stats.
-        if self.applied.is_some() {
-            self.restore("stale shrink before idle re-entry");
-            if self.applied.is_some() {
-                return Mode::IdleUnshrunk;
-            }
+        // Sizing requires balloon-empty stats, so a shrink still owed back
+        // must be returned before probing — and if it cannot be, retry later
+        // rather than size from numbers the balloon itself is perturbing.
+        if self.shrink.is_some() && !self.restore("stale shrink before idle re-entry") {
+            return Mode::IdleUnshrunk;
         }
         let Some(full) = self.deps.full_memory_bytes() else {
             return Mode::IdleUnshrunk;
@@ -408,13 +401,15 @@ impl<D: BalloonDeps> BalloonController<D> {
                     tracing::warn!("failed to shrink idle balloon: {e}");
                     return Mode::IdleUnshrunk;
                 }
-                self.applied = Some(first);
-                self.final_target = Some(final_target);
-                self.step_applied_at = Some(tokio::time::Instant::now());
+                self.shrink = Some(ShrinkState {
+                    applied: first,
+                    final_target,
+                    step_applied_at: tokio::time::Instant::now(),
+                });
                 tracing::info!(
                     target_mb = first / (1024 * 1024),
                     final_mb = final_target / (1024 * 1024),
-                    "idle balloon shrunk to guest usage + headroom"
+                    "idle balloon shrinking"
                 );
                 self.open_watch().await
             }
@@ -423,21 +418,34 @@ impl<D: BalloonDeps> BalloonController<D> {
 
     /// The next descent step, if the applied target is above the final one.
     fn next_pending_step(&self) -> Option<u64> {
-        let (applied, final_target) = (self.applied?, self.final_target?);
-        (applied > final_target).then(|| super::next_step(applied, final_target))
+        let s = self.shrink?;
+        (s.applied > s.final_target).then(|| super::next_step(s.applied, s.final_target))
     }
 
     /// Applies one descent step (best effort — a failed step leaves the
     /// current, already-settled target in place).
     fn apply_step(&mut self, next: u64) {
+        let Some(state) = self.shrink.as_mut() else {
+            return;
+        };
         match self.deps.set_balloon_target(next) {
             Ok(()) => {
-                self.applied = Some(next);
-                self.step_applied_at = Some(tokio::time::Instant::now());
+                state.applied = next;
+                state.step_applied_at = tokio::time::Instant::now();
                 tracing::info!(target_mb = next / (1024 * 1024), "idle balloon step");
             }
             Err(e) => tracing::warn!("failed to step idle balloon: {e}"),
         }
+    }
+
+    /// Handles the `ExitIdle` edge from any mode: hand back whatever the
+    /// guest is owed, then return to `Active`. A failed restore stays booked
+    /// and the `Active` timer keeps retrying it.
+    fn exit_idle(&mut self) -> Mode<D::Watch> {
+        if self.shrink.is_some() {
+            let _ = self.restore("idle exit");
+        }
+        Mode::Active
     }
 
     /// Continues the staged descent after the guest settled, or keeps
@@ -464,47 +472,47 @@ impl<D: BalloonDeps> BalloonController<D> {
     /// Restores full memory and exits idle via the state machine.
     fn fail_open(&mut self, reason: &str) -> Mode<D::Watch> {
         tracing::info!(reason, "restoring full memory");
-        self.restore(reason);
+        // Failure stays booked; the `Active` timer this returns into retries.
+        let _ = self.restore(reason);
         (self.activity)();
         Mode::Active
     }
 
-    /// Restores the balloon to the machine's full configured memory.
+    /// Restores the balloon to the machine's full configured memory, returning
+    /// whether the guest actually got its memory back.
     ///
-    /// Retried a few times on failure; if all attempts fail, the shrunk
-    /// bookkeeping is kept so the next idle entry knows memory was never
-    /// given back (a restore that silently "succeeds" in bookkeeping only
-    /// would leave the guest squeezed with nobody retrying). `enter_idle`
-    /// is the retrier: it restores before probing whenever `applied` is set.
-    fn restore(&mut self, reason: &str) {
+    /// Retried a few times inline; if every attempt fails the shrink stays
+    /// booked rather than being cleared, so `self.shrink.is_some()` keeps
+    /// meaning "the guest is owed memory" and the retriers (idle entry, the
+    /// `Active` timer, the activity edge) can see it.
+    #[must_use = "a failed restore leaves the guest squeezed — the caller must \
+                  keep it booked and retry"]
+    fn restore(&mut self, reason: &str) -> bool {
         let Some(full) = self.deps.full_memory_bytes() else {
             // No machine record: the VM is gone, and so is its balloon.
-            self.applied = None;
-            self.final_target = None;
-            self.step_applied_at = None;
-            return;
+            self.shrink = None;
+            return true;
         };
         const RESTORE_ATTEMPTS: u32 = 3;
         for attempt in 1..=RESTORE_ATTEMPTS {
             match self.deps.set_balloon_target(full) {
                 Ok(()) => {
-                    self.applied = None;
-                    self.final_target = None;
-                    self.step_applied_at = None;
+                    self.shrink = None;
                     tracing::info!(
                         full_mb = full / (1024 * 1024),
                         reason,
                         "balloon restored to full memory"
                     );
-                    return;
+                    return true;
                 }
                 Err(e) => tracing::warn!(attempt, "failed to restore balloon ({reason}): {e}"),
             }
         }
         tracing::error!(
             reason,
-            "balloon restore failed; guest remains shrunk until the next idle cycle"
+            "balloon restore failed; retrying while the guest stays shrunk"
         );
+        false
     }
 }
 

--- a/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
@@ -88,7 +88,16 @@ pub(in crate::vm_lifecycle) trait BalloonDeps:
     /// backend requires.
     fn reclaim_capable(&self) -> bool;
 
-    /// Configured full memory of the machine, if the machine record exists.
+    /// Configured full memory of the VM whose balloon can be addressed right
+    /// now, or `None` when there is none — no machine record, or a VM that
+    /// is not running.
+    ///
+    /// `None` is a *terminal* answer, not a transient one: a stopped guest is
+    /// unsqueezed by the stop itself and a fresh boot starts with an empty
+    /// balloon, so nothing is owed. The controller drops any booked shrink on
+    /// it rather than retrying a target that nothing can accept — an
+    /// implementation that reported a stopped VM's size here would spin
+    /// forever on a call the VM layer rejects.
     fn full_memory_bytes(&self) -> Option<u64>;
 
     /// Applies a balloon target on the hypervisor device.
@@ -489,7 +498,10 @@ impl<D: BalloonDeps> BalloonController<D> {
                   keep it booked and retry"]
     fn restore(&mut self, reason: &str) -> bool {
         let Some(full) = self.deps.full_memory_bytes() else {
-            // No machine record: the VM is gone, and so is its balloon.
+            // No addressable balloon: the VM is gone or stopped, so the guest
+            // is already unsqueezed and a fresh boot starts empty. Nothing is
+            // owed — book it as settled instead of retrying forever against a
+            // VM that cannot accept a target.
             self.shrink = None;
             return true;
         };
@@ -548,7 +560,9 @@ mod tests {
         /// Backend reclaim capability (default `true`: the shrink paths
         /// under test assume an HV-class backend).
         reclaim_capable: bool,
-        full: Option<u64>,
+        /// `None` models "no addressable balloon" (VM gone or stopped);
+        /// mutable so a test can stop the VM mid-flight.
+        full: Mutex<Option<u64>>,
         stats: Mutex<Vec<Option<GuestStats>>>,
         /// Injected latency for `guest_stats` (probe-race tests).
         stats_delay: Duration,
@@ -566,7 +580,7 @@ mod tests {
         fn new(full: Option<u64>) -> Self {
             Self {
                 reclaim_capable: true,
-                full,
+                full: Mutex::new(full),
                 stats: Mutex::new(Vec::new()),
                 stats_delay: Duration::ZERO,
                 targets: Arc::new(Mutex::new(Vec::new())),
@@ -602,7 +616,7 @@ mod tests {
         }
 
         fn full_memory_bytes(&self) -> Option<u64> {
-            self.full
+            *self.full.lock().unwrap()
         }
 
         fn set_balloon_target(&self, bytes: u64) -> Result<()> {
@@ -1118,6 +1132,51 @@ mod tests {
             h.targets(),
             vec![FIRST_STEP, FULL],
             "an active guest must not stay squeezed waiting for idle"
+        );
+    }
+
+    /// Review finding (pullfrog): the stranded-shrink retry needs a terminal
+    /// condition. A *stopped* VM keeps its machine record but rejects every
+    /// balloon target, so retrying against it would warn/error every 30 s for
+    /// the daemon's remaining lifetime — a worse shape than the silent
+    /// one-shot failure the retry replaced.
+    #[tokio::test(start_paused = true)]
+    async fn stranded_shrink_stops_retrying_once_the_vm_stops() {
+        let deps = FakeDeps::new(Some(FULL));
+        deps.push_stats(Some(idle_stats()));
+        let watch = deps.push_watch();
+        let h = Harness::spawn(deps);
+
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+
+        h.deps.fail_set_target.store(true, Ordering::SeqCst);
+        watch.send(WatchFrame::Pressure).unwrap();
+        h.settle().await;
+        assert_eq!(h.targets(), vec![FIRST_STEP], "restore did not land");
+
+        // The VM stops: no balloon left to address.
+        *h.deps.full.lock().unwrap() = None;
+        let attempts_before = h.deps.set_attempts.load(Ordering::SeqCst);
+        tokio::time::advance(STRANDED_RESTORE_RETRY * 4).await;
+        h.settle().await;
+
+        assert_eq!(
+            h.deps.set_attempts.load(Ordering::SeqCst),
+            attempts_before,
+            "a stopped VM cannot accept a target; the retry must terminate"
+        );
+
+        // And the booking is cleared, so a later boot starts clean rather
+        // than inheriting a shrink the new guest never had.
+        *h.deps.full.lock().unwrap() = Some(FULL);
+        h.deps.fail_set_target.store(false, Ordering::SeqCst);
+        tokio::time::advance(STRANDED_RESTORE_RETRY * 2).await;
+        h.settle().await;
+        assert_eq!(
+            h.deps.set_attempts.load(Ordering::SeqCst),
+            attempts_before,
+            "nothing is owed after the stop; no restore should fire"
         );
     }
 

--- a/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
@@ -336,6 +336,18 @@ impl<D: BalloonDeps> BalloonController<D> {
             );
             return Mode::Active;
         }
+        // A restore that exhausted its retries deliberately leaves `applied`
+        // set. Nothing else reads it, so without this the guest stays squeezed
+        // indefinitely — and any decision made now would violate the sizing
+        // invariant anyway, since the stats would be taken while the balloon
+        // is still inflated. Give the memory back first; if that still fails,
+        // retry later rather than size from perturbed stats.
+        if self.applied.is_some() {
+            self.restore("stale shrink before idle re-entry");
+            if self.applied.is_some() {
+                return Mode::IdleUnshrunk;
+            }
+        }
         let Some(full) = self.deps.full_memory_bytes() else {
             return Mode::IdleUnshrunk;
         };
@@ -429,7 +441,8 @@ impl<D: BalloonDeps> BalloonController<D> {
     /// Retried a few times on failure; if all attempts fail, the shrunk
     /// bookkeeping is kept so the next idle entry knows memory was never
     /// given back (a restore that silently "succeeds" in bookkeeping only
-    /// would leave the guest squeezed with nobody retrying).
+    /// would leave the guest squeezed with nobody retrying). `enter_idle`
+    /// is the retrier: it restores before probing whenever `applied` is set.
     fn restore(&mut self, reason: &str) {
         let Some(full) = self.deps.full_memory_bytes() else {
             // No machine record: the VM is gone, and so is its balloon.
@@ -728,6 +741,26 @@ mod tests {
         .skip(1)
         .collect();
 
+        // The sequence is derived from the policy helpers, so pin its shape
+        // independently: a self-consistent but wrong policy change must not
+        // slip through by rewriting the oracle along with the code.
+        assert_eq!(
+            expected.first().copied(),
+            Some(FULL - super::super::SHRINK_STEP)
+        );
+        assert_eq!(expected.last().copied(), Some(final_target()));
+        for pair in std::iter::once(FULL)
+            .chain(expected.iter().copied())
+            .collect::<Vec<_>>()
+            .windows(2)
+        {
+            let drop = pair[0] - pair[1];
+            assert!(
+                drop == super::super::SHRINK_STEP || pair[1] == final_target(),
+                "every move is a full step except the clamping last one: {pair:?}"
+            );
+        }
+
         let deps = FakeDeps::new(Some(FULL));
         deps.push_stats(Some(idle_stats()));
         let watches: Vec<_> = (0..expected.len()).map(|_| deps.push_watch()).collect();
@@ -1008,6 +1041,47 @@ mod tests {
             h.activity_count(),
             1,
             "idle exit still rides the state machine"
+        );
+    }
+
+    /// Review finding (greptile P1): after a restore exhausts its retries the
+    /// guest is still squeezed and `applied` stays set — but nothing read it,
+    /// so a later entry that decided `Keep` left the guest restricted forever.
+    /// Entry is the retrier: it must give the memory back before probing,
+    /// which the sizing invariant (balloon-empty stats) demands anyway.
+    #[tokio::test(start_paused = true)]
+    async fn stale_shrink_is_restored_on_next_entry() {
+        let deps = FakeDeps::new(Some(FULL));
+        deps.push_stats(Some(idle_stats()));
+        // Second entry sees a guest with almost nothing to give: the decision
+        // is `Keep`, the path that used to strand the stale shrink.
+        deps.push_stats(Some(GuestStats {
+            total: FULL,
+            available: 512 * MIB,
+            loadavg1: 0.1,
+        }));
+        let watch = deps.push_watch();
+        let h = Harness::spawn(deps);
+
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+        assert_eq!(h.targets(), vec![FIRST_STEP]);
+
+        // Restore fails every attempt: the guest stays shrunk.
+        h.deps.fail_set_target.store(true, Ordering::SeqCst);
+        watch.send(WatchFrame::Pressure).unwrap();
+        h.settle().await;
+        assert_eq!(h.targets(), vec![FIRST_STEP], "restore did not land");
+
+        // Next idle entry, with the backend healthy again.
+        h.deps.fail_set_target.store(false, Ordering::SeqCst);
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+
+        assert_eq!(
+            h.targets(),
+            vec![FIRST_STEP, FULL],
+            "entry must hand the memory back before deciding"
         );
     }
 

--- a/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
@@ -222,7 +222,15 @@ impl<D: BalloonDeps> BalloonController<D> {
                     tokio::select! {
                         cmd = self.commands.recv() => match cmd {
                             Some(BalloonCommand::EnterIdle) => self.enter_idle().await,
-                            Some(BalloonCommand::ExitIdle) => Mode::Active,
+                            Some(BalloonCommand::ExitIdle) => {
+                                // `fail_open` notes activity, so this edge
+                                // arrives right after a failed restore: retry
+                                // here rather than wait out the timer.
+                                if stranded {
+                                    self.restore("stale shrink on activity");
+                                }
+                                Mode::Active
+                            }
                             None => return,
                         },
                         () = async {
@@ -1092,7 +1100,8 @@ mod tests {
         h.settle().await;
         assert_eq!(h.targets(), vec![FIRST_STEP], "restore did not land");
 
-        // The backend recovers. No idle entry ever happens.
+        // The backend recovers. No idle entry and no activity edge ever
+        // happens again — only the timer can rescue this guest.
         h.deps.fail_set_target.store(false, Ordering::SeqCst);
         tokio::time::advance(STRANDED_RESTORE_RETRY + Duration::from_secs(1)).await;
         h.settle().await;
@@ -1101,6 +1110,37 @@ mod tests {
             h.targets(),
             vec![FIRST_STEP, FULL],
             "an active guest must not stay squeezed waiting for idle"
+        );
+    }
+
+    /// Review finding (pullfrog): the activity edge that `fail_open` itself
+    /// emits is the earliest retry point, so recovery should not have to wait
+    /// out the timer when the failure was transient.
+    #[tokio::test(start_paused = true)]
+    async fn stranded_shrink_is_retried_on_the_activity_edge() {
+        let deps = FakeDeps::new(Some(FULL));
+        deps.push_stats(Some(idle_stats()));
+        let watch = deps.push_watch();
+        let h = Harness::spawn(deps);
+
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+
+        h.deps.fail_set_target.store(true, Ordering::SeqCst);
+        watch.send(WatchFrame::Pressure).unwrap();
+        h.settle().await;
+        assert_eq!(h.targets(), vec![FIRST_STEP]);
+
+        // The actor's ExitIdle lands after the backend recovers, well inside
+        // the retry interval.
+        h.deps.fail_set_target.store(false, Ordering::SeqCst);
+        h.commands.send(BalloonCommand::ExitIdle).unwrap();
+        h.settle().await;
+
+        assert_eq!(
+            h.targets(),
+            vec![FIRST_STEP, FULL],
+            "the activity edge must retry without waiting for the timer"
         );
     }
 

--- a/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/controller.rs
@@ -1135,6 +1135,51 @@ mod tests {
         );
     }
 
+    /// Review finding (pullfrog): routing every `ExitIdle` through
+    /// `exit_idle()` also made `IdleUnshrunk` recover on the edge instead of
+    /// waiting out the `Active` timer — a behaviour change, and the one mode
+    /// no test reached. `IdleUnshrunk` can hold a booked shrink because
+    /// `enter_idle` returns it when the stale restore fails.
+    #[tokio::test(start_paused = true)]
+    async fn stranded_shrink_is_restored_on_exit_from_idle_unshrunk() {
+        let deps = FakeDeps::new(Some(FULL));
+        deps.push_stats(Some(idle_stats()));
+        let watch = deps.push_watch();
+        let h = Harness::spawn(deps);
+
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+        assert_eq!(h.targets(), vec![FIRST_STEP]);
+
+        // Fail open with a failing backend: the shrink stays booked.
+        h.deps.fail_set_target.store(true, Ordering::SeqCst);
+        watch.send(WatchFrame::Pressure).unwrap();
+        h.settle().await;
+
+        // Re-enter idle with the backend still failing: the stale restore
+        // fails, so entry parks in IdleUnshrunk still holding the shrink.
+        let before_entry = h.deps.set_attempts.load(Ordering::SeqCst);
+        h.commands.send(BalloonCommand::EnterIdle).unwrap();
+        h.settle().await;
+        assert_eq!(h.targets(), vec![FIRST_STEP], "still nothing given back");
+        // Exactly one failed restore (3 attempts) and no stats probe: that is
+        // the `enter_idle` early return, i.e. we are parked in IdleUnshrunk.
+        assert_eq!(h.deps.set_attempts.load(Ordering::SeqCst) - before_entry, 3);
+        assert_eq!(h.deps.stats.lock().unwrap().len(), 0);
+
+        // Heal the backend and leave idle without advancing the clock, so the
+        // 30s timers cannot be what rescues the guest.
+        h.deps.fail_set_target.store(false, Ordering::SeqCst);
+        h.commands.send(BalloonCommand::ExitIdle).unwrap();
+        h.settle().await;
+
+        assert_eq!(
+            h.targets(),
+            vec![FIRST_STEP, FULL],
+            "leaving idle must hand back a shrink booked in IdleUnshrunk"
+        );
+    }
+
     /// Review finding (pullfrog): the stranded-shrink retry needs a terminal
     /// condition. A *stopped* VM keeps its machine record but rejects every
     /// balloon target, so retrying against it would warn/error every 30 s for

--- a/app/arcbox-core/src/vm_lifecycle/balloon/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/mod.rs
@@ -124,24 +124,31 @@ pub(super) enum EntryDecision {
 
 /// Computes the idle balloon target for the observed guest usage.
 ///
-/// Two independent floors, whichever is higher:
+/// Two independent caps on the reclaim, whichever is smaller:
 ///
-/// - `used` plus [`IDLE_MIN_RESERVE`] — the guest keeps a working reserve;
-/// - `total` minus `available` over [`IDLE_RECLAIM_DIVISOR`] — one entry
-///   reclaims at most a bounded share of the slack.
+/// - `available` minus [`IDLE_MIN_RESERVE`] — the guest keeps a working
+///   reserve;
+/// - `available` over [`IDLE_RECLAIM_DIVISOR`] — one entry reclaims at most a
+///   bounded share of the slack.
 ///
-/// The result never exceeds the full configured size. Note the target only
-/// ever *approaches* the guest's usage from above, so it stays usage-aware
-/// without ever planning `MemAvailable` to zero. The reserve also subsumes
-/// the old absolute floor — no computed target can land near the level where
-/// the guest kernel itself destabilises.
+/// Both are expressed as a *reclaim* subtracted from `full`, never from the
+/// guest's `MemTotal`. The two are not the same number — the guest kernel
+/// reserves memory at boot, so `MemTotal` sits below the configured size (a
+/// 16384 MB VM reports 15.6 GiB) — and the balloon target the controller
+/// applies is in the configured domain. Computing a target from `MemTotal`
+/// and applying it against `full` reclaims that gap *on top of* the intended
+/// amount, eating into the very reserve this function exists to protect.
+/// `available` is used only as a delta, which is domain-free.
+///
+/// The reserve also subsumes the old absolute floor — no computed target can
+/// land near the level where the guest kernel itself destabilises.
 pub(super) fn idle_target(stats: GuestStats, full: u64) -> u64 {
-    let used = stats.total.saturating_sub(stats.available);
-    let reserve_floor = used.saturating_add(IDLE_MIN_RESERVE);
-    let share_floor = stats
-        .total
-        .saturating_sub(stats.available / IDLE_RECLAIM_DIVISOR);
-    reserve_floor.max(share_floor).min(full)
+    // `available` cannot exceed the guest's own total, nor the configured
+    // size; an inconsistent reading must not turn into a larger reclaim.
+    let available = stats.available.min(stats.total).min(full);
+    let by_reserve = available.saturating_sub(IDLE_MIN_RESERVE);
+    let by_share = available / IDLE_RECLAIM_DIVISOR;
+    full.saturating_sub(by_reserve.min(by_share))
 }
 
 /// Decides the balloon move when the VM enters idle.
@@ -194,10 +201,34 @@ mod tests {
 
     #[test]
     fn idle_target_reserve_binds_when_slack_is_small() {
-        // 15 GiB used, 1 GiB available: half the slack (512 MiB) would leave
-        // the guest under the reserve, so `used + reserve` wins.
-        let t = idle_target(stats(FULL, GIB), FULL);
-        assert_eq!(t, 15 * GIB + IDLE_MIN_RESERVE);
+        // 1.5 GiB available: half of it (768 MiB) would leave the guest under
+        // the 1 GiB reserve, so the reserve cap wins at 512 MiB.
+        let t = idle_target(stats(FULL, GIB + 512 * MIB), FULL);
+        assert_eq!(t, FULL - 512 * MIB);
+    }
+
+    /// The guest's `MemTotal` is always below the configured size (kernel
+    /// reservations at boot: a 16384 MB VM reports ~15.6 GiB). Computing the
+    /// target in the guest's domain and applying it against `full` would
+    /// reclaim that gap on top of the intended share.
+    #[test]
+    fn reclaim_ignores_the_memtotal_to_configured_gap() {
+        let mem_total = FULL - 400 * MIB;
+        let available = 15 * GIB;
+        let t = idle_target(
+            GuestStats {
+                total: mem_total,
+                available,
+                loadavg1: 0.1,
+            },
+            FULL,
+        );
+        assert_eq!(
+            FULL - t,
+            available / 2,
+            "reclaim must be the promised share, not the share plus the gap"
+        );
+        assert!(available - (FULL - t) >= IDLE_MIN_RESERVE);
     }
 
     /// CORE-45: the defect this policy replaced. With `used + 256 MiB` an
@@ -249,10 +280,10 @@ mod tests {
 
     #[test]
     fn idle_target_saturates_on_inconsistent_stats() {
-        // available > total must not underflow: used saturates to 0, so the
-        // reserve floor carries the result.
+        // available > total is not a real reading; it must be clamped down
+        // rather than inflate the reclaim.
         let t = idle_target(stats(4 * GIB, 8 * GIB), FULL);
-        assert_eq!(t, IDLE_MIN_RESERVE);
+        assert_eq!(t, FULL - 2 * GIB);
     }
 
     /// Incident guard #1: the 2026-07-15 thrash began with an unconditional
@@ -278,8 +309,9 @@ mod tests {
 
     #[test]
     fn entry_keeps_when_the_reclaim_is_not_worth_it() {
-        // 800 MiB available ⇒ half is 400 MiB, below the worthwhile bar.
-        let d = entry_decision(Some(stats(FULL, 800 * MIB)), FULL);
+        // 1.25 GiB available ⇒ the reserve caps the reclaim at 256 MiB,
+        // below the worthwhile bar.
+        let d = entry_decision(Some(stats(FULL, GIB + 256 * MIB)), FULL);
         assert_eq!(d, EntryDecision::Keep);
     }
 

--- a/app/arcbox-core/src/vm_lifecycle/balloon/mod.rs
+++ b/app/arcbox-core/src/vm_lifecycle/balloon/mod.rs
@@ -8,8 +8,11 @@
 //!
 //! - Never shrink without a fresh guest memory reading. An unreachable
 //!   agent means we know nothing about guest load — keep the balloon.
-//! - The idle target tracks actual guest usage plus headroom; it is never
-//!   an unconditional constant. A guest that is actively *working* (load)
+//! - The idle target tracks actual guest usage plus a reserve; it is never
+//!   an unconditional constant, and it never plans the guest's
+//!   `MemAvailable` to zero — a policy that walks the guest to the cliff
+//!   edge needs a millisecond-class rescue path to survive, and one that
+//!   stays clear of it does not. A guest that is actively *working* (load)
 //!   is not idle at all, no matter how quiet the host-side API is.
 //! - Entry-time stats are the only ones used for sizing: they are taken
 //!   while the balloon is empty, the one state where `/proc/meminfo` is
@@ -48,12 +51,28 @@ pub(super) mod controller;
 /// Bytes per MiB.
 const MIB: u64 = 1024 * 1024;
 
-/// Headroom added above observed guest usage when computing an idle target.
-pub(super) const IDLE_BALLOON_HEADROOM: u64 = 256 * MIB;
+/// Guest `MemAvailable` that an idle shrink must leave behind.
+///
+/// The target is never planned below `used + this`, so an idle guest keeps a
+/// working reserve instead of being walked to the edge. The predecessor
+/// constant was 256 MiB, which for an idle guest (`used ≈ 0`) collapsed the
+/// target onto the absolute floor: measured 2026-07-29 on a 16 GB VM, the
+/// descent asked for 15.8 GB of the guest's 15.96 GB available and pinned
+/// `MemAvailable` at literally 0 for ~98 s per cycle, which is both an OOM
+/// hazard for running containers and ~14 cores of reclaim spin.
+pub(super) const IDLE_MIN_RESERVE: u64 = 1024 * MIB;
 
-/// Absolute floor for a computed idle target. Below this the guest kernel
-/// itself becomes unstable regardless of workload.
-pub(super) const IDLE_BALLOON_FLOOR: u64 = 384 * MIB;
+/// Divisor bounding how much of the guest's available memory a single idle
+/// entry may reclaim (2 ⇒ at most half).
+///
+/// The reserve alone still permits a violent single step — on that same 16 GB
+/// idle guest it would allow reclaiming 14.9 GB. Leaving as much as we take
+/// bounds the guest-side reclaim cost of any one entry.
+pub(super) const IDLE_RECLAIM_DIVISOR: u64 = 2;
+
+/// Smallest reclaim worth a shrink at all. Below this the guest-side reclaim
+/// cost is not repaid by the memory returned.
+pub(super) const MIN_WORTHWHILE_RECLAIM: u64 = 512 * MIB;
 
 /// A guest with at least this 1-minute load average is doing real work —
 /// it is not idle, regardless of host-side API silence (in-guest workloads
@@ -103,13 +122,26 @@ pub(super) enum EntryDecision {
     Keep,
 }
 
-/// Computes the idle balloon target for the observed guest usage:
-/// used memory plus [`IDLE_BALLOON_HEADROOM`], clamped to
-/// [`IDLE_BALLOON_FLOOR`] and the full configured size.
+/// Computes the idle balloon target for the observed guest usage.
+///
+/// Two independent floors, whichever is higher:
+///
+/// - `used` plus [`IDLE_MIN_RESERVE`] — the guest keeps a working reserve;
+/// - `total` minus `available` over [`IDLE_RECLAIM_DIVISOR`] — one entry
+///   reclaims at most a bounded share of the slack.
+///
+/// The result never exceeds the full configured size. Note the target only
+/// ever *approaches* the guest's usage from above, so it stays usage-aware
+/// without ever planning `MemAvailable` to zero. The reserve also subsumes
+/// the old absolute floor — no computed target can land near the level where
+/// the guest kernel itself destabilises.
 pub(super) fn idle_target(stats: GuestStats, full: u64) -> u64 {
     let used = stats.total.saturating_sub(stats.available);
-    used.saturating_add(IDLE_BALLOON_HEADROOM)
-        .clamp(IDLE_BALLOON_FLOOR, full)
+    let reserve_floor = used.saturating_add(IDLE_MIN_RESERVE);
+    let share_floor = stats
+        .total
+        .saturating_sub(stats.available / IDLE_RECLAIM_DIVISOR);
+    reserve_floor.max(share_floor).min(full)
 }
 
 /// Decides the balloon move when the VM enters idle.
@@ -130,7 +162,7 @@ pub(super) fn entry_decision(stats: Option<GuestStats>, full: u64) -> EntryDecis
         return EntryDecision::NotIdle;
     }
     let target = idle_target(stats, full);
-    if target >= full {
+    if full.saturating_sub(target) < MIN_WORTHWHILE_RECLAIM {
         EntryDecision::Keep
     } else {
         EntryDecision::Shrink(target)
@@ -154,16 +186,58 @@ mod tests {
 
     #[test]
     fn idle_target_tracks_guest_usage() {
-        // 12 GiB used → target must follow usage, not a constant.
+        // 12 GiB used, 4 GiB available → the share floor binds: reclaim at
+        // most half the slack (2 GiB), never a constant.
         let t = idle_target(stats(FULL, 4 * GIB), FULL);
-        assert_eq!(t, 12 * GIB + IDLE_BALLOON_HEADROOM);
+        assert_eq!(t, FULL - 2 * GIB);
     }
 
     #[test]
-    fn idle_target_clamps_to_floor() {
-        // Near-empty guest: 100 MiB used + headroom is below the floor.
-        let t = idle_target(stats(FULL, FULL - 100 * MIB), FULL);
-        assert_eq!(t, IDLE_BALLOON_FLOOR);
+    fn idle_target_reserve_binds_when_slack_is_small() {
+        // 15 GiB used, 1 GiB available: half the slack (512 MiB) would leave
+        // the guest under the reserve, so `used + reserve` wins.
+        let t = idle_target(stats(FULL, GIB), FULL);
+        assert_eq!(t, 15 * GIB + IDLE_MIN_RESERVE);
+    }
+
+    /// CORE-45: the defect this policy replaced. With `used + 256 MiB` an
+    /// idle guest collapsed onto the floor — the descent asked for nearly
+    /// all of `MemAvailable` and pinned it at zero for ~98 s per cycle.
+    #[test]
+    fn idle_guest_is_never_walked_to_the_floor() {
+        let available = FULL - 100 * MIB;
+        let t = idle_target(stats(FULL, available), FULL);
+
+        assert!(
+            t >= FULL / 2,
+            "an idle guest must not be squeezed to a sliver, got {t}"
+        );
+        // Reclaim is bounded by the share cap ...
+        assert_eq!(FULL - t, available / 2);
+        // ... and what the guest keeps available stays far above the reserve.
+        assert!(available - (FULL - t) >= IDLE_MIN_RESERVE);
+    }
+
+    /// The planned reclaim must never eat into the reserve, at any usage.
+    #[test]
+    fn planned_reclaim_always_leaves_the_reserve() {
+        for available_gib in 0..=16 {
+            let available = available_gib * GIB;
+            let t = idle_target(stats(FULL, available), FULL);
+            let reclaim = FULL.saturating_sub(t);
+            assert!(
+                available.saturating_sub(reclaim) >= IDLE_MIN_RESERVE.min(available),
+                "available {available} reclaim {reclaim} breaches the reserve"
+            );
+        }
+    }
+
+    #[test]
+    fn idle_target_never_exceeds_a_tiny_configured_size() {
+        // A configured size below the reserve must not produce a target above
+        // it (the old `clamp(floor, full)` would have panicked here).
+        let t = idle_target(stats(256 * MIB, 200 * MIB), 256 * MIB);
+        assert_eq!(t, 256 * MIB);
     }
 
     #[test]
@@ -175,9 +249,10 @@ mod tests {
 
     #[test]
     fn idle_target_saturates_on_inconsistent_stats() {
-        // available > total must not underflow.
+        // available > total must not underflow: used saturates to 0, so the
+        // reserve floor carries the result.
         let t = idle_target(stats(4 * GIB, 8 * GIB), FULL);
-        assert_eq!(t, IDLE_BALLOON_FLOOR);
+        assert_eq!(t, IDLE_MIN_RESERVE);
     }
 
     /// Incident guard #1: the 2026-07-15 thrash began with an unconditional
@@ -189,15 +264,22 @@ mod tests {
 
     #[test]
     fn entry_shrinks_to_usage_aware_target() {
-        // 4 GiB used: shrink, but to usage + headroom — not to a constant.
+        // 4 GiB used, 12 GiB available: reclaim half the slack, not a constant.
         let d = entry_decision(Some(stats(FULL, 12 * GIB)), FULL);
-        assert_eq!(d, EntryDecision::Shrink(4 * GIB + IDLE_BALLOON_HEADROOM));
+        assert_eq!(d, EntryDecision::Shrink(FULL - 6 * GIB));
     }
 
     #[test]
     fn entry_with_no_reclaimable_memory_keeps() {
-        // Usage + headroom ≥ full: nothing to reclaim.
+        // Usage + reserve ≥ full: nothing to reclaim.
         let d = entry_decision(Some(stats(FULL, 100 * MIB)), FULL);
+        assert_eq!(d, EntryDecision::Keep);
+    }
+
+    #[test]
+    fn entry_keeps_when_the_reclaim_is_not_worth_it() {
+        // 800 MiB available ⇒ half is 400 MiB, below the worthwhile bar.
+        let d = entry_decision(Some(stats(FULL, 800 * MIB)), FULL);
         assert_eq!(d, EntryDecision::Keep);
     }
 


### PR DESCRIPTION
## Problem

`idle_target = used + 256MB` degenerates for an idle guest: `MemAvailable ≈ total` ⇒ `used ≈ 0` ⇒ the target collapses onto the 384MB floor. The module's own invariant says the target is "never an unconditional constant" — the formula violated it in exactly the idle case it exists for.

Measured 2026-07-29 (VZ, 16 GB VM, before #504 disabled the balloon): the descent asked the guest for 15.8 GB of its 15.96 GB available, drove `MemAvailable` to literally 0 for ~98 s per cycle, then pressure-restored and repeated every ~8.5 min — ~2.8 cores averaged while "idle". During the zero-available window any running container is an OOM candidate.

## Change

The target is now the higher of two floors:

- `used + IDLE_MIN_RESERVE` (1 GiB) — the guest keeps a working reserve;
- `total - available / IDLE_RECLAIM_DIVISOR` (2) — one entry reclaims at most half the slack, so no single descent walks the guest to the edge.

A reclaim below `MIN_WORTHWHILE_RECLAIM` (512 MB) is not repaid by its guest-side cost, so the balloon is kept instead.

`IDLE_BALLOON_FLOOR` is **removed**: the 1 GiB reserve strictly dominates the 384 MB floor, so it was unreachable code. Dropping it also removes a latent `clamp(min, max)` panic for any configured size below 384 MB.

For the 16 GB idle guest above, the target moves from 384 MB to ~8 GB — the host still gets ~8 GB back, without the cliff.

## Notes

- Pure policy; **inert today** — `BalloonDeps::reclaim_capable` is `false` on every macOS backend (#504). This is the precondition for re-enabling shrinking anywhere (CORE-44 flips HV back only after this lands).
- The controller's descent test no longer restates the formula: `final_target()` calls `idle_target` and the expected step sequence is derived from `next_step`, so a future policy change cannot silently desync the test.
- New regressions: `idle_guest_is_never_walked_to_the_floor`, `planned_reclaim_always_leaves_the_reserve` (sweeps availability 0–16 GiB), `entry_keeps_when_the_reclaim_is_not_worth_it`, `idle_target_never_exceeds_a_tiny_configured_size`.

## Validation

`cargo test -p arcbox-core --lib` — 172 passed. `cargo clippy -p arcbox-core --all-targets` — zero warnings. `cargo fmt --check` — clean. No e2e run: the shrink path this governs cannot execute while `reclaim_capable` is false, so `idle_balloon` (which pins the never-shrinks contract) is unaffected.

Closes CORE-45.