### PR TITLE
test(docker,proxy): close the remaining ABX-292 and ABX-303 gaps

### DIFF
--- a/app/arcbox-docker/tests/api_request_forwarding.rs
+++ b/app/arcbox-docker/tests/api_request_forwarding.rs
@@ -1,0 +1,178 @@
+//! What our interceptors do to a request on its way to guest dockerd
+//! (ABX-292).
+//!
+//! **We do not parse Docker's query parameters.** No handler takes an axum
+//! `Query<T>`; `remove_container` and friends take `OriginalUri` plus the raw
+//! `Request<Body>` and hand both to the proxy. `?all=`, `?filters=`, `?force=`
+//! are dockerd's to interpret.
+//!
+//! That makes forwarding fidelity the property worth testing, and it is a
+//! property with teeth: a query string that arrives re-encoded, reordered, or
+//! truncated silently changes what dockerd does — `docker ps --filter` returns
+//! the wrong set, `docker rm -f` stops forcing — while every status code stays
+//! 200 and every body-echo assertion still passes. `api_routing.rs` proves
+//! requests reach the backend; these prove they arrive *unaltered*.
+//!
+//! The other half is the error contract: Docker clients parse
+//! `{"message": "..."}`, so an error raised on our side of the boundary has to
+//! carry that shape and not just a status code.
+
+#[path = "support/api.rs"]
+mod api_support;
+use api_support::*;
+use http_body_util::BodyExt;
+
+/// Sends a request through the production version-stripping layer, exactly as
+/// `DockerApiServer` wraps the router.
+async fn send(router: &axum::Router, method: &str, uri: &str) -> (StatusCode, bytes::Bytes) {
+    let request = Request::builder()
+        .method(method)
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    let request = arcbox_docker::api::strip_api_version_prefix(request);
+    let response = router.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    (status, body)
+}
+
+/// The query string reaches dockerd exactly as the client sent it.
+///
+/// `docker rm -f -v` is `?force=true&v=true`. Dropping either turns a forced
+/// removal into a polite one, or leaks the volumes — with a 204 either way.
+#[tokio::test]
+async fn query_string_reaches_the_guest_verbatim() {
+    let (router, _runtime, guest, _tmp) = router_with_mock_guest(vec![MockRoute {
+        method: "DELETE",
+        path: "/containers/web",
+        status: 204,
+        body: "",
+    }])
+    .await;
+
+    let (status, _) = send(&router, "DELETE", "/containers/web?force=true&v=true").await;
+    assert_eq!(status, StatusCode::NO_CONTENT);
+
+    let seen = guest.last_request_uri().await.expect("guest saw a request");
+    assert!(
+        seen.ends_with("?force=true&v=true"),
+        "guest received {seen:?}; the query string must survive the proxy hop intact"
+    );
+}
+
+/// A percent-encoded JSON `filters` value is forwarded byte-for-byte.
+///
+/// This is the fragile one: `docker ps --filter label=a=b` sends
+/// `?filters={"label":{"a=b":true}}` percent-encoded. Decode-then-re-encode
+/// anywhere in the chain and dockerd sees a different filter — or none.
+#[tokio::test]
+async fn json_filters_query_is_not_re_encoded() {
+    let (router, _runtime, guest, _tmp) = router_with_mock_guest(vec![MockRoute {
+        method: "GET",
+        path: "/containers/json",
+        status: 200,
+        body: "[]",
+    }])
+    .await;
+
+    // {"label":{"a=b":true}}
+    let filters = "%7B%22label%22%3A%7B%22a%3Db%22%3Atrue%7D%7D";
+    let (status, _) = send(
+        &router,
+        "GET",
+        &format!("/containers/json?filters={filters}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let seen = guest.last_request_uri().await.expect("guest saw a request");
+    assert!(
+        seen.contains(filters),
+        "guest received {seen:?}; the percent-encoded filters value must not be rewritten"
+    );
+}
+
+/// The version prefix is stripped from the path without disturbing the query.
+///
+/// Stripping is string surgery on the URI (`strip_api_version_prefix`), so the
+/// boundary between path and query is the thing most likely to be got wrong.
+#[tokio::test]
+async fn version_prefix_strip_leaves_the_query_alone() {
+    let (router, _runtime, guest, _tmp) = router_with_mock_guest(vec![MockRoute {
+        method: "GET",
+        path: "/containers/json",
+        status: 200,
+        body: "[]",
+    }])
+    .await;
+
+    let (status, _) = send(&router, "GET", "/v1.43/containers/json?all=true&limit=5").await;
+    assert_eq!(status, StatusCode::OK);
+
+    let seen = guest.last_request_uri().await.expect("guest saw a request");
+    assert!(
+        seen.ends_with("?all=true&limit=5"),
+        "guest received {seen:?}; version stripping must not touch the query"
+    );
+    assert!(
+        seen.contains("/containers/json"),
+        "guest received {seen:?}; the path should still address the collection"
+    );
+}
+
+/// A request with no query arrives with no query — the proxy must not invent
+/// a trailing `?`, which some HTTP stacks do when rebuilding a URI.
+#[tokio::test]
+async fn absent_query_stays_absent() {
+    let (router, _runtime, guest, _tmp) = router_with_mock_guest(vec![MockRoute {
+        method: "GET",
+        path: "/containers/json",
+        status: 200,
+        body: "[]",
+    }])
+    .await;
+
+    let (status, _) = send(&router, "GET", "/containers/json").await;
+    assert_eq!(status, StatusCode::OK);
+
+    let seen = guest.last_request_uri().await.expect("guest saw a request");
+    assert!(
+        !seen.contains('?'),
+        "guest received {seen:?}; a query-less request must not gain an empty query"
+    );
+}
+
+/// An error raised on our side of the boundary is Docker-shaped.
+///
+/// Docker clients read `{"message": "..."}`; a bare status code or an
+/// axum-default body makes the CLI print nothing useful. The guest is stopped
+/// first so the failure comes from our proxy layer rather than being relayed
+/// from dockerd — `guest_error_status_passes_through` already covers the
+/// relayed case, and only checks the status.
+#[tokio::test]
+async fn proxy_failure_returns_a_docker_shaped_error() {
+    let (router, _runtime, guest, _tmp) = router_with_mock_guest(vec![]).await;
+
+    // Take the backend away, then ask for something that must reach it.
+    guest.cancel.cancel();
+    let _ = std::fs::remove_file(&guest.socket_path);
+
+    let (status, body) = send(&router, "GET", "/containers/json").await;
+    assert!(
+        status.is_client_error() || status.is_server_error(),
+        "an unreachable backend must not report success (got {status})"
+    );
+
+    let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap_or_else(|e| {
+        panic!(
+            "error body is not JSON ({e}): {:?}",
+            String::from_utf8_lossy(&body)
+        )
+    });
+    let message = parsed.get("message").and_then(serde_json::Value::as_str);
+    assert!(
+        message.is_some_and(|m| !m.is_empty()),
+        "error body must carry a non-empty `message` field, got {parsed}"
+    );
+}

--- a/app/arcbox-docker/tests/api_request_forwarding.rs
+++ b/app/arcbox-docker/tests/api_request_forwarding.rs
@@ -55,9 +55,9 @@ async fn query_string_reaches_the_guest_verbatim() {
     assert_eq!(status, StatusCode::NO_CONTENT);
 
     let seen = guest.last_request_uri().await.expect("guest saw a request");
-    assert!(
-        seen.ends_with("?force=true&v=true"),
-        "guest received {seen:?}; the query string must survive the proxy hop intact"
+    assert_eq!(
+        seen, "/containers/web?force=true&v=true",
+        "the request target must reach dockerd byte-for-byte"
     );
 }
 
@@ -87,18 +87,24 @@ async fn json_filters_query_is_not_re_encoded() {
     assert_eq!(status, StatusCode::OK);
 
     let seen = guest.last_request_uri().await.expect("guest saw a request");
-    assert!(
-        seen.contains(filters),
-        "guest received {seen:?}; the percent-encoded filters value must not be rewritten"
+    assert_eq!(
+        seen,
+        format!("/containers/json?filters={filters}"),
+        "the percent-encoded filters value must not be rewritten, extended, or joined by \
+         extra query material"
     );
 }
 
-/// The version prefix is stripped from the path without disturbing the query.
+/// A versioned request is forwarded with its prefix intact.
 ///
-/// Stripping is string surgery on the URI (`strip_api_version_prefix`), so the
-/// boundary between path and query is the thing most likely to be got wrong.
+/// `strip_api_version_prefix` strips `/v1.43` for **routing**, so local
+/// handlers match regardless of the client's negotiated version. It does not
+/// rewrite what goes on the wire: dockerd receives the client's original
+/// target, which it accepts. Asserting the full string is what pins that —
+/// an `ends_with` on the query alone would pass under either behavior and
+/// leave the reader guessing which one holds.
 #[tokio::test]
-async fn version_prefix_strip_leaves_the_query_alone() {
+async fn versioned_request_is_forwarded_with_its_prefix() {
     let (router, _runtime, guest, _tmp) = router_with_mock_guest(vec![MockRoute {
         method: "GET",
         path: "/containers/json",
@@ -111,13 +117,9 @@ async fn version_prefix_strip_leaves_the_query_alone() {
     assert_eq!(status, StatusCode::OK);
 
     let seen = guest.last_request_uri().await.expect("guest saw a request");
-    assert!(
-        seen.ends_with("?all=true&limit=5"),
-        "guest received {seen:?}; version stripping must not touch the query"
-    );
-    assert!(
-        seen.contains("/containers/json"),
-        "guest received {seen:?}; the path should still address the collection"
+    assert_eq!(
+        seen, "/v1.43/containers/json?all=true&limit=5",
+        "the client's original target reaches dockerd unchanged, prefix included"
     );
 }
 
@@ -137,9 +139,9 @@ async fn absent_query_stays_absent() {
     assert_eq!(status, StatusCode::OK);
 
     let seen = guest.last_request_uri().await.expect("guest saw a request");
-    assert!(
-        !seen.contains('?'),
-        "guest received {seen:?}; a query-less request must not gain an empty query"
+    assert_eq!(
+        seen, "/containers/json",
+        "a query-less request must not gain an empty query"
     );
 }
 

--- a/app/arcbox-docker/tests/support/mock_guest.rs
+++ b/app/arcbox-docker/tests/support/mock_guest.rs
@@ -80,6 +80,9 @@ pub struct MockGuest {
     pub cancel: CancellationToken,
     /// Body received on the most recent upgrade request (if any).
     last_upgrade_body: Arc<Mutex<Option<Bytes>>>,
+    /// Request target of the most recent request, exactly as it arrived —
+    /// path *and* query, before any version-prefix stripping.
+    last_request_uri: Arc<Mutex<Option<String>>>,
 }
 
 impl MockGuest {
@@ -87,6 +90,16 @@ impl MockGuest {
     #[allow(dead_code)] // used by the proxy_integration suite only
     pub async fn last_upgrade_body(&self) -> Option<Bytes> {
         self.last_upgrade_body.lock().await.clone()
+    }
+
+    /// Returns the request target of the most recent request.
+    ///
+    /// Recorded verbatim so a test can assert what the proxy actually put on
+    /// the wire — a query string that arrives re-encoded or truncated is
+    /// invisible to body-echo assertions but changes what dockerd does.
+    #[allow(dead_code)] // used by the api_request_forwarding suite only
+    pub async fn last_request_uri(&self) -> Option<String> {
+        self.last_request_uri.lock().await.clone()
     }
 }
 
@@ -105,6 +118,8 @@ pub async fn start_with_routes(dir: &Path, routes: Vec<MockRoute>) -> MockGuest 
     let token = cancel.clone();
     let last_upgrade_body: Arc<Mutex<Option<Bytes>>> = Arc::new(Mutex::new(None));
     let body_slot = Arc::clone(&last_upgrade_body);
+    let last_request_uri: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let uri_slot = Arc::clone(&last_request_uri);
     let routes = Arc::new(routes);
 
     tokio::spawn(async move {
@@ -118,13 +133,15 @@ pub async fn start_with_routes(dir: &Path, routes: Vec<MockRoute>) -> MockGuest 
             };
 
             let slot = Arc::clone(&body_slot);
+            let uris = Arc::clone(&uri_slot);
             let routes = Arc::clone(&routes);
             tokio::spawn(async move {
                 let io = TokioIo::new(stream);
                 let svc = service_fn(move |req| {
                     let slot = Arc::clone(&slot);
+                    let uris = Arc::clone(&uris);
                     let routes = Arc::clone(&routes);
-                    handle(req, slot, routes)
+                    handle(req, slot, uris, routes)
                 });
                 let _ = http1::Builder::new()
                     .serve_connection(io, svc)
@@ -138,6 +155,7 @@ pub async fn start_with_routes(dir: &Path, routes: Vec<MockRoute>) -> MockGuest 
         socket_path,
         cancel,
         last_upgrade_body,
+        last_request_uri,
     }
 }
 
@@ -169,8 +187,14 @@ fn strip_version_prefix(path: &str) -> &str {
 async fn handle(
     mut req: Request<Incoming>,
     upgrade_body_slot: Arc<Mutex<Option<Bytes>>>,
+    request_uri_slot: Arc<Mutex<Option<String>>>,
     routes: Arc<Vec<MockRoute>>,
 ) -> std::result::Result<Response<http_body_util::Full<Bytes>>, hyper::Error> {
+    // Recorded before anything else, and before version stripping, so a test
+    // sees exactly what the proxy sent — including the query string, which
+    // no canned route matches on.
+    *request_uri_slot.lock().await = Some(req.uri().to_string());
+
     // Canned routes take precedence over echo behavior.
     let path = strip_version_prefix(req.uri().path()).to_owned();
     if let Some(route) = routes

--- a/common/arcbox-proxy/src/egress/icmp.rs
+++ b/common/arcbox-proxy/src/egress/icmp.rs
@@ -370,12 +370,13 @@ mod tests {
     /// rewrites the identifier with a kernel-internal socket id, so a reply
     /// arriving with `ECHO_ID` intact is the whole point.
     ///
-    /// Ignored because it needs an ICMP datagram socket. That is unprivileged
-    /// on macOS but commonly unavailable in container-based CI, where the
-    /// proxy disables itself on `PermissionDenied` and this would time out —
-    /// a sandbox artifact, not a defect worth failing a build over.
+    /// Needs an ICMP datagram socket, which is unprivileged on macOS — and
+    /// the only CI job that runs tests is `runs-on: macos-26`, a full VM, so
+    /// this runs there like any other test. If that job ever moves somewhere
+    /// the socket is denied, `IcmpProxy` self-disables and never replies,
+    /// which surfaces here as the 10 s timeout below; re-gate it then, with
+    /// a reason that matches the CI of the day.
     #[tokio::test]
-    #[ignore = "needs an unprivileged ICMP datagram socket; run locally or on the e2e runner"]
     async fn echo_request_round_trips_with_the_guest_identifier() {
         let (tx, mut rx) = mpsc::channel(8);
         let proxy = IcmpProxy::new(tx, GW_MAC);

--- a/common/arcbox-proxy/src/egress/icmp.rs
+++ b/common/arcbox-proxy/src/egress/icmp.rs
@@ -311,6 +311,105 @@ fn ipv4_checksum(header: &[u8]) -> u16 {
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv4Addr;
+    use std::time::Duration;
+
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    use super::IcmpProxy;
+    use crate::egress::ETH_HEADER_LEN;
+
+    const GW_MAC: [u8; 6] = [0x02, 0xAB, 0xCD, 0x00, 0x00, 0x01];
+    const GUEST_MAC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x99];
+    const GUEST_IP: Ipv4Addr = Ipv4Addr::new(192, 168, 64, 2);
+    /// Distinctive so a reply carrying the kernel's rewritten value is
+    /// unmistakable rather than coincidentally equal.
+    const ECHO_ID: [u8; 2] = [0x5A, 0xC3];
+    const ECHO_SEQ: [u8; 2] = [0x00, 0x07];
+
+    /// Ethernet + IPv4 + ICMP echo request addressed to `dst`.
+    fn echo_request_frame(dst: Ipv4Addr) -> Vec<u8> {
+        let mut icmp = vec![
+            8,
+            0, // type 8 (echo request), code 0
+            0,
+            0, // checksum, filled in below
+            ECHO_ID[0],
+            ECHO_ID[1],
+            ECHO_SEQ[0],
+            ECHO_SEQ[1],
+        ];
+        icmp.extend_from_slice(b"arcbox-icmp-probe");
+        let checksum = super::internet_checksum(&icmp);
+        icmp[2..4].copy_from_slice(&checksum.to_be_bytes());
+
+        let total_len = (20 + icmp.len()) as u16;
+        let mut frame = Vec::with_capacity(ETH_HEADER_LEN + total_len as usize);
+        frame.extend_from_slice(&GW_MAC); // dst MAC (the gateway)
+        frame.extend_from_slice(&GUEST_MAC); // src MAC
+        frame.extend_from_slice(&[0x08, 0x00]); // EtherType IPv4
+
+        frame.extend_from_slice(&[0x45, 0x00]); // v4, IHL 5, DSCP 0
+        frame.extend_from_slice(&total_len.to_be_bytes());
+        frame.extend_from_slice(&[0x00, 0x00, 0x40, 0x00]); // id, flags/frag
+        frame.extend_from_slice(&[64, 1]); // TTL, protocol ICMP
+        frame.extend_from_slice(&[0x00, 0x00]); // header checksum (unchecked here)
+        frame.extend_from_slice(&GUEST_IP.octets());
+        frame.extend_from_slice(&dst.octets());
+        frame.extend_from_slice(&icmp);
+        frame
+    }
+
+    /// An echo request proxied to loopback comes back as an echo reply that
+    /// still carries the guest's own identifier and sequence.
+    ///
+    /// `test_icmp_identifier_restore` covers the patch arithmetic on a
+    /// hand-built packet; nothing exercised the socket path that makes the
+    /// patch necessary in the first place. macOS `SOCK_DGRAM`+`IPPROTO_ICMP`
+    /// rewrites the identifier with a kernel-internal socket id, so a reply
+    /// arriving with `ECHO_ID` intact is the whole point.
+    ///
+    /// Ignored because it needs an ICMP datagram socket. That is unprivileged
+    /// on macOS but commonly unavailable in container-based CI, where the
+    /// proxy disables itself on `PermissionDenied` and this would time out —
+    /// a sandbox artifact, not a defect worth failing a build over.
+    #[tokio::test]
+    #[ignore = "needs an unprivileged ICMP datagram socket; run locally or on the e2e runner"]
+    async fn echo_request_round_trips_with_the_guest_identifier() {
+        let (tx, mut rx) = mpsc::channel(8);
+        let proxy = IcmpProxy::new(tx, GW_MAC);
+
+        let frame = echo_request_frame(Ipv4Addr::LOCALHOST);
+        proxy.proxy_icmp(&frame, GUEST_MAC, CancellationToken::new());
+
+        let reply = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+            .await
+            .expect("an echo reply should arrive within 10s")
+            .expect("reply channel stayed open");
+
+        let ip_start = ETH_HEADER_LEN;
+        let ihl = ((reply[ip_start] & 0x0F) as usize) * 4;
+        let icmp = &reply[ip_start + ihl..];
+
+        assert_eq!(icmp[0], 0, "reply must be ICMP type 0 (echo reply)");
+        assert_eq!(
+            &icmp[4..6],
+            &ECHO_ID,
+            "the guest's identifier must be restored, not the kernel's rewritten one"
+        );
+        assert_eq!(
+            &icmp[6..8],
+            &ECHO_SEQ,
+            "the sequence number must survive the round trip"
+        );
+        assert_eq!(
+            &reply[..6],
+            &GUEST_MAC,
+            "the reply frame must be addressed back to the guest"
+        );
+    }
+
     /// Verifies that the ICMP identifier restoration logic patches Echo Reply
     /// (type 0) packets but leaves other ICMP types untouched.
     #[test]

--- a/common/arcbox-proxy/src/inbound_relay.rs
+++ b/common/arcbox-proxy/src/inbound_relay.rs
@@ -304,11 +304,21 @@ pub enum InboundProtocol {
     Udp,
 }
 
+/// Identifies a rule by the host address and the port the caller *asked* for.
+///
+/// Deliberately the requested port, not the bound one, so `remove_rule` can
+/// undo an `add_rule` with the same arguments the caller passed in.
+type ListenerKey = (Ipv4Addr, u16, InboundProtocol);
+
+/// A live listener: its task, its cancellation token, and the port it actually
+/// bound — which differs from the key's port only when the caller passed 0.
+type ListenerEntry = (JoinHandle<()>, CancellationToken, u16);
+
 /// Manages host-side listeners that accept incoming connections / datagrams
 /// and send `InboundCommand` messages to the datapath.
 pub struct InboundListenerManager {
     cmd_tx: mpsc::Sender<InboundCommand>,
-    listeners: HashMap<(Ipv4Addr, u16, InboundProtocol), (JoinHandle<()>, CancellationToken)>,
+    listeners: HashMap<ListenerKey, ListenerEntry>,
 }
 
 impl InboundListenerManager {
@@ -323,6 +333,11 @@ impl InboundListenerManager {
 
     /// Adds a forwarding rule and spawns a listener task.
     ///
+    /// Returns the port actually bound. That equals `host_port` unless the
+    /// caller passed 0 to let the OS choose, in which case it is the only way
+    /// to learn where the listener ended up — binding 0 and then probing for
+    /// the port separately would race anything else on the machine.
+    ///
     /// # Errors
     ///
     /// Returns an error if the listener cannot bind.
@@ -332,72 +347,76 @@ impl InboundListenerManager {
         host_port: u16,
         container_port: u16,
         protocol: InboundProtocol,
-    ) -> std::io::Result<()> {
+    ) -> std::io::Result<u16> {
         let key = (host_ip, host_port, protocol);
-        if self.listeners.contains_key(&key) {
-            return Ok(()); // Already listening.
+        if let Some((_, _, bound)) = self.listeners.get(&key) {
+            return Ok(*bound); // Already listening.
         }
 
         let cancel = CancellationToken::new();
         let cmd_tx = self.cmd_tx.clone();
 
-        let handle = match protocol {
+        let (handle, bound_port) = match protocol {
             InboundProtocol::Tcp => {
                 let listener =
                     TcpListener::bind(SocketAddr::V4(SocketAddrV4::new(host_ip, host_port)))
                         .await?;
+                let bound = listener.local_addr()?.port();
                 tracing::info!(
                     "Inbound listener: TCP {}:{} → container :{}",
                     host_ip,
-                    host_port,
+                    bound,
                     container_port,
                 );
                 let cancel_clone = cancel.clone();
-                tokio::spawn(async move {
+                let handle = tokio::spawn(async move {
                     tcp_listener_task(listener, container_port, cmd_tx, cancel_clone).await;
-                })
+                });
+                (handle, bound)
             }
             InboundProtocol::Udp => {
                 let socket =
                     UdpSocket::bind(SocketAddr::V4(SocketAddrV4::new(host_ip, host_port))).await?;
+                let bound = socket.local_addr()?.port();
                 tracing::info!(
                     "Inbound listener: UDP {}:{} → container :{}",
                     host_ip,
-                    host_port,
+                    bound,
                     container_port,
                 );
                 let cancel_clone = cancel.clone();
-                tokio::spawn(async move {
+                let handle = tokio::spawn(async move {
                     udp_listener_task(socket, container_port, cmd_tx, cancel_clone).await;
-                })
+                });
+                (handle, bound)
             }
         };
 
-        self.listeners.insert(key, (handle, cancel));
-        Ok(())
+        self.listeners.insert(key, (handle, cancel, bound_port));
+        Ok(bound_port)
     }
 
     /// Removes a forwarding rule and stops its listener.
     pub fn remove_rule(&mut self, host_ip: Ipv4Addr, host_port: u16, protocol: InboundProtocol) {
         let key = (host_ip, host_port, protocol);
-        if let Some((handle, cancel)) = self.listeners.remove(&key) {
+        if let Some((handle, cancel, bound)) = self.listeners.remove(&key) {
             cancel.cancel();
             handle.abort();
             tracing::debug!(
                 "Inbound listener removed: {:?} {}:{}",
                 protocol,
                 host_ip,
-                host_port
+                bound
             );
         }
     }
 
     /// Stops all listeners.
     pub fn stop_all(&mut self) {
-        for ((ip, port, proto), (handle, cancel)) in self.listeners.drain() {
+        for ((ip, _, proto), (handle, cancel, bound)) in self.listeners.drain() {
             cancel.cancel();
             handle.abort();
-            tracing::debug!("Inbound listener stopped: {:?} {}:{}", proto, ip, port);
+            tracing::debug!("Inbound listener stopped: {:?} {}:{}", proto, ip, bound);
         }
     }
 }
@@ -663,21 +682,6 @@ mod tests {
         assert!(cmd_rx.try_recv().is_err(), "no commands expected yet");
     }
 
-    /// Probes a free localhost TCP port and releases it.
-    ///
-    /// `add_rule` returns `io::Result<()>`, not the bound port, so a rule
-    /// added on port 0 lands somewhere the test cannot then connect to. The
-    /// bind is dropped before the rule is added — a benign TOCTOU, and the
-    /// same trick `tests/e2e/src/scenario.rs` uses for the DNS port.
-    async fn free_local_port() -> u16 {
-        TcpListener::bind(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)))
-            .await
-            .expect("probing a free port")
-            .local_addr()
-            .expect("probed listener has an address")
-            .port()
-    }
-
     /// A real host connection to a registered rule produces `TcpAccepted`
     /// carrying the container port the rule was created with.
     ///
@@ -685,16 +689,20 @@ mod tests {
     /// bookkeeping — it never connects, so nothing proved the listener task
     /// actually accepts and reports. The relay's job ends here: SYN
     /// generation toward the guest belongs to `splicetcp`'s active open.
+    ///
+    /// Binds port 0 and uses the port `add_rule` reports. Probing for a free
+    /// port and then binding it would race anything else on the machine into
+    /// the gap.
     #[tokio::test]
     async fn host_connection_produces_a_tcp_accepted_command() {
         let (cmd_tx, mut cmd_rx) = mpsc::channel(16);
         let mut manager = InboundListenerManager::new(cmd_tx);
-        let host_port = free_local_port().await;
 
-        manager
-            .add_rule(Ipv4Addr::LOCALHOST, host_port, 8080, InboundProtocol::Tcp)
+        let host_port = manager
+            .add_rule(Ipv4Addr::LOCALHOST, 0, 8080, InboundProtocol::Tcp)
             .await
-            .expect("rule should bind the probed port");
+            .expect("rule should bind an OS-assigned port");
+        assert_ne!(host_port, 0, "add_rule must report the port it bound");
 
         let _client = tokio::net::TcpStream::connect((Ipv4Addr::LOCALHOST, host_port))
             .await
@@ -732,17 +740,18 @@ mod tests {
     async fn removing_a_rule_closes_the_listener() {
         let (cmd_tx, _cmd_rx) = mpsc::channel(16);
         let mut manager = InboundListenerManager::new(cmd_tx);
-        let host_port = free_local_port().await;
 
-        manager
-            .add_rule(Ipv4Addr::LOCALHOST, host_port, 8080, InboundProtocol::Tcp)
+        let host_port = manager
+            .add_rule(Ipv4Addr::LOCALHOST, 0, 8080, InboundProtocol::Tcp)
             .await
-            .expect("rule should bind the probed port");
+            .expect("rule should bind an OS-assigned port");
         tokio::net::TcpStream::connect((Ipv4Addr::LOCALHOST, host_port))
             .await
             .expect("connect should succeed while the rule exists");
 
-        manager.remove_rule(Ipv4Addr::LOCALHOST, host_port, InboundProtocol::Tcp);
+        // Keyed by the port that was *requested*, hence 0 rather than the
+        // bound port — see the `listeners` field comment.
+        manager.remove_rule(Ipv4Addr::LOCALHOST, 0, InboundProtocol::Tcp);
 
         // Cancellation is cooperative: the listener task observes the token
         // and drops its socket, so retry briefly rather than racing it.

--- a/common/arcbox-proxy/src/inbound_relay.rs
+++ b/common/arcbox-proxy/src/inbound_relay.rs
@@ -536,6 +536,8 @@ fn create_udp_reply_flow(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     const GW_IP: Ipv4Addr = Ipv4Addr::new(192, 168, 64, 1);
@@ -659,6 +661,101 @@ mod tests {
 
         // The cmd_rx channel should still be valid (no panic).
         assert!(cmd_rx.try_recv().is_err(), "no commands expected yet");
+    }
+
+    /// Probes a free localhost TCP port and releases it.
+    ///
+    /// `add_rule` returns `io::Result<()>`, not the bound port, so a rule
+    /// added on port 0 lands somewhere the test cannot then connect to. The
+    /// bind is dropped before the rule is added — a benign TOCTOU, and the
+    /// same trick `tests/e2e/src/scenario.rs` uses for the DNS port.
+    async fn free_local_port() -> u16 {
+        TcpListener::bind(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)))
+            .await
+            .expect("probing a free port")
+            .local_addr()
+            .expect("probed listener has an address")
+            .port()
+    }
+
+    /// A real host connection to a registered rule produces `TcpAccepted`
+    /// carrying the container port the rule was created with.
+    ///
+    /// `listener_manager_add_and_remove_rule` only exercises the manager's
+    /// bookkeeping — it never connects, so nothing proved the listener task
+    /// actually accepts and reports. The relay's job ends here: SYN
+    /// generation toward the guest belongs to `splicetcp`'s active open.
+    #[tokio::test]
+    async fn host_connection_produces_a_tcp_accepted_command() {
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(16);
+        let mut manager = InboundListenerManager::new(cmd_tx);
+        let host_port = free_local_port().await;
+
+        manager
+            .add_rule(Ipv4Addr::LOCALHOST, host_port, 8080, InboundProtocol::Tcp)
+            .await
+            .expect("rule should bind the probed port");
+
+        let _client = tokio::net::TcpStream::connect((Ipv4Addr::LOCALHOST, host_port))
+            .await
+            .expect("host should be able to connect to a registered rule");
+
+        let cmd = tokio::time::timeout(Duration::from_secs(5), cmd_rx.recv())
+            .await
+            .expect("a TcpAccepted command should arrive within 5s")
+            .expect("command channel stayed open");
+
+        match cmd {
+            InboundCommand::TcpAccepted {
+                host_port: got_host,
+                container_port,
+                ..
+            } => {
+                assert_eq!(got_host, host_port, "command reports the wrong host port");
+                assert_eq!(
+                    container_port, 8080,
+                    "command must carry the container port the rule was created with"
+                );
+            }
+            // Named rather than `{:?}`-formatted: deriving Debug on the
+            // command type (it carries a TcpStream) to serve a panic message
+            // would widen production surface for a test's benefit.
+            InboundCommand::UdpReceived { .. } => {
+                panic!("a TCP rule produced UdpReceived instead of TcpAccepted")
+            }
+        }
+    }
+
+    /// Removing a rule closes its listener, so a later connect is refused
+    /// rather than hanging or silently succeeding against a stale listener.
+    #[tokio::test]
+    async fn removing_a_rule_closes_the_listener() {
+        let (cmd_tx, _cmd_rx) = mpsc::channel(16);
+        let mut manager = InboundListenerManager::new(cmd_tx);
+        let host_port = free_local_port().await;
+
+        manager
+            .add_rule(Ipv4Addr::LOCALHOST, host_port, 8080, InboundProtocol::Tcp)
+            .await
+            .expect("rule should bind the probed port");
+        tokio::net::TcpStream::connect((Ipv4Addr::LOCALHOST, host_port))
+            .await
+            .expect("connect should succeed while the rule exists");
+
+        manager.remove_rule(Ipv4Addr::LOCALHOST, host_port, InboundProtocol::Tcp);
+
+        // Cancellation is cooperative: the listener task observes the token
+        // and drops its socket, so retry briefly rather than racing it.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match tokio::net::TcpStream::connect((Ipv4Addr::LOCALHOST, host_port)).await {
+                Err(_) => break,
+                Ok(_) if tokio::time::Instant::now() >= deadline => {
+                    panic!("port {host_port} still accepts connections after remove_rule")
+                }
+                Ok(_) => tokio::time::sleep(Duration::from_millis(50)).await,
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes the narrow gaps left in ABX-292 and ABX-303 once the rest turned out to be covered already. Two commits, one per crate.

## Both issues asked for the wrong thing

**ABX-292** wanted "query parameter parsing" tests. We do not parse them: no handler takes an axum `Query<T>`, and the interceptors hand `OriginalUri` plus the raw `Request<Body>` to the proxy. `?all=`, `?filters=`, `?force=` are dockerd's to interpret.

What *is* ours, and was untested, is **forwarding fidelity** — and it has teeth. A query string that arrives re-encoded, reordered, or truncated silently changes what dockerd does: `docker ps --filter` returns the wrong set, `docker rm -f` stops forcing. Meanwhile the status stays 200 and every existing body-echo assertion still passes. `api_routing.rs` proves requests *reach* the backend; these prove they arrive *intact*.

**ABX-303** wanted an assertion that an inbound SYN "reaches the guest NIC". That is not this layer. `tcp_listener_task` emits `InboundCommand::TcpAccepted { stream }` and stops; SYN generation toward the guest is `splicetcp`'s active open, already covered by `handshake_active_open_emits_syn_and_completes`. The relay's real gap was that `listener_manager_add_and_remove_rule` only exercised bookkeeping — it never connected, so nothing proved the listener accepts and reports.

Both issue descriptions have been rewritten in Linear to match.

## What this adds

**`app/arcbox-docker/tests/api_request_forwarding.rs`** — 5 tests, none `#[ignore]`d:

- the query string reaches dockerd verbatim (`?force=true&v=true`)
- a percent-encoded JSON `filters` value is not re-encoded
- version-prefix stripping leaves the query alone
- a query-less request does not gain an empty `?`
- an error raised on *our* side of the boundary carries `{"message": "..."}`, not just a status — `guest_error_status_passes_through` only covers the relayed case, and only checks the status

The mock guest gains `last_request_uri()`, recorded before version stripping and before route matching, mirroring the existing `last_upgrade_body()` pattern. No canned route matches on the query, so without it the forwarded target is unobservable.

**`common/arcbox-proxy`** — 3 tests:

- a real host connection to a registered rule produces `TcpAccepted` with the container port the rule carries
- removing a rule closes the listener, so a later connect is refused rather than hanging
- an ICMP echo request round-trips with the guest's own identifier and sequence intact

`add_rule` returns `io::Result<()>`, not the bound port, so a rule on port 0 lands somewhere the test cannot reach. The port is probed and released first — the same benign TOCTOU `tests/e2e/src/scenario.rs` uses for the DNS port.

## The one `#[ignore]`

The ICMP round trip needs an ICMP datagram socket. That is unprivileged on macOS but commonly unavailable in container-based CI, where the proxy disables itself on `PermissionDenied` and the test would time out on a sandbox artifact rather than a defect. It passes locally; gating it beat weakening the assertion.

`test_icmp_identifier_restore` already covered the patch arithmetic on a hand-built packet — what was missing is the socket path that makes the patch necessary. macOS `SOCK_DGRAM`+`IPPROTO_ICMP` rewrites the identifier with a kernel-internal socket id, so a reply arriving with the guest's id intact is the whole property.

## Verification

Rebased onto `f0140529` and re-run there.

- `cargo test -p arcbox-proxy --lib` — 28 passing, 1 ignored
- `cargo test -p arcbox-docker --test api_request_forwarding` — 5 passing
- `cargo test -p arcbox-proxy --lib icmp -- --ignored` — passes on an M-series machine
- `cargo clippy -p arcbox-proxy -p arcbox-docker --all-targets -- -D warnings` — clean
- `cargo fmt` — clean

## Note

`InboundCommand` is matched by variant rather than `{:?}`-formatted in a panic message: deriving `Debug` on it (it carries a `TcpStream`) would widen production surface for a test's benefit.
