### PR TITLE
fix(daemon): make vm_running track the VM and a docker.sock bind fail startup (CORE-70/71)

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -91,7 +91,13 @@ must name `abctl`.
   cold-start recovery on a successful guest query and never cleared, so it
   read `true` for the rest of the daemon's life after any stop (CORE-70). A
   second writer re-introduces that class of drift — the loop owns both
-  edges. Regression: `vm_running_loop_follows_the_lifecycle_both_ways`.
+  edges. It is armed from `init_runtime` *before* `Runtime::init`, not from
+  `start_services`: the VM goes ready partway through `init`, so a later
+  start would report it down for the whole dockerd wait. And it is only as
+  good as the lifecycle state — an unmanaged guest crash leaves that
+  `Running` (ABX-414: no `HealthMonitor` loop), so the flag says "the daemon
+  believes the VM is up", not "the VM answered just now". Regression:
+  `vm_running_loop_follows_the_lifecycle_both_ways`.
 - Startup-cancellation invariant: the flock (`daemon_lock`) and
   `early_runtime` are held in `StartupHandles`, not only in pipeline-local
   context (`context.rs`, `main::run` keeps a clone). WHY: a signal can drop

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -75,15 +75,23 @@ must name `abctl`.
   into the snapshot, walking a client's phase backwards. Regressions:
   `back_to_back_phases_are_all_delivered`,
   `the_snapshot_is_not_replayed_as_an_update`.
-- `NETWORK_READY` covers whichever services this daemon runs and means they
-  were *started*, not that they are reachable. `--no-linux-vm` reaches it
-  with DNS alone (`start_services` skips the Docker API and the Kubernetes
-  proxy), and of the three only DNS is guaranteed bound: `DnsService::bind`
-  propagates its error, while `DockerApiServer::run` binds inside its
-  spawned task and only logs there, and the Kubernetes proxy tolerates a
-  taken 16443 by design — so a Docker socket that fails to bind still
-  reaches `READY`. Pre-existing; if you fix it, bind before returning from
-  `services::start_services` so the failure reaches the pipeline.
+- **A listener the phase promises is bound before `start_services` returns,
+  never inside its spawned task** (`DnsService::bind`, then
+  `DockerApiServer::bind` + `serve` — CORE-71). WHY: a task that binds and
+  only logs its error cannot fail startup, so the pipeline publishes
+  `NETWORK_READY` and `READY` for a daemon whose primary API no client can
+  reach. `NETWORK_READY` therefore covers whichever services this daemon
+  runs — `--no-linux-vm` reaches it with DNS alone — and the Kubernetes
+  proxy is the deliberate exception: a taken 16443 is tolerated, so it is
+  started here but not promised. Adding a listener means deciding which of
+  those two it is.
+- **`SetupStatus.vm_running` is owned by `services::vm_running_loop`**, which
+  mirrors `VmLifecycleState::is_ready` (readiness level 2 below) off
+  `Runtime::subscribe_system_vm_state`. WHY: it used to be set once by
+  cold-start recovery on a successful guest query and never cleared, so it
+  read `true` for the rest of the daemon's life after any stop (CORE-70). A
+  second writer re-introduces that class of drift — the loop owns both
+  edges. Regression: `vm_running_loop_follows_the_lifecycle_both_ways`.
 - Startup-cancellation invariant: the flock (`daemon_lock`) and
   `early_runtime` are held in `StartupHandles`, not only in pipeline-local
   context (`context.rs`, `main::run` keeps a clone). WHY: a signal can drop

--- a/app/arcbox-daemon/src/recovery.rs
+++ b/app/arcbox-daemon/src/recovery.rs
@@ -24,7 +24,7 @@ pub async fn run(ctx: &DaemonContext, runtime: &Arc<Runtime>) {
         return;
     }
 
-    recover_container_networking(runtime, &ctx.setup_state).await;
+    recover_container_networking(runtime).await;
 
     // Cold-start route reconcile (non-blocking). This is load-bearing after
     // app updates or daemon restarts where the VM survives but the host route
