### PR TITLE
feat(daemon): publish VM_STARTING/VM_READY/NETWORK_READY (CORE-67)

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -41,6 +41,26 @@ must name `abctl`.
   restarts install the route outside the cold-start path that sets the flag
   directly, so without the bridge the flag goes stale until the next daemon
   restart.
+- **A `SetupStatus.Phase` value that nothing publishes is invisible as a
+  gap** — it simply never arrives, so a client waits forever or reports a
+  plausible zero. Declaring a phase in `api.proto` therefore obliges you to
+  publish it; the happy-path progression and which phases are conditional
+  live in the enum's own doc comment (`api.proto`) and
+  `docs/daemon-lifecycle.md`, and must be updated with any change. This
+  was CORE-67: `VM_STARTING`/`VM_READY`/`NETWORK_READY` sat declared and
+  unpublished, leaving the slowest stretch of startup silent.
+- **The VM phases are reported from inside `Runtime::init`, not derived
+  from pipeline order** (`InitProgress` → `SetupPhase` in
+  `startup/mod.rs::init_runtime`). WHY: `boot_runtime` is one stage that
+  stages guest binaries, boots the VM, waits for the agent, then waits for
+  dockerd. Publishing at the stage boundaries would bill the binary
+  download to `VM_STARTING` and make `VM_READY` mean "dockerd answered" —
+  the span ABX-309 budgets would measure the wrong thing. `init` reports
+  `SystemVmStarting` after the binaries are staged and `SystemVmReady` when
+  `vm_lifecycle.ensure_ready` returns (readiness level 2 below); the
+  dockerd wait lands in the `VM_READY → NETWORK_READY` window. `init`
+  reports nothing under `--no-linux-vm`, which is what keeps the VM pair
+  off the wire when no guest boots.
 - Startup-cancellation invariant: the flock (`daemon_lock`) and
   `early_runtime` are held in `StartupHandles`, not only in pipeline-local
   context (`context.rs`, `main::run` keeps a clone). WHY: a signal can drop

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -67,11 +67,14 @@ must name `abctl`.
   ~300 µs apart with no await point between them, so a snapshot channel
   hands a subscriber only `READY` whenever it does not get scheduled in
   that window — indistinguishable from a phase that was never published,
