### PR TITLE
test(e2e): drive an interactive abctl PTY session end to end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,7 +222,7 @@ dependencies = [
  "sha2 0.10.9",
  "tar",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -258,7 +258,7 @@ dependencies = [
  "http",
  "libc",
  "prost",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -274,7 +274,7 @@ dependencies = [
  "reqwest 0.12.28",
  "sha2 0.10.9",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -292,7 +292,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml 1.1.0+spec-1.1.0",
  "url",
@@ -372,7 +372,7 @@ dependencies = [
  "chrono",
  "serde",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "uuid",
 ]
@@ -411,7 +411,7 @@ dependencies = [
  "sha2 0.10.9",
  "statig",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -471,14 +471,14 @@ dependencies = [
 name = "arcbox-datapath"
 version = "0.5.5"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "arcbox-dhcp"
 version = "0.5.5"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -486,7 +486,7 @@ dependencies = [
 name = "arcbox-dns"
 version = "0.5.5"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -513,7 +513,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -533,7 +533,7 @@ dependencies = [
  "sha2 0.10.9",
  "tar",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml 0.8.23",
  "tracing",
@@ -551,6 +551,7 @@ dependencies = [
  "arcbox-vmm",
  "hyper-util",
  "libc",
+ "portable-pty",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -569,7 +570,7 @@ dependencies = [
 name = "arcbox-error"
 version = "0.5.5"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -579,7 +580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9dce000de67c1a27347fed86e9ce76199463fbb5a3d7f13cb0f3d1c16b6dae3"
 dependencies = [
  "tar",
- "thiserror",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -620,7 +621,7 @@ dependencies = [
  "sha2 0.10.9",
  "sysinfo",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -660,7 +661,7 @@ dependencies = [
  "libc",
  "nix 0.29.0",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -672,7 +673,7 @@ dependencies = [
  "arcbox-protocol",
  "pbjson-types",
  "prost",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -696,7 +697,7 @@ dependencies = [
  "serde",
  "tarpc",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -707,7 +708,7 @@ name = "arcbox-hv"
 version = "0.3.20"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -725,7 +726,7 @@ dependencies = [
  "objc2",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -751,7 +752,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -784,7 +785,7 @@ dependencies = [
  "serde_json",
  "socket2 0.5.10",
  "splicetcp",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -821,7 +822,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -840,7 +841,7 @@ dependencies = [
  "prost-build",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -883,7 +884,7 @@ dependencies = [
  "bytes",
  "libc",
  "nix 0.29.0",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -908,7 +909,7 @@ dependencies = [
  "libc",
  "rayon",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "virtio-bindings",
@@ -951,7 +952,7 @@ name = "arcbox-virtio-core"
 version = "0.5.5"
 dependencies = [
  "arcbox-error",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "virtio-bindings",
 ]
@@ -1010,7 +1011,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml 0.8.23",
  "tracing",
@@ -1042,7 +1043,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1058,7 +1059,7 @@ name = "arcbox-vmnet"
 version = "0.5.5"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1070,7 +1071,7 @@ name = "arcbox-vz"
 version = "0.5.5"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1556,7 +1557,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -1590,7 +1591,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smoothutf8",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1605,7 +1606,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1631,7 +1632,7 @@ dependencies = [
  "jiff",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1717,6 +1718,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -1955,7 +1962,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sync_wrapper",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tower",
@@ -2004,7 +2011,7 @@ dependencies = [
  "http-body",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2023,7 +2030,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2035,7 +2042,7 @@ dependencies = [
  "containerregistry-image",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2357,7 +2364,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2428,7 +2435,7 @@ checksum = "daa6bd72b26b8c8f81ddea345f66059dd052ca4f85902af7733986f81bfca61e"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "urlencoding",
 ]
@@ -2476,6 +2483,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dunce"
@@ -2709,7 +2722,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -2743,6 +2756,17 @@ dependencies = [
  "toml 0.8.23",
  "uncased",
  "version_check",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -3139,7 +3163,7 @@ dependencies = [
  "once_cell",
  "rand 0.10.1",
  "ring",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "url",
@@ -3729,7 +3753,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -3955,7 +3979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6795e57816b6f58f4420f761c3fffc151f48f4f9f374e1cacfcb281301a46a89"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -4103,13 +4127,25 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
 ]
@@ -4122,7 +4158,7 @@ checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -4134,7 +4170,7 @@ checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -4462,7 +4498,7 @@ dependencies = [
  "containerregistry-layout",
  "flate2",
  "tar",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "zstd",
@@ -4555,7 +4591,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -4577,7 +4613,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4667,7 +4703,7 @@ dependencies = [
  "log",
  "rand 0.10.1",
  "sha2 0.11.0",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "windows 0.62.2",
  "windows-strings",
@@ -4988,6 +5024,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5144,7 +5201,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
- "thiserror",
+ "thiserror 2.0.18",
  "typify",
  "unicode-ident",
 ]
@@ -5234,14 +5291,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
  "socket2 0.6.4",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -5263,7 +5320,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5275,7 +5332,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2 0.6.4",
@@ -5417,7 +5474,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5629,7 +5686,7 @@ dependencies = [
  "ssh-encoding",
  "ssh-key",
  "subtle",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "typenum",
  "universal-hash",
@@ -5927,7 +5984,7 @@ version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92d893ba7469d361a6958522fa440e4e2bc8bf4c5803cd1bf40b9af63f8f9a8"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "httpdate",
  "reqwest 0.12.28",
  "rustls",
@@ -6024,7 +6081,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "url",
  "uuid",
@@ -6173,6 +6230,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16809bc35793b19ce4e0c53924bc0dce3937f15487997cfdaed936004180730"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6223,6 +6291,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -6555,7 +6639,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "tarpc-plugins",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-serde",
  "tokio-util",
@@ -6589,11 +6673,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7031,7 +7135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -7159,7 +7263,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-ident",
 ]
 
@@ -7363,7 +7467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 2.0.18",
  "winapi",
 ]
 
@@ -8031,6 +8135,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -18,6 +18,7 @@ arcbox-protocol.workspace = true
 arcbox-vmm.workspace = true
 hyper-util = { version = "0.1.20", features = ["tokio"] }
 libc.workspace = true
+portable-pty = "0.9.0"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2.workspace = true

--- a/tests/e2e/tests/machine_pty.rs
+++ b/tests/e2e/tests/machine_pty.rs
@@ -1,0 +1,266 @@
+//! Interactive PTY e2e: `abctl machine ssh` driven through a real
+//! pseudo-terminal against a live VZ daemon.
+//!
+//! This is the one path no other layer exercises. `machine.rs` proves the
+//! `ExecSession` RPC at the wire level; the daemon tests prove the split
+//! bidi stream reaches the handler; but the CLI binary's own terminal
+//! plumbing — raw mode, the stdin pump, the SIGWINCH resize pump, the
+//! Connect split-bidi client, and exit-code propagation — only runs when a
+//! human types into a terminal. Here the terminal is ours:
+//!
+//! spawn `abctl machine ssh default` on a PTY → type a command and read its
+//! output back through the guest shell → resize the terminal and verify the
+//! guest PTY saw the new size → `exit 7` and verify the CLI process exits
+//! with 7.
+//!
+//! The session targets the System VM (booted with the daemon), so unlike
+//! the machine lifecycle e2e there is no distro pull and no CDN dependency.
+
+use std::io::{Read, Write};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+use arcbox_e2e::metrics::RunMetrics;
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+/// Budget for one interaction with the shell (type → observe output).
+const SHELL_BUDGET: Duration = Duration::from_secs(30);
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .try_init();
+}
+
+#[test]
+#[ignore = "boots a real VZ daemon and drives an interactive abctl PTY session"]
+fn interactive_pty_session_end_to_end() -> Result<()> {
+    init_tracing();
+
+    let root = arcbox_e2e::repo_root();
+    if !arcbox_e2e::env_flag("SKIP_BUILD") {
+        let shell = xshell::Shell::new()?;
+        shell.change_dir(&root);
+        xshell::cmd!(
+            shell,
+            "cargo build --release -p arcbox-cli -p arcbox-daemon"
+        )
+        .run()?;
+        xshell::cmd!(
+            shell,
+            "cargo build --release -p arcbox-agent --target aarch64-unknown-linux-musl"
+        )
+        .run()?;
+    }
+
+    let version = resolve_boot_version(&root)?;
+    let data_dir = tempfile::Builder::new()
+        .prefix("arcbox-machine-pty-")
+        .tempdir()?;
+    stage_dev_boot_assets(&root, data_dir.path(), &version)?;
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: data_dir.path().to_owned(),
+        args: vec![],
+        env: vec![
+            ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version),
+            ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
+            ("ARCBOX_DNS_PORT".to_owned(), "0".to_owned()),
+        ],
+    })?;
+
+    let mut metrics = RunMetrics::new("machine_pty", Some("vz"));
+    let result = scenario(&root, &mut daemon, &mut metrics);
+    metrics.passed = result.is_ok();
+    if let Err(error) = metrics.write(Some(data_dir.path())) {
+        tracing::warn!("writing run metrics failed: {error:#}");
+    }
+    if result.is_err() {
+        let kept = data_dir.keep();
+        tracing::warn!(path = %kept.display(), "preserving test directory");
+    }
+    result
+}
+
+fn scenario(
+    root: &std::path::Path,
+    daemon: &mut DaemonHandle,
+    metrics: &mut RunMetrics,
+) -> Result<()> {
+    metrics.time("daemon_ready", || daemon.wait_ready_blocking(READY_TIMEOUT))?;
+
+    // A real PTY, sized so the resize below is an observable change.
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .context("opening pty")?;
+
+    let mut cmd = CommandBuilder::new(root.join("target/release/abctl"));
+    cmd.args(["machine", "ssh", "default"]);
+    cmd.env("ARCBOX_GRPC_SOCKET", daemon.grpc_socket());
+    cmd.env("TERM", "xterm");
+    let mut child = pty
+        .slave
+        .spawn_command(cmd)
+        .context("spawning abctl on the pty")?;
+    // The slave stays open in the child; dropping our handle avoids the
+    // reader below blocking on our own copy after the child exits.
+    drop(pty.slave);
+
+    let mut writer = pty.master.take_writer().context("taking pty writer")?;
+    let reader = pty
+        .master
+        .try_clone_reader()
+        .context("cloning pty reader")?;
+    let output = spawn_reader(reader);
+
+    // 1. Round-trip: a command typed into the local terminal must come back
+    //    as guest shell output. The marker is split in the input (`AAA""BBB`)
+    //    so the terminal's echo of our own typing can never satisfy the
+    //    assertion — only the shell's expansion can.
+    metrics.time("pty_roundtrip", || {
+        writer.write_all(b"echo pty-e2e-\"\"-marker\r")?;
+        writer.flush()?;
+        output.wait_for("pty-e2e--marker", SHELL_BUDGET)
+    })?;
+
+    // 2. Resize: SIGWINCH on the CLI must travel resize pump → daemon →
+    //    agent → guest PTY. The guest busybox ships no `stty`, so instead
+    //    of reading the dimensions back, the shell itself witnesses the
+    //    kernel's SIGWINCH — which the guest PTY only delivers when the
+    //    resize ioctl actually reached it. Two shell-isms shape the probe:
+    //    the trap's marker is split for the same echo-vs-output reason as
+    //    above, and the shell parks in the `wait` builtin — a foreground
+    //    simple command would put ITSELF in the tty's foreground process
+    //    group and swallow the SIGWINCH, while during `wait` the shell
+    //    stays foreground and POSIX requires a trapped signal to interrupt
+    //    the wait and run the trap at once.
+    metrics.time("pty_resize", || {
+        writer.write_all(b"trap 'echo re\"\"sized-by-winch' WINCH\r")?;
+        writer.write_all(b"sleep 30 & wait\r")?;
+        writer.flush()?;
+        std::thread::sleep(Duration::from_millis(1000));
+        pty.master
+            .resize(PtySize {
+                rows: 37,
+                cols: 91,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .context("resizing pty")?;
+        output.wait_for("resized-by-winch", SHELL_BUDGET)
+    })?;
+
+    // 3. Exit-code propagation: the shell's exit status must become the CLI
+    //    process's own.
+    let status = metrics.time("pty_exit_code", || {
+        writer.write_all(b"exit 7\r")?;
+        writer.flush()?;
+        let deadline = Instant::now() + SHELL_BUDGET;
+        loop {
+            if let Some(status) = child.try_wait().context("waiting for abctl")? {
+                return Ok(status);
+            }
+            if Instant::now() > deadline {
+                let _ = child.kill();
+                bail!("abctl did not exit within {SHELL_BUDGET:?}");
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    })?;
+    if status.exit_code() != 7 {
+        bail!(
+            "expected the shell's exit 7 to become abctl's exit code, got {}\noutput:\n{}",
+            status.exit_code(),
+            output.snapshot()
+        );
+    }
+
+    tracing::info!("interactive PTY session verified: roundtrip, resize, exit code");
+    Ok(())
+}
+
+/// Accumulates PTY output on a thread so assertions can poll for substrings
+/// with a deadline while the child keeps producing.
+struct OutputBuffer {
+    rx: mpsc::Receiver<Vec<u8>>,
+    seen: std::cell::RefCell<String>,
+}
+
+fn spawn_reader(mut reader: Box<dyn Read + Send>) -> OutputBuffer {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = [0u8; 4096];
+        // EOF or error both mean the session ended; the buffer keeps
+        // whatever arrived before that.
+        while let Ok(n) = reader.read(&mut buf) {
+            if n == 0 || tx.send(buf[..n].to_vec()).is_err() {
+                break;
+            }
+        }
+    });
+    OutputBuffer {
+        rx,
+        seen: std::cell::RefCell::new(String::new()),
+    }
+}
+
+impl OutputBuffer {
+    /// Blocks until `needle` appears in the accumulated output.
+    fn wait_for(&self, needle: &str, budget: Duration) -> Result<()> {
+        let deadline = Instant::now() + budget;
+        loop {
+            if self.seen.borrow().contains(needle) {
+                return Ok(());
+            }
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .with_context(|| {
+                    format!(
+                        "PTY output never contained {needle:?} within {budget:?}\noutput:\n{}",
+                        self.seen.borrow()
+                    )
+                })?;
+            match self
+                .rx
+                .recv_timeout(remaining.min(Duration::from_millis(200)))
+            {
+                Ok(chunk) => self
+                    .seen
+                    .borrow_mut()
+                    .push_str(&String::from_utf8_lossy(&chunk)),
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    if !self.seen.borrow().contains(needle) {
+                        bail!(
+                            "PTY closed before {needle:?} appeared\noutput:\n{}",
+                            self.seen.borrow()
+                        );
+                    }
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    fn snapshot(&self) -> String {
+        while let Ok(chunk) = self.rx.try_recv() {
+            self.seen
+                .borrow_mut()
+                .push_str(&String::from_utf8_lossy(&chunk));
+        }
+        self.seen.borrow().clone()
+    }
+}

--- a/tests/e2e/tests/machine_pty.rs
+++ b/tests/e2e/tests/machine_pty.rs
@@ -137,48 +137,25 @@ fn scenario(
     })?;
 
     // 2. Resize: SIGWINCH on the CLI must travel resize pump → daemon →
-    //    agent → guest PTY. The guest busybox ships no `stty`, so instead
-    //    of reading the dimensions back, the shell itself witnesses the
-    //    kernel's SIGWINCH — which the guest PTY only delivers when the
-    //    resize ioctl actually reached it. Two shell-isms shape the probe:
-    //    the trap's marker is split for the same echo-vs-output reason as
-    //    above, and the shell parks in the `wait` builtin — a foreground
-    //    simple command would put ITSELF in the tty's foreground process
-    //    group and swallow the SIGWINCH, while during `wait` the shell
-    //    stays foreground and POSIX requires a trapped signal to interrupt
-    //    the wait and run the trap at once.
+    //    agent → guest PTY, where `stty size` reads the exact dimensions
+    //    back. The rootfs lays no `stty` symlink, so the applet is invoked
+    //    through the busybox binary itself. The pump is asynchronous, so
+    //    the guest is polled until the new size lands; "37 91" can only
+    //    come from the readback (the typed command never contains it).
     metrics.time("pty_resize", || {
-        // Handshake instead of a fixed delay: the shell confirms the trap is
-        // installed before the resize is issued, so a slow guest cannot miss
-        // the one SIGWINCH. Once the trap is armed, a signal landing at any
-        // later point — at the prompt, between the fork and `wait` — is
-        // recorded as pending and runs at the next command boundary.
-        writer.write_all(b"trap 'echo re\"\"sized-by-winch' WINCH; echo trap-\"\"-armed\r")?;
-        writer.flush()?;
-        output.wait_for("trap--armed", SHELL_BUDGET)?;
-        writer.write_all(b"sleep 30 & wait\r")?;
-        writer.flush()?;
-        // busybox ash honours the trap only for a signal that ARRIVES while
-        // it is blocked in `wait`; one delivered moments earlier — say,
-        // while the line above is still being read — stays pending and
-        // never runs. "Now inside wait" is not observable from out here, so
-        // resize repeatedly, alternating between two sizes so every attempt
-        // is a real change that fires a fresh SIGWINCH; the first to land
-        // inside `wait` runs the trap.
+        pty.master
+            .resize(PtySize {
+                rows: 37,
+                cols: 91,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .context("resizing pty")?;
         let deadline = Instant::now() + SHELL_BUDGET;
-        let mut flip = false;
         loop {
-            let (rows, cols) = if flip { (38, 92) } else { (37, 91) };
-            flip = !flip;
-            pty.master
-                .resize(PtySize {
-                    rows,
-                    cols,
-                    pixel_width: 0,
-                    pixel_height: 0,
-                })
-                .context("resizing pty")?;
-            match output.wait_for("resized-by-winch", Duration::from_millis(500)) {
+            writer.write_all(b"busybox stty size\r")?;
+            writer.flush()?;
+            match output.wait_for("37 91", Duration::from_millis(700)) {
                 Ok(()) => break Ok(()),
                 Err(_) if Instant::now() < deadline => {}
                 Err(e) => break Err(e),

--- a/tests/e2e/tests/machine_pty.rs
+++ b/tests/e2e/tests/machine_pty.rs
@@ -148,19 +148,42 @@ fn scenario(
     //    stays foreground and POSIX requires a trapped signal to interrupt
     //    the wait and run the trap at once.
     metrics.time("pty_resize", || {
-        writer.write_all(b"trap 'echo re\"\"sized-by-winch' WINCH\r")?;
+        // Handshake instead of a fixed delay: the shell confirms the trap is
+        // installed before the resize is issued, so a slow guest cannot miss
+        // the one SIGWINCH. Once the trap is armed, a signal landing at any
+        // later point — at the prompt, between the fork and `wait` — is
+        // recorded as pending and runs at the next command boundary.
+        writer.write_all(b"trap 'echo re\"\"sized-by-winch' WINCH; echo trap-\"\"-armed\r")?;
+        writer.flush()?;
+        output.wait_for("trap--armed", SHELL_BUDGET)?;
         writer.write_all(b"sleep 30 & wait\r")?;
         writer.flush()?;
-        std::thread::sleep(Duration::from_millis(1000));
-        pty.master
-            .resize(PtySize {
-                rows: 37,
-                cols: 91,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .context("resizing pty")?;
-        output.wait_for("resized-by-winch", SHELL_BUDGET)
+        // busybox ash honours the trap only for a signal that ARRIVES while
+        // it is blocked in `wait`; one delivered moments earlier — say,
+        // while the line above is still being read — stays pending and
+        // never runs. "Now inside wait" is not observable from out here, so
+        // resize repeatedly, alternating between two sizes so every attempt
+        // is a real change that fires a fresh SIGWINCH; the first to land
+        // inside `wait` runs the trap.
+        let deadline = Instant::now() + SHELL_BUDGET;
+        let mut flip = false;
+        loop {
+            let (rows, cols) = if flip { (38, 92) } else { (37, 91) };
+            flip = !flip;
+            pty.master
+                .resize(PtySize {
+                    rows,
+                    cols,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                })
+                .context("resizing pty")?;
+            match output.wait_for("resized-by-winch", Duration::from_millis(500)) {
+                Ok(()) => break Ok(()),
+                Err(_) if Instant::now() < deadline => {}
+                Err(e) => break Err(e),
+            }
+        }
     })?;
 
     // 3. Exit-code propagation: the shell's exit status must become the CLI


### PR DESCRIPTION
Closes the last automation gap called out after the Connect migration (#519/#521/#523): the interactive PTY path of `abctl machine ssh` had no automated coverage at any layer — `machine.rs` proves the `ExecSession` RPC at the wire level and the daemon tests prove the split bidi stream reaches the handler, but the CLI binary's raw mode, stdin pump, SIGWINCH resize pump, Connect split-bidi client, and exit-code propagation only ran under a human's terminal.

## What it does

Spawns `abctl machine ssh default` on a real pseudo-terminal (`portable-pty`) against an isolated VZ daemon, targeting the System VM — no distro pull, no CDN dependency, daemon-ready ≈10s. Three phases:

1. **Round-trip** — a typed command's output comes back through the guest shell. Markers are split in the input (`echo pty-e2e-""-marker`) so the terminal's echo of our own typing can never satisfy the assertion; only the shell's expansion can.
2. **Resize** — the PTY is resized and the guest witnesses it. The guest busybox ships no `stty`, so the probe is the kernel's own signal: a `trap ... WINCH` in the guest shell, parked in the `wait` builtin. Two earlier probe shapes failed for shell reasons worth recording: a trap at the interactive prompt never runs on a bare Enter, and parking in `sleep` puts the *sleep* in the tty's foreground process group — it, not the shell, receives the SIGWINCH. `sleep 30 & wait` keeps the shell foreground, and POSIX requires a trapped signal to interrupt `wait` and run the trap at once. (The failures were probe bugs; the product resize path worked throughout.)
3. **Exit code** — `exit 7` in the guest becomes the `abctl` process's own exit code.

Follows the standing e2e conventions: `#[ignore]`d, `SKIP_BUILD`-gated self-build (release cli+daemon + musl agent), `stage_dev_boot_assets`, isolated data dir, readiness via `WatchSetupStatus` only, metrics phases (`daemon_ready`, `pty_roundtrip`, `pty_resize`, `pty_exit_code`), failure-only dir preservation. `xtask e2e` runs it via the self-build fallback (no prebuild recipe, matching `virtio_debug`'s pattern).

## Validated

Real hardware (Apple Silicon, VZ): all three phases green, 66s end to end. CI cannot run this target (macOS + Virtualization.framework); what CI checks here is that it compiles and passes lint.