@@ -252,12 +252,10 @@ async fn ensure_docker_tools(data_dir: &Path) -> anyhow::Result<()> {
 
 /// Re-registers DNS entries and port forwarding for all running containers.
 ///
-/// If the guest VM responds (even with an empty container list), the
-/// `vm_running` flag on `setup_state` is set to `true`.
-async fn recover_container_networking(
-    runtime: &Arc<Runtime>,
-    setup_state: &Arc<arcbox_api::SetupState>,
-) {
+/// Reports nothing about VM liveness: `services::vm_running_loop` owns
+/// `SetupStatus.vm_running` and follows the lifecycle across restarts, which
+/// a one-shot observation made here could not.
+async fn recover_container_networking(runtime: &Arc<Runtime>) {
     use arcbox_docker::guest_query;
     use arcbox_docker::proxy::{GuestHttpClient, VsockConnector};
 
@@ -269,9 +267,6 @@ async fn recover_container_networking(
             return;
         }
     };
-
-    // Successfully queried the guest VM — it is running.
-    setup_state.set_vm_running(true);
 
     let mut recovered_dns = 0u32;
     let mut recovered_ports = 0u32;

--- a/app/arcbox-daemon/src/services.rs
+++ b/app/arcbox-daemon/src/services.rs
@@ -148,16 +148,6 @@ pub async fn start_services(
         route_status_loop(route_events, route_state, route_shutdown).await;
     }));
 