-  and the exact bug CORE-67 set out to remove. `subscribe` takes the
-  snapshot and the receiver together under the write lock; splitting them
-  either drops an update or replays one already folded in, walking a
-  client's phase backwards. Regressions: `back_to_back_phases_are_all_
-  delivered`, `the_snapshot_is_not_replayed_as_an_update`.
+  and the exact bug CORE-67 set out to remove. The two halves are kept
+  atomic by opposite sides of one lock: `publish` broadcasts from inside
+  `send_modify`, holding the write lock, and `subscribe` takes the snapshot
+  and the receiver together under the read lock that write lock excludes.
+  Split either pair and you drop an update or replay one already folded
+  into the snapshot, walking a client's phase backwards. Regressions:
+  `back_to_back_phases_are_all_delivered`,
+  `the_snapshot_is_not_replayed_as_an_update`.
 - `NETWORK_READY` covers whichever services this daemon runs and means they
   were *started*, not that they are reachable. `--no-linux-vm` reaches it
   with DNS alone (`start_services` skips the Docker API and the Kubernetes

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -61,6 +61,24 @@ must name `abctl`.
   dockerd wait lands in the `VM_READY → NETWORK_READY` window. `init`
   reports nothing under `--no-linux-vm`, which is what keeps the VM pair
   off the wire when no guest boots.
+- **`SetupState` streams every update, not the newest snapshot**
+  (`arcbox-api/src/system.rs`: a `watch` for `GetSetupStatus`, a `broadcast`
+  for `WatchSetupStatus`). WHY: `NETWORK_READY` and `READY` are published
+  ~300 µs apart with no await point between them, so a snapshot channel
+  hands a subscriber only `READY` whenever it does not get scheduled in
+  that window — indistinguishable from a phase that was never published,
+  and the exact bug CORE-67 set out to remove. `subscribe` takes the
+  snapshot and the receiver together under the write lock; splitting them
+  either drops an update or replays one already folded in, walking a
+  client's phase backwards. Regressions: `back_to_back_phases_are_all_
+  delivered`, `the_snapshot_is_not_replayed_as_an_update`.
+- `NETWORK_READY` means the host services were *started*, not that they are
+  reachable. `DnsService::bind` propagates its error, but
+  `DockerApiServer::run` binds inside its spawned task and only logs there,
+  and the Kubernetes proxy tolerates a taken 16443 by design — so a Docker
+  socket that fails to bind still reaches `READY`. Pre-existing; if you fix
+  it, bind before returning from `services::start_services` so the failure
+  reaches the pipeline.
 - Startup-cancellation invariant: the flock (`daemon_lock`) and
   `early_runtime` are held in `StartupHandles`, not only in pipeline-local
   context (`context.rs`, `main::run` keeps a clone). WHY: a signal can drop

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -72,13 +72,15 @@ must name `abctl`.
   either drops an update or replays one already folded in, walking a
   client's phase backwards. Regressions: `back_to_back_phases_are_all_
   delivered`, `the_snapshot_is_not_replayed_as_an_update`.
-- `NETWORK_READY` means the host services were *started*, not that they are
-  reachable. `DnsService::bind` propagates its error, but
-  `DockerApiServer::run` binds inside its spawned task and only logs there,
-  and the Kubernetes proxy tolerates a taken 16443 by design — so a Docker
-  socket that fails to bind still reaches `READY`. Pre-existing; if you fix
-  it, bind before returning from `services::start_services` so the failure
-  reaches the pipeline.
+- `NETWORK_READY` covers whichever services this daemon runs and means they
+  were *started*, not that they are reachable. `--no-linux-vm` reaches it
+  with DNS alone (`start_services` skips the Docker API and the Kubernetes
+  proxy), and of the three only DNS is guaranteed bound: `DnsService::bind`
+  propagates its error, while `DockerApiServer::run` binds inside its
+  spawned task and only logs there, and the Kubernetes proxy tolerates a
+  taken 16443 by design — so a Docker socket that fails to bind still
+  reaches `READY`. Pre-existing; if you fix it, bind before returning from
+  `services::start_services` so the failure reaches the pipeline.
 - Startup-cancellation invariant: the flock (`daemon_lock`) and
   `early_runtime` are held in `StartupHandles`, not only in pipeline-local
   context (`context.rs`, `main::run` keeps a clone). WHY: a signal can drop

--- a/app/arcbox-api/src/system.rs
+++ b/app/arcbox-api/src/system.rs
@@ -13,11 +13,16 @@ use arcbox_protocol::v1::{
     SystemVmBackendInfo, VcpuDebug, VirtioDebugInfo, VirtioDeviceDebug, VirtioQueueDebug,
     setup_status,
 };
-use tokio::sync::watch;
+use tokio::sync::{broadcast, watch};
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
 use crate::grpc::{SharedRuntime, SharedRuntimeExt};
+
+/// Buffered updates per streaming client. Startup publishes on the order of a
+/// dozen; the margin covers a client that stalls briefly mid-boot without
+/// dropping a phase.
+const UPDATE_BUFFER: usize = 64;
 
 /// Shared state tracking daemon startup progress.
 ///
@@ -25,7 +30,17 @@ use crate::grpc::{SharedRuntime, SharedRuntimeExt};
 /// Observed by `SystemServiceImpl` to serve gRPC queries.
 #[derive(Debug, Clone)]
 pub struct SetupState {
+    /// Latest snapshot, for `GetSetupStatus` and for seeding a new stream.
     tx: Arc<watch::Sender<SetupStatus>>,
+    /// Every update, in order.
+    ///
+    /// A `watch` keeps only the newest value, so two updates in quick
+    /// succession collapse into one for a subscriber that has not polled in
+    /// between — and a phase a client never receives is indistinguishable
+    /// from one the daemon never published. `NETWORK_READY` and `READY` are
+    /// ~300 µs apart with no await point between them, so on that pair the
+    /// collapse is a live race rather than a theoretical one.
+    updates: broadcast::Sender<SetupStatus>,
 }
 
 impl SetupState {
@@ -42,22 +57,39 @@ impl SetupState {
             error: String::new(),
         };
         let (tx, _) = watch::channel(initial);
-        Self { tx: Arc::new(tx) }
+        Self {
+            tx: Arc::new(tx),
+            updates: broadcast::channel(UPDATE_BUFFER).0,
+        }
+    }
+
+    /// Applies an update to the snapshot and publishes it to every stream.
+    ///
+    /// The broadcast happens inside `send_modify`, under the write lock, so a
+    /// concurrent publisher cannot interleave the two halves and deliver
+    /// updates in an order the snapshot never passed through — recovery and
+    /// the route loop write flags while startup writes phases.
+    fn publish(&self, update: impl FnOnce(&mut SetupStatus)) {
+        self.tx.send_modify(|status| {
+            update(status);
+            // Fails only when nobody is streaming, which is the common case.
+            let _ = self.updates.send(status.clone());
+        });
     }
 
     /// Updates the current setup phase.
     pub fn set_phase(&self, phase: setup_status::Phase, message: &str) {
-        self.tx.send_modify(|s| {
+        self.publish(|s| {
             s.phase = phase.into();
             message.clone_into(&mut s.message);
         });
     }
 
     /// Marks startup as fatally failed. The daemon exits shortly after;
-    /// the error rides the final watch update so streaming clients learn
+    /// the error rides the final update so streaming clients learn
     /// the cause instead of seeing a bare disconnect.
     pub fn set_failed(&self, error: &str) {
-        self.tx.send_modify(|s| {
+        self.publish(|s| {
             s.phase = setup_status::Phase::Failed.into();
             "Daemon startup failed".clone_into(&mut s.message);
             error.clone_into(&mut s.error);
@@ -66,30 +98,36 @@ impl SetupState {
 
     /// Updates a specific infrastructure flag.
     pub fn set_dns_installed(&self, installed: bool) {
-        self.tx
-            .send_modify(|s| s.dns_resolver_installed = installed);
+        self.publish(|s| s.dns_resolver_installed = installed);
     }
 
     pub fn set_docker_socket_linked(&self, linked: bool) {
-        self.tx.send_modify(|s| s.docker_socket_linked = linked);
+        self.publish(|s| s.docker_socket_linked = linked);
     }
 
     pub fn set_route_installed(&self, installed: bool) {
-        self.tx.send_modify(|s| s.route_installed = installed);
+        self.publish(|s| s.route_installed = installed);
     }
 
     pub fn set_vm_running(&self, running: bool) {
-        self.tx.send_modify(|s| s.vm_running = running);
+        self.publish(|s| s.vm_running = running);
     }
 
     pub fn set_docker_tools_installed(&self, installed: bool) {
-        self.tx
-            .send_modify(|s| s.docker_tools_installed = installed);
+        self.publish(|s| s.docker_tools_installed = installed);
     }
 
-    /// Returns a watch receiver for streaming updates.
-    fn subscribe(&self) -> watch::Receiver<SetupStatus> {
-        self.tx.subscribe()
+    /// Returns the current snapshot plus a receiver for every update after it.
+    ///
+    /// Both are taken while holding the snapshot's read lock, which excludes
+    /// [`Self::publish`]'s write lock. Subscribing after reading the snapshot
+    /// would drop an update landing between the two; reading the snapshot
+    /// after subscribing could replay one already folded into it, walking a
+    /// client's phase backwards.
+    fn subscribe(&self) -> (SetupStatus, broadcast::Receiver<SetupStatus>) {
+        let snapshot = self.tx.borrow();
+        let updates = self.updates.subscribe();
+        (snapshot.clone(), updates)
     }
 
     /// Returns the current status snapshot.
@@ -241,15 +279,21 @@ impl SystemService for SystemServiceImpl {
         &self,
         _request: Request<Empty>,
     ) -> Result<Response<Self::WatchSetupStatusStream>, Status> {
-        let mut rx = self.setup_state.subscribe();
+        let (initial, mut updates) = self.setup_state.subscribe();
         let stream = async_stream::stream! {
-            // Send current state immediately.
-            let initial = rx.borrow_and_update().clone();
+            // Send current state immediately, then every update after it.
             yield Ok(initial);
-            // Then stream changes.
-            while rx.changed().await.is_ok() {
-                let status = rx.borrow_and_update().clone();
-                yield Ok(status);
+            loop {
+                match updates.recv().await {
+                    Ok(status) => yield Ok(status),
+                    // Too slow to keep up: the next recv resumes from the
+                    // oldest retained update, so the client stays live and
+                    // converges — it has only missed intermediate phases.
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        tracing::warn!(skipped, "setup status client lagged");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
             }
         };
         Ok(Response::new(Box::pin(stream)))
@@ -353,5 +397,65 @@ impl SystemService for SystemServiceImpl {
         Ok(Response::new(SystemVmBackendInfo {
             backend: backend_to_proto(runtime.system_vm_backend()) as i32,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every update currently buffered for `updates`, as phases.
+    fn drain(updates: &mut broadcast::Receiver<SetupStatus>) -> Vec<setup_status::Phase> {
+        std::iter::from_fn(|| updates.try_recv().ok())
+            .map(|status| status.phase())
+            .collect()
+    }
+
+    /// The regression this exists for: `NETWORK_READY` and `READY` are
+    /// published ~300 µs apart with no await point between them, so a
+    /// snapshot-only channel hands a client just the last one — a phase that
+    /// was published but never observed, which is exactly what CORE-67 set
+    /// out to make impossible.
+    #[test]
+    fn back_to_back_phases_are_all_delivered() {
+        let state = SetupState::new();
+        let (_snapshot, mut updates) = state.subscribe();
+
+        state.set_phase(setup_status::Phase::NetworkReady, "network");
+        state.set_phase(setup_status::Phase::Ready, "ready");
+
+        assert_eq!(
+            drain(&mut updates),
+            [
+                setup_status::Phase::NetworkReady,
+                setup_status::Phase::Ready
+            ]
+        );
+    }
+
+    /// A subscriber's snapshot already folds in every earlier update, so
+    /// replaying one would walk the client's phase backwards.
+    #[test]
+    fn the_snapshot_is_not_replayed_as_an_update() {
+        let state = SetupState::new();
+        state.set_phase(setup_status::Phase::AssetsReady, "assets");
+
+        let (snapshot, mut updates) = state.subscribe();
+
+        assert_eq!(snapshot.phase(), setup_status::Phase::AssetsReady);
+        assert!(drain(&mut updates).is_empty());
+    }
+
+    /// Flags travel the same path as phases: a client watching for the route
+    /// must not have to wait for an unrelated phase change to learn of it.
+    #[test]
+    fn flag_updates_reach_subscribers() {
+        let state = SetupState::new();
+        let (_snapshot, mut updates) = state.subscribe();
+
+        state.set_route_installed(true);
+
+        let update = updates.try_recv().expect("flag update delivered");
+        assert!(update.route_installed);
     }
 }

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -69,7 +69,7 @@ pub use macos::{
 #[cfg(feature = "macos-ipsw-install")]
 pub use macos::{PullPhase, PullSource};
 pub use migration::MigrationManager;
-pub use runtime::{Runtime, SandboxPortExposure};
+pub use runtime::{InitProgress, Runtime, SandboxPortExposure};
 pub use vm::{SharedDirConfig, VmConfig, VmManager};
 pub use vm_lifecycle::{
     ActivityScope, DEFAULT_MACHINE_NAME, DefaultVmConfig, HealthMonitor, VmLifecycleConfig,

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -2,9 +2,12 @@
 
 mod assets;
 mod kubeconfig;
+mod progress;
 
 #[cfg(test)]
 mod tests;
+
+pub use progress::InitProgress;
 
 use crate::config::Config;
 use crate::container_backend::{DynContainerBackend, create_backend};
@@ -711,10 +714,15 @@ impl Runtime {
     /// Validates that all guest binaries (agent + runtime) are present and
     /// executable before starting the VM. This is a boot-blocking check.
     ///
+    /// `progress` observes the [`InitProgress`] milestones as they are
+    /// reached — this is the only way to see inside the call, which spans
+    /// the slowest part of daemon startup. It is never invoked in
+    /// VM-host-only mode, where no VM starts.
+    ///
     /// # Errors
     ///
     /// Returns an error if initialization fails or guest binaries are missing.
-    pub async fn init(&self) -> Result<()> {
+    pub async fn init(&self, progress: impl Fn(InitProgress) + Send) -> Result<()> {
         // Create data directories.
         tokio::fs::create_dir_all(&self.config.data_dir).await?;
         tokio::fs::create_dir_all(self.config.data_dir.join("vms")).await?;
@@ -745,6 +753,15 @@ impl Runtime {
 
         // Validate all guest binaries are present and executable (boot-blocking).
         ensure_guest_binaries(&self.config.data_dir)?;
+
+        // Boot the VM through the lifecycle manager first so the agent
+        // handshake is observable on its own: `ensure_vm_ready` below covers
+        // the VM *and* the guest container runtime with no boundary between
+        // them. With the VM already up it short-circuits on the lifecycle
+        // actor's cached CID and only waits for dockerd.
+        progress(InitProgress::SystemVmStarting);
+        self.vm_lifecycle.ensure_ready().await?;
+        progress(InitProgress::SystemVmReady);
 
         self.ensure_vm_ready().await?;
 

--- a/app/arcbox-core/src/runtime/progress.rs
+++ b/app/arcbox-core/src/runtime/progress.rs
@@ -1,0 +1,25 @@
+//! Startup milestones reported out of [`Runtime::init`](crate::Runtime::init).
+
+/// A milestone [`Runtime::init`](crate::Runtime::init) passes while bringing
+/// the System VM up.
+///
+/// `init` is a single call spanning the slowest stretch of daemon startup:
+/// staging the guest runtime binaries, booting the VM, the agent handshake,
+/// then probing the guest container runtime. A caller that wants to report
+/// progress to its own clients needs the boundaries *inside* that call, and
+/// cannot recover them from call order — doing so would bill the binary
+/// download to VM boot and could not separate "the agent answered" from
+/// "dockerd answered".
+///
+/// Reported on the calling task, in declaration order, and only while a
+/// System VM is actually coming up: VM-host-only mode (`vm.autostart =
+/// false`) starts no VM and reports nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InitProgress {
+    /// Guest binaries are staged and validated; the System VM is about to
+    /// boot. Everything before this point is host-side preparation.
+    SystemVmStarting,
+    /// The System VM booted and its guest agent answered, so the VM accepts
+    /// commands. Its container runtime may still be starting.
+    SystemVmReady,
+}

