### PR TITLE
test(e2e): smoke suite, VirtioFS consistency, and daemon lock coverage

### DIFF
--- a/.github/workflows/docker-api-e2e.yml
+++ b/.github/workflows/docker-api-e2e.yml
@@ -13,7 +13,10 @@ jobs:
   # Basic API tests that don't require VM
   api-compatibility:
     name: Docker API Compatibility
-    runs-on: macos-26  # Apple Silicon runner
+    # GitHub-hosted, so no Virtualization.framework — fine for this job,
+    # which is the VM-free half. The comment above explains why the whole
+    # workflow stays dispatch-only until a self-hosted runner exists.
+    runs-on: macos-26
     timeout-minutes: 30
 
     steps:

--- a/tests/e2e/src/daemon.rs
+++ b/tests/e2e/src/daemon.rs
@@ -177,6 +177,15 @@ impl DaemonHandle {
         self.child.id()
     }
 
+    /// Whether the daemon has exited, reaping it when it has.
+    ///
+    /// The reaping is the point: an exited child this handle has not waited
+    /// on stays a zombie, and a zombie still answers `kill(pid, 0)`, so a
+    /// signal-0 probe would report it alive forever.
+    pub fn has_exited(&mut self) -> Result<bool> {
+        Ok(self.child.try_wait().context("polling daemon")?.is_some())
+    }
+
     /// The Docker API socket under the handle's data directory.
     pub fn docker_socket(&self) -> PathBuf {
         self.data_dir.join("run/docker.sock")

--- a/tests/e2e/src/daemon.rs
+++ b/tests/e2e/src/daemon.rs
@@ -49,12 +49,62 @@ pub struct DaemonConfig {
     pub env: Vec<(String, String)>,
 }
 
+/// When each setup phase was first observed on the readiness stream,
+/// relative to the start of [`DaemonHandle::wait_ready`].
+///
+/// Only the FIRST sighting of a phase is kept: the daemon republishes the
+/// current phase to every new subscriber and may re-send one unchanged, and
+/// a span should measure when a stage began, not when it was last echoed.
+///
+/// A phase the daemon had already left before the harness subscribed is
+/// never observed, so every lookup is fallible — callers must treat a
+/// missing mark as "unknown", never as zero.
+#[derive(Debug, Default)]
+pub struct PhaseMarks {
+    marks: Vec<(setup_status::Phase, Duration)>,
+}
+
+impl PhaseMarks {
+    fn mark(&mut self, phase: setup_status::Phase, elapsed: Duration) {
+        if self.marks.iter().any(|(seen, _)| *seen == phase) {
+            return;
+        }
+        self.marks.push((phase, elapsed));
+    }
+
+    /// When `phase` was first observed, if it was.
+    #[must_use]
+    pub fn at(&self, phase: setup_status::Phase) -> Option<Duration> {
+        self.marks
+            .iter()
+            .find(|(seen, _)| *seen == phase)
+            .map(|(_, at)| *at)
+    }
+
+    /// Elapsed time between two observed phases.
+    ///
+    /// `None` when either was missed, or when `to` was seen before `from` —
+    /// an out-of-order pair is a caller error, and a saturating zero would
+    /// read as a suspiciously fast stage.
+    #[must_use]
+    pub fn span(&self, from: setup_status::Phase, to: setup_status::Phase) -> Option<Duration> {
+        self.at(to)?.checked_sub(self.at(from)?)
+    }
+
+    /// Observed phases in sighting order, as `(name, elapsed)` — suitable
+    /// for recording into `metrics.json`.
+    pub fn timeline(&self) -> impl Iterator<Item = (&'static str, Duration)> + '_ {
+        self.marks.iter().map(|(p, at)| (p.as_str_name(), *at))
+    }
+}
+
 /// A running daemon owned by the harness. Dropping the handle terminates
 /// the daemon (SIGTERM, then SIGKILL after a grace period).
 pub struct DaemonHandle {
     child: Child,
     data_dir: PathBuf,
     log_path: PathBuf,
+    phase_marks: PhaseMarks,
 }
 
 impl DaemonHandle {
@@ -106,7 +156,19 @@ impl DaemonHandle {
             child,
             data_dir: config.data_dir,
             log_path,
+            phase_marks: PhaseMarks::default(),
         })
+    }
+
+    /// Setup-phase timings observed during [`Self::wait_ready`].
+    ///
+    /// Empty before a readiness wait. The span most callers want is
+    /// `VmStarting → VmReady`: guest binaries are already staged when the
+    /// daemon publishes `VmStarting`, and the guest agent has answered by
+    /// `VmReady`, so it isolates the guest boot itself (CORE-67).
+    #[must_use]
+    pub fn phase_marks(&self) -> &PhaseMarks {
+        &self.phase_marks
     }
 
     /// The daemon's process ID (for external diagnostics such as `sample`).
@@ -168,6 +230,13 @@ impl DaemonHandle {
             .context("opening WatchSetupStatus stream")?
             .into_inner();
 
+        // Phase marks are relative to the subscription, not to spawn: the
+        // socket-wait above is unmeasured, so an absolute "time since
+        // spawn" would silently fold it in. Spans between two observed
+        // phases are unaffected by the offset.
+        let stream_start = Instant::now();
+        self.phase_marks = PhaseMarks::default();
+
         loop {
             self.check_alive()?;
             if Instant::now() >= deadline {
@@ -179,20 +248,24 @@ impl DaemonHandle {
             match tokio::time::timeout(POLL_TICK, stream.message()).await {
                 // Poll tick elapsed without an update: re-check liveness.
                 Err(_) => {}
-                Ok(Ok(Some(status))) => match status.phase() {
-                    setup_status::Phase::Ready => {
-                        info!("daemon reported READY");
-                        return Ok(());
+                Ok(Ok(Some(status))) => {
+                    let phase = status.phase();
+                    self.phase_marks.mark(phase, stream_start.elapsed());
+                    match phase {
+                        setup_status::Phase::Ready => {
+                            info!("daemon reported READY");
+                            return Ok(());
+                        }
+                        setup_status::Phase::Failed => {
+                            bail!(
+                                "daemon startup failed: {} (log: {})",
+                                status.error,
+                                self.log_path.display()
+                            );
+                        }
+                        phase => info!(?phase, message = %status.message, "setup phase"),
                     }
-                    setup_status::Phase::Failed => {
-                        bail!(
-                            "daemon startup failed: {} (log: {})",
-                            status.error,
-                            self.log_path.display()
-                        );
-                    }
-                    phase => info!(?phase, message = %status.message, "setup phase"),
-                },
+                }
                 // Stream ended or errored — the daemon is going away; the
                 // next liveness check reports its exit status and log tail.
                 Ok(Ok(None) | Err(_)) => {
@@ -377,5 +450,67 @@ mod tests {
         assert_isolated(dir.path()).expect("tempdir must be accepted");
         // Not-yet-created children are fine too — spawn creates them.
         assert_isolated(&dir.path().join("does-not-exist-yet")).expect("child of tempdir");
+    }
+
+    /// A republished phase must not move its mark: the daemon re-sends the
+    /// current phase to every subscriber, and a span has to measure when a
+    /// stage began, not when it was last echoed.
+    #[test]
+    fn phase_marks_keep_the_first_sighting() {
+        let mut marks = PhaseMarks::default();
+        marks.mark(setup_status::Phase::AssetsReady, Duration::from_secs(1));
+        marks.mark(setup_status::Phase::AssetsReady, Duration::from_secs(9));
+        assert_eq!(
+            marks.at(setup_status::Phase::AssetsReady),
+            Some(Duration::from_secs(1))
+        );
+    }
+
+    #[test]
+    fn phase_span_measures_between_sightings() {
+        let mut marks = PhaseMarks::default();
+        marks.mark(setup_status::Phase::AssetsReady, Duration::from_secs(2));
+        marks.mark(setup_status::Phase::Ready, Duration::from_secs(5));
+        assert_eq!(
+            marks.span(setup_status::Phase::AssetsReady, setup_status::Phase::Ready),
+            Some(Duration::from_secs(3))
+        );
+    }
+
+    /// An unobserved phase yields `None`, never zero — the harness
+    /// subscribes after the socket appears, so an early phase can be missed
+    /// entirely, and a zero would read as an implausibly fast stage.
+    #[test]
+    fn phase_span_is_none_when_a_mark_was_missed() {
+        let mut marks = PhaseMarks::default();
+        marks.mark(setup_status::Phase::Ready, Duration::from_secs(5));
+        assert_eq!(
+            marks.span(setup_status::Phase::AssetsReady, setup_status::Phase::Ready),
+            None
+        );
+        assert_eq!(marks.at(setup_status::Phase::AssetsReady), None);
+    }
+
+    /// Out-of-order pairs are a caller error; saturating to zero would hide
+    /// it behind a plausible-looking number.
+    #[test]
+    fn phase_span_is_none_when_reversed() {
+        let mut marks = PhaseMarks::default();
+        marks.mark(setup_status::Phase::AssetsReady, Duration::from_secs(2));
+        marks.mark(setup_status::Phase::Ready, Duration::from_secs(5));
+        assert_eq!(
+            marks.span(setup_status::Phase::Ready, setup_status::Phase::AssetsReady),
+            None
+        );
+    }
+
+    #[test]
+    fn timeline_reports_sighting_order_with_names() {
+        let mut marks = PhaseMarks::default();
+        marks.mark(setup_status::Phase::Initializing, Duration::from_millis(10));
+        marks.mark(setup_status::Phase::AssetsReady, Duration::from_millis(20));
+        marks.mark(setup_status::Phase::Ready, Duration::from_millis(30));
+        let names: Vec<&str> = marks.timeline().map(|(name, _)| name).collect();
+        assert_eq!(names, ["INITIALIZING", "ASSETS_READY", "READY"]);
     }
 }

--- a/tests/e2e/tests/daemon_lifecycle.rs
+++ b/tests/e2e/tests/daemon_lifecycle.rs
@@ -28,7 +28,7 @@
 use std::fs::OpenOptions;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
-use std::sync::Once;
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
@@ -43,11 +43,32 @@ const LOCK_TIMEOUT: Duration = Duration::from_secs(60);
 const RELEASE_TIMEOUT: Duration = Duration::from_secs(30);
 const POLL: Duration = Duration::from_millis(100);
 
-static BUILD: Once = Once::new();
+/// Outcome of the one-time daemon build, shared by every test in this binary.
+///
+/// The result is stored rather than just the fact of having run: tests here
+/// run concurrently, so with a bare `Once` only the thread that happened to
+/// run the closure would see a build failure, and the rest would go on to
+/// spawn a missing or stale binary and fail for reasons that look unrelated.
+/// `anyhow::Error` is not `Clone`, so the message is kept as a `String`.
+static BUILD: OnceLock<Result<(), String>> = OnceLock::new();
 
-// ---------------------------------------------------------------------------
-// Lock probing
-// ---------------------------------------------------------------------------
+/// Builds the release daemon once per test binary, reporting the same
+/// outcome to every caller.
+fn build_daemon_once(root: &Path) -> Result<()> {
+    let outcome = BUILD.get_or_init(|| {
+        (|| {
+            let shell = xshell::Shell::new()?;
+            shell.change_dir(root);
+            xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+            anyhow::Ok(())
+        })()
+        .map_err(|e| e.to_string())
+    });
+    match outcome {
+        Ok(()) => Ok(()),
+        Err(e) => bail!("building arcbox-daemon: {e}"),
+    }
+}
 
 /// Whether the daemon lock at `path` is currently held by some process.
 ///
@@ -102,16 +123,6 @@ fn wait_until(
     }
 }
 
-/// True once the process has gone away (or become a zombie we can't signal).
-fn process_gone(pid: u32) -> bool {
-    // SAFETY: signal 0 performs error checking without delivering a signal.
-    unsafe { libc::kill(pid.cast_signed(), 0) != 0 }
-}
-
-// ---------------------------------------------------------------------------
-// Daemon scaffolding
-// ---------------------------------------------------------------------------
-
 /// Two daemons in one test need their own spawn path — `run_vz_scenario`
 /// owns a single handle and a scenario closure.
 struct Fixture {
@@ -124,16 +135,7 @@ impl Fixture {
     fn new(name: &str) -> Result<Self> {
         let root = arcbox_e2e::repo_root();
         if !arcbox_e2e::env_flag("SKIP_BUILD") {
-            let mut built = Ok(());
-            BUILD.call_once(|| {
-                built = (|| {
-                    let shell = xshell::Shell::new()?;
-                    shell.change_dir(&root);
-                    xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
-                    anyhow::Ok(())
-                })();
-            });
-            built?;
+            build_daemon_once(&root)?;
         }
         let version = resolve_boot_version(&root)?;
         let data_dir = tempfile::Builder::new()
@@ -180,10 +182,6 @@ impl Fixture {
         })
     }
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 /// A running daemon holds the lock and records its own PID in it.
 #[test]
@@ -252,24 +250,23 @@ fn killed_daemon_releases_the_lock_for_the_next_one() -> Result<()> {
 fn second_daemon_displaces_the_first() -> Result<()> {
     let fixture = Fixture::new("lock-takeover")?;
 
-    let first = fixture.spawn()?;
+    let mut first = fixture.spawn()?;
     fixture.wait_lock_held()?;
-    let first_pid = first.pid();
 
     // The displaced daemon is terminated by the newcomer, not by us.
     let second = fixture.spawn()?;
 
+    // Reaping poll rather than `kill(pid, 0)`: the displaced daemon stays a
+    // zombie until this handle waits on it, and a zombie answers signal 0, so
+    // a liveness probe would never see it leave.
     wait_until("the displaced daemon to exit", RELEASE_TIMEOUT, || {
-        Ok(process_gone(first_pid))
+        first.has_exited()
     })?;
 
     let lock = fixture.lock_file();
     wait_until("the newcomer to own the lock", RELEASE_TIMEOUT, || {
         Ok(lock_is_held(&lock)? && lock_pid(&lock) == Some(second.pid()))
     })?;
-
-    // Keep `first` alive as a handle so its Drop reaps the process.
-    drop(first);
     Ok(())
 }
 
@@ -303,10 +300,6 @@ fn graceful_shutdown_releases_lock_and_socket() -> Result<()> {
     })?;
     Ok(())
 }
-
-// ---------------------------------------------------------------------------
-// Probe self-check (no daemon, no VM)
-// ---------------------------------------------------------------------------
 
 /// The probe itself must distinguish held from free, and must not leave the
 /// lock held — otherwise every assertion above would read "held" forever.

--- a/tests/e2e/tests/daemon_lifecycle.rs
+++ b/tests/e2e/tests/daemon_lifecycle.rs
@@ -1,0 +1,358 @@
+//! Daemon ownership lifecycle: the `flock` contract (ABX-293).
+//!
+//! `startup::lock::DaemonLock` is the mechanism that keeps two daemons from
+//! driving the same data dir. Nothing tested it. These checks pin the
+//! contract as implemented — which is **not** what ABX-293's description
+//! assumed.
+//!
+//! **The lock is takeover, not exclusion.** The description expects a second
+//! daemon to "exit with error". It does not. `DaemonLock::acquire` reads the
+//! holder's PID, `SIGTERM`s it if it is an arcbox daemon, then takes a
+//! *blocking* `LOCK_EX` and waits for the release. So the second daemon wins
+//! and the first one leaves. `displaced_stale_daemon()` exists precisely to
+//! report that a takeover happened. Asserting the description's behavior
+//! would encode a defect that isn't there.
+//!
+//! **Why these are cheap.** The lock is taken in `acquire_daemon_lease`,
+//! stage 2 of the startup pipeline — before assets and long before the
+//! System VM. Every assertion here lands as soon as the lock changes hands,
+//! so no test waits for READY. Boot assets are still staged so the daemons
+//! behave normally rather than dying early on a missing asset.
+//!
+//! **Exit status is deliberately not asserted.** ABX-415 is a known teardown
+//! bug where the daemon can exit on a signal *after* doing its work
+//! correctly. Requiring exit code 0 would make these tests fail for a
+//! defect they are not about. The lock and the socket are the observable
+//! contract; the exit code is not yet trustworthy.
+
+use std::fs::OpenOptions;
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::sync::Once;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+
+/// Ceiling for a daemon to reach `acquire_daemon_lease` (pipeline stage 2).
+/// Generous: it covers process start and the host-prep stage before it.
+const LOCK_TIMEOUT: Duration = Duration::from_secs(60);
+/// Ceiling for a displaced daemon to release, or a killed one's lock to be
+/// reclaimed by the kernel.
+const RELEASE_TIMEOUT: Duration = Duration::from_secs(30);
+const POLL: Duration = Duration::from_millis(100);
+
+static BUILD: Once = Once::new();
+
+// ---------------------------------------------------------------------------
+// Lock probing
+// ---------------------------------------------------------------------------
+
+/// Whether the daemon lock at `path` is currently held by some process.
+///
+/// Mirrors what a starting daemon does — a non-blocking `LOCK_EX` — and
+/// releases immediately on success, so the probe never becomes the blocker
+/// the next daemon trips over.
+fn lock_is_held(path: &Path) -> Result<bool> {
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(path)
+        .with_context(|| format!("opening {}", path.display()))?;
+
+    // SAFETY: `file` owns a valid fd for the duration of both calls.
+    let acquired = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0;
+    if acquired {
+        // SAFETY: same fd, still owned.
+        unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+        return Ok(false);
+    }
+
+    let err = std::io::Error::last_os_error();
+    if err.raw_os_error() == Some(libc::EWOULDBLOCK) {
+        return Ok(true);
+    }
+    bail!("unexpected flock error probing {}: {err}", path.display())
+}
+
+/// PID recorded in the lock file. Diagnostics only in the daemon, but a
+/// useful identity check here: it tells us *which* daemon holds the lock.
+fn lock_pid(path: &Path) -> Option<u32> {
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+/// Polls `condition` until it holds or `timeout` elapses.
+fn wait_until(
+    what: &str,
+    timeout: Duration,
+    mut condition: impl FnMut() -> Result<bool>,
+) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if condition()? {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            bail!("timed out after {timeout:?} waiting for {what}");
+        }
+        std::thread::sleep(POLL);
+    }
+}
+
+/// True once the process has gone away (or become a zombie we can't signal).
+fn process_gone(pid: u32) -> bool {
+    // SAFETY: signal 0 performs error checking without delivering a signal.
+    unsafe { libc::kill(pid.cast_signed(), 0) != 0 }
+}
+
+// ---------------------------------------------------------------------------
+// Daemon scaffolding
+// ---------------------------------------------------------------------------
+
+/// Two daemons in one test need their own spawn path — `run_vz_scenario`
+/// owns a single handle and a scenario closure.
+struct Fixture {
+    root: PathBuf,
+    version: String,
+    data_dir: tempfile::TempDir,
+}
+
+impl Fixture {
+    fn new(name: &str) -> Result<Self> {
+        let root = arcbox_e2e::repo_root();
+        if !arcbox_e2e::env_flag("SKIP_BUILD") {
+            let mut built = Ok(());
+            BUILD.call_once(|| {
+                built = (|| {
+                    let shell = xshell::Shell::new()?;
+                    shell.change_dir(&root);
+                    xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+                    anyhow::Ok(())
+                })();
+            });
+            built?;
+        }
+        let version = resolve_boot_version(&root)?;
+        let data_dir = tempfile::Builder::new()
+            .prefix(&format!("arcbox-{name}-"))
+            .tempdir()?;
+        // Staged so a daemon behaves normally instead of failing out at the
+        // asset stage, which would release the lock mid-assertion.
+        stage_dev_boot_assets(&root, data_dir.path(), &version)?;
+        Ok(Self {
+            root,
+            version,
+            data_dir,
+        })
+    }
+
+    fn lock_file(&self) -> PathBuf {
+        self.data_dir.path().join("run/daemon.lock")
+    }
+
+    /// Spawns a daemon against the fixture's shared data dir.
+    fn spawn(&self) -> Result<DaemonHandle> {
+        let dns_port = std::net::UdpSocket::bind("127.0.0.1:0")
+            .and_then(|s| s.local_addr())
+            .context("probing a free DNS port")?
+            .port();
+        DaemonHandle::spawn(DaemonConfig {
+            binary: self.root.join("target/release/arcbox-daemon"),
+            data_dir: self.data_dir.path().to_owned(),
+            args: vec![],
+            env: vec![
+                ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), self.version.clone()),
+                ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
+                ("ARCBOX_DNS_PORT".to_owned(), dns_port.to_string()),
+                ("RUST_LOG".to_owned(), "info".to_owned()),
+            ],
+        })
+    }
+
+    /// Blocks until some daemon holds the lock.
+    fn wait_lock_held(&self) -> Result<()> {
+        let lock = self.lock_file();
+        wait_until("the daemon lock to be held", LOCK_TIMEOUT, || {
+            lock_is_held(&lock)
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// A running daemon holds the lock and records its own PID in it.
+#[test]
+#[ignore = "spawns a signed daemon; run on the e2e runner"]
+fn running_daemon_holds_the_lock() -> Result<()> {
+    let fixture = Fixture::new("lock-held")?;
+    let daemon = fixture.spawn()?;
+    fixture.wait_lock_held()?;
+
+    let pid = lock_pid(&fixture.lock_file());
+    if pid != Some(daemon.pid()) {
+        bail!(
+            "lock file records PID {pid:?} but the daemon we spawned is {}",
+            daemon.pid()
+        );
+    }
+    Ok(())
+}
+
+/// A SIGKILLed daemon's lock is reclaimed by the kernel, and the next daemon
+/// starts on the same data dir without a leftover socket blocking it.
+///
+/// This is the crash-recovery case: no cooperative cleanup runs, so anything
+/// that has to be released must be released by the kernel.
+#[test]
+#[ignore = "spawns a signed daemon; run on the e2e runner"]
+fn killed_daemon_releases_the_lock_for_the_next_one() -> Result<()> {
+    let fixture = Fixture::new("lock-crash")?;
+
+    let first = fixture.spawn()?;
+    fixture.wait_lock_held()?;
+    let first_pid = first.pid();
+
+    // SIGKILL: no destructor, no cleanup — exactly the crash shape.
+    // SAFETY: `first_pid` is a child we spawned and have not reaped.
+    unsafe { libc::kill(first_pid.cast_signed(), libc::SIGKILL) };
+    drop(first); // reaps the zombie
+
+    let lock = fixture.lock_file();
+    wait_until(
+        "the kernel to release a killed daemon's lock",
+        RELEASE_TIMEOUT,
+        || Ok(!lock_is_held(&lock)?),
+    )?;
+
+    let second = fixture.spawn()?;
+    fixture.wait_lock_held()?;
+    let pid = lock_pid(&lock);
+    if pid != Some(second.pid()) {
+        bail!(
+            "after a crash the replacement daemon should own the lock; file says {pid:?}, \
+             replacement is {}",
+            second.pid()
+        );
+    }
+    Ok(())
+}
+
+/// A second daemon displaces a live one: it signals the holder, waits for
+/// the release, and takes ownership.
+///
+/// Note this asserts *takeover*, not the "second daemon errors out" behavior
+/// ABX-293's description assumed — see the module docs.
+#[test]
+#[ignore = "spawns two signed daemons; run on the e2e runner"]
+fn second_daemon_displaces_the_first() -> Result<()> {
+    let fixture = Fixture::new("lock-takeover")?;
+
+    let first = fixture.spawn()?;
+    fixture.wait_lock_held()?;
+    let first_pid = first.pid();
+
+    // The displaced daemon is terminated by the newcomer, not by us.
+    let second = fixture.spawn()?;
+
+    wait_until("the displaced daemon to exit", RELEASE_TIMEOUT, || {
+        Ok(process_gone(first_pid))
+    })?;
+
+    let lock = fixture.lock_file();
+    wait_until("the newcomer to own the lock", RELEASE_TIMEOUT, || {
+        Ok(lock_is_held(&lock)? && lock_pid(&lock) == Some(second.pid()))
+    })?;
+
+    // Keep `first` alive as a handle so its Drop reaps the process.
+    drop(first);
+    Ok(())
+}
+
+/// A graceful shutdown releases the lock and removes the gRPC socket.
+///
+/// Exit status is not asserted — see the module docs on ABX-415.
+#[test]
+#[ignore = "spawns a signed daemon; run on the e2e runner"]
+fn graceful_shutdown_releases_lock_and_socket() -> Result<()> {
+    let fixture = Fixture::new("lock-shutdown")?;
+    let daemon = fixture.spawn()?;
+    fixture.wait_lock_held()?;
+
+    // The gRPC socket appears in stage 3, right after the lock.
+    let socket = daemon.grpc_socket();
+    wait_until("the gRPC socket to appear", LOCK_TIMEOUT, || {
+        Ok(socket.exists())
+    })?;
+
+    let status = daemon.shutdown().context("SIGTERM shutdown")?;
+    tracing::info!(%status, "daemon stopped");
+
+    let lock = fixture.lock_file();
+    wait_until(
+        "the lock to be released after SIGTERM",
+        RELEASE_TIMEOUT,
+        || Ok(!lock_is_held(&lock)?),
+    )?;
+    wait_until("the gRPC socket to be removed", RELEASE_TIMEOUT, || {
+        Ok(!socket.exists())
+    })?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Probe self-check (no daemon, no VM)
+// ---------------------------------------------------------------------------
+
+/// The probe itself must distinguish held from free, and must not leave the
+/// lock held — otherwise every assertion above would read "held" forever.
+///
+/// `flock` is per open-file-description, so a second open in this same
+/// process is a faithful stand-in for another process.
+#[test]
+fn lock_probe_detects_held_and_frees_what_it_takes() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("daemon.lock");
+
+    assert!(!lock_is_held(&path)?, "a fresh lock file is not held");
+    // Probing must not leave it held.
+    assert!(!lock_is_held(&path)?, "the probe released what it acquired");
+
+    let holder = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&path)?;
+    // SAFETY: `holder` owns a valid fd for the duration of the call.
+    assert_eq!(
+        unsafe { libc::flock(holder.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+        0,
+        "test could not take the lock it means to hold"
+    );
+    assert!(lock_is_held(&path)?, "a held lock must probe as held");
+
+    drop(holder);
+    assert!(
+        !lock_is_held(&path)?,
+        "closing the holder releases the lock"
+    );
+    Ok(())
+}
+
+#[test]
+fn lock_pid_reads_what_the_daemon_writes() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("daemon.lock");
+    // The daemon writes `writeln!(file, "{pid}")` — trailing newline included.
+    std::fs::write(&path, "4242\n")?;
+    assert_eq!(lock_pid(&path), Some(4242));
+
+    std::fs::write(&path, "")?;
+    assert_eq!(lock_pid(&path), None, "an empty lock file has no PID");
+    Ok(())
+}

--- a/tests/e2e/tests/smoke.rs
+++ b/tests/e2e/tests/smoke.rs
@@ -52,12 +52,14 @@ const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 /// **A regression backstop, not the performance target.** The span is the
 /// guest boot on its own — guest binaries are staged before `VmStarting` and
 /// the agent has answered by `VmReady` (CORE-67) — so it is directly
-/// comparable to the ~1.5 s cold-boot target. The default sits well above
-/// that: a CI runner under load boots slower than a developer's machine, and
-/// a ceiling tight enough to be a target would buy flakes rather than
-/// signal. Tighten via `ARCBOX_E2E_BOOT_BUDGET_SECS` as `metrics.json`
-/// accumulates a distribution to argue from.
-const BOOT_BUDGET_DEFAULT_SECS: f64 = 30.0;
+/// comparable to the ~1.5 s cold-boot target, unlike the `AssetsReady →
+/// Ready` window it replaced. Measured 1.55 s and 2.29 s on an M-series
+/// developer machine under VZ (2026-08-01); the ceiling leaves roughly 4×
+/// for a loaded CI runner, because a bound tight enough to double as the
+/// target would buy flakes rather than signal. Tighten via
+/// `ARCBOX_E2E_BOOT_BUDGET_SECS` as `metrics.json` accumulates a
+/// distribution to argue from.
+const BOOT_BUDGET_DEFAULT_SECS: f64 = 10.0;
 
 /// Phases a healthy cold start publishes, in order.
 ///
@@ -162,17 +164,16 @@ fn check_phase_progression(marks: &PhaseMarks) -> Result<()> {
 /// so runtime construction, asset preparation, the dockerd wait, and host
 /// service startup all fall outside it (CORE-67).
 ///
-/// A missing mark is **not** a failure here. [`check_phase_progression`]
-/// already fails the run when the daemon publishes neither, so the only way
-/// to reach this without both marks is a `--no-linux-vm` daemon, which boots
-/// no guest and has no boot span to budget.
+/// Both marks are required, not skipped when absent: they are published long
+/// after the harness subscribes, so a missing one means the daemon never sent
+/// it — which is unobservable as a gap and would otherwise pass as a silent
+/// skip (CORE-67).
 fn check_boot_budget(marks: &PhaseMarks, metrics: &mut RunMetrics) -> Result<()> {
     let Some(span) = marks.span(Phase::VmStarting, Phase::VmReady) else {
-        tracing::warn!(
-            "boot span unavailable — no VmStarting → VmReady pair was observed; skipping the \
-             ABX-309 budget check for this run"
+        bail!(
+            "no VmStarting → VmReady pair on the setup stream, so the guest boot cannot be \
+             measured at all"
         );
-        return Ok(());
     };
     metrics.record("boot_span", span.as_secs_f64());
 

--- a/tests/e2e/tests/smoke.rs
+++ b/tests/e2e/tests/smoke.rs
@@ -1,0 +1,362 @@
+//! Smoke suite — the "does the product basically work" checks (ABX-291).
+//!
+//! These are the assertions a release should never ship without: a container
+//! runs and the CLI returns, a published port reaches it from the host, and a
+//! container resolves a sibling by name. Everything else in `tests/e2e`
+//! targets a specific defect class; this file targets the happy path itself,
+//! which until now had no automated coverage at all.
+//!
+//! **One VM, sequential phases.** Each phase costs a full System VM boot if
+//! split across `#[test]` functions, so this follows `boot_assets`: one boot,
+//! phases named for the issue they close, recorded into `metrics.json`. A
+//! failing phase masks later ones — acceptable here, since a broken
+//! `docker run` makes the rest meaningless anyway.
+//!
+//! **Isolation.** No fixed host ports: the published-port phase asks Docker
+//! for an ephemeral one on `127.0.0.1` and reads it back with `docker port`,
+//! per the parallel-safety contract in AGENTS.md.
+//!
+//! Covers ABX-305 (run & exit), ABX-306 (published port), ABX-308 (name
+//! resolution), ABX-309 (boot budget), CORE-67 (setup phase progression).
+//!
+//! Deliberately **not** covered: **ABX-307** (L3 direct routing to a
+//! container IP via bridge100). The host route is installed by the
+//! privileged helper (`route_add` in `app/arcbox-helper`), which the harness
+//! does not run and AGENTS.md forbids touching. A test here would silently
+//! depend on the developer's installed ArcBox having placed the route — host
+//! state, not product behavior. It needs a helper-aware harness first.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use arcbox_e2e::daemon::PhaseMarks;
+use arcbox_e2e::docker::{docker_ignore, docker_output, ensure_image};
+use arcbox_e2e::metrics::RunMetrics;
+use arcbox_e2e::scenario::run_vz_scenario;
+use arcbox_protocol::v1::setup_status::Phase;
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+const DOCKER_TIMEOUT: Duration = Duration::from_secs(60);
+/// Body the in-container httpd serves; distinctive enough that a stray proxy
+/// or a wrong-port connection cannot produce it by accident.
+const MARKER: &str = "arcbox-smoke-ok";
+/// How long to wait for busybox httpd to bind inside the container. The
+/// container is already running by then — this only covers process start.
+const HTTPD_READY: Duration = Duration::from_secs(30);
+/// Per-attempt budget for a host→container HTTP request.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+/// Default ceiling for the `VmStarting → VmReady` span (ABX-309).
+///
+/// **A regression backstop, not the performance target.** The span is the
+/// guest boot on its own — guest binaries are staged before `VmStarting` and
+/// the agent has answered by `VmReady` (CORE-67) — so it is directly
+/// comparable to the ~1.5 s cold-boot target. The default sits well above
+/// that: a CI runner under load boots slower than a developer's machine, and
+/// a ceiling tight enough to be a target would buy flakes rather than
+/// signal. Tighten via `ARCBOX_E2E_BOOT_BUDGET_SECS` as `metrics.json`
+/// accumulates a distribution to argue from.
+const BOOT_BUDGET_DEFAULT_SECS: f64 = 30.0;
+
+/// Phases a healthy cold start publishes, in order.
+///
+/// `AssetsReady` may be missed — the harness subscribes only once the gRPC
+/// socket exists, and a fast startup can already be past it. Everything from
+/// `VmStarting` on is published well after that point, so a missing one is a
+/// real defect, not a fast run.
+const EXPECTED_PROGRESSION: [Phase; 5] = [
+    Phase::AssetsReady,
+    Phase::VmStarting,
+    Phase::VmReady,
+    Phase::NetworkReady,
+    Phase::Ready,
+];
+
+#[test]
+#[ignore = "boots a VZ System VM through a real daemon; run on the e2e runner"]
+fn smoke_suite() -> Result<()> {
+    run_vz_scenario("smoke", |daemon, data_dir, metrics| {
+        // Measured directly rather than via `metrics.time` because ABX-309
+        // wants the number, not just the recording.
+        let started = Instant::now();
+        daemon.wait_ready_blocking(READY_TIMEOUT)?;
+        let ready_elapsed = started.elapsed();
+        metrics.record("daemon_ready", ready_elapsed.as_secs_f64());
+        tracing::info!(?ready_elapsed, "daemon ready");
+
+        // Every observed phase lands in metrics.json so a baseline can be
+        // built from passing runs, not just from failures.
+        for (name, at) in daemon.phase_marks().timeline() {
+            metrics.record(
+                &format!("phase_{}", name.to_ascii_lowercase()),
+                at.as_secs_f64(),
+            );
+        }
+        check_phase_progression(daemon.phase_marks())?;
+        check_boot_budget(daemon.phase_marks(), metrics)?;
+
+        let image =
+            std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+        metrics.time("image_pull", || ensure_image(data_dir, &image))?;
+
+        // Unique per run so parallel harnesses cannot collide on names.
+        let suffix = std::process::id();
+        let server_name = format!("arcbox-smoke-httpd-{suffix}");
+        let guard = ContainerGuard::new(data_dir, &server_name);
+
+        metrics.time("container_run", || run_and_exit(data_dir, &image))?;
+        let host_port = metrics.time("published_port", || {
+            published_port_reaches_container(data_dir, &image, &server_name)
+        })?;
+        tracing::info!(host_port, "published port verified");
+        metrics.time("name_resolution", || {
+            name_resolves_from_sibling(data_dir, &image, &server_name)
+        })?;
+
+        drop(guard);
+        Ok(())
+    })
+}
+
+/// CORE-67 — the setup stream reports the whole progression, in order.
+///
+/// An unpublished phase is not observable as a gap: it never arrives, so a
+/// client waits forever or reports a plausible zero. This asserts the phases
+/// actually show up, and that their sighting order matches the declared
+/// progression, so a reordering of the startup pipeline cannot silently
+/// start lying to clients.
+fn check_phase_progression(marks: &PhaseMarks) -> Result<()> {
+    let observed: Vec<Phase> = EXPECTED_PROGRESSION
+        .into_iter()
+        .filter(|phase| marks.at(*phase).is_some())
+        .collect();
+
+    for phase in EXPECTED_PROGRESSION {
+        // AssetsReady is genuinely missable on a fast start; the rest are
+        // published long after the harness subscribes.
+        if phase != Phase::AssetsReady && !observed.contains(&phase) {
+            bail!(
+                "daemon never published {} — observed {:?}. A declared-but-unpublished phase \
+                 leaves clients blind to that stage (CORE-67).",
+                phase.as_str_name(),
+                observed
+            );
+        }
+    }
+
+    // Sorting by sighting time is a stable no-op when the order is right;
+    // ties (two phases in the same instant) keep declaration order.
+    let mut by_sighting = observed.clone();
+    by_sighting.sort_by_key(|phase| marks.at(*phase).expect("filtered to observed phases"));
+    if by_sighting != observed {
+        bail!("setup phases arrived out of order: {by_sighting:?}, expected {observed:?}");
+    }
+    Ok(())
+}
+
+/// ABX-309 — the boot span stays within budget.
+///
+/// Measures `VmStarting → VmReady`: the guest boot alone. Guest binaries are
+/// staged before `VmStarting`, and `VmReady` means the guest agent answered,
+/// so runtime construction, asset preparation, the dockerd wait, and host
+/// service startup all fall outside it (CORE-67).
+///
+/// A missing mark is **not** a failure here. [`check_phase_progression`]
+/// already fails the run when the daemon publishes neither, so the only way
+/// to reach this without both marks is a `--no-linux-vm` daemon, which boots
+/// no guest and has no boot span to budget.
+fn check_boot_budget(marks: &PhaseMarks, metrics: &mut RunMetrics) -> Result<()> {
+    let Some(span) = marks.span(Phase::VmStarting, Phase::VmReady) else {
+        tracing::warn!(
+            "boot span unavailable — no VmStarting → VmReady pair was observed; skipping the \
+             ABX-309 budget check for this run"
+        );
+        return Ok(());
+    };
+    metrics.record("boot_span", span.as_secs_f64());
+
+    let budget = std::env::var("ARCBOX_E2E_BOOT_BUDGET_SECS")
+        .ok()
+        .and_then(|value| value.parse::<f64>().ok())
+        .unwrap_or(BOOT_BUDGET_DEFAULT_SECS);
+
+    if span.as_secs_f64() > budget {
+        bail!(
+            "guest boot took {:.1}s, over the {budget:.1}s budget (VmStarting → VmReady: System \
+             VM boot through agent readiness). Either this is a boot regression, or the machine \
+             is legitimately slower — raise ARCBOX_E2E_BOOT_BUDGET_SECS.",
+            span.as_secs_f64()
+        );
+    }
+    tracing::info!(?span, budget, "guest boot within budget");
+    Ok(())
+}
+
+/// ABX-305 — `docker run --rm <image> echo hello` exits 0 with "hello".
+///
+/// The assertion is as much about *returning* as about the output: ABX-372
+/// reports foreground `docker run` hanging after the container exits, in
+/// which case `docker_output` trips its timeout and this fails loudly.
+fn run_and_exit(data_dir: &std::path::Path, image: &str) -> Result<()> {
+    let out = docker_output(
+        data_dir,
+        &["run", "--rm", image, "echo", MARKER],
+        DOCKER_TIMEOUT,
+    )
+    .context("docker run --rm did not return (see ABX-372 for the known hang)")?;
+
+    if !out.contains(MARKER) {
+        bail!("container ran but stdout lacked {MARKER:?}; got: {out:?}");
+    }
+    Ok(())
+}
+
+/// ABX-306 — a published port on the host reaches the container.
+///
+/// Publishes to `127.0.0.1` on an *ephemeral* host port (`-p 127.0.0.1::80`)
+/// rather than the fixed `18080` the original issue suggested: a fixed host
+/// port is one of the globals a data dir does not isolate, so it would break
+/// parallel runs and collide with an installed ArcBox. Returns the assigned
+/// port so the caller can record it.
+fn published_port_reaches_container(
+    data_dir: &std::path::Path,
+    image: &str,
+    name: &str,
+) -> Result<u16> {
+    docker_output(
+        data_dir,
+        &[
+            "run",
+            "-d",
+            "--name",
+            name,
+            "-p",
+            "127.0.0.1::80",
+            image,
+            "sh",
+            "-c",
+            &httpd_command(),
+        ],
+        DOCKER_TIMEOUT,
+    )
+    .context("starting the httpd container")?;
+
+    let mapping = docker_output(data_dir, &["port", name, "80/tcp"], DOCKER_TIMEOUT)
+        .context("reading the assigned host port")?;
+    let host_port = parse_host_port(&mapping)
+        .with_context(|| format!("parsing `docker port` output: {mapping:?}"))?;
+
+    let addr = format!("127.0.0.1:{host_port}");
+    let body = http_get_with_retry(&addr, HTTPD_READY)
+        .with_context(|| format!("host could not reach the published port at {addr}"))?;
+    if !body.contains(MARKER) {
+        bail!("published port answered but body lacked {MARKER:?}; got: {body:?}");
+    }
+    Ok(host_port)
+}
+
+/// ABX-308 — a container resolves a sibling by name and can reach it.
+///
+/// Runs guest-side on purpose. The original issue framed this as
+/// `curl http://name.arcbox.local/` from the *host*, which needs
+/// `/etc/resolver/arcbox.local` — written by the privileged helper, outside
+/// what this harness may touch. Container→container resolution exercises the
+/// same registration path (`dns_server::register_container`, driven by the
+/// agent's docker event stream) without any host-global state.
+fn name_resolves_from_sibling(data_dir: &std::path::Path, image: &str, target: &str) -> Result<()> {
+    let url = format!("http://{target}/");
+    let out = docker_output(
+        data_dir,
+        &[
+            "run", "--rm", image, "wget", "-q", "-T", "20", "-O", "-", &url,
+        ],
+        DOCKER_TIMEOUT,
+    )
+    .with_context(|| {
+        format!(
+            "a sibling container could not resolve/reach {target:?} — the agent registers \
+             container names for DNS in dns_server::register_container"
+        )
+    })?;
+
+    if !out.contains(MARKER) {
+        bail!("resolved {target:?} but body lacked {MARKER:?}; got: {out:?}");
+    }
+    Ok(())
+}
+
+/// busybox httpd serving a single file containing [`MARKER`].
+///
+/// Uses what alpine already ships rather than pulling nginx, so the suite
+/// needs exactly one image.
+fn httpd_command() -> String {
+    format!("mkdir -p /www && printf '%s' '{MARKER}' > /www/index.html && httpd -f -p 80 -h /www")
+}
+
+/// Extracts the host port from `docker port <c> 80/tcp` output, e.g.
+/// `127.0.0.1:54321` (possibly several lines for multiple bindings).
+fn parse_host_port(mapping: &str) -> Option<u16> {
+    mapping
+        .lines()
+        .filter_map(|line| line.trim().rsplit_once(':'))
+        .find_map(|(_, port)| port.trim().parse::<u16>().ok())
+}
+
+/// Retries [`http_get`] until `deadline` elapses — the container is running
+/// before httpd has necessarily bound.
+fn http_get_with_retry(addr: &str, grace: Duration) -> Result<String> {
+    let started = Instant::now();
+    let mut last: Option<anyhow::Error> = None;
+    while started.elapsed() < grace {
+        match http_get(addr) {
+            Ok(body) => return Ok(body),
+            Err(e) => last = Some(e),
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    Err(last.unwrap_or_else(|| anyhow::anyhow!("no attempt was made")))
+        .with_context(|| format!("no successful response within {grace:?}"))
+}
+
+/// Minimal HTTP/1.0 GET — avoids depending on `curl` being installed on the
+/// runner, and keeps the host side dependency-free like `net_fixtures`.
+fn http_get(addr: &str) -> Result<String> {
+    let mut stream = TcpStream::connect(addr).context("connect")?;
+    stream.set_read_timeout(Some(HTTP_TIMEOUT))?;
+    stream.set_write_timeout(Some(HTTP_TIMEOUT))?;
+    stream
+        .write_all(b"GET / HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .context("write request")?;
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .context("read response")?;
+    Ok(response)
+}
+
+/// Removes a container on drop so a failed assertion cannot leak it into the
+/// next run. The data dir is per-run, but a preserved dir (`KEEP_TEST_DIR`)
+/// keeps its daemon's state around.
+struct ContainerGuard<'a> {
+    data_dir: &'a std::path::Path,
+    name: String,
+}
+
+impl<'a> ContainerGuard<'a> {
+    fn new(data_dir: &'a std::path::Path, name: &str) -> Self {
+        Self {
+            data_dir,
+            name: name.to_owned(),
+        }
+    }
+}
+
+impl Drop for ContainerGuard<'_> {
+    fn drop(&mut self) {
+        docker_ignore(
+            self.data_dir,
+            &["rm".to_owned(), "-f".to_owned(), self.name.clone()],
+        );
+    }
+}

--- a/tests/e2e/tests/virtiofs_consistency.rs
+++ b/tests/e2e/tests/virtiofs_consistency.rs
@@ -1,0 +1,297 @@
+//! VirtioFS host↔guest consistency (ABX-296 Layer B).
+//!
+//! `arcbox-fs` is well covered below the boundary — 65 unit tests across
+//! `passthrough`, `dispatcher`, and `cache` exercise the FUSE opcodes, inode
+//! refcounting, and negative-cache behavior. What none of them can prove is
+//! that a byte written on one side of the share is the same byte on the
+//! other: that needs a booted guest.
+//!
+//! `bench_virtiofs` already measures throughput (and deliberately asserts no
+//! ratio — there is no baseline yet). This file is the correctness half:
+//! round-trip integrity, permission preservation, and concurrent metadata
+//! operations from both sides.
+//!
+//! **How the share is reached.** The daemon shares its `--data-dir` with the
+//! guest under the `arcbox` tag, mounted at `/arcbox`. So host
+//! `<data_dir>/<name>` is guest `/arcbox/<name>`, and a container sees it via
+//! `-v /arcbox/<name>:/mnt` — the same path `bench_virtiofs` uses.
+//!
+//! **Assertions run guest-side where possible.** Piping a payload back
+//! through `docker_output` would compare against stdout that also carries
+//! stderr; instead the guest checks length and boundaries itself and the
+//! host asserts on a short verdict. That keeps the check exact without
+//! shipping the payload through a shell.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use arcbox_e2e::docker::{docker_output, ensure_image};
+use arcbox_e2e::scenario::run_vz_scenario;
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+const DOCKER_TIMEOUT: Duration = Duration::from_secs(60);
+/// Share subdirectory used by this scenario, under both `<data_dir>` on the
+/// host and `/arcbox` in the guest.
+const SHARE_SUBDIR: &str = "fsconsistency";
+/// Distinctive head/tail sentinels — a truncated or offset read cannot
+/// reproduce both.
+const HEAD: &str = "ARCBOX-HEAD-7f3a";
+const TAIL: &str = "ARCBOX-TAIL-c19e";
+/// Body chunk repeated between the sentinels. Exactly 64 bytes so the guest
+/// can rebuild a byte-identical payload with a bounded shell loop.
+const FILL_CHUNK: &str = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+/// Repeats of [`FILL_CHUNK`]. The total lands just past 64 KiB, well beyond
+/// a page or FUSE buffer boundary, so a read that stops at one shows up as a
+/// length mismatch rather than passing.
+///
+/// The length is *derived* from this rather than fixed: both sides build the
+/// payload from the same chunk count, so they cannot drift. Fixing a target
+/// length instead and dividing to get the chunk count silently truncates
+/// (65536 − 32 is not a multiple of 64) and the two sides disagree by the
+/// remainder.
+const FILL_CHUNKS: usize = 1024;
+/// Metadata objects created per side in the concurrency phase.
+const CONCURRENT_EACH: usize = 10;
+
+#[test]
+#[ignore = "boots a VZ System VM through a real daemon; run on the e2e runner"]
+fn virtiofs_host_guest_consistency() -> Result<()> {
+    run_vz_scenario("virtiofs_consistency", |daemon, data_dir, metrics| {
+        metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
+        let image =
+            std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+        metrics.time("image_pull", || ensure_image(data_dir, &image))?;
+
+        let host_dir = data_dir.join(SHARE_SUBDIR);
+        std::fs::create_dir_all(&host_dir)
+            .with_context(|| format!("creating {}", host_dir.display()))?;
+
+        metrics.time("host_to_guest", || host_write_guest_read(data_dir, &image))?;
+        metrics.time("guest_to_host", || guest_write_host_read(data_dir, &image))?;
+        metrics.time("permissions", || permissions_round_trip(data_dir, &image))?;
+        metrics.time("concurrent_metadata", || {
+            concurrent_metadata(data_dir, &image)
+        })?;
+        Ok(())
+    })
+}
+
+/// Guest mount argument for the scenario's share subdirectory.
+fn mount_arg() -> String {
+    format!("/arcbox/{SHARE_SUBDIR}:/mnt")
+}
+
+/// Runs `sh -c <script>` in a throwaway container with the share mounted.
+fn guest_sh(data_dir: &Path, image: &str, script: &str) -> Result<String> {
+    docker_output(
+        data_dir,
+        &["run", "--rm", "-v", &mount_arg(), image, "sh", "-c", script],
+        DOCKER_TIMEOUT,
+    )
+}
+
+/// Byte length of [`payload`], derived from the same constants the guest
+/// rebuilds it from.
+fn payload_len() -> usize {
+    HEAD.len() + FILL_CHUNKS * FILL_CHUNK.len() + TAIL.len()
+}
+
+/// Sentinel-bracketed payload. Built from whole [`FILL_CHUNK`] repeats so
+/// the guest's shell loop produces exactly the same bytes.
+fn payload() -> String {
+    let mut body = String::with_capacity(payload_len());
+    body.push_str(HEAD);
+    for _ in 0..FILL_CHUNKS {
+        body.push_str(FILL_CHUNK);
+    }
+    body.push_str(TAIL);
+    body
+}
+
+/// Guards the host/guest payload contract without needing a VM: the two
+/// sides agree only because both are whole-chunk multiples. This is the
+/// check that catches a constant edit desynchronising them.
+#[test]
+fn payload_is_whole_chunks_and_sentinel_bracketed() {
+    assert_eq!(FILL_CHUNK.len(), 64, "the guest loop writes 64-byte chunks");
+    let body = payload();
+    assert_eq!(body.len(), payload_len());
+    assert!(body.starts_with(HEAD));
+    assert!(body.ends_with(TAIL));
+    assert_eq!(
+        body.len() - HEAD.len() - TAIL.len(),
+        FILL_CHUNKS * FILL_CHUNK.len(),
+        "fill must be whole chunks — a remainder would make the guest's \
+         reconstruction shorter than the host's expectation"
+    );
+    assert!(
+        body.len() > 64 * 1024,
+        "payload must cross a 64 KiB boundary"
+    );
+}
+
+/// Host writes, guest reads back identical content.
+fn host_write_guest_read(data_dir: &Path, image: &str) -> Result<()> {
+    let body = payload();
+    let path = data_dir.join(SHARE_SUBDIR).join("h2g.bin");
+    std::fs::write(&path, &body).with_context(|| format!("writing {}", path.display()))?;
+
+    // Length and both sentinels are checked in the guest; only the verdict
+    // crosses back, so stdout framing cannot corrupt the comparison.
+    let script = format!(
+        "set -e; \
+         len=$(wc -c < /mnt/h2g.bin); \
+         [ \"$len\" = \"{expected_len}\" ] || {{ echo \"BADLEN:$len\"; exit 1; }}; \
+         [ \"$(head -c {head_len} /mnt/h2g.bin)\" = \"{HEAD}\" ] || {{ echo BADHEAD; exit 1; }}; \
+         [ \"$(tail -c {tail_len} /mnt/h2g.bin)\" = \"{TAIL}\" ] || {{ echo BADTAIL; exit 1; }}; \
+         echo OK",
+        expected_len = payload_len(),
+        head_len = HEAD.len(),
+        tail_len = TAIL.len(),
+    );
+    let out = guest_sh(data_dir, image, &script)
+        .context("guest could not read back the host-written file")?;
+    if !out.contains("OK") {
+        bail!("guest read mismatch for a host-written file: {out:?}");
+    }
+    Ok(())
+}
+
+/// Guest writes, host reads back identical content.
+fn guest_write_host_read(data_dir: &Path, image: &str) -> Result<()> {
+    let body = payload();
+    // Same constants as `payload()`, so the two constructions cannot drift.
+    let script = format!(
+        "set -e; \
+         printf '%s' '{HEAD}' > /mnt/g2h.bin; \
+         i=0; while [ $i -lt {FILL_CHUNKS} ]; do \
+         printf '%s' '{FILL_CHUNK}' >> /mnt/g2h.bin; i=$((i+1)); done; \
+         printf '%s' '{TAIL}' >> /mnt/g2h.bin; \
+         echo OK"
+    );
+    let out = guest_sh(data_dir, image, &script).context("guest could not write to the share")?;
+    if !out.contains("OK") {
+        bail!("guest write reported failure: {out:?}");
+    }
+
+    let path = data_dir.join(SHARE_SUBDIR).join("g2h.bin");
+    let read = std::fs::read_to_string(&path)
+        .with_context(|| format!("host reading guest-written {}", path.display()))?;
+    if read.len() != body.len() {
+        bail!(
+            "host saw {} bytes of a guest-written file, expected {}",
+            read.len(),
+            body.len()
+        );
+    }
+    if read != body {
+        bail!("host content differs from what the guest wrote (same length, differing bytes)");
+    }
+    Ok(())
+}
+
+/// Mode bits survive the boundary in both directions.
+fn permissions_round_trip(data_dir: &Path, image: &str) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Host → guest.
+    let host_set = data_dir.join(SHARE_SUBDIR).join("hostmode");
+    std::fs::write(&host_set, b"m")?;
+    std::fs::set_permissions(&host_set, std::fs::Permissions::from_mode(0o750))
+        .with_context(|| format!("chmod {}", host_set.display()))?;
+    let seen = guest_sh(data_dir, image, "stat -c %a /mnt/hostmode")
+        .context("guest could not stat a host-chmodded file")?;
+    if !seen.trim().contains("750") {
+        bail!("guest saw mode {seen:?} for a file the host set to 750");
+    }
+
+    // Guest → host.
+    guest_sh(
+        data_dir,
+        image,
+        "set -e; echo m > /mnt/guestmode; chmod 705 /mnt/guestmode; echo OK",
+    )
+    .context("guest could not chmod on the share")?;
+    let host_view = std::fs::metadata(data_dir.join(SHARE_SUBDIR).join("guestmode"))
+        .context("host stat of a guest-chmodded file")?;
+    let mode = host_view.permissions().mode() & 0o777;
+    if mode != 0o705 {
+        bail!("host saw mode {mode:o} for a file the guest set to 705");
+    }
+    Ok(())
+}
+
+/// Concurrent metadata operations from both sides stay coherent.
+///
+/// Each side owns a disjoint name range, so this measures cross-boundary
+/// visibility and cache coherence rather than racing two writers on one
+/// target (whose outcome would be legitimately undefined).
+fn concurrent_metadata(data_dir: &Path, image: &str) -> Result<()> {
+    let dir = data_dir.join(SHARE_SUBDIR).join("concurrent");
+    std::fs::create_dir_all(&dir)?;
+
+    // Guest creates its range while the host creates its own.
+    let guest = std::thread::scope(|scope| -> Result<String> {
+        let handle = scope.spawn(|| {
+            guest_sh(
+                data_dir,
+                image,
+                &format!(
+                    "set -e; i=0; while [ $i -lt {CONCURRENT_EACH} ]; do \
+                     mkdir -p /mnt/concurrent/g$i; i=$((i+1)); done; echo OK"
+                ),
+            )
+        });
+        for i in 0..CONCURRENT_EACH {
+            std::fs::create_dir_all(dir.join(format!("h{i}")))
+                .with_context(|| format!("host mkdir h{i}"))?;
+        }
+        handle
+            .join()
+            .map_err(|_| anyhow::anyhow!("guest mkdir thread panicked"))?
+    })
+    .context("concurrent mkdir phase")?;
+    if !guest.contains("OK") {
+        bail!("guest mkdir batch reported failure: {guest:?}");
+    }
+
+    // Both ranges must be visible from both sides.
+    let listing = guest_sh(data_dir, image, "ls /mnt/concurrent | sort | tr '\\n' ' '")
+        .context("guest listing after concurrent mkdir")?;
+    for i in 0..CONCURRENT_EACH {
+        for name in [format!("g{i}"), format!("h{i}")] {
+            if !listing.contains(&name) {
+                bail!("guest listing is missing {name:?} after concurrent mkdir: {listing:?}");
+            }
+            if !dir.join(&name).is_dir() {
+                bail!("host cannot see {name:?} after concurrent mkdir");
+            }
+        }
+    }
+
+    // Each side removes its own range; the other must observe the removal.
+    guest_sh(
+        data_dir,
+        image,
+        &format!(
+            "set -e; i=0; while [ $i -lt {CONCURRENT_EACH} ]; do \
+             rmdir /mnt/concurrent/g$i; i=$((i+1)); done; echo OK"
+        ),
+    )
+    .context("guest rmdir batch")?;
+    for i in 0..CONCURRENT_EACH {
+        std::fs::remove_dir(dir.join(format!("h{i}")))
+            .with_context(|| format!("host rmdir h{i}"))?;
+        if dir.join(format!("g{i}")).exists() {
+            bail!("host still sees g{i} after the guest removed it (stale dentry cache)");
+        }
+    }
+
+    let after = guest_sh(data_dir, image, "ls -A /mnt/concurrent | wc -l")
+        .context("guest listing after concurrent rmdir")?;
+    if !after.trim().starts_with('0') {
+        bail!("guest still sees entries under concurrent/ after both sides cleaned up: {after:?}");
+    }
+    Ok(())
+}

--- a/virt/arcbox-net/tests/datapath_test.rs
+++ b/virt/arcbox-net/tests/datapath_test.rs
@@ -3,8 +3,17 @@
 //! These tests exercise the full `NetworkDatapath` event loop by creating a
 //! socketpair mock in place of the real VZ framework guest FD. L2 Ethernet
 //! frames are injected through the "guest" end and responses are read back,
-//! verifying DHCP, DNS, frame classification, and TCP SYN gating without
-//! requiring a VM, root privileges, or code signing.
+//! without requiring a VM, root privileges, or code signing.
+//!
+//! Covered here: the DHCP discover/offer/request/ack cycle, and frame
+//! classification for ARP, TCP SYN, ICMP, and DHCP.
+//!
+//! Not covered here, despite living in this file's setup: a `DnsForwarder` is
+//! constructed and handed to the datapath so it can be built, but no test
+//! exercises resolution — that coverage is in `arcbox_net::dns`'s own unit
+//! tests and in `dns_shared_table.rs`. Likewise the SYN *gate* itself lives in
+//! `splicetcp` and is tested there; this file only asserts that a SYN is
+//! classified as one.
 
 #![cfg(target_os = "macos")]
 


### PR DESCRIPTION
Six commits of e2e coverage for behaviour that had none, plus two doc corrections the audit turned up. Rebased onto master now that #522 (CORE-67) has landed — the smoke suite's phase assertions require the daemon to publish `VM_STARTING`/`VM_READY`/`NETWORK_READY`, so this could not pass CI before that merged.

## What is covered

**Setup-phase timings** (`tests/e2e/src/daemon.rs`) — `wait_ready` followed the setup-status stream to READY and discarded every phase it passed through, so nothing could measure a stage. `PhaseMarks` records the first sighting of each phase and exposes spans. First sighting rather than latest: the daemon republishes the current phase to every new subscriber, and a span has to measure when a stage began, not when it was last echoed. An unobserved phase yields `None`, never zero — the harness subscribes only once the gRPC socket appears, so an early phase can be missed entirely, and a zero would read as an implausibly fast stage. Marks are kept in sighting order rather than by enum value, which also sidesteps the ordinal trap (`DOWNLOADING_ASSETS = 8` precedes `READY = 6`).

**Smoke suite** (ABX-305/306/308/309) — the happy path had no automated coverage at all: nothing asserted that a container runs and the CLI returns, that a published port reaches it from the host, or that a container resolves a sibling by name. One VM boot with sequential phases rather than a test per behaviour, since each would otherwise cost a full System VM boot.

Two deliberate deviations from the original issue specs, both forced by the isolation contract in `tests/e2e/AGENTS.md`:

- The published port is ephemeral on `127.0.0.1`, read back with `docker port`, not a fixed `18080`. A fixed host port is one of the globals a per-test data dir does not isolate.
- Name resolution is checked container-to-container, not from the host. The host path needs `/etc/resolver/arcbox.local`, written by the privileged helper, which the harness may not touch. Both exercise the same registration path in `dns_server::register_container`.

**VirtioFS host/guest consistency** (ABX-296) — `arcbox-fs` has 65 unit tests below the boundary and `bench_virtiofs` measures throughput across it, but nothing proved a byte written on one side is the same byte on the other. Four phases on one boot: round-trips in both directions of a 64 KiB sentinel-bracketed payload, permission preservation both ways, and concurrent metadata operations from both sides. Verdicts cross the boundary, not payloads — `docker_output` concatenates stderr onto stdout, so comparing a 64 KiB payload against its return value would be fragile; the guest checks length and sentinels itself.

**Daemon lock lifecycle** (ABX-293) — flock ownership is what keeps two daemons off one data dir and had no coverage. Worth reading the commit: **the lock is takeover, not exclusion.** ABX-293 expected a second daemon to exit with an error; `DaemonLock::acquire` instead reads the holder's PID, SIGTERMs it, and takes a blocking `LOCK_EX` — the newcomer wins and the incumbent leaves. The tests assert the implemented behaviour; asserting the issue's would have encoded a defect that is not there.

**Two doc corrections** (ABX-294/302) — `datapath_test.rs` claimed to verify DNS resolution and TCP SYN gating; it does neither (a `DnsForwarder` is constructed so the datapath can be built, but nothing resolves; the SYN gate lives in splicetcp, where it is tested — this file only asserts a SYN is classified as one). And `docker-api-e2e.yml` carried `runs-on: macos-26  # Apple Silicon runner` four lines below a header explaining the workflow is disabled precisely because hosted macOS runners cannot do the job. Neither changes behaviour.

## The boot budget, post-CORE-67

The final commit calibrates ABX-309's check now that the span is measurable. `VmStarting → VmReady` is the guest boot on its own — guest binaries are staged before `VmStarting`, and `VmReady` means the agent answered — so unlike the `AssetsReady → Ready` window it replaces, it is directly comparable to the ~1.5 s cold-boot target.

Measured **1.55 s and 2.29 s** on an M-series machine under VZ. The default ceiling is 10 s, leaving roughly 4× for a loaded CI runner: a bound tight enough to double as the target would buy flakes rather than signal. The doc comment records the measurements so the next tightening argues from a baseline rather than a fresh guess.

A missing mark is now a failure rather than a logged skip. That branch was written when `VmStarting`/`VmReady` did not exist and could legitimately be absent; they are now published long after the harness subscribes, so their absence means the daemon never sent them — the exact defect CORE-67 removed, and one a silent skip would let back in unnoticed. `check_phase_progression` additionally asserts the whole progression arrives in order, so a reordering of the startup pipeline cannot silently start lying to clients.

## Note on history

`test(e2e): add the smoke suite` carries a commit message written before CORE-67 landed: it describes a 90 s budget over `AssetsReady → Ready` that "skips rather than fails", while the file it commits already measures `VmStarting → VmReady`. The final commit supersedes both the number and the skip. Left as-is rather than rewritten; the end state is what the last commit and this description say. Happy to reword it if you would rather the history read cleanly.

## Validation

`cargo fmt --check` and clippy clean; the 14 harness unit tests pass. The suites themselves are `#[ignore]`d and need hardware — `boot_assets` and `smoke` were both run under VZ during CORE-67 validation on this content.

One known-red scenario, filed rather than papered over: the smoke suite's published-port phase fails deterministically (CORE-69) — `docker port` reports no mapping for `-p 127.0.0.1::80`. It reproduced identically on two runs and is upstream of anything this branch touches.

Refs ABX-291, ABX-293, ABX-294, ABX-296, ABX-302, ABX-305, ABX-306, ABX-308, ABX-309, CORE-67.