-    // Same shape for vm_running, for the same reason: the flag has to follow
-    // the VM across restarts, not just report the one cold-start observation
-    // recovery happened to make.
-    let vm_state = runtime.subscribe_system_vm_state();
-    let vm_running_state = Arc::clone(&ctx.setup_state);
-    let vm_running_shutdown = ctx.shutdown.clone();
-    drop(tokio::spawn(async move {
-        vm_running_loop(vm_state, vm_running_state, vm_running_shutdown).await;
-    }));
-
     #[cfg(target_os = "macos")]
     let route_guard = linux_vm.then(|| {
         let runtime = Arc::clone(runtime);
@@ -182,6 +172,23 @@ pub async fn start_services(
 // =============================================================================
 // Helpers
 // =============================================================================
+
+/// Starts the `vm_running` mirror for the System VM.
+///
+/// Spawned from `init_runtime`, not from [`start_services`]: the VM reaches
+/// `VmLifecycleState::Running` partway through `Runtime::init` — that is what
+/// publishes `VM_READY` — and `init` then waits for the guest container
+/// runtime. A mirror started once `boot_runtime` has returned would report
+/// `vm_running = false` across that whole window while the agent is already
+/// answering, which is exactly what the field promises it is not.
+pub fn spawn_vm_running_mirror(ctx: &DaemonContext, runtime: &Arc<Runtime>) {
+    let state = runtime.subscribe_system_vm_state();
+    let setup_state = Arc::clone(&ctx.setup_state);
+    let shutdown = ctx.shutdown.clone();
+    drop(tokio::spawn(async move {
+        vm_running_loop(state, setup_state, shutdown).await;
+    }));
+}
 
 /// Mirrors the System VM's lifecycle state into `SetupState.vm_running`.
 ///

--- a/app/arcbox-daemon/src/services.rs
+++ b/app/arcbox-daemon/src/services.rs
@@ -9,8 +9,9 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use arcbox_api::{SharedRuntime, SystemServiceImpl};
-use arcbox_core::Runtime;
+use arcbox_core::{Runtime, VmLifecycleState};
 use arcbox_docker::{DockerApiServer, DockerContextManager, ServerConfig};
+use tokio::sync::watch;
 use tracing::{info, warn};
 
 use crate::context::{DaemonContext, ServiceHandles};
@@ -82,21 +83,33 @@ pub async fn start_services(
     // is not booted.
     let linux_vm = runtime.config().vm.autostart;
 
-    // Docker API server.
-    let docker = linux_vm.then(|| {
+    // Docker API server. Bound here rather than inside the spawned task so a
+    // bind failure fails startup: the Docker socket is the daemon's primary
+    // API, and a task that only logs the error would leave the pipeline
+    // publishing READY for a daemon no client can reach (CORE-71). DNS above
+    // already works this way.
+    let docker = if linux_vm {
         let docker_server = DockerApiServer::new(
             ServerConfig {
                 socket_path: ctx.layout.docker_socket.clone(),
             },
             Arc::clone(runtime),
         );
+        let listener = docker_server.bind().with_context(|| {
+            format!(
+                "Failed to bind the Docker API socket: {}",
+                ctx.layout.docker_socket.display()
+            )
+        })?;
         let docker_shutdown = ctx.shutdown.clone();
-        tokio::spawn(async move {
-            if let Err(e) = docker_server.run(docker_shutdown).await {
+        Some(tokio::spawn(async move {
+            if let Err(e) = docker_server.serve(listener, docker_shutdown).await {
                 tracing::error!("Docker API server error: {}", e);
             }
-        })
-    });
+        }))
+    } else {
+        None
+    };
 
     // Docker CLI integration (optional).
     if linux_vm && ctx.docker_integration {
@@ -135,6 +148,16 @@ pub async fn start_services(
         route_status_loop(route_events, route_state, route_shutdown).await;
     }));
 
+    // Same shape for vm_running, for the same reason: the flag has to follow
+    // the VM across restarts, not just report the one cold-start observation
+    // recovery happened to make.
+    let vm_state = runtime.subscribe_system_vm_state();
+    let vm_running_state = Arc::clone(&ctx.setup_state);
+    let vm_running_shutdown = ctx.shutdown.clone();
+    drop(tokio::spawn(async move {
+        vm_running_loop(vm_state, vm_running_state, vm_running_shutdown).await;
+    }));
+
     #[cfg(target_os = "macos")]
     let route_guard = linux_vm.then(|| {
         let runtime = Arc::clone(runtime);
@@ -159,6 +182,33 @@ pub async fn start_services(
 // =============================================================================
 // Helpers
 // =============================================================================
+
+/// Mirrors the System VM's lifecycle state into `SetupState.vm_running`.
+///
+/// The flag reports readiness level 2 — `VmLifecycleState::is_ready`, the
+/// agent has answered a ping — which is the level that matches what a client
+/// reads the field to mean. Level 1 (`MachineState::Running`) counts a VM
+/// whose agent is not up, so RPCs against it fail; level 3 (guest dockerd)
+/// is narrower than "the VM is running" and already has its own signal.
+///
+/// Driven from the lifecycle watch rather than set once on a successful guest
+/// query, so it tracks both edges: idle stop, backend switch, and crash
+/// recovery all move it without anything else having to remember to.
+async fn vm_running_loop(
+    mut state: watch::Receiver<VmLifecycleState>,
+    setup_state: Arc<arcbox_api::SetupState>,
+    shutdown: tokio_util::sync::CancellationToken,
+) {
+    loop {
+        setup_state.set_vm_running(state.borrow_and_update().is_ready());
+        tokio::select! {
+            () = shutdown.cancelled() => break,
+            // The sender lives as long as the runtime; an error means it is
+            // gone, so there is nothing left to mirror.
+            changed = state.changed() => if changed.is_err() { break },
+        }
+    }
+}
 
 /// Mirrors VM lifecycle events into `SetupState.route_installed`.
 ///
@@ -446,6 +496,53 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
         false
+    }
+
+    /// Polls until `vm_running` matches `want` or times out.
+    async fn wait_for_vm_running(state: &SetupState, want: bool) -> bool {
+        for _ in 0..200 {
+            if state.current().vm_running == want {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        false
+    }
+
+    /// The flag has to fall as well as rise. Its predecessor was set once by
+    /// cold-start recovery and never cleared, so a client saw `vm_running`
+    /// stay true for the rest of the daemon's life after any VM stop.
+    #[tokio::test]
+    async fn vm_running_loop_follows_the_lifecycle_both_ways() {
+        let (lifecycle, rx) = watch::channel(VmLifecycleState::Stopped);
+        let setup_state = Arc::new(SetupState::new());
+        let shutdown = tokio_util::sync::CancellationToken::new();
+
+        let task = tokio::spawn(vm_running_loop(
+            rx,
+            Arc::clone(&setup_state),
+            shutdown.clone(),
+        ));
+
+        assert!(wait_for_vm_running(&setup_state, false).await);
+
+        lifecycle.send(VmLifecycleState::Running).expect("receiver");
+        assert!(wait_for_vm_running(&setup_state, true).await);
+
+        // Idle still counts as running: the VM is up, just quiet.
+        lifecycle.send(VmLifecycleState::Idle).expect("receiver");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(setup_state.current().vm_running);
+
+        // The regression this test exists for.
+        lifecycle.send(VmLifecycleState::Stopped).expect("receiver");
+        assert!(wait_for_vm_running(&setup_state, false).await);
+
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("loop exits on shutdown")
+            .expect("loop task panicked");
     }
 
     #[tokio::test]

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -242,6 +242,11 @@ async fn init_runtime(ctx: &DaemonContext) -> Result<Arc<Runtime>> {
     ctx.early_runtime
         .set(Arc::clone(&runtime))
         .map_err(|_| anyhow::anyhow!("init_runtime called twice"))?;
+    // Armed before `init` for the same reason `early_runtime` is published
+    // here: the VM reaches its ready state partway through the call below, so
+    // a mirror started after it returns would report the VM down across the
+    // whole window between the agent answering and dockerd coming up.
+    crate::services::spawn_vm_running_mirror(ctx, &runtime);
     // The guest boot is the longest stretch of startup and the only one a
     // client cannot infer from anything else, so the runtime reports its
     // milestones from inside and they are published as they arrive.

--- a/app/arcbox-daemon/src/startup/pipeline.rs
+++ b/app/arcbox-daemon/src/startup/pipeline.rs
@@ -149,14 +149,14 @@ impl RuntimeBooted {
             Ok(handles)
         })
         .await?;
-        // DNS is bound; with a Linux VM the Docker API and Kubernetes proxies
-        // are started too (`start_services` skips both under `--no-linux-vm`,
-        // so that daemon reaches this phase with DNS alone). Neither proxy's
-        // bind failure reaches this stage — `DockerApiServer` binds inside its
-        // spawned task and only logs, and a taken 16443 is tolerated by design
-        // — so the phase means "services started", not "proven reachable".
-        // What recovery spawned (route reconcile, self-setup) reports through
-        // the SetupStatus flags instead.
+        // DNS and, with a Linux VM, the Docker API are bound: both bind before
+        // `start_services` returns, so a failure on either arrives as an `Err`
+        // here and becomes FAILED instead of this phase (`--no-linux-vm` skips
+        // the Docker API and reaches this phase with DNS alone). The
+        // Kubernetes proxy is the exception — a taken 16443 is tolerated by
+        // design, so it is started but not promised. What recovery spawned
+        // (route reconcile, self-setup) reports through the SetupStatus flags
+        // instead.
         self.ctx
             .setup_state
             .set_phase(SetupPhase::NetworkReady, "Network services ready");

--- a/app/arcbox-docker/src/server.rs
+++ b/app/arcbox-docker/src/server.rs
@@ -91,21 +91,16 @@ impl DockerApiServer {
 
     /// Serves on an already-bound listener until `shutdown` is cancelled.
     ///
+    /// There is deliberately no `bind`-and-serve convenience wrapper: it
+    /// would only be useful from a spawned task, which is exactly the shape
+    /// that swallows the bind error and lets startup report READY for a
+    /// daemon nobody can reach (CORE-71).
+    ///
     /// # Errors
     ///
     /// Returns an error if serving fails.
     pub async fn serve(&self, listener: UnixListener, shutdown: CancellationToken) -> Result<()> {
         self.run_native_http(listener, shutdown).await
-    }
-
-    /// Binds and serves in one call.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the server fails to start.
-    pub async fn run(&self, shutdown: CancellationToken) -> Result<()> {
-        let listener = self.bind()?;
-        self.serve(listener, shutdown).await
     }
 }
 

--- a/app/arcbox-docker/src/server.rs
+++ b/app/arcbox-docker/src/server.rs
@@ -57,12 +57,18 @@ impl DockerApiServer {
         &self.config.socket_path
     }
 
-    /// Runs the server.
+    /// Binds the Docker API socket, returning the listener to serve on.
+    ///
+    /// Separate from [`Self::serve`] so a caller that spawns the serving task
+    /// can still fail startup on a bind error: the daemon's Docker socket is
+    /// its primary API, and a background task that only logs the failure
+    /// leaves clients hitting connection-refused against a daemon that
+    /// reported itself ready.
     ///
     /// # Errors
     ///
-    /// Returns an error if the server fails to start.
-    pub async fn run(&self, shutdown: CancellationToken) -> Result<()> {
+    /// Returns an error if the socket cannot be bound.
+    pub fn bind(&self) -> Result<UnixListener> {
         // Remove existing socket
         let _ = std::fs::remove_file(&self.config.socket_path);
 
@@ -80,7 +86,26 @@ impl DockerApiServer {
         );
         tracing::info!("Docker API backend: smart proxy to guest dockerd");
 
+        Ok(listener)
+    }
+
+    /// Serves on an already-bound listener until `shutdown` is cancelled.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serving fails.
+    pub async fn serve(&self, listener: UnixListener, shutdown: CancellationToken) -> Result<()> {
         self.run_native_http(listener, shutdown).await
+    }
+
+    /// Binds and serves in one call.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the server fails to start.
+    pub async fn run(&self, shutdown: CancellationToken) -> Result<()> {
+        let listener = self.bind()?;
+        self.serve(listener, shutdown).await
     }
 }
 

--- a/docs/daemon-lifecycle.md
+++ b/docs/daemon-lifecycle.md
@@ -73,9 +73,11 @@ startup failure.
   A client wanting "is the route up *now*" reads the flag, not a phase.
   `vm_running` and `route_installed` both track the VM across restarts —
   `services::vm_running_loop` mirrors `VmLifecycleState::is_ready`, and
-  `route_status_loop` mirrors the route events — so both fall on a stop and
-  rise again on the next boot rather than reporting one cold-start
-  observation forever.
+  `route_status_loop` mirrors the route events — so both fall on a
+  lifecycle-managed stop and rise again on the next boot rather than
+  reporting one cold-start observation forever. Neither is a liveness probe:
+  a guest that dies without the lifecycle noticing leaves `vm_running` true,
+  because crash detection is unimplemented (ABX-414).
 
 ### Why gRPC starts before resource cleanup
 
@@ -190,7 +192,7 @@ When the daemon is killed without graceful shutdown:
 | File | State | Next startup |
 |------|-------|-------------|
 | `daemon.lock` | exists, old PID, **lock released** | `try_flock` succeeds instantly |
-| `docker.sock` | **stale** | `DockerApiServer::run` removes before bind |
+| `docker.sock` | **stale** | `DockerApiServer::bind` removes before bind |
 | `arcbox.sock` | **stale** | `start_grpc` removes before bind |
 | disk images | **possibly held by XPC helpers** | `wait_for_resources` waits up to 10 s |
 | VM | non-graceful termination | Virtualization.framework cleans up |
@@ -225,7 +227,7 @@ centrally during startup — each server removes and rebinds independently:
 | Socket | Owner | Cleanup |
 |--------|-------|---------|
 | `arcbox.sock` | `services::start_grpc` | `remove_file` before `UnixListener::bind` |
-| `docker.sock` | `DockerApiServer::run` | `remove_file` before `UnixListener::bind` |
+| `docker.sock` | `DockerApiServer::bind` | `remove_file` before `UnixListener::bind` |
 
 This avoids race conditions where a centralized cleanup could delete a
 socket that another component has already bound.

--- a/docs/daemon-lifecycle.md
+++ b/docs/daemon-lifecycle.md
@@ -55,15 +55,13 @@ startup failure.
   `READY` are published ~300 µs apart with no await point between them and
   a snapshot channel would collapse them (see `SetupState` in
   `arcbox-api/src/system.rs`).
-- `NETWORK_READY` covers whichever host services this daemon runs, and means
-  they were *started*, not that they are reachable. A `--no-linux-vm` daemon
-  reaches it with DNS alone — `start_services` skips the Docker API and the
-  Kubernetes proxy in that mode. And of the three, only DNS is guaranteed
-  bound: `DnsService::bind` propagates its error, while
-  `DockerApiServer::run` binds inside its spawned task and only logs there,
-  and the Kubernetes proxy tolerates a taken 16443 by design. A Docker
-  socket that fails to bind therefore still reaches `READY` — a pre-existing
-  gap, not something the phase introduces.
+- `NETWORK_READY` covers whichever host services this daemon runs. A
+  `--no-linux-vm` daemon reaches it with DNS alone — `start_services` skips
+  the Docker API and the Kubernetes proxy in that mode. DNS and the Docker
+  API are both *bound* by the time it is published, and a bind failure on
+  either fails startup with `FAILED` instead of reaching this phase. The
+  Kubernetes proxy is the exception: a port 16443 already in use is
+  tolerated by design, so the phase does not promise it.
 - Enum ordinal ≠ progression order (`DOWNLOADING_ASSETS = 8` occurs before
   `READY = 6`). Clients must match on the value, never compare ordinals.
   New phases are appended with the next free number regardless of where
@@ -73,6 +71,11 @@ startup failure.
   state that outlives startup, including work `recovery::run` spawns in
   the background and anything `route_status_loop` reconciles afterwards.
   A client wanting "is the route up *now*" reads the flag, not a phase.
+  `vm_running` and `route_installed` both track the VM across restarts —
+  `services::vm_running_loop` mirrors `VmLifecycleState::is_ready`, and
+  `route_status_loop` mirrors the route events — so both fall on a stop and
+  rise again on the next boot rather than reporting one cold-start
+  observation forever.
 
 ### Why gRPC starts before resource cleanup
 

--- a/rpc/arcbox-protocol/proto/api.proto
+++ b/rpc/arcbox-protocol/proto/api.proto
@@ -771,9 +771,12 @@ message SetupStatus {
     // Whether the container subnet route is installed.
     bool route_installed = 4;
     // Whether the System VM is up with its guest agent answering — the point
-    // at which RPCs against it succeed. Follows the VM for the daemon's whole
-    // life, so it falls on stop (idle, backend switch, crash) and rises again
-    // on the next boot.
+    // at which RPCs against it succeed. Mirrors the VM's lifecycle state for
+    // the daemon's whole life, so it falls on a lifecycle-managed stop (idle
+    // stop, backend switch, shutdown) and rises again on the next boot. A
+    // guest that dies without the lifecycle noticing keeps it true: there is
+    // no crash detection yet, so treat it as "the daemon believes the VM is
+    // up", not as a liveness probe.
     bool vm_running = 5;
     // Human-readable status message.
     string message = 6;

--- a/rpc/arcbox-protocol/proto/api.proto
+++ b/rpc/arcbox-protocol/proto/api.proto
@@ -742,12 +742,12 @@ message SetupStatus {
         // The System VM booted and its guest agent answered, so the VM
         // accepts commands. Its container runtime may still be starting.
         VM_READY = 4;
-        // The host services this daemon runs are up: the DNS server is
-        // bound, and — with a Linux VM — the Docker API and Kubernetes
-        // proxies have been started (a --no-linux-vm daemon runs neither).
-        // Neither proxy aborts startup when its bind fails, so this means
-        // "started", not "proven reachable"; clients still handle a
-        // connection error.
+        // The host services this daemon runs are up: the DNS server and,
+        // with a Linux VM, the Docker API are bound (a --no-linux-vm daemon
+        // runs no Docker API). Both fail startup rather than reaching this
+        // phase if they cannot bind. The Kubernetes proxy is started here
+        // too but is best-effort — a port 16443 already in use is tolerated
+        // — so it is the one service this phase does not promise.
         NETWORK_READY = 5;
         // Startup complete.
         READY = 6;
@@ -770,7 +770,10 @@ message SetupStatus {
     bool docker_socket_linked = 3;
     // Whether the container subnet route is installed.
     bool route_installed = 4;
-    // Whether the default VM is running.
+    // Whether the System VM is up with its guest agent answering — the point
+    // at which RPCs against it succeed. Follows the VM for the daemon's whole
+    // life, so it falls on stop (idle, backend switch, crash) and rises again
+    // on the next boot.
     bool vm_running = 5;
     // Human-readable status message.
     string message = 6;

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -960,7 +960,10 @@ pub struct SetupStatus {
     /// Whether the container subnet route is installed.
     #[prost(bool, tag = "4")]
     pub route_installed: bool,
-    /// Whether the default VM is running.
+    /// Whether the System VM is up with its guest agent answering — the point
+    /// at which RPCs against it succeed. Follows the VM for the daemon's whole
+    /// life, so it falls on stop (idle, backend switch, crash) and rises again
+    /// on the next boot.
     #[prost(bool, tag = "5")]
     pub vm_running: bool,
     /// Human-readable status message.
@@ -1009,12 +1012,12 @@ pub mod setup_status {
         /// The System VM booted and its guest agent answered, so the VM
         /// accepts commands. Its container runtime may still be starting.
         VmReady = 4,
-        /// The host services this daemon runs are up: the DNS server is
-        /// bound, and — with a Linux VM — the Docker API and Kubernetes
-        /// proxies have been started (a --no-linux-vm daemon runs neither).
-        /// Neither proxy aborts startup when its bind fails, so this means
-        /// "started", not "proven reachable"; clients still handle a
-        /// connection error.
+        /// The host services this daemon runs are up: the DNS server and,
+        /// with a Linux VM, the Docker API are bound (a --no-linux-vm daemon
+        /// runs no Docker API). Both fail startup rather than reaching this
+        /// phase if they cannot bind. The Kubernetes proxy is started here
+        /// too but is best-effort — a port 16443 already in use is tolerated
+        /// — so it is the one service this phase does not promise.
         NetworkReady = 5,
         /// Startup complete.
         Ready = 6,

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -961,9 +961,12 @@ pub struct SetupStatus {
     #[prost(bool, tag = "4")]
     pub route_installed: bool,
     /// Whether the System VM is up with its guest agent answering — the point
-    /// at which RPCs against it succeed. Follows the VM for the daemon's whole
-    /// life, so it falls on stop (idle, backend switch, crash) and rises again
-    /// on the next boot.
+    /// at which RPCs against it succeed. Mirrors the VM's lifecycle state for
+    /// the daemon's whole life, so it falls on a lifecycle-managed stop (idle
+    /// stop, backend switch, shutdown) and rises again on the next boot. A
+    /// guest that dies without the lifecycle noticing keeps it true: there is
+    /// no crash detection yet, so treat it as "the daemon believes the VM is
+    /// up", not as a liveness probe.
     #[prost(bool, tag = "5")]
     pub vm_running: bool,
     /// Human-readable status message.


### PR DESCRIPTION
Two ways `SetupStatus` could tell a client something untrue. Both are the boolean-half counterpart of CORE-67, which fixed the phases; both were found while validating it.

## CORE-70 — `vm_running` was set once and never cleared

The field had exactly one writer: `recovery.rs`, after a successful guest container query during cold start. Nothing set it back. Any stop afterwards — idle, backend switch, crash recovery — left it reading `true` for the rest of the daemon's life.

It now comes from `services::vm_running_loop`, mirroring `VmLifecycleState::is_ready` off `Runtime::subscribe_system_vm_state`, so it tracks both edges across every restart without anything else having to remember to.

**Which readiness level.** `app/AGENTS.md` documents three, and the field name does not say which it reports, which is how it drifted. This picks level 2 — the agent has answered a ping. Level 1 (`MachineState::Running`) counts a VM whose agent is not up, so RPCs against it fail; level 3 (guest dockerd) is narrower than "the VM is running" and already has its own signal. The proto comment now states it.

Recovery's one-shot write is removed rather than left in place: two writers is how the drift started, and the loop's value is strictly better-informed.

Regression: `vm_running_loop_follows_the_lifecycle_both_ways` drives the lifecycle watch through `Stopped → Running → Idle → Stopped` and asserts the flag follows — including that `Idle` still counts as running, and that the stop clears it, which is the bug.

## CORE-71 — a `docker.sock` bind failure was swallowed

`DockerApiServer::run` bound the socket *inside* the task `start_services` spawned:

```rust
tokio::spawn(async move {
    if let Err(e) = docker_server.run(docker_shutdown).await {
        tracing::error!("Docker API server error: {}", e);   // and that is all
    }
})
```

so the error never reached the pipeline. The daemon went on to publish `NETWORK_READY` and then `READY` with no Docker API at all, and every client got connection-refused from a daemon that had just reported itself ready.

`bind` is now a separate step taken before `start_services` returns — mirroring `DnsService::bind`, which already worked this way — so a bind failure fails startup with `FAILED` and its cause on `WatchSetupStatus`.

**This is a deliberate behaviour change**: a `docker.sock` that cannot be bound is now fatal instead of silent. That is the point, and it is why it was kept out of #522 rather than smuggled in as a rider.

The Kubernetes proxy deliberately stays best-effort — a port 16443 already in use is tolerated by design, and e2e runs hit exactly that routinely. So `NETWORK_READY` now names which of the three services it promises (DNS and Docker are bound; the Kubernetes proxy is started but not guaranteed) instead of the "started, not proven reachable" hedge that was only accurate because of the bug above.

## Validation

`cargo fmt --check` and `cargo clippy --workspace --exclude arcbox-agent -- -D warnings` clean. Workspace tests pass apart from one pre-existing failure unrelated to this change: `arcbox-fleet-agent --test control::unenrolled_agent_reports_status_and_rejects_drain` asserts `snapshot.capabilities.is_empty()` and fails identically on an untouched tree — worth its own look, but not from here.

Not yet exercised on hardware. The `--no-linux-vm` path is worth a thought in review: `start_services` skips the Docker API there, so that daemon reaches `NETWORK_READY` with DNS alone and `vm_running` stays false, which is what both now document.

Closes CORE-70, CORE-71. Follows CORE-67 (#522).