--- a/app/arcbox-core/src/runtime/tests.rs
+++ b/app/arcbox-core/src/runtime/tests.rs
@@ -100,6 +100,33 @@ fn networking_test_runtime() -> (Runtime, tempfile::TempDir) {
     (runtime, temp_dir)
 }
 
+/// VM-host-only mode reports no milestones, because no VM starts.
+///
+/// The guarantee is the `!vm.autostart` early return in `init`. Four places
+/// state the invariant — `InitProgress`'s docs, the `Phase` enum in
+/// `api.proto`, `app/AGENTS.md`, `docs/daemon-lifecycle.md` — and nothing
+/// enforced it: work moved above that return would announce `VM_STARTING`
+/// for a daemon that boots no guest, and all four would quietly go false.
+#[tokio::test]
+async fn init_reports_no_milestones_without_a_linux_vm() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut config = Config {
+        data_dir: temp_dir.path().to_path_buf(),
+        ..Default::default()
+    };
+    config.vm.autostart = false;
+    let runtime = Runtime::new(config).expect("runtime init should succeed");
+
+    let reported = std::sync::Mutex::new(Vec::new());
+    runtime
+        .init(|milestone| reported.lock().unwrap().push(milestone))
+        .await
+        .expect("VM-host-only init only creates data directories");
+
+    let reported = reported.into_inner().unwrap();
+    assert!(reported.is_empty(), "expected silence, got {reported:?}");
+}
+
 #[tokio::test]
 async fn resolve_registered_container_by_id_alias_and_prefix() {
     let (runtime, _tmp) = networking_test_runtime();

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use arcbox_api::SetupPhase;
 use arcbox_constants::paths::{ArcboxProfile, HostLayout};
-use arcbox_core::{Config, Runtime};
+use arcbox_core::{Config, InitProgress, Runtime};
 use macos_resolver::to_env_prefix;
 use tracing::{info, warn};
 
@@ -207,7 +207,8 @@ async fn prepare_assets(ctx: &DaemonContext) -> Result<assets::PreparedAssets> {
 /// Phase 2: seed/download boot assets, build runtime, start VM.
 ///
 /// Called after gRPC SystemService is already listening so clients
-/// can observe DOWNLOADING_ASSETS → ASSETS_READY progression.
+/// can observe DOWNLOADING_ASSETS → ASSETS_READY progression, and
+/// publishes VM_STARTING → VM_READY around the guest boot itself.
 /// Returns the initialized runtime.
 async fn init_runtime(ctx: &DaemonContext) -> Result<Arc<Runtime>> {
     let mut config = Config::load_for_profile(ctx.profile).unwrap_or_else(|err| {
@@ -241,8 +242,19 @@ async fn init_runtime(ctx: &DaemonContext) -> Result<Arc<Runtime>> {
     ctx.early_runtime
         .set(Arc::clone(&runtime))
         .map_err(|_| anyhow::anyhow!("init_runtime called twice"))?;
+    // The guest boot is the longest stretch of startup and the only one a
+    // client cannot infer from anything else, so the runtime reports its
+    // milestones from inside and they are published as they arrive.
     runtime
-        .init()
+        .init(|milestone| match milestone {
+            InitProgress::SystemVmStarting => ctx
+                .setup_state
+                .set_phase(SetupPhase::VmStarting, "Starting the Linux VM…"),
+            InitProgress::SystemVmReady => ctx.setup_state.set_phase(
+                SetupPhase::VmReady,
+                "Linux VM ready; waiting for the container runtime…",
+            ),
+        })
         .await
         .context("Failed to initialize runtime")?;
     info!(

--- a/app/arcbox-daemon/src/startup/pipeline.rs
+++ b/app/arcbox-daemon/src/startup/pipeline.rs
@@ -149,6 +149,13 @@ impl RuntimeBooted {
             Ok(handles)
         })
         .await?;
+        // DNS, the Docker API, and the Kubernetes proxy are listening: every
+        // path a client reaches the VM through is open. What recovery spawned
+        // (route reconcile, self-setup) reports separately through the
+        // SetupStatus flags, not through this phase.
+        self.ctx
+            .setup_state
+            .set_phase(SetupPhase::NetworkReady, "Network services ready");
         Ok(RuntimeServicesStarted {
             ctx: self.ctx,
             handles,

--- a/app/arcbox-daemon/src/startup/pipeline.rs
+++ b/app/arcbox-daemon/src/startup/pipeline.rs
@@ -149,10 +149,12 @@ impl RuntimeBooted {
             Ok(handles)
         })
         .await?;
-        // DNS, the Docker API, and the Kubernetes proxy are listening: every
-        // path a client reaches the VM through is open. What recovery spawned
-        // (route reconcile, self-setup) reports separately through the
-        // SetupStatus flags, not through this phase.
+        // DNS is bound; the Docker API and Kubernetes proxies are started.
+        // Neither proxy's bind failure reaches this stage — `DockerApiServer`
+        // binds inside its spawned task and only logs, and a taken 16443 is
+        // tolerated by design — so the phase means "services started", not
+        // "proven reachable". What recovery spawned (route reconcile,
+        // self-setup) reports through the SetupStatus flags instead.
         self.ctx
             .setup_state
             .set_phase(SetupPhase::NetworkReady, "Network services ready");

--- a/app/arcbox-daemon/src/startup/pipeline.rs
+++ b/app/arcbox-daemon/src/startup/pipeline.rs
@@ -149,12 +149,14 @@ impl RuntimeBooted {
             Ok(handles)
         })
         .await?;
-        // DNS is bound; the Docker API and Kubernetes proxies are started.
-        // Neither proxy's bind failure reaches this stage — `DockerApiServer`
-        // binds inside its spawned task and only logs, and a taken 16443 is
-        // tolerated by design — so the phase means "services started", not
-        // "proven reachable". What recovery spawned (route reconcile,
-        // self-setup) reports through the SetupStatus flags instead.
+        // DNS is bound; with a Linux VM the Docker API and Kubernetes proxies
+        // are started too (`start_services` skips both under `--no-linux-vm`,
+        // so that daemon reaches this phase with DNS alone). Neither proxy's
+        // bind failure reaches this stage — `DockerApiServer` binds inside its
+        // spawned task and only logs, and a taken 16443 is tolerated by design
+        // — so the phase means "services started", not "proven reachable".
+        // What recovery spawned (route reconcile, self-setup) reports through
+        // the SetupStatus flags instead.
         self.ctx
             .setup_state
             .set_phase(SetupPhase::NetworkReady, "Network services ready");

--- a/app/arcbox-docker/tests/support/api.rs
+++ b/app/arcbox-docker/tests/support/api.rs
@@ -31,7 +31,7 @@ pub async fn create_test_runtime() -> (Arc<Runtime>, Arc<VsockConnector>, TempDi
         Runtime::with_vm_lifecycle_config(config, vm_lifecycle_config)
             .expect("Failed to create runtime"),
     );
-    runtime.init().await.expect("Failed to init runtime");
+    runtime.init(|_| {}).await.expect("Failed to init runtime");
     let connector = Arc::new(VsockConnector::new(Arc::clone(&runtime)));
     (runtime, connector, tmp_dir)
 }

--- a/docs/daemon-lifecycle.md
+++ b/docs/daemon-lifecycle.md
@@ -55,12 +55,15 @@ startup failure.
   `READY` are published ~300 µs apart with no await point between them and
   a snapshot channel would collapse them (see `SetupState` in
   `arcbox-api/src/system.rs`).
-- `NETWORK_READY` means the host services were *started*, not that they are
-  reachable: `DnsService::bind` propagates its error, but
-  `DockerApiServer::run` binds inside its spawned task and only logs, and
-  the Kubernetes proxy tolerates a taken 16443 by design. A Docker socket
-  that fails to bind therefore still reaches `READY` — a pre-existing gap,
-  not something the phase introduces.
+- `NETWORK_READY` covers whichever host services this daemon runs, and means
+  they were *started*, not that they are reachable. A `--no-linux-vm` daemon
+  reaches it with DNS alone — `start_services` skips the Docker API and the
+  Kubernetes proxy in that mode. And of the three, only DNS is guaranteed
+  bound: `DnsService::bind` propagates its error, while
+  `DockerApiServer::run` binds inside its spawned task and only logs there,
+  and the Kubernetes proxy tolerates a taken 16443 by design. A Docker
+  socket that fails to bind therefore still reaches `READY` — a pre-existing
+  gap, not something the phase introduces.
 - Enum ordinal ≠ progression order (`DOWNLOADING_ASSETS = 8` occurs before
   `READY = 6`). Clients must match on the value, never compare ordinals.
   New phases are appended with the next free number regardless of where

--- a/docs/daemon-lifecycle.md
+++ b/docs/daemon-lifecycle.md
@@ -49,7 +49,18 @@ startup failure.
   daemon, which boots no guest. `DEGRADED` is reserved and never emitted.
 - A phase the daemon had already left before a client subscribed is never
   observed. Treat a missing phase as unknown, not as zero elapsed and not
-  as a reason to keep waiting — the stream never replays it.
+  as a reason to keep waiting — the stream never replays it. Once
+  subscribed, though, no transition is dropped: `WatchSetupStatus` streams
+  every update rather than the newest snapshot, because `NETWORK_READY` and
+  `READY` are published ~300 µs apart with no await point between them and
+  a snapshot channel would collapse them (see `SetupState` in
+  `arcbox-api/src/system.rs`).
+- `NETWORK_READY` means the host services were *started*, not that they are
+  reachable: `DnsService::bind` propagates its error, but
+  `DockerApiServer::run` binds inside its spawned task and only logs, and
+  the Kubernetes proxy tolerates a taken 16443 by design. A Docker socket
+  that fails to bind therefore still reaches `READY` — a pre-existing gap,
+  not something the phase introduces.
 - Enum ordinal ≠ progression order (`DOWNLOADING_ASSETS = 8` occurs before
   `READY = 6`). Clients must match on the value, never compare ordinals.
   New phases are appended with the next free number regardless of where

--- a/docs/daemon-lifecycle.md
+++ b/docs/daemon-lifecycle.md
@@ -24,11 +24,12 @@ prepare_assets           Seed/download boot assets               variable
     │                    ASSETS_READY.
     │
 boot_runtime             Construct Runtime, boot the System VM   variable
-    │                    Emits no phase of its own; VM/network
-    │                    progress surfaces as SetupStatus infra
-    │                    flags, not phases (see below).
+    │                    Reported as VM_STARTING → VM_READY,
+    │                    published from inside Runtime::init so
+    │                    the span covers the guest boot alone.
     │
 start_runtime_services   DNS, Docker API, recovery               ~instant
+    │                    Reported as NETWORK_READY.
     │
 mark_ready               SetupPhase::Ready
 ```
@@ -41,19 +42,23 @@ startup failure.
 
 ### Phase enum caveats
 
-- The observable progression is `INITIALIZING → [CLEANING_UP] →
-  DOWNLOADING_ASSETS → ASSETS_READY → READY` (or `FAILED`). The
-  `VM_STARTING` / `VM_READY` / `NETWORK_READY` / `DEGRADED` values in
-  `SetupStatus.Phase` are reserved but currently never emitted — do not
-  wait on them.
+- The observable progression is `INITIALIZING → [CLEANING_UP →
+  INITIALIZING] → [DOWNLOADING_ASSETS] → ASSETS_READY → [VM_STARTING →
+  VM_READY] → NETWORK_READY → READY` (or `FAILED`). Bracketed phases are
+  conditional; the VM pair is skipped entirely by a `--no-linux-vm`
+  daemon, which boots no guest. `DEGRADED` is reserved and never emitted.
+- A phase the daemon had already left before a client subscribed is never
+  observed. Treat a missing phase as unknown, not as zero elapsed and not
+  as a reason to keep waiting — the stream never replays it.
 - Enum ordinal ≠ progression order (`DOWNLOADING_ASSETS = 8` occurs before
   `READY = 6`). Clients must match on the value, never compare ordinals.
   New phases are appended with the next free number regardless of where
   they sit in the progression — values are additive-only.
-- VM / route / DNS progress during and after `boot_runtime` is carried by
-  the boolean `SetupStatus` fields (`vm_running`, `route_installed`,
-  `dns_resolver_installed`, …), set by recovery and `route_status_loop`,
-  not by phase transitions.
+- Phases mark the transitions; the boolean `SetupStatus` fields
+  (`vm_running`, `route_installed`, `dns_resolver_installed`, …) carry the
+  state that outlives startup, including work `recovery::run` spawns in
+  the background and anything `route_status_loop` reconciles afterwards.
+  A client wanting "is the route up *now*" reads the flag, not a phase.
 
 ### Why gRPC starts before resource cleanup
 

--- a/rpc/arcbox-protocol/proto/api.proto
+++ b/rpc/arcbox-protocol/proto/api.proto
@@ -742,7 +742,10 @@ message SetupStatus {
         // The System VM booted and its guest agent answered, so the VM
         // accepts commands. Its container runtime may still be starting.
         VM_READY = 4;
-        // DNS, the Docker API, and the Kubernetes proxy are listening.
+        // Host services for the VM are up: the DNS server is bound, and the
+        // Docker API and Kubernetes proxies have been started. Neither proxy
+        // aborts startup when its bind fails, so this means "started", not
+        // "proven reachable" — clients still handle a connection error.
         NETWORK_READY = 5;
         // Startup complete.
         READY = 6;

--- a/rpc/arcbox-protocol/proto/api.proto
+++ b/rpc/arcbox-protocol/proto/api.proto
@@ -742,10 +742,12 @@ message SetupStatus {
         // The System VM booted and its guest agent answered, so the VM
         // accepts commands. Its container runtime may still be starting.
         VM_READY = 4;
-        // Host services for the VM are up: the DNS server is bound, and the
-        // Docker API and Kubernetes proxies have been started. Neither proxy
-        // aborts startup when its bind fails, so this means "started", not
-        // "proven reachable" — clients still handle a connection error.
+        // The host services this daemon runs are up: the DNS server is
+        // bound, and — with a Linux VM — the Docker API and Kubernetes
+        // proxies have been started (a --no-linux-vm daemon runs neither).
+        // Neither proxy aborts startup when its bind fails, so this means
+        // "started", not "proven reachable"; clients still handle a
+        // connection error.
         NETWORK_READY = 5;
         // Startup complete.
         READY = 6;

--- a/rpc/arcbox-protocol/proto/api.proto
+++ b/rpc/arcbox-protocol/proto/api.proto
@@ -714,17 +714,43 @@ message TerminalSize {
 // Allows the desktop app (or any gRPC client) to observe daemon readiness
 // without managing its lifecycle.
 message SetupStatus {
-    // Daemon startup phases, ordered by progression.
+    // Daemon startup phases.
+    //
+    // Numbers follow the order phases were introduced, NOT the order they
+    // occur in (DOWNLOADING_ASSETS = 8 precedes READY = 6), so match on the
+    // value and never compare ordinals. The happy path is:
+    //
+    //   INITIALIZING -> [CLEANING_UP -> INITIALIZING] -> [DOWNLOADING_ASSETS]
+    //   -> ASSETS_READY -> [VM_STARTING -> VM_READY] -> NETWORK_READY -> READY
+    //
+    // Bracketed steps are conditional: CLEANING_UP only when a displaced
+    // daemon's resources must be released, DOWNLOADING_ASSETS only when boot
+    // assets are missing, and the VM pair only when the Linux VM is enabled
+    // (a --no-linux-vm daemon boots no guest and publishes neither). FAILED
+    // can replace any of them. A phase already passed before a client
+    // subscribes is simply never seen, so treat an unobserved phase as
+    // unknown rather than waiting for it.
     enum Phase {
         PHASE_UNSPECIFIED = 0;
+        // Host directories, config, and sockets are being prepared.
         INITIALIZING = 1;
+        // Kernel, rootfs, and guest binaries are present and verified.
         ASSETS_READY = 2;
+        // The System VM is booting. Guest binaries are already staged by
+        // this point, so the phase covers the guest boot and nothing else.
         VM_STARTING = 3;
+        // The System VM booted and its guest agent answered, so the VM
+        // accepts commands. Its container runtime may still be starting.
         VM_READY = 4;
+        // DNS, the Docker API, and the Kubernetes proxy are listening.
         NETWORK_READY = 5;
+        // Startup complete.
         READY = 6;
+        // Reserved; never published.
         DEGRADED = 7;
+        // Boot assets are being downloaded.
         DOWNLOADING_ASSETS = 8;
+        // Waiting for a displaced daemon to release its disk images.
         CLEANING_UP = 9;
         // Startup failed fatally; the daemon exits shortly after
         // publishing this phase. See the `error` field for the cause.

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -1009,7 +1009,10 @@ pub mod setup_status {
         /// The System VM booted and its guest agent answered, so the VM
         /// accepts commands. Its container runtime may still be starting.
         VmReady = 4,
-        /// DNS, the Docker API, and the Kubernetes proxy are listening.
+        /// Host services for the VM are up: the DNS server is bound, and the
+        /// Docker API and Kubernetes proxies have been started. Neither proxy
+        /// aborts startup when its bind fails, so this means "started", not
+        /// "proven reachable" — clients still handle a connection error.
         NetworkReady = 5,
         /// Startup complete.
         Ready = 6,

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -977,21 +977,47 @@ pub struct SetupStatus {
 }
 /// Nested message and enum types in `SetupStatus`.
 pub mod setup_status {
-    /// Daemon startup phases, ordered by progression.
+    /// Daemon startup phases.
+    ///
+    /// Numbers follow the order phases were introduced, NOT the order they
+    /// occur in (DOWNLOADING_ASSETS = 8 precedes READY = 6), so match on the
+    /// value and never compare ordinals. The happy path is:
+    ///
+    ///    INITIALIZING -> \[CLEANING_UP -> INITIALIZING\] -> \[DOWNLOADING_ASSETS\]
+    ///    -> ASSETS_READY -> \[VM_STARTING -> VM_READY\] -> NETWORK_READY -> READY
+    ///
+    /// Bracketed steps are conditional: CLEANING_UP only when a displaced
+    /// daemon's resources must be released, DOWNLOADING_ASSETS only when boot
+    /// assets are missing, and the VM pair only when the Linux VM is enabled
+    /// (a --no-linux-vm daemon boots no guest and publishes neither). FAILED
+    /// can replace any of them. A phase already passed before a client
+    /// subscribes is simply never seen, so treat an unobserved phase as
+    /// unknown rather than waiting for it.
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(rename_all = "camelCase")]
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum Phase {
         Unspecified = 0,
+        /// Host directories, config, and sockets are being prepared.
         Initializing = 1,
+        /// Kernel, rootfs, and guest binaries are present and verified.
         AssetsReady = 2,
+        /// The System VM is booting. Guest binaries are already staged by
+        /// this point, so the phase covers the guest boot and nothing else.
         VmStarting = 3,
+        /// The System VM booted and its guest agent answered, so the VM
+        /// accepts commands. Its container runtime may still be starting.
         VmReady = 4,
+        /// DNS, the Docker API, and the Kubernetes proxy are listening.
         NetworkReady = 5,
+        /// Startup complete.
         Ready = 6,
+        /// Reserved; never published.
         Degraded = 7,
+        /// Boot assets are being downloaded.
         DownloadingAssets = 8,
+        /// Waiting for a displaced daemon to release its disk images.
         CleaningUp = 9,
         /// Startup failed fatally; the daemon exits shortly after
         /// publishing this phase. See the `error` field for the cause.

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -1009,10 +1009,12 @@ pub mod setup_status {
         /// The System VM booted and its guest agent answered, so the VM
         /// accepts commands. Its container runtime may still be starting.
         VmReady = 4,
-        /// Host services for the VM are up: the DNS server is bound, and the
-        /// Docker API and Kubernetes proxies have been started. Neither proxy
-        /// aborts startup when its bind fails, so this means "started", not
-        /// "proven reachable" — clients still handle a connection error.
+        /// The host services this daemon runs are up: the DNS server is
+        /// bound, and — with a Linux VM — the Docker API and Kubernetes
+        /// proxies have been started (a --no-linux-vm daemon runs neither).
+        /// Neither proxy aborts startup when its bind fails, so this means
+        /// "started", not "proven reachable"; clients still handle a
+        /// connection error.
         NetworkReady = 5,
         /// Startup complete.
         Ready = 6,


### PR DESCRIPTION
`SetupStatus.Phase` declares eleven values. The daemon published five, and the
three it skipped — `VM_STARTING`, `VM_READY`, `NETWORK_READY` — bracket the
slowest stretch of startup. A client following `WatchSetupStatus` saw "Boot
assets ready" and then nothing for tens of seconds, precisely when it most
wants progress. The desktop setup UI looks stalled while the daemon is doing
the most work, and ABX-309's cold-boot budget had to settle for
`AssetsReady → Ready`, which conflates runtime build, guest boot, dockerd, and
service startup.

A phase nothing publishes is not observable as a gap. It simply never arrives:
a consumer either waits forever or reports a plausible zero.

## Why not publish at the pipeline's stage edges

That was the obvious fix and it produces the wrong measurements.

`boot_runtime` is a single stage that stages guest binaries, boots the VM,
waits for the agent, then waits for dockerd. Publishing `VM_STARTING` on entry
bills the guest-binary download — hundreds of MB on a cold cache — to VM boot,
and `VM_READY` on exit actually means "dockerd answered". The span ABX-309
wants to budget would measure the wrong thing. A `--no-linux-vm` daemon would
also announce a VM it never boots.

The boundaries those phases name live inside `Runtime::init`, so that is where
they are reported from.

## What changed

`Runtime::init` takes a progress callback and reports `InitProgress`
milestones as it passes them: `SystemVmStarting` once the guest binaries are
staged and validated, `SystemVmReady` when `vm_lifecycle::ensure_ready`
returns — readiness level 2, "the agent replied to a ping". The daemon maps
those onto the wire in `startup/mod.rs::init_runtime`.

Booting through the lifecycle manager before the backend's own `ensure_ready`
is what creates the observable seam. The second call short-circuits on the
lifecycle actor's cached CID and waits only for dockerd, so the container
backend remains the authority on readiness and nothing is duplicated.

`init` reports nothing when the Linux VM is disabled — it returns before
reaching either call — so the VM pair stays off the wire for a `--no-linux-vm`
daemon with no separate condition to keep in sync.

`NETWORK_READY` is published where its boundary really is: after
`start_runtime_services`, when DNS, the Docker API, and the Kubernetes proxy
are listening. The dockerd wait therefore falls in the `VM_READY →
NETWORK_READY` window.

Publication is sequential on the startup task, so the progression is monotonic
by construction — there is no watcher task that could race `READY`.

## Documentation

The enum's `// Daemon startup phases, ordered by progression.` comment was
false: values follow the order phases were introduced, not the order they
occur in (`DOWNLOADING_ASSETS = 8` precedes `READY = 6`). It now states the
real happy path, which phases are conditional, and what each value means.
`docs/daemon-lifecycle.md` and `app/AGENTS.md` follow; the AGENTS.md entry
records the rule that declaring a phase obliges you to publish it, and why the
VM pair cannot be derived from pipeline order.

Only comments changed in the `.proto`, so `buf breaking` is unaffected; the
regenerated prost output is committed alongside it.

## Validation

`cargo fmt --check` and `cargo clippy --workspace --exclude arcbox-agent --
-D warnings` are clean. Unit tests pass (the four `arcbox-api` icon tests fail
locally only because they make live requests to cdn.jsdelivr.net and
avatars.githubusercontent.com).

Two VZ cold boots on hardware, via `cargo test -p arcbox-e2e --test smoke --
--ignored`. All three phases published, in order:

```
AssetsReady → VmStarting → VmReady → NetworkReady → Ready
```

| | run 1 | run 2 |
|---|---|---|
| `VmStarting → VmReady` | 2.289 s | 1.548 s |

Against the ~1.5 s cold-boot target — a number the previous phase vocabulary
could not isolate at all.

No desktop change is needed: `DaemonManager+Watch.swift` already maps all
eleven phases exhaustively, and `isDockerReady` matches only `.ready` /
`.degraded`, so the new intermediate phases cannot trip it. The setup UI picks
up the progress for free.

## Follow-ups (not in this PR)

- The e2e branch `test/e2e-smoke-and-lifecycle-coverage` narrows ABX-309's
  budget to `VmStarting → VmReady` and asserts the progression. It **depends on
  this PR**: those checks hard-fail against a daemon that does not publish the
  pair. The two branches touch disjoint files, so they merge in either order,
  but only this order passes CI.
- `SetupStatus.vm_running` is set only by `recovery.rs` and never cleared, so
  it goes stale on VM stop. Fixing it needs a decision on whether it means "VM
  process up" or "agent answered" — separate from the phase vocabulary.

Closes CORE-67. Refs ABX-309.
