### PR TITLE
fix(sandbox): make create retries idempotent

### DIFF
--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -53,7 +53,7 @@ pub(super) fn sandbox_service() -> Result<&'static Arc<SandboxService>, &'static
                 Ok(svc) => {
                     tracing::info!("sandbox service initialised");
                     let svc = Arc::new(svc);
-                    spawn_port_forward_cleanup(&svc);
+                    spawn_sandbox_cleanup(&svc);
                     Ok(svc)
                 }
                 Err(e) => {
@@ -65,22 +65,24 @@ pub(super) fn sandbox_service() -> Result<&'static Arc<SandboxService>, &'static
         .as_ref()
 }
 
-/// Drop every DNAT mapping of a sandbox as soon as it stops.
+/// Reconcile process-local state when a sandbox stops.
 ///
 /// Subscribing to lifecycle events covers all teardown paths — explicit
 /// Stop/Remove, TTL expiry, and boot failures — without threading cleanup
-/// hooks through each of them.
-fn spawn_port_forward_cleanup(svc: &Arc<SandboxService>) {
+/// hooks through each of them. Terminal sandboxes also release their retained
+/// idempotent Create response.
+fn spawn_sandbox_cleanup(svc: &Arc<SandboxService>) {
     use arcbox_connect::sandbox_v1::{SandboxEvent, SandboxEventKind, SandboxEventsRequest};
 
     let payload = SandboxEventsRequest::default().encode_to_vec();
     let mut rx = match svc.subscribe_events(&payload) {
         Ok(rx) => rx,
         Err(e) => {
-            tracing::warn!(error = %e, "port-forward cleanup subscription failed");
+            tracing::warn!(error = %e, "sandbox cleanup subscription failed");
             return;
         }
     };
+    let svc = Arc::clone(svc);
     tokio::spawn(async move {
         while let Some(encoded) = rx.recv().await {
             let Ok(event) = SandboxEvent::decode_from_slice(&encoded) else {
@@ -94,6 +96,7 @@ fn spawn_port_forward_cleanup(svc: &Arc<SandboxService>) {
                         | SandboxEventKind::Failed
                 )
             ) {
+                svc.clear_stale_completed_create(&event.sandbox_id);
                 port_forwards()
                     .lock()
                     .await

--- a/guest/arcbox-agent/src/create_registry.rs
+++ b/guest/arcbox-agent/src/create_registry.rs
@@ -1,0 +1,203 @@
+//! In-flight and completed sandbox creates keyed by caller-supplied ID.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use arcbox_connect::sandbox_v1::{CreateSandboxRequest, CreateSandboxResponse};
+use tokio::sync::watch;
+
+/// Coordinates idempotent sandbox creates for one guest-agent process.
+#[derive(Default)]
+pub struct CreateRegistry {
+    entries: Mutex<HashMap<String, Entry>>,
+}
+
+enum Entry {
+    Pending {
+        request: CreateSandboxRequest,
+        done: watch::Sender<bool>,
+    },
+    Completed {
+        request: CreateSandboxRequest,
+        response: CreateSandboxResponse,
+    },
+}
+
+/// Result of reserving a caller-supplied sandbox ID.
+pub enum Reserve {
+    Existing(CreateSandboxResponse),
+    Slot(SlotGuard),
+    AwaitPending(watch::Receiver<bool>),
+}
+
+/// The ID belongs to a different create request.
+#[derive(Debug)]
+pub struct Collision;
+
+/// Removes an unfinished reservation on drop.
+pub struct SlotGuard {
+    registry: Arc<CreateRegistry>,
+    id: String,
+    committed: bool,
+}
+
+impl SlotGuard {
+    /// Publish the response before waking matching retries.
+    pub(crate) fn commit(mut self, response: &CreateSandboxResponse) {
+        let mut entries = self.registry.entries.lock().unwrap();
+        let Some(Entry::Pending { request, done }) = entries.remove(&self.id) else {
+            unreachable!("a create slot stays pending until commit or drop");
+        };
+        entries.insert(
+            self.id.clone(),
+            Entry::Completed {
+                request,
+                response: response.clone(),
+            },
+        );
+        self.committed = true;
+        drop(entries);
+        let _ = done.send(true);
+    }
+}
+
+impl Drop for SlotGuard {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        let entry = self.registry.entries.lock().unwrap().remove(&self.id);
+        if let Some(Entry::Pending { done, .. }) = entry {
+            let _ = done.send(true);
+        }
+    }
+}
+
+impl CreateRegistry {
+    /// Reserve an ID, replay its response, or wait for its matching request.
+    pub(crate) fn reserve(
+        self: &Arc<Self>,
+        request: &CreateSandboxRequest,
+    ) -> Result<Reserve, Collision> {
+        debug_assert!(!request.id.is_empty());
+        let mut entries = self.entries.lock().unwrap();
+        match entries.get(&request.id) {
+            Some(Entry::Completed {
+                request: existing,
+                response,
+                ..
+            }) if existing == request => return Ok(Reserve::Existing(response.clone())),
+            Some(Entry::Pending {
+                request: existing,
+                done,
+            }) if existing == request => {
+                return Ok(Reserve::AwaitPending(done.subscribe()));
+            }
+            Some(_) => return Err(Collision),
+            None => {}
+        }
+
+        entries.insert(
+            request.id.clone(),
+            Entry::Pending {
+                request: request.clone(),
+                done: watch::channel(false).0,
+            },
+        );
+        Ok(Reserve::Slot(SlotGuard {
+            registry: Arc::clone(self),
+            id: request.id.clone(),
+            committed: false,
+        }))
+    }
+
+    /// Forget a completed response when its sandbox is no longer live.
+    pub(crate) fn clear_completed_if(&self, id: &str, should_clear: impl FnOnce() -> bool) {
+        let mut entries = self.entries.lock().unwrap();
+        if matches!(entries.get(id), Some(Entry::Completed { .. })) && should_clear() {
+            entries.remove(id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_request(template: &str) -> CreateSandboxRequest {
+        CreateSandboxRequest {
+            id: "fixed-id".into(),
+            template: template.into(),
+            ..CreateSandboxRequest::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn matching_retry_waits_and_replays_the_original_response() {
+        let registry = Arc::new(CreateRegistry::default());
+        let request = create_request("docker:alpine");
+        let Reserve::Slot(slot) = registry.reserve(&request).unwrap() else {
+            panic!("first create must reserve the ID");
+        };
+        let Reserve::AwaitPending(mut waiter) = registry.reserve(&request).unwrap() else {
+            panic!("matching retry must wait");
+        };
+
+        let response = CreateSandboxResponse {
+            id: request.id.clone(),
+            ip_address: "172.20.0.2".into(),
+            ..CreateSandboxResponse::default()
+        };
+        slot.commit(&response);
+        waiter.changed().await.expect("commit wakes retry");
+
+        let Reserve::Existing(replayed) = registry.reserve(&request).unwrap() else {
+            panic!("completed create must replay");
+        };
+        assert_eq!(replayed, response);
+        assert!(registry.reserve(&create_request("docker:debian")).is_err());
+    }
+
+    #[tokio::test]
+    async fn failed_create_releases_the_id() {
+        let registry = Arc::new(CreateRegistry::default());
+        let request = create_request("");
+        let Reserve::Slot(slot) = registry.reserve(&request).unwrap() else {
+            panic!("first create must reserve the ID");
+        };
+        let Reserve::AwaitPending(mut waiter) = registry.reserve(&request).unwrap() else {
+            panic!("matching retry must wait");
+        };
+        drop(slot);
+        waiter.changed().await.expect("drop wakes retry");
+        assert!(matches!(
+            registry.reserve(&request).unwrap(),
+            Reserve::Slot(_)
+        ));
+    }
+
+    #[test]
+    fn stale_completed_create_releases_the_id() {
+        let registry = Arc::new(CreateRegistry::default());
+        let request = create_request("");
+        let Reserve::Slot(slot) = registry.reserve(&request).unwrap() else {
+            panic!("first create must reserve the ID");
+        };
+        let response = CreateSandboxResponse {
+            id: request.id.clone(),
+            ..CreateSandboxResponse::default()
+        };
+        slot.commit(&response);
+        registry.clear_completed_if(&request.id, || false);
+        assert!(matches!(
+            registry.reserve(&request).unwrap(),
+            Reserve::Existing(_)
+        ));
+
+        registry.clear_completed_if(&request.id, || true);
+        assert!(matches!(
+            registry.reserve(&request).unwrap(),
+            Reserve::Slot(_)
+        ));
+    }
+}

--- a/guest/arcbox-agent/src/lib.rs
+++ b/guest/arcbox-agent/src/lib.rs
@@ -8,6 +8,8 @@ mod rpc;
 #[cfg(target_os = "linux")]
 pub mod config;
 pub mod containerd;
+#[cfg(any(target_os = "linux", test))]
+mod create_registry;
 pub mod dns;
 pub mod dns_server;
 #[cfg(target_os = "linux")]

--- a/guest/arcbox-agent/src/main.rs
+++ b/guest/arcbox-agent/src/main.rs
@@ -29,6 +29,8 @@ mod stats;
 mod metadata_migrate;
 
 #[cfg(target_os = "linux")]
+mod create_registry;
+#[cfg(target_os = "linux")]
 mod error;
 
 mod rpc;

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -15,9 +15,13 @@ mod template;
 use std::sync::Arc;
 
 use arcbox_connect::sandbox_v1;
-use arcbox_vm::{SandboxManager, SandboxMountSpec, SandboxNetworkSpec, SandboxSpec, VmmConfig};
+use arcbox_vm::{
+    SandboxManager, SandboxMountSpec, SandboxNetworkSpec, SandboxSpec, SandboxState, VmmConfig,
+    VmmError,
+};
 use buffa::Message;
 
+use crate::create_registry::{CreateRegistry, Reserve as CreateReserve};
 use crate::error::SandboxError;
 
 /// Verify the nested-virtualization prerequisite for sandboxes.
@@ -49,6 +53,7 @@ pub fn probe_kvm() -> Result<(), String> {
 /// Thin wrapper around [`SandboxManager`] for use in the agent's RPC layer.
 pub struct SandboxService {
     manager: Arc<SandboxManager>,
+    creates: Arc<CreateRegistry>,
     /// Default rootfs image path; auto-built on first use when missing.
     default_rootfs: String,
 }
@@ -57,9 +62,11 @@ impl SandboxService {
     /// Create a new [`SandboxService`] from the given config.
     pub fn new(config: VmmConfig) -> anyhow::Result<Self> {
         let default_rootfs = config.defaults.rootfs.clone();
-        let manager = SandboxManager::new(config).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let manager = Arc::new(SandboxManager::new(config).map_err(|e| anyhow::anyhow!("{e}"))?);
+        let creates = Arc::new(CreateRegistry::default());
         Ok(Self {
-            manager: Arc::new(manager),
+            manager,
+            creates,
             default_rootfs,
         })
     }
@@ -76,10 +83,39 @@ impl SandboxService {
         &self,
         payload: &[u8],
     ) -> Result<sandbox_v1::CreateSandboxResponse, SandboxError> {
-        let req = sandbox_v1::CreateSandboxRequest::decode_from_slice(payload)
+        let request = sandbox_v1::CreateSandboxRequest::decode_from_slice(payload)
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
-        let template = template::Template::parse(&req.template)?;
-        let mut spec = proto_to_spec(req);
+        if request.id.is_empty() {
+            return self.create_once(request).await;
+        }
+
+        let id = request.id.clone();
+        loop {
+            self.clear_stale_completed_create(&id);
+            match self.creates.reserve(&request).map_err(|_| {
+                SandboxError::AlreadyExists(format!(
+                    "sandbox '{id}' (id reused for a different create request)"
+                ))
+            })? {
+                CreateReserve::Existing(response) => return Ok(response),
+                CreateReserve::Slot(slot) => {
+                    let response = self.create_once(request).await?;
+                    slot.commit(&response);
+                    return Ok(response);
+                }
+                CreateReserve::AwaitPending(mut done) => {
+                    let _ = done.changed().await;
+                }
+            }
+        }
+    }
+
+    async fn create_once(
+        &self,
+        request: sandbox_v1::CreateSandboxRequest,
+    ) -> Result<sandbox_v1::CreateSandboxResponse, SandboxError> {
+        let template = template::Template::parse(&request.template)?;
+        let mut spec = proto_to_spec(request);
 
         // V1 contract: reject declared-but-unimplemented spec fields
         // explicitly instead of silently ignoring them.
@@ -167,6 +203,7 @@ impl SandboxService {
             .await
             .map_err(SandboxError::from)?;
         deregister_sandbox_dns(&req.id);
+        self.clear_stale_completed_create(&req.id);
         Ok(())
     }
 
@@ -208,6 +245,29 @@ impl SandboxService {
             .ok_or_else(|| {
                 SandboxError::Internal(format!("sandbox '{sandbox_id}' has no network allocation"))
             })
+    }
+
+    pub(crate) fn clear_stale_completed_create(&self, id: &str) {
+        self.creates.clear_completed_if(id, || {
+            completed_create_is_stale(
+                self.manager
+                    .inspect_sandbox(&id.to_owned())
+                    .map(|info| info.state),
+            )
+        });
+    }
+}
+
+fn completed_create_is_stale(state: Result<SandboxState, VmmError>) -> bool {
+    match state {
+        Ok(SandboxState::Stopped | SandboxState::Failed) | Err(VmmError::NotFound(_)) => true,
+        Ok(
+            SandboxState::Starting
+            | SandboxState::Ready
+            | SandboxState::Running
+            | SandboxState::Stopping,
+        )
+        | Err(_) => false,
     }
 }
 
@@ -271,5 +331,31 @@ fn proto_to_spec(req: sandbox_v1::CreateSandboxRequest) -> SandboxSpec {
         network: SandboxNetworkSpec { mode: mode.into() },
         ttl_seconds: req.ttl_seconds,
         ssh_public_key: req.ssh_public_key,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completed_create_is_stale_only_after_terminal_or_removed_state() {
+        for state in [
+            SandboxState::Starting,
+            SandboxState::Ready,
+            SandboxState::Running,
+            SandboxState::Stopping,
+        ] {
+            assert!(!completed_create_is_stale(Ok(state)));
+        }
+        for state in [SandboxState::Stopped, SandboxState::Failed] {
+            assert!(completed_create_is_stale(Ok(state)));
+        }
+        assert!(completed_create_is_stale(Err(VmmError::NotFound(
+            "removed".into()
+        ))));
+        assert!(!completed_create_is_stale(Err(VmmError::Config(
+            "inspect failed".into()
+        ))));
     }
 }

--- a/guest/arcbox-agent/src/sandbox/snapshots.rs
+++ b/guest/arcbox-agent/src/sandbox/snapshots.rs
@@ -30,6 +30,9 @@ impl SandboxService {
     ) -> Result<sandbox_v1::RestoreResponse, SandboxError> {
         let req = sandbox_v1::RestoreRequest::decode_from_slice(payload)
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
+        if !req.id.is_empty() {
+            self.clear_stale_completed_create(&req.id);
+        }
         let spec = RestoreSandboxSpec {
             id: if req.id.is_empty() {
                 None

--- a/guest/arcbox-agent/tests/sandbox_service_manager.rs
+++ b/guest/arcbox-agent/tests/sandbox_service_manager.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use arcbox_agent::error::SandboxError;
 use arcbox_agent::sandbox::SandboxService;
 use arcbox_connect::sandbox_v1::{
     CreateSandboxRequest, InspectSandboxRequest, ListSandboxesRequest, NetworkMode, NetworkSpec,
@@ -71,6 +72,7 @@ async fn sandbox_service_calls_sandbox_manager() {
 
     // Empty template = the built-in busybox image.
     let create_req = CreateSandboxRequest {
+        id: "svc-manager".to_string(),
         labels: std::iter::once(("suite".to_string(), "svc-manager".to_string())).collect(),
         network: NetworkSpec {
             mode: NetworkMode::None.into(),
@@ -168,6 +170,12 @@ async fn sandbox_service_calls_sandbox_manager() {
     }
     .encode_to_vec();
     service.stop(&stop_payload).await.expect("stop failed");
+
+    let retry_error = match service.create(&create_payload).await {
+        Err(error) => error,
+        Ok(_) => panic!("stopped sandbox must not replay its stale Create response"),
+    };
+    assert!(matches!(retry_error, SandboxError::AlreadyExists(_)));
 
     let remove_payload = RemoveSandboxRequest {
         id: sandbox_id,


### PR DESCRIPTION
## Summary

- coalesce concurrent `CreateSandbox` calls with the same caller-supplied ID and identical request
- replay the original successful response instead of returning `ALREADY_EXISTS`
- reject reuse of an ID with a different request
- release failed or cancelled reservations and clean retained results on remove, TTL expiry, and restore

## Root cause

The manager atomically reserved sandbox IDs to protect resources, but every duplicate request was treated as a collision. If the first response was lost, an identical retry reached that reservation and returned `ALREADY_EXISTS`, so clients could not determine whether creation had succeeded.

## Validation

- `devenv shell -- cargo test -p arcbox-agent` — 124 passed
- `devenv shell -- cargo build -p arcbox-agent --target aarch64-unknown-linux-musl --release`
- `devenv shell -- cargo clippy -p arcbox-agent --target aarch64-unknown-linux-musl --all-targets`
- `devenv shell -- cargo fmt --all --check`
