### PR TITLE
refactor(core): port the host agent channel to buffa message types (CORE-73 B2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,7 @@ name = "arcbox-core"
 version = "0.5.5"
 dependencies = [
  "arcbox-boot",
+ "arcbox-connect",
  "arcbox-constants",
  "arcbox-dns",
  "arcbox-error",
@@ -400,6 +401,7 @@ dependencies = [
  "arcbox-vz",
  "async-trait",
  "base64",
+ "buffa",
  "bytes",
  "chrono",
  "dirs",
@@ -546,6 +548,7 @@ name = "arcbox-e2e"
 version = "0.5.5"
 dependencies = [
  "anyhow",
+ "arcbox-connect",
  "arcbox-constants",
  "arcbox-core",
  "arcbox-grpc",

--- a/app/arcbox-core/Cargo.toml
+++ b/app/arcbox-core/Cargo.toml
@@ -44,6 +44,8 @@ tempfile = "3"
 statig = "0.4.1"
 zstd = "0.13.3"
 base64 = "0.22.1"
+arcbox-connect.workspace = true
+buffa = "0.9.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 arcbox-route.workspace = true

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -1,24 +1,37 @@
 //! Agent client for communicating with the guest VM.
 //!
 //! Provides RPC communication with the arcbox-agent running inside guest VMs.
+//!
+//! Message types come from two codegens during the CORE-73 convergence, and
+//! they encode identical bytes, so the wire cannot tell them apart:
+//!
+//! * buffa (`arcbox_connect::v1`) for RPCs whose types stay inside
+//!   `arcbox-core` — the target state.
+//! * prost (`arcbox_protocol`) for the surface whose types still cross into
+//!   `arcbox-api` handlers as prost values (sandbox, machine exec,
+//!   kubernetes, machine stats). Phase B3 moves those handlers and retires
+//!   the prost half — see [`AgentClient::unary_rpc_prost`].
 
 mod transport;
 mod wire;
 
 use self::transport::{AgentTransport, BLOCKING_RPC_TIMEOUT};
 use crate::error::{CoreError, Result};
+use arcbox_connect::v1::{
+    AgentPingRequest as PingRequest, AgentPingResponse as PingResponse, ContainerFsPathsRequest,
+    ContainerFsPathsResponse, DiskTrimRequest, DiskTrimResponse, EnsureNfsExportRequest,
+    EnsureNfsExportResponse, ImageFsPathsRequest, ImageFsPathsResponse, MemoryPressureEvent,
+    MmapReadFileRequest, MmapReadFileResponse, ReadinessEvent, RuntimeEnsureRequest,
+    RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse, SystemInfo,
+    WatchMemoryPressureRequest, WatchReadinessRequest, WatchStatsRequest,
+};
 use arcbox_constants::ports::AGENT_PORT;
 use arcbox_constants::wire::MessageType;
 use arcbox_protocol::agent::{
-    ContainerFsPathsRequest, ContainerFsPathsResponse, DiskTrimRequest, DiskTrimResponse,
-    EnsureNfsExportRequest, EnsureNfsExportResponse, ImageFsPathsRequest, ImageFsPathsResponse,
     KubernetesDeleteRequest, KubernetesDeleteResponse, KubernetesKubeconfigRequest,
     KubernetesKubeconfigResponse, KubernetesStartRequest, KubernetesStartResponse,
     KubernetesStatusRequest, KubernetesStatusResponse, KubernetesStopRequest,
-    KubernetesStopResponse, MachineStats, MemoryPressureEvent, MmapReadFileRequest,
-    MmapReadFileResponse, PingRequest, PingResponse, ReadinessEvent, RuntimeEnsureRequest,
-    RuntimeEnsureResponse, RuntimeStatusRequest, RuntimeStatusResponse, SystemInfo,
-    WatchMemoryPressureRequest, WatchReadinessRequest, WatchStatsRequest,
+    KubernetesStopResponse, MachineStats,
 };
 use arcbox_protocol::sandbox_v1::{
     AttachExecutionRequest, CheckpointRequest, CheckpointResponse, CreateSandboxRequest,
@@ -34,8 +47,9 @@ use arcbox_protocol::v1::{
 };
 use arcbox_transport::Transport;
 use arcbox_transport::vsock::{BlockingVsockTransport, VsockAddr, VsockTransport};
+use buffa::Message;
 use bytes::Bytes;
-use prost::Message;
+use prost::Message as ProstMessage;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
@@ -274,7 +288,15 @@ impl AgentClient {
         Ok((resp_type, payload))
     }
 
-    fn decode_response<T: Message + Default>(payload: &[u8]) -> Result<T> {
+    fn decode_response<T: Message>(payload: &[u8]) -> Result<T> {
+        T::decode_from_slice(payload)
+            .map_err(|e| CoreError::Machine(format!("failed to decode response: {e}")))
+    }
+
+    /// Prost twin of [`Self::decode_response`], for the RPC surface whose
+    /// message types still cross into `arcbox-api` handlers as prost values.
+    /// CORE-73 Phase B3 retires it together with [`Self::unary_rpc_prost`].
+    fn decode_response_prost<T: ProstMessage + Default>(payload: &[u8]) -> Result<T> {
         T::decode(payload)
             .map_err(|e| CoreError::Machine(format!("failed to decode response: {e}")))
     }
@@ -299,7 +321,7 @@ impl AgentClient {
         }
     }
 
-    async fn unary_rpc<T: Message + Default>(
+    async fn unary_rpc<T: Message>(
         &mut self,
         request_type: MessageType,
         payload: &[u8],
@@ -310,7 +332,25 @@ impl AgentClient {
         Self::decode_response(&resp_payload)
     }
 
-    fn unary_rpc_blocking<T: Message + Default>(
+    /// [`Self::unary_rpc`] for responses still decoded as prost types.
+    ///
+    /// The kubernetes, sandbox, machine-exec, and machine-stats surfaces
+    /// keep their prost signatures because `arcbox-api` handlers pass and
+    /// forward those exact types (`wire_request`/`wire_response` bound on
+    /// `prost::Message`). Both codegens decode the same bytes, so this is
+    /// only a type-level split; CORE-73 Phase B3 removes it.
+    async fn unary_rpc_prost<T: ProstMessage + Default>(
+        &mut self,
+        request_type: MessageType,
+        payload: &[u8],
+        response_type: MessageType,
+    ) -> Result<T> {
+        let (resp_type, resp_payload) = self.rpc_call(request_type, payload).await?;
+        Self::expect_response_type(resp_type, response_type)?;
+        Self::decode_response_prost(&resp_payload)
+    }
+
+    fn unary_rpc_blocking<T: Message>(
         &mut self,
         request_type: MessageType,
         payload: &[u8],
@@ -367,6 +407,7 @@ impl AgentClient {
             timestamp_secs: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(0)),
+            ..Default::default()
         };
         let payload = req.encode_to_vec();
         self.unary_rpc_blocking(
@@ -405,6 +446,7 @@ impl AgentClient {
             timestamp_secs: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_or(0, |d| i64::try_from(d.as_secs()).unwrap_or(0)),
+            ..Default::default()
         };
         let payload = req.encode_to_vec();
         self.unary_rpc(
@@ -457,6 +499,7 @@ impl AgentClient {
             path: path.to_string(),
             offset,
             length,
+            ..Default::default()
         };
         let payload = req.encode_to_vec();
         self.unary_rpc_blocking(
@@ -472,7 +515,10 @@ impl AgentClient {
     ///
     /// Returns an error if the request fails.
     pub async fn ensure_runtime(&mut self, start_if_needed: bool) -> Result<RuntimeEnsureResponse> {
-        let req = RuntimeEnsureRequest { start_if_needed };
+        let req = RuntimeEnsureRequest {
+            start_if_needed,
+            ..Default::default()
+        };
         let payload = req.encode_to_vec();
         self.unary_rpc(
             MessageType::EnsureRuntimeRequest,
@@ -492,7 +538,10 @@ impl AgentClient {
         &mut self,
         start_if_needed: bool,
     ) -> Result<RuntimeEnsureResponse> {
-        let req = RuntimeEnsureRequest { start_if_needed };
+        let req = RuntimeEnsureRequest {
+            start_if_needed,
+            ..Default::default()
+        };
         let payload = req.encode_to_vec();
         let (resp_type, resp_payload) =
             self.rpc_call_blocking(MessageType::EnsureRuntimeRequest, &payload)?;
@@ -501,7 +550,7 @@ impl AgentClient {
                 "unexpected response type: {resp_type}"
             )));
         }
-        RuntimeEnsureResponse::decode(&resp_payload[..])
+        RuntimeEnsureResponse::decode_from_slice(&resp_payload)
             .map_err(|e| CoreError::Machine(format!("failed to decode response: {e}")))
     }
 
@@ -511,7 +560,7 @@ impl AgentClient {
     ///
     /// Returns an error if the request fails.
     pub async fn get_runtime_status(&mut self) -> Result<RuntimeStatusResponse> {
-        let req = RuntimeStatusRequest {};
+        let req = RuntimeStatusRequest::default();
         let payload = req.encode_to_vec();
         self.unary_rpc(
             MessageType::RuntimeStatusRequest,
@@ -539,6 +588,7 @@ impl AgentClient {
         let req = WatchReadinessRequest {
             start_runtime_if_needed,
             timeout_ms: u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX),
+            ..Default::default()
         };
         let payload = req.encode_to_vec();
         let buf = Self::build_message(MessageType::WatchReadinessRequest, trace_id, &payload);
@@ -607,6 +657,7 @@ impl AgentClient {
         let req = WatchReadinessRequest {
             start_runtime_if_needed,
             timeout_ms: u32::try_from(timeout.as_millis()).unwrap_or(u32::MAX),
+            ..Default::default()
         };
         let payload = req.encode_to_vec();
         let buf = Self::build_message(MessageType::WatchReadinessRequest, trace_id, &payload);
@@ -741,6 +792,9 @@ impl AgentClient {
         }
     }
 
+    /// Decodes a stats frame as the prost [`MachineStats`]: the sample flows
+    /// through `StatsHub` into `Runtime::subscribe_machine_stats*`, whose
+    /// receivers `arcbox-api` forwards as prost values (B3 worklist).
     fn decode_machine_stats(raw: &[u8]) -> Result<MachineStats> {
         let (resp_type, _, resp_payload) = wire::parse_response(raw)?;
         if resp_type == MessageType::Error as u32 {
@@ -767,7 +821,7 @@ impl AgentClient {
                 "unexpected memory pressure response type: 0x{resp_type:04x}"
             )));
         }
-        MemoryPressureEvent::decode(&resp_payload[..])
+        MemoryPressureEvent::decode_from_slice(&resp_payload)
             .map_err(|e| CoreError::Machine(format!("failed to decode memory pressure event: {e}")))
     }
 
@@ -782,7 +836,7 @@ impl AgentClient {
                 "unexpected readiness response type: 0x{resp_type:04x}"
             )));
         }
-        ReadinessEvent::decode(&resp_payload[..])
+        ReadinessEvent::decode_from_slice(&resp_payload)
             .map_err(|e| CoreError::Machine(format!("failed to decode readiness event: {e}")))
     }
 
@@ -793,7 +847,7 @@ impl AgentClient {
     /// Returns an error if the request fails.
     pub async fn start_kubernetes(&mut self) -> Result<KubernetesStartResponse> {
         let payload = KubernetesStartRequest {}.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::KubernetesStartRequest,
             &payload,
             MessageType::KubernetesStartResponse,
@@ -808,7 +862,7 @@ impl AgentClient {
     /// Returns an error if the request fails.
     pub async fn stop_kubernetes(&mut self) -> Result<KubernetesStopResponse> {
         let payload = KubernetesStopRequest {}.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::KubernetesStopRequest,
             &payload,
             MessageType::KubernetesStopResponse,
@@ -823,7 +877,7 @@ impl AgentClient {
     /// Returns an error if the request fails.
     pub async fn delete_kubernetes(&mut self) -> Result<KubernetesDeleteResponse> {
         let payload = KubernetesDeleteRequest {}.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::KubernetesDeleteRequest,
             &payload,
             MessageType::KubernetesDeleteResponse,
@@ -838,7 +892,7 @@ impl AgentClient {
     /// Returns an error if the request fails.
     pub async fn get_kubernetes_status(&mut self) -> Result<KubernetesStatusResponse> {
         let payload = KubernetesStatusRequest {}.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::KubernetesStatusRequest,
             &payload,
             MessageType::KubernetesStatusResponse,
@@ -853,7 +907,7 @@ impl AgentClient {
     /// Returns an error if the request fails.
     pub async fn get_kubeconfig(&mut self) -> Result<KubernetesKubeconfigResponse> {
         let payload = KubernetesKubeconfigRequest {}.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::KubernetesKubeconfigRequest,
             &payload,
             MessageType::KubernetesKubeconfigResponse,
@@ -874,6 +928,7 @@ impl AgentClient {
     ) -> Result<ContainerFsPathsResponse> {
         let payload = ContainerFsPathsRequest {
             container_id: container_id.to_string(),
+            ..Default::default()
         }
         .encode_to_vec();
         self.unary_rpc(
@@ -897,6 +952,7 @@ impl AgentClient {
     ) -> Result<ContainerFsPathsResponse> {
         let payload = ContainerFsPathsRequest {
             container_id: container_id.to_string(),
+            ..Default::default()
         }
         .encode_to_vec();
         self.unary_rpc_blocking(
@@ -916,6 +972,7 @@ impl AgentClient {
     pub async fn image_fs_paths(&mut self, top_chain_id: &str) -> Result<ImageFsPathsResponse> {
         let payload = ImageFsPathsRequest {
             top_chain_id: top_chain_id.to_string(),
+            ..Default::default()
         }
         .encode_to_vec();
         self.unary_rpc(
@@ -936,6 +993,7 @@ impl AgentClient {
     pub fn image_fs_paths_blocking(&mut self, top_chain_id: &str) -> Result<ImageFsPathsResponse> {
         let payload = ImageFsPathsRequest {
             top_chain_id: top_chain_id.to_string(),
+            ..Default::default()
         }
         .encode_to_vec();
         self.unary_rpc_blocking(
@@ -954,7 +1012,7 @@ impl AgentClient {
     /// Returns an error if the request fails or the guest could not establish
     /// the export.
     pub async fn ensure_nfs_export(&mut self) -> Result<EnsureNfsExportResponse> {
-        let payload = EnsureNfsExportRequest {}.encode_to_vec();
+        let payload = EnsureNfsExportRequest::default().encode_to_vec();
         self.unary_rpc(
             MessageType::EnsureNfsExportRequest,
             &payload,
@@ -971,7 +1029,7 @@ impl AgentClient {
     /// Returns an error if the request fails or the guest could not establish
     /// the export.
     pub fn ensure_nfs_export_blocking(&mut self) -> Result<EnsureNfsExportResponse> {
-        let payload = EnsureNfsExportRequest {}.encode_to_vec();
+        let payload = EnsureNfsExportRequest::default().encode_to_vec();
         self.unary_rpc_blocking(
             MessageType::EnsureNfsExportRequest,
             &payload,
@@ -985,7 +1043,7 @@ impl AgentClient {
     ///
     /// Returns an error if the request fails.
     pub async fn disk_trim(&mut self) -> Result<DiskTrimResponse> {
-        let payload = DiskTrimRequest {}.encode_to_vec();
+        let payload = DiskTrimRequest::default().encode_to_vec();
         self.unary_rpc(
             MessageType::DiskTrimRequest,
             &payload,
@@ -1004,7 +1062,7 @@ impl AgentClient {
         req: CreateSandboxRequest,
     ) -> Result<CreateSandboxResponse> {
         let payload = req.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::SandboxCreateRequest,
             &payload,
             MessageType::SandboxCreateResponse,
@@ -1022,7 +1080,7 @@ impl AgentClient {
         req: SandboxPortForwardRequest,
     ) -> Result<SandboxPortForwardResponse> {
         let payload = req.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::SandboxPortForwardRequest,
             &payload,
             MessageType::SandboxPortForwardResponse,
@@ -1079,7 +1137,7 @@ impl AgentClient {
     /// Returns an error if the request fails.
     pub async fn sandbox_inspect(&mut self, req: InspectSandboxRequest) -> Result<SandboxInfo> {
         let payload = req.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::SandboxInspectRequest,
             &payload,
             MessageType::SandboxInspectResponse,
@@ -1097,7 +1155,7 @@ impl AgentClient {
         req: ListSandboxesRequest,
     ) -> Result<ListSandboxesResponse> {
         let payload = req.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::SandboxListRequest,
             &payload,
             MessageType::SandboxListResponse,
@@ -1475,7 +1533,7 @@ impl AgentClient {
     /// Returns an error if the request fails.
     pub async fn sandbox_exec_start(&mut self, req: StartExecutionRequest) -> Result<Execution> {
         let payload = req.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::SandboxExecStartRequest,
             &payload,
             MessageType::SandboxExecStartResponse,
@@ -1491,7 +1549,7 @@ impl AgentClient {
     /// Returns an error if the request fails.
     pub async fn sandbox_stdin_write(&mut self, req: WriteStdinRequest) -> Result<StdinStatus> {
         let payload = req.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::SandboxStdinWriteRequest,
             &payload,
             MessageType::SandboxStdinStatus,
@@ -1509,7 +1567,7 @@ impl AgentClient {
         req: GetStdinStatusRequest,
     ) -> Result<StdinStatus> {
         let payload = req.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::SandboxStdinStatusRequest,
             &payload,
             MessageType::SandboxStdinStatus,
@@ -1551,7 +1609,7 @@ impl AgentClient {
     /// Returns an error if the request fails.
     pub async fn sandbox_exec_wait(&mut self, req: WaitExecutionRequest) -> Result<Execution> {
         let payload = req.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::SandboxExecWaitRequest,
             &payload,
             MessageType::SandboxExecWaitResponse,
@@ -1734,7 +1792,7 @@ impl AgentClient {
         req: CheckpointRequest,
     ) -> Result<CheckpointResponse> {
         let payload = req.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::SandboxCheckpointRequest,
             &payload,
             MessageType::SandboxCheckpointResponse,
@@ -1749,7 +1807,7 @@ impl AgentClient {
     /// Returns an error if the request fails.
     pub async fn sandbox_restore(&mut self, req: RestoreRequest) -> Result<RestoreResponse> {
         let payload = req.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::SandboxRestoreRequest,
             &payload,
             MessageType::SandboxRestoreResponse,
@@ -1767,7 +1825,7 @@ impl AgentClient {
         req: ListSnapshotsRequest,
     ) -> Result<ListSnapshotsResponse> {
         let payload = req.encode_to_vec();
-        self.unary_rpc(
+        self.unary_rpc_prost(
             MessageType::SandboxListSnapshotsRequest,
             &payload,
             MessageType::SandboxListSnapshotsResponse,
@@ -1790,11 +1848,11 @@ impl AgentClient {
 }
 
 fn readiness_event_is_terminal(event: &ReadinessEvent) -> bool {
-    use arcbox_protocol::agent::readiness_event::Kind;
+    use arcbox_connect::v1::readiness_event::Kind;
 
     matches!(
-        Kind::try_from(event.kind),
-        Ok(Kind::RuntimeReady | Kind::RuntimeFailed)
+        event.kind.as_known(),
+        Some(Kind::RuntimeReady | Kind::RuntimeFailed)
     )
 }
 #[cfg(test)]
@@ -1829,6 +1887,7 @@ mod tests {
             message: "pong".to_string(),
             version: "0.4.16".to_string(),
             protocol_version,
+            ..Default::default()
         }
     }
 

--- a/app/arcbox-core/src/container_backend/guest_docker.rs
+++ b/app/arcbox-core/src/container_backend/guest_docker.rs
@@ -3,7 +3,7 @@ use crate::config::ContainerRuntimeConfig;
 use crate::error::{CoreError, Result};
 use crate::machine::MachineManager;
 use crate::vm_lifecycle::VmLifecycleManager;
-use arcbox_protocol::agent::readiness_event::Kind;
+use arcbox_connect::v1::readiness_event::Kind;
 use async_trait::async_trait;
 use std::sync::Arc;
 use std::time::Duration;
@@ -42,7 +42,7 @@ impl GuestDockerBackend {
             .watch_readiness(true, timeout, &crate::trace::current_trace_id())
             .await
         {
-            Ok(event) if Kind::try_from(event.kind) == Ok(Kind::RuntimeReady) => {
+            Ok(event) if event.kind == Kind::RuntimeReady => {
                 validate_reported_vsock_endpoint(&event.endpoint, port)?;
                 tracing::debug!(port, "guest docker runtime is ready");
                 Ok(())

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -21,15 +21,18 @@ use crate::vm::VmManager;
 use crate::vm_lifecycle::{
     DEFAULT_MACHINE_NAME, VmLifecycleConfig, VmLifecycleManager, VmLifecycleState,
 };
+use arcbox_connect::v1::{ContainerFsPathsResponse, ImageFsPathsResponse};
 use arcbox_net::NetworkManager;
 #[cfg(target_os = "macos")]
 use arcbox_net::darwin::inbound_relay::{InboundListenerManager, InboundProtocol};
 #[cfg(not(target_os = "macos"))]
 use arcbox_net::port_forward::{PortForwardRule, PortForwarder};
+// The kubernetes responses stay on the prost side of the CORE-73 split:
+// `arcbox-api` forwards them through `wire_response`, which is bound on
+// `prost::Message` (Phase B3 worklist).
 use arcbox_protocol::agent::{
-    ContainerFsPathsResponse, ImageFsPathsResponse, KubernetesDeleteResponse,
-    KubernetesKubeconfigResponse, KubernetesStartResponse, KubernetesStatusResponse,
-    KubernetesStopResponse, ServiceStatus,
+    KubernetesDeleteResponse, KubernetesKubeconfigResponse, KubernetesStartResponse,
+    KubernetesStatusResponse, KubernetesStopResponse, ServiceStatus,
 };
 use assets::ensure_guest_binaries;
 use kubeconfig::{KUBERNETES_HOST_ENDPOINT, rewrite_kubeconfig_server};

--- a/app/arcbox-core/src/stats_hub.rs
+++ b/app/arcbox-core/src/stats_hub.rs
@@ -14,7 +14,11 @@ use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use arcbox_protocol::agent::{MachineStats, WatchStatsRequest};
+use arcbox_connect::v1::WatchStatsRequest;
+// `MachineStats` stays on the prost side of the CORE-73 split: samples flow
+// through `Runtime::subscribe_machine_stats*`, whose receivers `arcbox-api`
+// forwards as prost values (Phase B3 worklist).
+use arcbox_protocol::agent::MachineStats;
 use tokio::sync::broadcast;
 
 use crate::error::Result;
@@ -175,6 +179,7 @@ impl StatsSource for AgentStatsSource {
             .watch_stats(WatchStatsRequest {
                 timeout_ms: u32::try_from(WATCH_WINDOW.as_millis()).unwrap_or(u32::MAX),
                 interval_ms: u32::try_from(SAMPLE_INTERVAL.as_millis()).unwrap_or(u32::MAX),
+                ..Default::default()
             })
             .await?;
         Ok(AgentStatsStream { agent })

--- a/app/arcbox-core/src/vm.rs
+++ b/app/arcbox-core/src/vm.rs
@@ -470,12 +470,15 @@ impl VmManager {
     fn send_shutdown_rpc(&self, id: &VmId, timeout_seconds: u32) -> Result<()> {
         use arcbox_constants::ports::AGENT_PORT;
         use arcbox_constants::wire::MessageType;
-        use prost::Message;
+        use buffa::Message;
 
         let fd = self.connect_vsock(id, AGENT_PORT)?;
 
         // Build the shutdown request wire frame.
-        let req = arcbox_protocol::ShutdownRequest { timeout_seconds };
+        let req = arcbox_connect::v1::ShutdownRequest {
+            timeout_seconds,
+            ..Default::default()
+        };
         let payload = req.encode_to_vec();
         let frame = crate::AgentClient::build_message(MessageType::ShutdownRequest, "", &payload);
 

--- a/app/arcbox-core/src/vm_lifecycle/actor.rs
+++ b/app/arcbox-core/src/vm_lifecycle/actor.rs
@@ -245,12 +245,13 @@ impl BalloonDeps for RealBalloonDeps {
 
         let mut agent = self.connect_agent()?;
         agent
-            .watch_memory_pressure(arcbox_protocol::agent::WatchMemoryPressureRequest {
+            .watch_memory_pressure(arcbox_connect::v1::WatchMemoryPressureRequest {
                 timeout_ms: u32::try_from(WATCH_WINDOW.as_millis()).unwrap_or(u32::MAX),
                 min_available_bytes: PRESSURE_MIN_AVAILABLE,
                 max_refault_rate: PRESSURE_MAX_REFAULT_RATE,
                 keepalive_ms: u32::try_from(WATCH_KEEPALIVE.as_millis()).unwrap_or(u32::MAX),
                 psi_full_stall_us: PRESSURE_PSI_FULL_STALL_US,
+                ..Default::default()
             })
             .await?;
         let mut watch = AgentPressureWatch { agent };
@@ -269,14 +270,17 @@ pub(super) struct AgentPressureWatch {
 
 impl PressureWatch for AgentPressureWatch {
     async fn next_frame(&mut self, max_wait: Duration) -> Result<WatchFrame> {
-        use arcbox_protocol::agent::memory_pressure_event::Reason;
+        use arcbox_connect::v1::memory_pressure_event::Reason;
 
         let event = self.agent.next_memory_pressure_event(max_wait).await?;
-        Ok(match event.reason() {
-            Reason::Keepalive => WatchFrame::Keepalive,
-            Reason::LowAvailable | Reason::RefaultSpike => WatchFrame::Pressure,
-            Reason::Settled => WatchFrame::Settled,
-            Reason::WindowElapsed => WatchFrame::WindowElapsed,
+        Ok(match event.reason.as_known() {
+            Some(Reason::LowAvailable | Reason::RefaultSpike) => WatchFrame::Pressure,
+            Some(Reason::Settled) => WatchFrame::Settled,
+            Some(Reason::WindowElapsed) => WatchFrame::WindowElapsed,
+            // KEEPALIVE, plus any reason newer than this host: the proto
+            // pins unknown reasons to decode as KEEPALIVE, so `None` must
+            // fold the same way and never read as pressure.
+            Some(Reason::Keepalive) | None => WatchFrame::Keepalive,
         })
     }
 }

--- a/rpc/arcbox-connect/build.rs
+++ b/rpc/arcbox-connect/build.rs
@@ -2,11 +2,12 @@
 //!
 //! Generates buffa message types plus ConnectRPC service traits and clients
 //! for every ArcBox-owned proto (`arcbox.v1` and `arcbox.sandbox.v1`).
-//! These types serve the daemon's client-facing Connect surface AND the
-//! guest agent's vsock frames (CORE-73); the host side of the vsock wire
-//! still decodes with the prost twins in `arcbox-protocol` until the
-//! remaining convergence phases land — safe because buffa and prost emit
-//! identical protobuf bytes.
+//! These types serve the daemon's client-facing Connect surface and both
+//! ends of the host↔guest vsock wire (CORE-73); the host `AgentClient`
+//! still decodes the surfaces that cross into `arcbox-api` handlers as
+//! prost twins (sandbox, machine exec, kubernetes, machine stats) until
+//! the remaining convergence phases land — safe because buffa and prost
+//! emit identical protobuf bytes.
 
 fn main() {
     let proto_dir = "../arcbox-protocol/proto";

--- a/rpc/arcbox-connect/src/lib.rs
+++ b/rpc/arcbox-connect/src/lib.rs
@@ -15,8 +15,11 @@
 //! * The **guest agent** encodes its vsock frames with these types too —
 //!   the crate compiles for `aarch64-unknown-linux-musl` (base `connectrpc`
 //!   is transport-free) and must stay musl-clean.
-//! * The **host side of the vsock wire** still uses the prost twins in
-//!   `arcbox-protocol` until the remaining CORE-73 phases land.
+//! * The **host side of the vsock wire** (`arcbox-core`'s `AgentClient`)
+//!   uses these types too, except for the RPCs whose messages still cross
+//!   into `arcbox-api` handlers as prost twins (sandbox, machine exec,
+//!   kubernetes, machine stats) — the remaining CORE-73 phase moves those
+//!   handlers and retires the prost half.
 //!
 //! buffa and prost encode identical protobuf bytes, so mixed-codec peers
 //! interoperate; both representations are generated from the same `.proto`

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -11,6 +11,7 @@ description = "End-to-end integration tests for the ArcBox container and VM runt
 
 [dependencies]
 anyhow.workspace = true
+arcbox-connect.workspace = true
 arcbox-constants.workspace = true
 arcbox-core.workspace = true
 arcbox-grpc.workspace = true

--- a/tests/e2e/src/bin/hv_e2e.rs
+++ b/tests/e2e/src/bin/hv_e2e.rs
@@ -603,7 +603,7 @@ impl DaxFixture {
     }
 }
 
-fn get_system_info(vmm: &Vmm) -> Result<arcbox_protocol::SystemInfo, String> {
+fn get_system_info(vmm: &Vmm) -> Result<arcbox_connect::v1::SystemInfo, String> {
     let fd = vmm
         .connect_vsock(AGENT_PORT)
         .map_err(|e| format!("connect_vsock: {e}"))?;


### PR DESCRIPTION
Stacked on #531 (B1). Phase B2: `AgentClient` and the arcbox-core consumers of agent-channel messages move to buffa. Interoperates with both old and new guests — byte-identical wire, no protocol bump.

The split is deliberate and grep-able: `unary_rpc` (buffa) vs `unary_rpc_prost` — the prost survivors are exactly the types arcbox-api's `wire_request`/`wire_response` bridge pins (sandbox surface, machine exec, kubernetes responses, MachineStats, port-forward), each commented with its B3 dependency. B3 single-types the handlers and deletes both the bridge and `unary_rpc_prost`.

⚠️ **Stacked PR — CI does not run** (`ci.yml` fires only on master-targeted PRs). Locally validated: workspace check + clippy `-D warnings` --all-targets, `cargo test -p arcbox-core` (169 passed), guest musl check stays green, `cargo fmt --check`. Full CI runs when the stack lands on master.