### PR TITLE
fix(daemon): unmount NFS before shutdown

### DIFF
--- a/app/arcbox-cli/src/commands/install.rs
+++ b/app/arcbox-cli/src/commands/install.rs
@@ -253,8 +253,9 @@ fn register_daemon_service() -> Result<()> {
     <true/>
     <!--
       ExitTimeOut: seconds launchd waits after SIGTERM before sending SIGKILL.
-      Default is 20s, but daemon shutdown needs ~35s (5s service drain + 30s VM
-      graceful stop). Set to 45s to avoid SIGKILL mid-shutdown.
+      Daemon shutdown can use all 45s (two 5s NFS unmount attempts + 5s service
+      drain + 30s VM graceful stop). This preserves the full VM stop budget;
+      only final best-effort cleanup may run up against the deadline.
     -->
     <key>ExitTimeOut</key>
     <integer>45</integer>

--- a/app/arcbox-daemon/src/nfs_mount.rs
+++ b/app/arcbox-daemon/src/nfs_mount.rs
@@ -33,6 +33,7 @@ use crate::context::DaemonContext;
 
 const MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
 const MOUNT_RETRY_INTERVAL: Duration = Duration::from_millis(500);
+const UNMOUNT_TIMEOUT: Duration = Duration::from_secs(5);
 /// Pause before retrying a failed incarnation, so a guest that is up but not
 /// yet able to serve the export is retried without spinning.
 const RETRY_BACKOFF: Duration = Duration::from_secs(30);
@@ -65,7 +66,7 @@ pub fn spawn(ctx: &DaemonContext, runtime: &Arc<Runtime>) {
 }
 
 /// Unmounts `~/ArcBox` on shutdown, but only the mount this daemon created.
-pub fn cleanup(ctx: &DaemonContext) {
+pub async fn cleanup(ctx: &DaemonContext) {
     if !ctx.mount_nfs {
         return;
     }
@@ -78,7 +79,7 @@ pub fn cleanup(ctx: &DaemonContext) {
 
     // Re-check the shape in case the user replaced the mount since.
     match current_mount_info(mount_path) {
-        Some(info) if is_arcbox_nfs_mount(&info) => match unmount(mount_path) {
+        Some(info) if is_arcbox_nfs_mount(&info) => match unmount(mount_path).await {
             Ok(()) => info!(path = %mount_path.display(), "unmounted ~/ArcBox host NFS mount"),
             Err(e) => warn!(path = %mount_path.display(), error = %e, "failed to unmount ~/ArcBox"),
         },
@@ -162,7 +163,7 @@ async fn establish(
 ) -> Result<()> {
     if occupancy == MountPoint::Stale {
         info!(path = %mount_path.display(), "replacing stale ~/ArcBox NFS mount");
-        unmount(mount_path)?;
+        unmount(mount_path).await?;
     }
     std::fs::create_dir_all(mount_path)?;
 
@@ -577,8 +578,12 @@ fn parse_mount_line(line: &str) -> Option<(&str, MountInfo)> {
     ))
 }
 
-fn unmount(path: &Path) -> Result<()> {
-    let status = Command::new("/sbin/umount").arg(path).status()?;
+async fn unmount(path: &Path) -> Result<()> {
+    let mut command = tokio::process::Command::new("/sbin/umount");
+    command.arg(path).kill_on_drop(true);
+    let status = tokio::time::timeout(UNMOUNT_TIMEOUT, command.status())
+        .await
+        .context("umount timed out")??;
     if status.success() {
         Ok(())
     } else {

--- a/app/arcbox-daemon/src/nfs_mount.rs
+++ b/app/arcbox-daemon/src/nfs_mount.rs
@@ -33,6 +33,8 @@ use crate::context::DaemonContext;
 
 const MOUNT_TIMEOUT: Duration = Duration::from_secs(30);
 const MOUNT_RETRY_INTERVAL: Duration = Duration::from_millis(500);
+/// Shutdown may make two attempts; their 10s total is part of launchd's
+/// 45s budget.
 const UNMOUNT_TIMEOUT: Duration = Duration::from_secs(5);
 /// Pause before retrying a failed incarnation, so a guest that is up but not
 /// yet able to serve the export is retried without spinning.

--- a/app/arcbox-daemon/src/shutdown.rs
+++ b/app/arcbox-daemon/src/shutdown.rs
@@ -33,6 +33,10 @@ pub async fn run(ctx: DaemonContext, mut handles: ServiceHandles) -> Result<()> 
     wait_for_signal().await;
     println!("Shutting down guest VM... (press Ctrl+C again to force quit)");
     info!("Shutdown signal received, draining connections...");
+
+    // Keep the NFS proxy and guest alive until macOS has detached the mount.
+    // Cutting either connection first triggers its interrupted-server alert.
+    crate::nfs_mount::cleanup(&ctx);
     ctx.shutdown.cancel();
 
     drain(&mut handles).await;
@@ -123,6 +127,7 @@ async fn cleanup(ctx: &DaemonContext) {
         }
     }
 
+    // Retry if shutdown raced a mount that was still being established.
     crate::nfs_mount::cleanup(ctx);
 
     remove_sockets(ctx);

--- a/app/arcbox-daemon/src/shutdown.rs
+++ b/app/arcbox-daemon/src/shutdown.rs
@@ -36,7 +36,7 @@ pub async fn run(ctx: DaemonContext, mut handles: ServiceHandles) -> Result<()> 
 
     // Keep the NFS proxy and guest alive until macOS has detached the mount.
     // Cutting either connection first triggers its interrupted-server alert.
-    crate::nfs_mount::cleanup(&ctx);
+    crate::nfs_mount::cleanup(&ctx).await;
     ctx.shutdown.cancel();
 
     drain(&mut handles).await;
@@ -128,7 +128,7 @@ async fn cleanup(ctx: &DaemonContext) {
     }
 
     // Retry if shutdown raced a mount that was still being established.
-    crate::nfs_mount::cleanup(ctx);
+    crate::nfs_mount::cleanup(ctx).await;
 
     remove_sockets(ctx);
 }

--- a/scripts/dev.arcbox.daemon.plist
+++ b/scripts/dev.arcbox.daemon.plist
@@ -72,8 +72,9 @@
 
     <!--
       ExitTimeOut: seconds launchd waits after SIGTERM before sending SIGKILL.
-      Default is 20s, but daemon shutdown needs ~35s (5s gRPC drain + 30s VM
-      graceful stop). Set to 45s to avoid SIGKILL mid-shutdown.
+      Daemon shutdown can use all 45s (two 5s NFS unmount attempts + 5s service
+      drain + 30s VM graceful stop). This preserves the full VM stop budget;
+      only final best-effort cleanup may run up against the deadline.
     -->
     <key>ExitTimeOut</key>
     <integer>45</integer>


### PR DESCRIPTION
## Summary

- unmount the `~/ArcBox` NFS share before cancelling the daemon shutdown token or stopping the guest VM
- retry the cleanup at the end of shutdown in case mount establishment raced the first attempt

## Why

The shutdown sequence previously stopped the NFS proxy and guest before running `/sbin/umount`. macOS therefore treated the ArcBox share as an interrupted server connection, displayed a system alert, and could leave the mount stale. Daemon logs confirmed the late unmount failed with `umount exited with 1`.

This keeps the server path alive until macOS has detached the mount, so quitting ArcBox no longer interrupts the mounted connection.

## Validation

- `devenv shell -- cargo fmt --all -- --check`
- `devenv shell -- cargo test -p arcbox-daemon nfs_mount` (7 passed)
- `devenv shell -- cargo clippy -p arcbox-daemon --all-targets -- -D warnings`