### PR TITLE
refactor(cli): port abctl to buffa types, delete the prost seam (CORE-73 B4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,6 @@ dependencies = [
  "arcbox-fs",
  "arcbox-hypervisor",
  "arcbox-net",
- "arcbox-protocol",
  "arcbox-virtio",
  "arcbox-vmm",
 ]
@@ -308,7 +307,6 @@ dependencies = [
  "arcbox-docker",
  "arcbox-docker-tools",
  "arcbox-helper",
- "arcbox-protocol",
  "buffa",
  "buffa-types",
  "chrono",
@@ -321,7 +319,6 @@ dependencies = [
  "humantime",
  "libc",
  "macos-resolver",
- "prost",
  "sentry",
  "serde",
  "serde_json",
@@ -494,7 +491,6 @@ version = "0.5.5"
 dependencies = [
  "arcbox-core",
  "arcbox-error",
- "arcbox-protocol",
  "arcbox-transport",
  "axum",
  "bytes",
@@ -877,7 +873,6 @@ version = "0.5.5"
 dependencies = [
  "arcbox-constants",
  "arcbox-error",
- "arcbox-protocol",
  "async-trait",
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "arcbox-helper",
  "arcbox-protocol",
  "buffa",
+ "buffa-types",
  "chrono",
  "clap",
  "clap_complete",

--- a/app/arcbox-cli/Cargo.toml
+++ b/app/arcbox-cli/Cargo.toml
@@ -23,7 +23,6 @@ path = "src/bin/arcbox_placeholder.rs"
 [dependencies]
 arcbox-core = { workspace = true }
 arcbox-docker = { workspace = true }
-arcbox-protocol = { workspace = true }
 arcbox-constants = { workspace = true }
 arcbox-docker-tools = { workspace = true }
 arcbox-asset = { workspace = true }
@@ -50,7 +49,6 @@ uuid = { workspace = true, features = ["v4"] }
 arcbox-connect.workspace = true
 connectrpc = { version = "0.8.1", features = ["client"], git = "https://github.com/connectrpc/connect-rust", rev = "c5c1a6faa5d7f4d681662731db61e1fbe7796eec" }
 buffa = { version = "0.9.1", features = ["json"] }
-prost.workspace = true
 tower.workspace = true
 buffa-types = { version = "0.9.1", features = ["json"] }
 

--- a/app/arcbox-cli/Cargo.toml
+++ b/app/arcbox-cli/Cargo.toml
@@ -52,6 +52,7 @@ connectrpc = { version = "0.8.1", features = ["client"], git = "https://github.c
 buffa = { version = "0.9.1", features = ["json"] }
 prost.workspace = true
 tower.workspace = true
+buffa-types = { version = "0.9.1", features = ["json"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 macos-resolver = { workspace = true }

--- a/app/arcbox-cli/src/commands/agent.rs
+++ b/app/arcbox-cli/src/commands/agent.rs
@@ -12,16 +12,14 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
-use arcbox_connect::sandbox_v1 as pb;
 use arcbox_connect::sandbox_v1::SandboxServiceClient;
-use arcbox_protocol::sandbox_v1::{
+use arcbox_connect::sandbox_v1::{
     CreateSandboxRequest, InspectSandboxRequest, RemoveSandboxRequest, ResourceLimits, SandboxInfo,
     SandboxState, StartExecutionRequest,
 };
 use clap::Args;
 
 use super::sandbox::{current_tty_size, exec_session, sandbox_channel};
-use crate::connect::UnaryExt as _;
 
 /// How long to wait for a freshly created sandbox to become ready.
 ///
@@ -123,6 +121,12 @@ enum Action {
     Refuse,
 }
 
+/// The sandbox's state with prost-getter semantics: an unknown wire value
+/// reads as `Unspecified`.
+fn state_of(info: &SandboxInfo) -> SandboxState {
+    info.state.as_known().unwrap_or_default()
+}
+
 /// Decide how to reach a usable sandbox from its current state.
 fn plan_action(state: Option<SandboxState>) -> Action {
     match state {
@@ -185,11 +189,13 @@ pub async fn execute(def: &AgentDef, args: AgentArgs) -> Result<()> {
     let client = SandboxServiceClient::new(transport.clone(), config.clone());
 
     let existing = inspect(&client, &id).await?;
-    match plan_action(existing.as_ref().map(SandboxInfo::state)) {
+    match plan_action(existing.as_ref().map(state_of)) {
         Action::Attach => {}
         Action::WaitReady => wait_ready(&client, &id).await?,
         Action::Refuse => {
-            let state = existing.map_or("unknown", |info| super::sandbox::state_name(info.state()));
+            let state = existing.map_or("unknown", |info| {
+                super::sandbox::state_name(state_of(&info))
+            });
             bail!(
                 "sandbox '{id}' is {state} — a session may already be active. \
                  Use --id <name> for a second one, or remove it with \
@@ -216,11 +222,11 @@ pub async fn execute(def: &AgentDef, args: AgentArgs) -> Result<()> {
     let start = StartExecutionRequest {
         sandbox_id: id.clone(),
         cmd,
-        env,
+        env: env.into_iter().collect(),
         working_dir: def.workdir.to_string(),
         user: def.user.to_string(),
         tty: true,
-        tty_size: current_tty_size(true),
+        tty_size: current_tty_size(true).into(),
         stdin: true,
         ..Default::default()
     };
@@ -245,12 +251,12 @@ async fn inspect(
     client: &SandboxServiceClient<connectrpc::client::SharedHttp2Connection>,
     id: &str,
 ) -> Result<Option<SandboxInfo>> {
-    let request =
-        crate::connect::request::<pb::InspectSandboxRequest, _>(&InspectSandboxRequest {
-            id: id.to_string(),
-        })?;
+    let request = InspectSandboxRequest {
+        id: id.to_string(),
+        ..Default::default()
+    };
     match client.inspect(request).await {
-        Ok(response) => Ok(Some(response.prost()?)),
+        Ok(response) => Ok(Some(response.into_owned())),
         Err(status) if status.code == connectrpc::ErrorCode::NotFound => Ok(None),
         Err(status) => Err(status).context("Failed to inspect sandbox")?,
     }
@@ -261,12 +267,12 @@ async fn remove(
     client: &SandboxServiceClient<connectrpc::client::SharedHttp2Connection>,
     id: &str,
 ) -> Result<()> {
-    let request = crate::connect::request::<pb::RemoveSandboxRequest, _>(&RemoveSandboxRequest {
-        id: id.to_string(),
-        force: true,
-    })?;
     client
-        .remove(request)
+        .remove(RemoveSandboxRequest {
+            id: id.to_string(),
+            force: true,
+            ..Default::default()
+        })
         .await
         .context("Failed to remove the previous sandbox")?;
     Ok(())
@@ -282,17 +288,21 @@ async fn create(
 ) -> Result<()> {
     let template = super::sandbox::resolve_template(def.template).await?;
 
-    let request = crate::connect::request::<pb::CreateSandboxRequest, _>(&CreateSandboxRequest {
-        id: id.to_string(),
-        labels: HashMap::from([("arcbox.agent".to_string(), def.name.to_string())]),
-        template,
-        limits: Some(ResourceLimits { vcpus, memory_mib }),
-        // No TTL: expiry would take /workspace with it mid-session.
-        ttl_seconds: 0,
-        ..Default::default()
-    })?;
     client
-        .create(request)
+        .create(CreateSandboxRequest {
+            id: id.to_string(),
+            labels: std::iter::once(("arcbox.agent".to_string(), def.name.to_string())).collect(),
+            template,
+            limits: ResourceLimits {
+                vcpus,
+                memory_mib,
+                ..Default::default()
+            }
+            .into(),
+            // No TTL: expiry would take /workspace with it mid-session.
+            ttl_seconds: 0,
+            ..Default::default()
+        })
         .await
         .context("Failed to create the agent sandbox")?;
     Ok(())
@@ -306,8 +316,8 @@ async fn wait_ready(
     let deadline = tokio::time::Instant::now() + READY_TIMEOUT;
     loop {
         match inspect(client, id).await? {
-            Some(info) if info.state() == SandboxState::Ready => return Ok(()),
-            Some(info) if info.state() == SandboxState::Failed => {
+            Some(info) if info.state == SandboxState::Ready => return Ok(()),
+            Some(info) if info.state == SandboxState::Failed => {
                 let detail = if info.error.is_empty() {
                     "no reason reported".to_string()
                 } else {

--- a/app/arcbox-cli/src/commands/disk.rs
+++ b/app/arcbox-cli/src/commands/disk.rs
@@ -3,7 +3,6 @@
 //! Inspect and manage the Docker data disk image.
 
 use anyhow::{Context, Result};
-use arcbox_protocol::v1::MachineAgentRequest;
 use clap::Subcommand;
 
 /// Disk management commands.
@@ -143,12 +142,10 @@ async fn execute_compact() -> Result<()> {
     println!("Compacting Docker data disk (running fstrim in the guest)...");
     let client = super::machine::machine_client();
     client
-        .compact_disk(crate::connect::request::<
-            arcbox_connect::v1::MachineAgentRequest,
-            _,
-        >(&MachineAgentRequest {
+        .compact_disk(arcbox_connect::v1::MachineAgentRequest {
             id: DEFAULT_MACHINE.to_string(),
-        })?)
+            ..Default::default()
+        })
         .await
         .context("Failed to compact data disk via the daemon")?;
 

--- a/app/arcbox-cli/src/commands/kubernetes.rs
+++ b/app/arcbox-cli/src/commands/kubernetes.rs
@@ -9,7 +9,7 @@ use arcbox_constants::paths::{ArcboxProfile, HostLayout};
 use arcbox_docker_tools::{HostToolManager, ToolGroup, parse_tools_for_group};
 use clap::Subcommand;
 
-use crate::connect::{self, UnaryExt as _};
+use crate::connect;
 
 /// Embedded `assets.lock` (same copy used by Docker/Kubernetes host tools).
 const LOCK_TOML: &str = include_str!("../../../../assets.lock");
@@ -274,11 +274,11 @@ async fn delete_context_entries(home: &Path) -> Result<()> {
 
 async fn refresh_managed_kubeconfig(home: &Path) -> Result<()> {
     let client = kubernetes_client();
-    let response: arcbox_protocol::v1::KubernetesKubeconfigResponse = client
+    let response: pb::KubernetesKubeconfigResponse = client
         .get_kubeconfig(pb::KubernetesKubeconfigRequest::default())
         .await
         .context("failed to get ArcBox kubeconfig; run 'abctl k8s start' first")?
-        .prost()?;
+        .into_owned();
 
     let managed = managed_kubeconfig_path(home);
     if let Some(parent) = managed.parent() {
@@ -302,11 +302,11 @@ async fn refresh_if_enabled(home: &Path) -> Result<()> {
 
 async fn execute_start() -> Result<()> {
     let client = kubernetes_client();
-    let response: arcbox_protocol::v1::KubernetesStartResponse = client
+    let response: pb::KubernetesStartResponse = client
         .start(pb::KubernetesStartRequest::default())
         .await
         .context("failed to start Kubernetes")?
-        .prost()?;
+        .into_owned();
 
     println!(
         "Kubernetes: {}",
@@ -328,11 +328,11 @@ async fn execute_start() -> Result<()> {
 
 async fn execute_stop() -> Result<()> {
     let client = kubernetes_client();
-    let response: arcbox_protocol::v1::KubernetesStopResponse = client
+    let response: pb::KubernetesStopResponse = client
         .stop(pb::KubernetesStopRequest::default())
         .await
         .context("failed to stop Kubernetes")?
-        .prost()?;
+        .into_owned();
 
     println!("Kubernetes stopped: {}", response.stopped);
     if !response.detail.is_empty() {
@@ -348,11 +348,11 @@ async fn execute_restart() -> Result<()> {
 
 async fn execute_delete() -> Result<()> {
     let client = kubernetes_client();
-    let response: arcbox_protocol::v1::KubernetesDeleteResponse = client
+    let response: pb::KubernetesDeleteResponse = client
         .delete(pb::KubernetesDeleteRequest::default())
         .await
         .context("failed to delete Kubernetes")?
-        .prost()?;
+        .into_owned();
 
     println!("Kubernetes cluster deleted.");
     if !response.detail.is_empty() {
@@ -367,11 +367,11 @@ async fn execute_status() -> Result<()> {
     let kubectl_installed = kubectl_bin(&home).exists();
 
     let client = kubernetes_client();
-    let status: arcbox_protocol::v1::KubernetesStatusResponse = client
+    let status: pb::KubernetesStatusResponse = client
         .status(pb::KubernetesStatusRequest::default())
         .await
         .context("failed to get Kubernetes status")?
-        .prost()?;
+        .into_owned();
 
     println!(
         "Cluster:      {}",
@@ -458,11 +458,11 @@ async fn execute_disable() -> Result<()> {
 
 async fn execute_kubeconfig() -> Result<()> {
     let client = kubernetes_client();
-    let response: arcbox_protocol::v1::KubernetesKubeconfigResponse = client
+    let response: pb::KubernetesKubeconfigResponse = client
         .get_kubeconfig(pb::KubernetesKubeconfigRequest::default())
         .await
         .context("failed to get kubeconfig")?
-        .prost()?;
+        .into_owned();
     print!("{}", response.kubeconfig);
     Ok(())
 }

--- a/app/arcbox-cli/src/commands/machine.rs
+++ b/app/arcbox-cli/src/commands/machine.rs
@@ -1,12 +1,11 @@
 //! Machine management commands.
 
-use crate::connect::{StreamItemExt as _, UnaryExt as _};
 use anyhow::{Context, Result};
 use arcbox_cli::terminal::{RawModeGuard, TerminalSize};
 use arcbox_connect::v1 as pb;
 use arcbox_connect::v1::MachineServiceClient;
-use arcbox_protocol::v1::TerminalSize as ProtoTerminalSize;
-use arcbox_protocol::v1::{
+use arcbox_connect::v1::TerminalSize as ProtoTerminalSize;
+use arcbox_connect::v1::{
     CreateMachineRequest, DirectoryMount, InspectMachineRequest, ListMachinesRequest,
     MachineAgentRequest, MachineExecInput, MachineExecRequest, RemoveMachineRequest,
     StartMachineRequest, StopMachineRequest, machine_exec_input,
@@ -25,17 +24,16 @@ pub fn machine_client() -> MachineServiceClient<connectrpc::client::SharedHttp2C
 /// Returns the number of machines visible through the daemon gRPC API.
 pub async fn machine_count() -> Result<usize> {
     let client = machine_client();
-    let response = client
-        .list(crate::connect::request::<pb::ListMachinesRequest, _>(
-            &ListMachinesRequest { all: true },
-        )?)
+    let response: pb::ListMachinesResponse = client
+        .list(ListMachinesRequest {
+            all: true,
+            ..Default::default()
+        })
         .await
-        .context("Failed to list machines")?;
+        .context("Failed to list machines")?
+        .into_owned();
 
-    Ok(response
-        .prost::<arcbox_protocol::v1::ListMachinesResponse>()?
-        .machines
-        .len())
+    Ok(response.machines.len())
 }
 
 fn parse_mount(mount: &str) -> Result<DirectoryMount> {
@@ -51,6 +49,7 @@ fn parse_mount(mount: &str) -> Result<DirectoryMount> {
         host_path: host.to_string(),
         guest_path: guest.to_string(),
         readonly: false,
+        ..Default::default()
     })
 }
 
@@ -223,22 +222,21 @@ async fn execute_create(args: CreateArgs) -> Result<()> {
         .collect::<Result<Vec<_>>>()?;
 
     client
-        .create(crate::connect::request::<pb::CreateMachineRequest, _>(
-            &CreateMachineRequest {
-                name: args.name.clone(),
-                // 0 = let the daemon apply its default (host core count).
-                cpus: args.cpus.unwrap_or(0),
-                memory: args.memory.saturating_mul(1024_u64 * 1024),
-                disk_size: args.disk.saturating_mul(1024_u64 * 1024 * 1024),
-                distro: args.distro.clone().unwrap_or_default(),
-                version: args.distro_version.clone().unwrap_or_default(),
-                arch: std::env::consts::ARCH.to_string(),
-                mounts,
-                ssh_public_key: String::new(),
-                kernel: args.kernel.clone().unwrap_or_default(),
-                cmdline: args.cmdline.clone().unwrap_or_default(),
-            },
-        )?)
+        .create(CreateMachineRequest {
+            name: args.name.clone(),
+            // 0 = let the daemon apply its default (host core count).
+            cpus: args.cpus.unwrap_or(0),
+            memory: args.memory.saturating_mul(1024_u64 * 1024),
+            disk_size: args.disk.saturating_mul(1024_u64 * 1024 * 1024),
+            distro: args.distro.clone().unwrap_or_default(),
+            version: args.distro_version.clone().unwrap_or_default(),
+            arch: std::env::consts::ARCH.to_string(),
+            mounts,
+            ssh_public_key: String::new(),
+            kernel: args.kernel.clone().unwrap_or_default(),
+            cmdline: args.cmdline.clone().unwrap_or_default(),
+            ..Default::default()
+        })
         .await
         .context("Failed to create machine")?;
 
@@ -262,11 +260,10 @@ async fn execute_start(args: StartArgs) -> Result<()> {
     println!("Starting machine '{}'...", args.name);
 
     client
-        .start(crate::connect::request::<pb::StartMachineRequest, _>(
-            &StartMachineRequest {
-                id: args.name.clone(),
-            },
-        )?)
+        .start(StartMachineRequest {
+            id: args.name.clone(),
+            ..Default::default()
+        })
         .await
         .context("Failed to start machine")?;
 
@@ -274,11 +271,10 @@ async fn execute_start(args: StartArgs) -> Result<()> {
     let mut delay = std::time::Duration::from_millis(200);
     for attempt in 1..=MAX_AGENT_WAIT_ATTEMPTS {
         match client
-            .ping(crate::connect::request::<pb::MachineAgentRequest, _>(
-                &MachineAgentRequest {
-                    id: args.name.clone(),
-                },
-            )?)
+            .ping(MachineAgentRequest {
+                id: args.name.clone(),
+                ..Default::default()
+            })
             .await
         {
             Ok(_) => break,
@@ -295,17 +291,17 @@ async fn execute_start(args: StartArgs) -> Result<()> {
 
     println!("Machine '{}' started", args.name);
     if let Ok(resp) = client
-        .inspect(crate::connect::request::<pb::InspectMachineRequest, _>(
-            &InspectMachineRequest {
-                id: args.name.clone(),
-            },
-        )?)
+        .inspect(InspectMachineRequest {
+            id: args.name.clone(),
+            ..Default::default()
+        })
         .await
     {
-        if let Some(network) = resp.prost::<arcbox_protocol::v1::MachineInfo>()?.network {
-            if !network.ip_address.is_empty() {
-                println!("IP:      {}", network.ip_address);
-            }
+        let info: pb::MachineInfo = resp.into_owned();
+        // An unset `network` derefs to the default instance (empty IP), so
+        // the "no IP" case needs no separate branch.
+        if !info.network.ip_address.is_empty() {
+            println!("IP:      {}", info.network.ip_address);
         }
     }
 
@@ -318,12 +314,11 @@ async fn execute_stop(args: StopArgs) -> Result<()> {
     println!("Stopping machine '{}'...", args.name);
 
     client
-        .stop(crate::connect::request::<pb::StopMachineRequest, _>(
-            &StopMachineRequest {
-                id: args.name.clone(),
-                force: args.force,
-            },
-        )?)
+        .stop(StopMachineRequest {
+            id: args.name.clone(),
+            force: args.force,
+            ..Default::default()
+        })
         .await
         .context("Failed to stop machine")?;
 
@@ -336,15 +331,14 @@ async fn execute_remove(args: RemoveArgs) -> Result<()> {
     let client = machine_client();
 
     client
-        .remove(crate::connect::request::<pb::RemoveMachineRequest, _>(
-            &RemoveMachineRequest {
-                id: args.name.clone(),
-                force: args.force,
-                // Removal always deletes the machine directory; the wire field
-                // is retained for compatibility only.
-                volumes: false,
-            },
-        )?)
+        .remove(RemoveMachineRequest {
+            id: args.name.clone(),
+            force: args.force,
+            // Removal always deletes the machine directory; the wire field
+            // is retained for compatibility only.
+            volumes: false,
+            ..Default::default()
+        })
         .await
         .context("Failed to remove machine")?;
 
@@ -356,12 +350,13 @@ async fn execute_remove(args: RemoveArgs) -> Result<()> {
 async fn execute_list(args: ListArgs) -> Result<()> {
     let client = machine_client();
     let machines = client
-        .list(crate::connect::request::<pb::ListMachinesRequest, _>(
-            &ListMachinesRequest { all: args.all },
-        )?)
+        .list(ListMachinesRequest {
+            all: args.all,
+            ..Default::default()
+        })
         .await
         .context("Failed to list machines")?
-        .prost::<arcbox_protocol::v1::ListMachinesResponse>()?
+        .into_owned()
         .machines;
 
     if args.quiet {
@@ -410,29 +405,21 @@ async fn execute_list(args: ListArgs) -> Result<()> {
 
 async fn execute_status(args: StatusArgs) -> Result<()> {
     let client = machine_client();
-    let machine = client
-        .inspect(crate::connect::request::<pb::InspectMachineRequest, _>(
-            &InspectMachineRequest {
-                id: args.name.clone(),
-            },
-        )?)
+    let machine: pb::MachineInfo = client
+        .inspect(InspectMachineRequest {
+            id: args.name.clone(),
+            ..Default::default()
+        })
         .await
         .context("Failed to get machine status")?
-        .prost::<arcbox_protocol::v1::MachineInfo>()?;
+        .into_owned();
 
-    let cpus = machine.hardware.as_ref().map_or(0, |h| h.cpus);
-    let memory_mb = machine
-        .hardware
-        .as_ref()
-        .map_or(0, |h| h.memory / (1024 * 1024));
-    let disk_gb = machine
-        .storage
-        .as_ref()
-        .map_or(0, |s| s.disk_size / (1024 * 1024 * 1024));
-    let ip_address = machine
-        .network
-        .as_ref()
-        .map(|n| n.ip_address.as_str())
+    // Unset sub-messages deref to their default instances, which carry the
+    // same zero/empty values the old Option-based fallbacks produced.
+    let cpus = machine.hardware.cpus;
+    let memory_mb = machine.hardware.memory / (1024 * 1024);
+    let disk_gb = machine.storage.disk_size / (1024 * 1024 * 1024);
+    let ip_address = Some(machine.network.ip_address.as_str())
         .filter(|ip| !ip.is_empty())
         .unwrap_or("-");
 
@@ -449,27 +436,29 @@ async fn execute_status(args: StatusArgs) -> Result<()> {
 
 async fn execute_inspect(args: InspectArgs) -> Result<()> {
     let client = machine_client();
-    let machine = client
-        .inspect(crate::connect::request::<pb::InspectMachineRequest, _>(
-            &InspectMachineRequest {
-                id: args.name.clone(),
-            },
-        )?)
+    let machine: pb::MachineInfo = client
+        .inspect(InspectMachineRequest {
+            id: args.name.clone(),
+            ..Default::default()
+        })
         .await
         .context("Failed to inspect machine")?
-        .prost::<arcbox_protocol::v1::MachineInfo>()?;
+        .into_owned();
 
+    // Sub-message derefs fall back to default instances (zero/empty), which
+    // matches the old Option-based fallbacks — the JSON shape is unchanged,
+    // including `ip_address: null` when the machine has no address.
     let payload = serde_json::json!({
         "id": machine.id,
         "name": machine.name,
         "state": machine.state,
-        "cpus": machine.hardware.as_ref().map_or(0, |h| h.cpus),
-        "memory_mb": machine.hardware.as_ref().map_or(0, |h| h.memory / (1024 * 1024)),
-        "disk_gb": machine.storage.as_ref().map_or(0, |s| s.disk_size / (1024 * 1024 * 1024)),
-        "ip_address": machine.network.as_ref().map(|n| n.ip_address.clone()).filter(|ip| !ip.is_empty()),
-        "kernel": machine.os.as_ref().map_or(String::new(), |os| os.kernel.clone()),
-        "distro": machine.os.as_ref().map_or(String::new(), |os| os.distro.clone()),
-        "distro_version": machine.os.as_ref().map_or(String::new(), |os| os.version.clone()),
+        "cpus": machine.hardware.cpus,
+        "memory_mb": machine.hardware.memory / (1024 * 1024),
+        "disk_gb": machine.storage.disk_size / (1024 * 1024 * 1024),
+        "ip_address": Some(machine.network.ip_address.clone()).filter(|ip| !ip.is_empty()),
+        "kernel": machine.os.kernel.clone(),
+        "distro": machine.os.distro.clone(),
+        "distro_version": machine.os.version.clone(),
     });
 
     println!(
@@ -483,15 +472,14 @@ async fn execute_inspect(args: InspectArgs) -> Result<()> {
 async fn execute_ping(args: PingArgs) -> Result<()> {
     let client = machine_client();
     let started = std::time::Instant::now();
-    let response = client
-        .ping(crate::connect::request::<pb::MachineAgentRequest, _>(
-            &MachineAgentRequest {
-                id: args.name.clone(),
-            },
-        )?)
+    let response: pb::MachinePingResponse = client
+        .ping(MachineAgentRequest {
+            id: args.name.clone(),
+            ..Default::default()
+        })
         .await
         .context("Failed to ping agent")?
-        .prost::<arcbox_protocol::v1::MachinePingResponse>()?;
+        .into_owned();
     let elapsed = started.elapsed();
 
     println!(
@@ -505,15 +493,14 @@ async fn execute_ping(args: PingArgs) -> Result<()> {
 
 async fn execute_info(args: InfoArgs) -> Result<()> {
     let client = machine_client();
-    let info = client
-        .get_system_info(crate::connect::request::<pb::MachineAgentRequest, _>(
-            &MachineAgentRequest {
-                id: args.name.clone(),
-            },
-        )?)
+    let info: pb::MachineSystemInfo = client
+        .get_system_info(MachineAgentRequest {
+            id: args.name.clone(),
+            ..Default::default()
+        })
         .await
         .context("Failed to get system info")?
-        .prost::<arcbox_protocol::v1::MachineSystemInfo>()?;
+        .into_owned();
 
     let total_mb = info.total_memory / 1024 / 1024;
     let available_mb = info.available_memory / 1024 / 1024;
@@ -552,18 +539,21 @@ async fn exec_session_interactive(name: &str, cmd: Vec<String>) -> Result<()> {
     let tty_size = TerminalSize::current().ok().map(|s| ProtoTerminalSize {
         width: u32::from(s.cols),
         height: u32::from(s.rows),
+        ..Default::default()
     });
 
     // The first message in the stream must be the Init payload.
     msg_tx
         .send(MachineExecInput {
-            payload: Some(machine_exec_input::Payload::Init(MachineExecRequest {
+            payload: MachineExecRequest {
                 id: name.to_string(),
                 cmd,
                 tty: true,
-                tty_size,
+                tty_size: tty_size.into(),
                 ..Default::default()
-            })),
+            }
+            .into(),
+            ..Default::default()
         })
         .await
         .context("Failed to send exec session init")?;
@@ -577,10 +567,13 @@ async fn exec_session_interactive(name: &str, cmd: Vec<String>) -> Result<()> {
             tokio::spawn(async move {
                 while let Some(size) = watcher.recv().await {
                     let msg = MachineExecInput {
-                        payload: Some(machine_exec_input::Payload::Resize(ProtoTerminalSize {
+                        payload: ProtoTerminalSize {
                             width: u32::from(size.cols),
                             height: u32::from(size.rows),
-                        })),
+                            ..Default::default()
+                        }
+                        .into(),
+                        ..Default::default()
                     };
                     if resize_tx.send(msg).await.is_err() {
                         break;
@@ -603,6 +596,7 @@ async fn exec_session_interactive(name: &str, cmd: Vec<String>) -> Result<()> {
                     if stdin_tx
                         .send(MachineExecInput {
                             payload: Some(machine_exec_input::Payload::Stdin(buf[..n].to_vec())),
+                            ..Default::default()
                         })
                         .await
                         .is_err()
@@ -624,20 +618,13 @@ async fn exec_session_interactive(name: &str, cmd: Vec<String>) -> Result<()> {
         .context("Failed to open machine exec session")?;
     let (mut send, mut recv) = stream.into_split();
 
-    // Forwarder: prost inputs from the pumps → wire. When every pump has
-    // dropped its sender the channel drains, and closing the send half ends
-    // the request body cleanly; the session keeps running until the server
+    // Forwarder: inputs from the pumps → wire. When every pump has dropped
+    // its sender the channel drains, and closing the send half ends the
+    // request body cleanly; the session keeps running until the server
     // finishes the response side.
     tokio::spawn(async move {
         while let Some(msg) = msg_rx.recv().await {
-            let req = match crate::connect::request::<pb::MachineExecInput, _>(&msg) {
-                Ok(req) => req,
-                Err(e) => {
-                    tracing::error!(error = %e, "dropping exec session input");
-                    break;
-                }
-            };
-            if send.send(req).await.is_err() {
+            if send.send(msg).await.is_err() {
                 break;
             }
         }
@@ -651,7 +638,7 @@ async fn exec_session_interactive(name: &str, cmd: Vec<String>) -> Result<()> {
         .await
         .context("Failed to read session output")?
     {
-        let output: arcbox_protocol::v1::MachineExecOutput = item.prost()?;
+        let output = item.to_owned_message();
         if !output.data.is_empty() {
             // The PTY merges stdout/stderr into one stream.
             std::io::stdout()
@@ -690,17 +677,15 @@ async fn exec_via_grpc(
 ) -> Result<()> {
     let client = machine_client();
     let mut stream = client
-        .exec(crate::connect::request::<pb::MachineExecRequest, _>(
-            &MachineExecRequest {
-                id: name.to_string(),
-                cmd,
-                working_dir: String::new(),
-                user: String::new(),
-                env,
-                tty,
-                tty_size: None,
-            },
-        )?)
+        .exec(MachineExecRequest {
+            id: name.to_string(),
+            cmd,
+            working_dir: String::new(),
+            user: String::new(),
+            env: env.into_iter().collect(),
+            tty,
+            ..Default::default()
+        })
         .await
         .context("Failed to execute command in machine")?;
 
@@ -710,7 +695,7 @@ async fn exec_via_grpc(
         .await
         .context("Failed to read exec output")?
     {
-        let output: arcbox_protocol::v1::MachineExecOutput = item.prost()?;
+        let output = item.to_owned_message();
         if !output.data.is_empty() {
             match output.stream.as_str() {
                 "stderr" => {

--- a/app/arcbox-cli/src/commands/macos.rs
+++ b/app/arcbox-cli/src/commands/macos.rs
@@ -5,11 +5,10 @@
 //! distinct noun from `abctl machine` (Linux) and talks to its own
 //! `MacosService`.
 
-use crate::connect::{StreamItemExt as _, UnaryExt as _};
 use anyhow::{Context, Result};
 use arcbox_connect::v1 as pb;
 use arcbox_connect::v1::MacosServiceClient;
-use arcbox_protocol::v1::{
+use arcbox_connect::v1::{
     CreateMacosMachineRequest, Empty, InspectMacosMachineRequest, MacosImagePullRequest,
     MacosImageRemoveRequest, MacosImageResolveRequest, RemoveMacosMachineRequest,
     StartMacosMachineRequest, StopMacosMachineRequest,
@@ -144,17 +143,14 @@ async fn execute_ip(args: IpArgs) -> Result<()> {
     let client = macos_client();
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(args.wait.into());
     loop {
-        let info = client
-            .inspect(
-                crate::connect::request::<pb::InspectMacosMachineRequest, _>(
-                    &InspectMacosMachineRequest {
-                        name: args.name.clone(),
-                    },
-                )?,
-            )
+        let info: pb::MacosMachineInfo = client
+            .inspect(InspectMacosMachineRequest {
+                name: args.name.clone(),
+                ..Default::default()
+            })
             .await
             .context("Failed to inspect macOS guest")?
-            .prost::<arcbox_protocol::v1::MacosMachineInfo>()?;
+            .into_owned();
         if !info.ip_address.is_empty() {
             println!("{}", info.ip_address);
             return Ok(());
@@ -174,14 +170,13 @@ async fn execute_ip(args: IpArgs) -> Result<()> {
 async fn execute_create(args: CreateArgs) -> Result<()> {
     let client = macos_client();
     client
-        .create(crate::connect::request::<pb::CreateMacosMachineRequest, _>(
-            &CreateMacosMachineRequest {
-                name: args.name.clone(),
-                image: args.image.clone(),
-                cpus: args.cpus,
-                memory_mib: args.memory,
-            },
-        )?)
+        .create(CreateMacosMachineRequest {
+            name: args.name.clone(),
+            image: args.image.clone(),
+            cpus: args.cpus,
+            memory_mib: args.memory,
+            ..Default::default()
+        })
         .await
         .context("Failed to create macOS guest")?;
 
@@ -201,11 +196,10 @@ async fn execute_start(args: NameArgs) -> Result<()> {
     let client = macos_client();
     println!("Starting macOS guest '{}'...", args.name);
     client
-        .start(crate::connect::request::<pb::StartMacosMachineRequest, _>(
-            &StartMacosMachineRequest {
-                name: args.name.clone(),
-            },
-        )?)
+        .start(StartMacosMachineRequest {
+            name: args.name.clone(),
+            ..Default::default()
+        })
         .await
         .context("Failed to start macOS guest")?;
     println!("macOS guest '{}' started", args.name);
@@ -216,11 +210,10 @@ async fn execute_stop(args: NameArgs) -> Result<()> {
     let client = macos_client();
     println!("Stopping macOS guest '{}'...", args.name);
     client
-        .stop(crate::connect::request::<pb::StopMacosMachineRequest, _>(
-            &StopMacosMachineRequest {
-                name: args.name.clone(),
-            },
-        )?)
+        .stop(StopMacosMachineRequest {
+            name: args.name.clone(),
+            ..Default::default()
+        })
         .await
         .context("Failed to stop macOS guest")?;
     println!("macOS guest '{}' stopped", args.name);
@@ -230,12 +223,11 @@ async fn execute_stop(args: NameArgs) -> Result<()> {
 async fn execute_remove(args: RemoveArgs) -> Result<()> {
     let client = macos_client();
     client
-        .remove(crate::connect::request::<pb::RemoveMacosMachineRequest, _>(
-            &RemoveMacosMachineRequest {
-                name: args.name.clone(),
-                force: args.force,
-            },
-        )?)
+        .remove(RemoveMacosMachineRequest {
+            name: args.name.clone(),
+            force: args.force,
+            ..Default::default()
+        })
         .await
         .context("Failed to remove macOS guest")?;
     println!("macOS guest '{}' removed", args.name);
@@ -245,10 +237,10 @@ async fn execute_remove(args: RemoveArgs) -> Result<()> {
 async fn execute_list() -> Result<()> {
     let client = macos_client();
     let machines = client
-        .list(crate::connect::request::<pb::Empty, _>(&Empty {})?)
+        .list(Empty::default())
         .await
         .context("Failed to list macOS guests")?
-        .prost::<arcbox_protocol::v1::MacosMachineListResponse>()?
+        .into_owned()
         .machines;
 
     if machines.is_empty() {
@@ -288,12 +280,11 @@ async fn execute_image(cmd: ImageCommands) -> Result<()> {
                 .or_else(|| args.manifest.clone())
                 .unwrap_or_default();
             let mut stream = client
-                .image_pull(crate::connect::request::<pb::MacosImagePullRequest, _>(
-                    &MacosImagePullRequest {
-                        reference: args.reference.unwrap_or_default(),
-                        manifest_url: args.manifest.unwrap_or_default(),
-                    },
-                )?)
+                .image_pull(MacosImagePullRequest {
+                    reference: args.reference.unwrap_or_default(),
+                    manifest_url: args.manifest.unwrap_or_default(),
+                    ..Default::default()
+                })
                 .await
                 .context("Failed to pull macOS image")?;
 
@@ -304,10 +295,10 @@ async fn execute_image(cmd: ImageCommands) -> Result<()> {
                 .await
                 .context("Failed to pull macOS image")?
             {
-                let event: arcbox_protocol::v1::MacosImagePullEvent = item.prost()?;
+                let event = item.to_owned_message();
                 // The terminal event carries the landed image instead of
                 // progress; report it as the outcome, not as a stage line.
-                if let Some(image) = event.image {
+                if let Some(image) = event.image.into_option() {
                     landed = Some(image);
                     continue;
                 }
@@ -327,16 +318,15 @@ async fn execute_image(cmd: ImageCommands) -> Result<()> {
         }
         ImageCommands::Resolve(args) => {
             let client = macos_client();
-            let info = client
-                .image_resolve(crate::connect::request::<pb::MacosImageResolveRequest, _>(
-                    &MacosImageResolveRequest {
-                        reference: args.reference.unwrap_or_default(),
-                        manifest_url: args.manifest.unwrap_or_default(),
-                    },
-                )?)
+            let info: pb::MacosImageResolveResponse = client
+                .image_resolve(MacosImageResolveRequest {
+                    reference: args.reference.unwrap_or_default(),
+                    manifest_url: args.manifest.unwrap_or_default(),
+                    ..Default::default()
+                })
                 .await
                 .context("Failed to resolve macOS image")?
-                .prost::<arcbox_protocol::v1::MacosImageResolveResponse>()?;
+                .into_owned();
             println!("{}@{}", info.name, info.version);
             println!("os: macOS {}", info.os_version);
             println!(
@@ -355,10 +345,10 @@ async fn execute_image(cmd: ImageCommands) -> Result<()> {
         ImageCommands::List => {
             let client = macos_client();
             let images = client
-                .image_list(crate::connect::request::<pb::Empty, _>(&Empty {})?)
+                .image_list(Empty::default())
                 .await
                 .context("Failed to list macOS images")?
-                .prost::<arcbox_protocol::v1::MacosImageListResponse>()?
+                .into_owned()
                 .images;
 
             if images.is_empty() {
@@ -399,11 +389,10 @@ async fn execute_image(cmd: ImageCommands) -> Result<()> {
         ImageCommands::Remove(args) => {
             let client = macos_client();
             client
-                .image_remove(crate::connect::request::<pb::MacosImageRemoveRequest, _>(
-                    &MacosImageRemoveRequest {
-                        name: args.name.clone(),
-                    },
-                )?)
+                .image_remove(MacosImageRemoveRequest {
+                    name: args.name.clone(),
+                    ..Default::default()
+                })
                 .await
                 .context("Failed to remove macOS image")?;
             println!("macOS image '{}' removed", args.name);

--- a/app/arcbox-cli/src/commands/migrate.rs
+++ b/app/arcbox-cli/src/commands/migrate.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result, bail};
 use arcbox_connect::v1 as pb;
 use arcbox_connect::v1::MigrationServiceClient;
-use arcbox_protocol::v1::{
+use arcbox_connect::v1::{
     PrepareMigrationRequest, PrepareMigrationResponse, RunMigrationEvent, RunMigrationRequest,
 };
 use clap::{Args, Subcommand};
@@ -14,7 +14,7 @@ use std::fmt::Write as _;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
-use crate::connect::{self, StreamItemExt as _, UnaryExt as _};
+use crate::connect;
 
 /// Runtime migration commands.
 #[derive(Subcommand)]
@@ -101,17 +101,16 @@ async fn execute_source(source_kind: MigrationSourceKind, args: MigrateSourceArg
     println!("Preparing migration from {}...", source_kind.display_name());
 
     let client = migration_client();
-    let prepare = client
-        .prepare_migration(connect::request::<pb::PrepareMigrationRequest, _>(
-            &PrepareMigrationRequest {
-                source_kind: source_kind.as_str().to_string(),
-                source_socket_path: source_socket.to_string_lossy().into_owned(),
-                allow_replacements: true,
-            },
-        )?)
+    let prepare: PrepareMigrationResponse = client
+        .prepare_migration(PrepareMigrationRequest {
+            source_kind: source_kind.as_str().to_string(),
+            source_socket_path: source_socket.to_string_lossy().into_owned(),
+            allow_replacements: true,
+            ..Default::default()
+        })
         .await
         .context("Failed to prepare migration")?
-        .prost::<PrepareMigrationResponse>()?;
+        .into_owned();
 
     if prepare.plan_id.is_empty() {
         bail!("Migration prepare response did not include a plan ID");
@@ -132,15 +131,14 @@ async fn execute_source(source_kind: MigrationSourceKind, args: MigrateSourceArg
     println!("Running migration...");
 
     let mut stream = client
-        .run_migration(connect::request::<pb::RunMigrationRequest, _>(
-            &RunMigrationRequest {
-                plan_id: prepare.plan_id.clone(),
-                // We only reach this point after the user has explicitly confirmed
-                // (either via interactive prompt or --yes), so allow both
-                // replacements and stopping blocker containers.
-                allow_replacements: true,
-            },
-        )?)
+        .run_migration(RunMigrationRequest {
+            plan_id: prepare.plan_id.clone(),
+            // We only reach this point after the user has explicitly confirmed
+            // (either via interactive prompt or --yes), so allow both
+            // replacements and stopping blocker containers.
+            allow_replacements: true,
+            ..Default::default()
+        })
         .await
         .context("Failed to start migration")?;
 
@@ -150,7 +148,7 @@ async fn execute_source(source_kind: MigrationSourceKind, args: MigrateSourceArg
         .await
         .context("Failed to read migration progress")?
     {
-        let event: RunMigrationEvent = item.prost()?;
+        let event: RunMigrationEvent = item.to_owned_message();
         print_progress_event(&event);
         if event.done {
             final_status = Some(event.success);

--- a/app/arcbox-cli/src/commands/sandbox.rs
+++ b/app/arcbox-cli/src/commands/sandbox.rs
@@ -3,16 +3,9 @@
 //! Sandboxes are short-lived, strongly-isolated microVMs. The underlying guest
 //! VM is managed transparently by the daemon and is not visible to the user.
 
-use crate::connect::{StreamItemExt as _, UnaryExt as _};
 use anyhow::{Context, Result};
 use arcbox_connect::sandbox_v1 as pb;
 use arcbox_connect::sandbox_v1::{
-    SandboxFilesystemServiceClient, SandboxProcessServiceClient, SandboxServiceClient,
-    SandboxSnapshotServiceClient,
-};
-use arcbox_core::vm_lifecycle::DEFAULT_MACHINE_NAME;
-use arcbox_protocol::pbjson_types::Timestamp;
-use arcbox_protocol::sandbox_v1::{
     AttachExecutionRequest, CheckpointRequest, CreateSandboxRequest, DeleteSnapshotRequest,
     Execution, ExposePortRequest, FileChunk, InspectSandboxRequest, ListSandboxesRequest,
     ListSnapshotsRequest, PortProtocol, ReadFileRequest, RemoveSandboxRequest,
@@ -20,8 +13,13 @@ use arcbox_protocol::sandbox_v1::{
     SandboxEventsRequest, SandboxState, StartExecutionRequest, StdioChannel, StopSandboxRequest,
     TerminalSize as ProtoTerminalSize, UnexposePortRequest, WaitExecutionRequest, WriteFileOpen,
     WriteFileRequest, WriteStdinRequest, execution_event, exit_status, watch_events_response,
-    write_file_request,
 };
+use arcbox_connect::sandbox_v1::{
+    SandboxFilesystemServiceClient, SandboxProcessServiceClient, SandboxServiceClient,
+    SandboxSnapshotServiceClient,
+};
+use arcbox_core::vm_lifecycle::DEFAULT_MACHINE_NAME;
+use buffa_types::google::protobuf::Timestamp;
 use clap::{Args, Subcommand};
 use std::collections::HashMap;
 use std::io::Write;
@@ -423,8 +421,10 @@ fn format_timestamp(ts: Option<&Timestamp>) -> String {
 /// Shell-convention scalar exit code of a finished execution
 /// (`128 + signal` for signal deaths; 1 when torn down without an exit).
 fn exit_code_of(execution: &Execution) -> i32 {
-    match execution.exit_status.as_ref().and_then(|s| s.status) {
-        Some(exit_status::Status::Code(code)) => code,
+    // An unset `exit_status` derefs to the default instance, whose oneof is
+    // `None` — the same "torn down without an exit" case as before.
+    match execution.exit_status.status.as_ref() {
+        Some(exit_status::Status::Code(code)) => *code,
         Some(exit_status::Status::Signal(signal)) => 128 + signal,
         None => 1,
     }
@@ -454,26 +454,31 @@ async fn execute_create(args: CreateArgs) -> Result<()> {
 
     let req = CreateSandboxRequest {
         id: args.id.unwrap_or_default(),
-        labels,
+        labels: labels.into_iter().collect(),
         template,
-        limits: Some(ResourceLimits {
+        limits: ResourceLimits {
             vcpus: args.cpus,
             memory_mib: args.memory,
-        }),
+            ..Default::default()
+        }
+        .into(),
         ttl_seconds: args.ttl,
         ..Default::default()
     };
 
-    let resp = client
-        .create(crate::connect::request(&req)?)
+    let resp: pb::CreateSandboxResponse = client
+        .create(req)
         .await
         .context("Failed to create sandbox")?
-        .prost::<arcbox_protocol::sandbox_v1::CreateSandboxResponse>()?;
+        .into_owned();
 
     println!("Sandbox created");
     println!("  ID:    {}", resp.id);
     println!("  IP:    {}", resp.ip_address);
-    println!("  State: {}", state_name(resp.state()));
+    println!(
+        "  State: {}",
+        state_name(resp.state.as_known().unwrap_or_default())
+    );
     Ok(())
 }
 
@@ -481,12 +486,12 @@ async fn execute_stop(args: StopArgs) -> Result<()> {
     let (transport, config) = sandbox_channel();
     let client = SandboxServiceClient::new(transport.clone(), config.clone());
 
-    let req = StopSandboxRequest {
-        id: args.id.clone(),
-        timeout_seconds: args.timeout,
-    };
     client
-        .stop(crate::connect::request(&req)?)
+        .stop(StopSandboxRequest {
+            id: args.id.clone(),
+            timeout_seconds: args.timeout,
+            ..Default::default()
+        })
         .await
         .context("Failed to stop sandbox")?;
 
@@ -498,12 +503,12 @@ async fn execute_remove(args: RemoveArgs) -> Result<()> {
     let (transport, config) = sandbox_channel();
     let client = SandboxServiceClient::new(transport.clone(), config.clone());
 
-    let req = RemoveSandboxRequest {
-        id: args.id.clone(),
-        force: args.force,
-    };
     client
-        .remove(crate::connect::request(&req)?)
+        .remove(RemoveSandboxRequest {
+            id: args.id.clone(),
+            force: args.force,
+            ..Default::default()
+        })
         .await
         .context("Failed to remove sandbox")?;
 
@@ -523,17 +528,15 @@ async fn execute_list(args: ListArgs) -> Result<()> {
     let mut sandboxes = Vec::new();
     let mut page_token = String::new();
     loop {
-        let req = ListSandboxesRequest {
-            state: state.into(),
-            labels: HashMap::new(),
-            page_size: 0,
-            page_token: page_token.clone(),
-        };
-        let mut resp = client
-            .list(crate::connect::request(&req)?)
+        let mut resp: pb::ListSandboxesResponse = client
+            .list(ListSandboxesRequest {
+                state: state.into(),
+                page_token: page_token.clone(),
+                ..Default::default()
+            })
             .await
             .context("Failed to list sandboxes")?
-            .prost::<arcbox_protocol::sandbox_v1::ListSandboxesResponse>()?;
+            .into_owned();
         sandboxes.append(&mut resp.sandboxes);
         if resp.next_page_token.is_empty() {
             break;
@@ -558,9 +561,9 @@ async fn execute_list(args: ListArgs) -> Result<()> {
         println!(
             "{:<36} {:<12} {:<18} {}",
             sb.id,
-            state_name(sb.state()),
+            state_name(sb.state.as_known().unwrap_or_default()),
             sb.ip_address,
-            format_timestamp(sb.created_at.as_ref()),
+            format_timestamp(sb.created_at.as_option()),
         );
     }
     Ok(())
@@ -570,36 +573,38 @@ async fn execute_inspect(args: InspectArgs) -> Result<()> {
     let (transport, config) = sandbox_channel();
     let client = SandboxServiceClient::new(transport.clone(), config.clone());
 
-    let req = InspectSandboxRequest { id: args.id };
-    let info = client
-        .inspect(crate::connect::request(&req)?)
+    let info: pb::SandboxInfo = client
+        .inspect(InspectSandboxRequest {
+            id: args.id,
+            ..Default::default()
+        })
         .await
         .context("Failed to inspect sandbox")?
-        .prost::<arcbox_protocol::sandbox_v1::SandboxInfo>()?;
+        .into_owned();
 
     let last_exit_status = info
         .last_exit_status
-        .as_ref()
-        .and_then(|s| s.status)
+        .as_option()
+        .and_then(|s| s.status.as_ref())
         .map(|status| match status {
             exit_status::Status::Code(code) => serde_json::json!({ "code": code }),
             exit_status::Status::Signal(signal) => serde_json::json!({ "signal": signal }),
         });
     let payload = serde_json::json!({
         "id": info.id,
-        "state": state_name(info.state()),
+        "state": state_name(info.state.as_known().unwrap_or_default()),
         "labels": info.labels,
-        "limits": info.limits.map(|l| serde_json::json!({
+        "limits": info.limits.as_option().map(|l| serde_json::json!({
             "vcpus": l.vcpus,
             "memory_mib": l.memory_mib,
         })),
-        "network": info.network.map(|n| serde_json::json!({
+        "network": info.network.as_option().map(|n| serde_json::json!({
             "ip_address": n.ip_address,
             "gateway": n.gateway,
         })),
-        "created_at": format_timestamp(info.created_at.as_ref()),
-        "ready_at": format_timestamp(info.ready_at.as_ref()),
-        "last_exited_at": format_timestamp(info.last_exited_at.as_ref()),
+        "created_at": format_timestamp(info.created_at.as_option()),
+        "ready_at": format_timestamp(info.ready_at.as_option()),
+        "last_exited_at": format_timestamp(info.last_exited_at.as_option()),
         "last_exit_status": last_exit_status,
         "error": info.error,
     });
@@ -618,7 +623,7 @@ async fn execute_run(args: RunArgs) -> Result<()> {
         sandbox_id: args.id,
         cmd: args.cmd,
         tty: args.tty,
-        tty_size: current_tty_size(args.tty),
+        tty_size: current_tty_size(args.tty).into(),
         timeout_seconds: args.timeout,
         stdin: false,
         ..Default::default()
@@ -638,7 +643,7 @@ async fn execute_exec(args: ExecArgs) -> Result<()> {
         sandbox_id: args.id,
         cmd: args.cmd,
         tty: args.tty,
-        tty_size: current_tty_size(args.tty),
+        tty_size: current_tty_size(args.tty).into(),
         timeout_seconds: args.timeout,
         stdin: true,
         ..Default::default()
@@ -659,6 +664,7 @@ pub(super) fn current_tty_size(tty: bool) -> Option<ProtoTerminalSize> {
     TerminalSize::current().ok().map(|s| ProtoTerminalSize {
         width: u32::from(s.cols),
         height: u32::from(s.rows),
+        ..Default::default()
     })
 }
 
@@ -691,9 +697,7 @@ pub(super) async fn exec_session(
     let execution_id = start.execution_id.clone();
 
     client
-        .start_execution(crate::connect::request::<pb::StartExecutionRequest, _>(
-            &start,
-        )?)
+        .start_execution(start)
         .await
         .context("Failed to start execution in sandbox")?;
 
@@ -716,18 +720,13 @@ pub(super) async fn exec_session(
                         let req = ResizeExecutionTtyRequest {
                             sandbox_id: sandbox_id.clone(),
                             execution_id: execution_id.clone(),
-                            size: Some(ProtoTerminalSize {
+                            size: ProtoTerminalSize {
                                 width: u32::from(size.cols),
                                 height: u32::from(size.rows),
-                            }),
-                        };
-                        // A conversion failure here can only mean the two
-                        // generated representations disagree, which is a
-                        // build fault; either way this pump is best-effort.
-                        let Ok(req) =
-                            crate::connect::request::<pb::ResizeExecutionTtyRequest, _>(&req)
-                        else {
-                            break;
+                                ..Default::default()
+                            }
+                            .into(),
+                            ..Default::default()
                         };
                         if resize_client.resize_execution_tty(req).await.is_err() {
                             break;
@@ -762,12 +761,9 @@ pub(super) async fn exec_session(
                                 offset,
                                 data: Vec::new(),
                                 eof: true,
+                                ..Default::default()
                             };
-                            if let Ok(req) =
-                                crate::connect::request::<pb::WriteStdinRequest, _>(&req)
-                            {
-                                let _ = stdin_client.write_stdin(req).await;
-                            }
+                            let _ = stdin_client.write_stdin(req).await;
                         }
                         break;
                     }
@@ -783,19 +779,11 @@ pub(super) async fn exec_session(
                                 offset,
                                 data: buf[..n].to_vec(),
                                 eof: false,
-                            };
-                            let Ok(req) = crate::connect::request::<pb::WriteStdinRequest, _>(&req)
-                            else {
-                                break 'pump;
+                                ..Default::default()
                             };
                             match stdin_client.write_stdin(req).await {
                                 Ok(resp) => {
-                                    let Ok(status) =
-                                        resp.prost::<arcbox_protocol::sandbox_v1::StdinStatus>()
-                                    else {
-                                        break 'pump;
-                                    };
-                                    offset = status.bytes_written;
+                                    offset = resp.into_owned().bytes_written;
                                     break;
                                 }
                                 Err(_) if failures < ATTACH_RESUME_ATTEMPTS => {
@@ -834,11 +822,9 @@ pub(super) async fn exec_session(
             execution_id: execution_id.clone(),
             stdout_offset,
             stderr_offset,
+            ..Default::default()
         };
-        let mut stream = match client
-            .attach_execution(crate::connect::request(&attach)?)
-            .await
-        {
+        let mut stream = match client.attach_execution(attach).await {
             Ok(response) => response,
             Err(status) => {
                 attempt += 1;
@@ -858,7 +844,7 @@ pub(super) async fn exec_session(
 
         loop {
             let event = match stream.message::<pb::ExecutionEvent>().await {
-                Ok(Some(item)) => item.prost::<arcbox_protocol::sandbox_v1::ExecutionEvent>()?,
+                Ok(Some(item)) => item.to_owned_message(),
                 // Clean end without an exit event: fall through to the
                 // authoritative wait below.
                 Ok(None) => break 'resume,
@@ -883,7 +869,7 @@ pub(super) async fn exec_session(
                     // offset than requested when retention dropped bytes.
                     let end = output.offset + output.data.len() as u64;
                     let (target, sink): (&mut u64, &mut dyn Write) =
-                        if output.channel() == StdioChannel::Stderr {
+                        if output.channel == StdioChannel::Stderr {
                             (&mut stderr_offset, &mut std::io::stderr())
                         } else {
                             (&mut stdout_offset, &mut std::io::stdout())
@@ -898,7 +884,7 @@ pub(super) async fn exec_session(
                     }
                 }
                 Some(execution_event::Event::Exited(exited)) => {
-                    result = exited.execution;
+                    result = exited.execution.into_option();
                     break 'resume;
                 }
                 // The Started preamble and idle keepalives carry no output.
@@ -920,16 +906,15 @@ pub(super) async fn exec_session(
         // recover it. The execution itself is unaffected, so block on its
         // real outcome rather than reporting a synthetic failure.
         None => client
-            .wait_execution(crate::connect::request::<pb::WaitExecutionRequest, _>(
-                &WaitExecutionRequest {
-                    sandbox_id,
-                    execution_id,
-                    timeout_seconds: EXEC_WAIT_TIMEOUT_SECS,
-                },
-            )?)
+            .wait_execution(WaitExecutionRequest {
+                sandbox_id,
+                execution_id,
+                timeout_seconds: EXEC_WAIT_TIMEOUT_SECS,
+                ..Default::default()
+            })
             .await
             .context("attach stream closed without an exit event")?
-            .prost::<arcbox_protocol::sandbox_v1::Execution>()?,
+            .into_owned(),
     };
     Ok(exit_code_of(&execution))
 }
@@ -942,13 +927,12 @@ async fn execute_events(args: EventsArgs) -> Result<()> {
         Some(value) => parse_event_kind(value)?,
         None => SandboxEventKind::Unspecified,
     };
-    let req = SandboxEventsRequest {
-        sandbox_id: args.id.unwrap_or_default(),
-        kind: kind.into(),
-    };
-
     let mut stream = client
-        .events(crate::connect::request(&req)?)
+        .events(SandboxEventsRequest {
+            sandbox_id: args.id.unwrap_or_default(),
+            kind: kind.into(),
+            ..Default::default()
+        })
         .await
         .context("Failed to subscribe to sandbox events")?;
 
@@ -957,17 +941,16 @@ async fn execute_events(args: EventsArgs) -> Result<()> {
         .message::<pb::WatchEventsResponse>()
         .await
         .context("Failed to read sandbox event")?
-        .map(|item| item.prost::<arcbox_protocol::sandbox_v1::WatchEventsResponse>())
-        .transpose()?
+        .map(|item| item.to_owned_message())
     {
         let Some(watch_events_response::Payload::Event(event)) = frame.payload else {
             continue; // keepalive
         };
         println!(
             "[{}] sandbox={} kind={}",
-            format_timestamp(event.time.as_ref()),
+            format_timestamp(event.time.as_option()),
             event.sandbox_id,
-            event_kind_name(event.kind()),
+            event_kind_name(event.kind.as_known().unwrap_or_default()),
         );
         if !event.attributes.is_empty() {
             for (k, v) in &event.attributes {
@@ -982,22 +965,21 @@ async fn execute_checkpoint(args: CheckpointArgs) -> Result<()> {
     let (transport, config) = sandbox_channel();
     let client = SandboxSnapshotServiceClient::new(transport.clone(), config.clone());
 
-    let req = CheckpointRequest {
-        sandbox_id: args.id,
-        name: args.name,
-        labels: HashMap::new(),
-    };
-    let resp = client
-        .checkpoint(crate::connect::request(&req)?)
+    let resp: pb::CheckpointResponse = client
+        .checkpoint(CheckpointRequest {
+            sandbox_id: args.id,
+            name: args.name,
+            ..Default::default()
+        })
         .await
         .context("Failed to checkpoint sandbox")?
-        .prost::<arcbox_protocol::sandbox_v1::CheckpointResponse>()?;
+        .into_owned();
 
     println!("Snapshot created");
     println!("  Snapshot ID: {}", resp.snapshot_id);
     println!(
         "  Created at:  {}",
-        format_timestamp(resp.created_at.as_ref())
+        format_timestamp(resp.created_at.as_option())
     );
     Ok(())
 }
@@ -1006,17 +988,16 @@ async fn execute_restore(args: RestoreArgs) -> Result<()> {
     let (transport, config) = sandbox_channel();
     let client = SandboxSnapshotServiceClient::new(transport.clone(), config.clone());
 
-    let req = RestoreRequest {
-        id: args.sandbox_id.unwrap_or_default(),
-        snapshot_id: args.snapshot_id,
-        ttl_seconds: args.ttl,
-        ..Default::default()
-    };
-    let resp = client
-        .restore(crate::connect::request(&req)?)
+    let resp: pb::RestoreResponse = client
+        .restore(RestoreRequest {
+            id: args.sandbox_id.unwrap_or_default(),
+            snapshot_id: args.snapshot_id,
+            ttl_seconds: args.ttl,
+            ..Default::default()
+        })
         .await
         .context("Failed to restore sandbox")?
-        .prost::<arcbox_protocol::sandbox_v1::RestoreResponse>()?;
+        .into_owned();
 
     println!("Sandbox restored");
     println!("  ID: {}", resp.id);
@@ -1032,17 +1013,15 @@ async fn execute_list_snapshots(args: ListSnapshotsArgs) -> Result<()> {
     let mut snapshots = Vec::new();
     let mut page_token = String::new();
     loop {
-        let req = ListSnapshotsRequest {
-            sandbox_id: args.sandbox_id.clone().unwrap_or_default(),
-            labels: HashMap::new(),
-            page_size: 0,
-            page_token: page_token.clone(),
-        };
-        let mut resp = client
-            .list_snapshots(crate::connect::request(&req)?)
+        let mut resp: pb::ListSnapshotsResponse = client
+            .list_snapshots(ListSnapshotsRequest {
+                sandbox_id: args.sandbox_id.clone().unwrap_or_default(),
+                page_token: page_token.clone(),
+                ..Default::default()
+            })
             .await
             .context("Failed to list snapshots")?
-            .prost::<arcbox_protocol::sandbox_v1::ListSnapshotsResponse>()?;
+            .into_owned();
         snapshots.append(&mut resp.snapshots);
         if resp.next_page_token.is_empty() {
             break;
@@ -1065,7 +1044,7 @@ async fn execute_list_snapshots(args: ListSnapshotsArgs) -> Result<()> {
             snap.id,
             snap.sandbox_id,
             snap.name,
-            format_timestamp(snap.created_at.as_ref()),
+            format_timestamp(snap.created_at.as_option()),
         );
     }
     Ok(())
@@ -1075,11 +1054,11 @@ async fn execute_delete_snapshot(args: DeleteSnapshotArgs) -> Result<()> {
     let (transport, config) = sandbox_channel();
     let client = SandboxSnapshotServiceClient::new(transport.clone(), config.clone());
 
-    let req = DeleteSnapshotRequest {
-        snapshot_id: args.snapshot_id.clone(),
-    };
     client
-        .delete_snapshot(crate::connect::request(&req)?)
+        .delete_snapshot(DeleteSnapshotRequest {
+            snapshot_id: args.snapshot_id.clone(),
+            ..Default::default()
+        })
         .await
         .context("Failed to delete snapshot")?;
 
@@ -1131,29 +1110,37 @@ async fn execute_cp(args: CpArgs) -> Result<()> {
             // requests is enough — no channel or spawned task.
             const CHUNK: usize = 1024 * 1024;
             let open = WriteFileRequest {
-                payload: Some(write_file_request::Payload::Open(WriteFileOpen {
+                payload: WriteFileOpen {
                     id,
                     path,
                     mode,
-                })),
+                    ..Default::default()
+                }
+                .into(),
+                ..Default::default()
             };
             let chunks = data.chunks(CHUNK).map(|part| WriteFileRequest {
-                payload: Some(write_file_request::Payload::Chunk(FileChunk {
+                payload: FileChunk {
                     data: part.to_vec(),
                     done: false,
-                })),
+                    ..Default::default()
+                }
+                .into(),
+                ..Default::default()
             });
             let done = WriteFileRequest {
-                payload: Some(write_file_request::Payload::Chunk(FileChunk {
+                payload: FileChunk {
                     data: Vec::new(),
                     done: true,
-                })),
+                    ..Default::default()
+                }
+                .into(),
+                ..Default::default()
             };
-            let requests = std::iter::once(open)
+            let requests: Vec<_> = std::iter::once(open)
                 .chain(chunks)
                 .chain(std::iter::once(done))
-                .map(|msg| crate::connect::request::<pb::WriteFileRequest, _>(&msg))
-                .collect::<Result<Vec<_>>>()?;
+                .collect();
             client
                 .write_file(connectrpc::client::stream_iter(requests))
                 .await
@@ -1162,9 +1149,11 @@ async fn execute_cp(args: CpArgs) -> Result<()> {
         }
         (CpEndpoint::Sandbox { id, path }, CpEndpoint::Local(dst)) => {
             let mut stream = client
-                .read_file(crate::connect::request::<pb::ReadFileRequest, _>(
-                    &ReadFileRequest { id, path },
-                )?)
+                .read_file(ReadFileRequest {
+                    id,
+                    path,
+                    ..Default::default()
+                })
                 .await
                 .context("Failed to read file from sandbox")?;
 
@@ -1176,8 +1165,7 @@ async fn execute_cp(args: CpArgs) -> Result<()> {
                 .message::<pb::FileChunk>()
                 .await
                 .context("Failed to read file stream")?
-                .map(|item| item.prost::<arcbox_protocol::sandbox_v1::FileChunk>())
-                .transpose()?
+                .map(|item| item.to_owned_message())
             {
                 if !chunk.data.is_empty() {
                     tokio::io::AsyncWriteExt::write_all(&mut out, &chunk.data)
@@ -1206,17 +1194,17 @@ async fn execute_expose(args: ExposeArgs) -> Result<()> {
     let (transport, config) = sandbox_channel();
     let client = SandboxServiceClient::new(transport.clone(), config.clone());
     let protocol = parse_protocol(&args.protocol)?;
-    let request = crate::connect::request::<pb::ExposePortRequest, _>(&ExposePortRequest {
-        id: args.id.clone(),
-        sandbox_port: u32::from(args.port),
-        host_port: u32::from(args.host_port),
-        protocol: protocol.into(),
-    })?;
-    let resp = client
-        .expose_port(request)
+    let resp: pb::ExposePortResponse = client
+        .expose_port(ExposePortRequest {
+            id: args.id.clone(),
+            sandbox_port: u32::from(args.port),
+            host_port: u32::from(args.host_port),
+            protocol: protocol.into(),
+            ..Default::default()
+        })
         .await
         .context("Failed to expose sandbox port")?
-        .prost::<arcbox_protocol::sandbox_v1::ExposePortResponse>()?;
+        .into_owned();
     println!(
         "{}:{}/{} exposed on localhost:{}",
         args.id, args.port, args.protocol, resp.host_port
@@ -1228,13 +1216,13 @@ async fn execute_unexpose(args: UnexposeArgs) -> Result<()> {
     let (transport, config) = sandbox_channel();
     let client = SandboxServiceClient::new(transport.clone(), config.clone());
     let protocol = parse_protocol(&args.protocol)?;
-    let request = crate::connect::request::<pb::UnexposePortRequest, _>(&UnexposePortRequest {
-        id: args.id.clone(),
-        sandbox_port: u32::from(args.port),
-        protocol: protocol.into(),
-    })?;
     client
-        .unexpose_port(request)
+        .unexpose_port(UnexposePortRequest {
+            id: args.id.clone(),
+            sandbox_port: u32::from(args.port),
+            protocol: protocol.into(),
+            ..Default::default()
+        })
         .await
         .context("Failed to unexpose sandbox port")?;
     println!("{}:{}/{} unexposed", args.id, args.port, args.protocol);

--- a/app/arcbox-cli/src/commands/system.rs
+++ b/app/arcbox-cli/src/commands/system.rs
@@ -3,10 +3,10 @@
 use anyhow::{Context, Result};
 use arcbox_connect::v1 as pb;
 use arcbox_connect::v1::SystemServiceClient;
-use arcbox_protocol::v1::{SetSystemVmBackendRequest, SystemVmBackend};
+use arcbox_connect::v1::SystemVmBackend;
 use clap::{Subcommand, ValueEnum};
 
-use crate::connect::{self, UnaryExt as _};
+use crate::connect;
 
 #[derive(Debug, Subcommand)]
 pub enum SystemCommands {
@@ -58,30 +58,28 @@ pub async fn execute(cmd: SystemCommands) -> Result<()> {
     match cmd {
         SystemCommands::Backend { set } => {
             let client = system_client();
-            let info = if let Some(arg) = set {
+            let info: pb::SystemVmBackendInfo = if let Some(arg) = set {
                 let backend = SystemVmBackend::from(arg);
                 println!(
                     "Switching System VM backend to {} — restarting the System VM...",
                     label(backend)
                 );
-                let req: pb::SetSystemVmBackendRequest =
-                    connect::request(&SetSystemVmBackendRequest {
-                        backend: backend as i32,
-                    })?;
                 client
-                    .set_system_vm_backend(req)
+                    .set_system_vm_backend(pb::SetSystemVmBackendRequest {
+                        backend: backend.into(),
+                        ..Default::default()
+                    })
                     .await
                     .context("failed to switch System VM backend")?
-                    .prost::<arcbox_protocol::v1::SystemVmBackendInfo>()?
+                    .into_owned()
             } else {
                 client
                     .get_system_vm_backend(pb::Empty::default())
                     .await
                     .context("failed to query System VM backend")?
-                    .prost::<arcbox_protocol::v1::SystemVmBackendInfo>()?
+                    .into_owned()
             };
-            let current =
-                SystemVmBackend::try_from(info.backend).unwrap_or(SystemVmBackend::Unspecified);
+            let current = info.backend.as_known().unwrap_or_default();
             println!("System VM backend: {}", label(current));
             Ok(())
         }

--- a/app/arcbox-cli/src/commands/top.rs
+++ b/app/arcbox-cli/src/commands/top.rs
@@ -11,11 +11,11 @@ use std::fmt::Write as _;
 use anyhow::{Context, Result, bail};
 use arcbox_connect::v1 as pb;
 use arcbox_connect::v1::StatsServiceClient;
-use arcbox_protocol::v1::{ContainerStats, MachineStats};
+use arcbox_connect::v1::{ContainerStats, MachineStats};
 use clap::Args;
 
 use super::OutputFormat;
-use crate::connect::{self, StreamItemExt as _};
+use crate::connect;
 
 /// Arguments for `abctl top`.
 #[derive(Debug, Args)]
@@ -40,7 +40,7 @@ pub async fn execute(args: TopArgs, format: OutputFormat) -> Result<()> {
     let mut previous: Option<MachineStats> = None;
     loop {
         let sample: MachineStats = match stream.message::<pb::MachineStats>().await? {
-            Some(item) => item.prost()?,
+            Some(item) => item.to_owned_message(),
             None => bail!("stats stream ended (daemon shutting down?)"),
         };
         // Compute against the prior sample (if any) before it becomes the
@@ -310,6 +310,7 @@ mod tests {
             net_rx_bytes: 3000,
             net_tx_bytes: 4000,
             containers: vec![],
+            ..Default::default()
         }
     }
 
@@ -325,6 +326,7 @@ mod tests {
             pids: 3,
             net_rx_bytes: 0,
             net_tx_bytes: 0,
+            ..Default::default()
         }
     }
 

--- a/app/arcbox-cli/src/connect.rs
+++ b/app/arcbox-cli/src/connect.rs
@@ -12,10 +12,7 @@
 
 use std::path::Path;
 
-use anyhow::{Context as _, Result};
-
-use buffa::view::OwnedView;
-use connectrpc::client::{ClientConfig, Http2Connection, SharedHttp2Connection, UnaryResponse};
+use connectrpc::client::{ClientConfig, Http2Connection, SharedHttp2Connection};
 
 /// Concurrent in-flight requests a single client transport will buffer.
 ///
@@ -51,85 +48,4 @@ pub fn daemon(socket: &Path) -> (SharedHttp2Connection, ClientConfig) {
 pub fn daemon_for_machine(socket: &Path, machine: &str) -> (SharedHttp2Connection, ClientConfig) {
     let (transport, config) = daemon(socket);
     (transport, config.with_default_header("x-machine", machine))
-}
-
-/// Builds a Connect request from its prost twin.
-///
-/// The two representations come from the same `.proto` and encode identical
-/// bytes, so this is a re-encode rather than a field-by-field mapping — the
-/// same argument as the daemon's own bridge. It lets each command keep
-/// building requests from the prost types its argument parsing already
-/// produces, including enum discriminants.
-///
-/// # Errors
-///
-/// Returns an error if the bytes do not decode as `B`, which would mean the
-/// two generated representations disagree — a build fault, not a user one.
-pub fn request<B, P>(msg: &P) -> Result<B>
-where
-    B: buffa::Message + Default,
-    P: prost::Message,
-{
-    B::decode_from_slice(&msg.encode_to_vec()).with_context(|| {
-        format!(
-            "daemon request did not encode as {}",
-            std::any::type_name::<B>()
-        )
-    })
-}
-
-/// Reads a Connect response back as its prost twin.
-///
-/// The response arrives as a zero-copy view over the wire bytes; this
-/// decodes those same bytes as the prost message the rest of the CLI
-/// already formats and serializes. That is what keeps `--json` output
-/// byte-identical across this migration.
-pub trait UnaryExt {
-    /// The prost message the response bytes decode as.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the bytes do not decode as `P`, which would mean
-    /// the two generated representations disagree — a build fault, not a
-    /// user one.
-    fn prost<P: prost::Message + Default>(self) -> Result<P>;
-}
-
-impl<V: buffa::view::MessageView<'static>> UnaryExt for UnaryResponse<OwnedView<V>> {
-    fn prost<P: prost::Message + Default>(self) -> Result<P> {
-        P::decode(self.into_view().bytes().clone()).with_context(|| {
-            format!(
-                "daemon response did not decode as {}",
-                std::any::type_name::<P>()
-            )
-        })
-    }
-}
-
-/// The same crossing for one item of a server stream.
-///
-/// Streaming items arrive as views over retained wire bytes, exactly as
-/// unary responses do, so progress-rendering code keeps working on the
-/// prost types it already matches on.
-pub trait StreamItemExt {
-    /// The prost message this item's bytes decode as.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the bytes do not decode as `P`.
-    fn prost<P: prost::Message + Default>(&self) -> Result<P>;
-}
-
-impl<M> StreamItemExt for connectrpc::StreamMessage<M>
-where
-    M: buffa::Message + connectrpc::HasMessageView,
-{
-    fn prost<P: prost::Message + Default>(&self) -> Result<P> {
-        P::decode(self.bytes().clone()).with_context(|| {
-            format!(
-                "daemon stream item did not decode as {}",
-                std::any::type_name::<P>()
-            )
-        })
-    }
 }

--- a/app/arcbox-docker/Cargo.toml
+++ b/app/arcbox-docker/Cargo.toml
@@ -10,7 +10,6 @@ authors.workspace = true
 
 [dependencies]
 arcbox-core = { workspace = true }
-arcbox-protocol = { workspace = true }
 arcbox-transport = { workspace = true }
 arcbox-error = { workspace = true }
 thiserror = { workspace = true }

--- a/app/arcbox/Cargo.toml
+++ b/app/arcbox/Cargo.toml
@@ -13,7 +13,6 @@ categories = ["virtualization", "development-tools"]
 [dependencies]
 arcbox-hypervisor = { workspace = true }
 arcbox-virtio = { workspace = true }
-arcbox-protocol = { workspace = true }
 arcbox-vmm = { workspace = true }
 arcbox-container = { workspace = true }
 arcbox-fs = { workspace = true }

--- a/app/arcbox/src/lib.rs
+++ b/app/arcbox/src/lib.rs
@@ -9,20 +9,17 @@
 //!
 //! - **Hypervisor**: Platform abstraction for virtualization (macOS/Linux)
 //! - **VirtIO**: Virtual device implementations (block, net, fs, console)
-//! - **Protocol**: Protobuf message and service definitions
 //!
 //! # Example
 //!
 //! ```ignore
-//! use arcbox::{protocol, version};
+//! use arcbox::version;
 //!
-//! let _ = protocol::v1::Empty {};
 //! println!("arcbox facade version: {}", version());
 //! ```
 
 // Re-export core crates (available in this version)
 pub use arcbox_hypervisor as hypervisor;
-pub use arcbox_protocol as protocol;
 pub use arcbox_virtio as virtio;
 
 // TODO: uncomment after publishing these crates

--- a/rpc/arcbox-transport/Cargo.toml
+++ b/rpc/arcbox-transport/Cargo.toml
@@ -10,7 +10,6 @@ authors.workspace = true
 
 [dependencies]
 arcbox-error = { workspace = true }
-arcbox-protocol = { workspace = true }
 arcbox-constants = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
Stacked on #533 (B3). Phase B4, five commits: every abctl command consumes `arcbox_connect` buffa values directly. The prost bridge in `cli/connect.rs` (`request()` re-encode, `UnaryExt::prost`, `StreamItemExt::prost`) is deleted — the file keeps only the transport builders (136 → 54 lines). Dead `arcbox-protocol` deps dropped from arcbox-docker/arcbox-transport and the unused `arcbox::protocol` facade re-export removed.

Behavior invariants audited site-by-site: `--json` shapes unchanged (null semantics and the `last_exit_status` object preserved exactly), human output identical, interactive exec/PTY path untouched in behavior. With this, **ArcBox-owned protocols are single-typed on buffa end to end**; prost/tonic survive only as the deliberate exceptions (daemon+e2e wire-format proofs, daemon reflection's FILE_DESCRIPTOR_SET, guest containerd client, fleet).

⚠️ **Stacked PR — CI does not run** (`ci.yml` fires only on master-targeted PRs). Locally validated with exit codes: workspace check, clippy `-D warnings` --all-targets, `cargo test -p arcbox-cli -p arcbox-daemon` (62+35 pass), guest musl check, `cargo fmt --check`, release `abctl` builds and runs. Full CI runs when the stack lands on master.