### PR TITLE
refactor(rpc,daemon,fleet): prost becomes test support only (CORE-73 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,6 @@ dependencies = [
  "dashmap",
  "dirs",
  "hostname",
- "hyper",
  "hyper-util",
  "keyring",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,7 @@ name = "arcbox-fleet-agent"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "arcbox-connect",
  "arcbox-constants",
  "arcbox-fleet-control-proto",
  "arcbox-fleet-proto",
@@ -602,9 +603,11 @@ dependencies = [
  "bollard",
  "clap",
  "command-group",
+ "connectrpc",
  "dashmap",
  "dirs",
  "hostname",
+ "hyper",
  "hyper-util",
  "keyring",
  "libc",

--- a/app/arcbox-daemon/Cargo.toml
+++ b/app/arcbox-daemon/Cargo.toml
@@ -36,12 +36,12 @@ http-body-util = "0.1"
 tokio-util = "0.7"
 arcbox-docker-tools.workspace = true
 filetime = "0.2.29"
-arcbox-grpc.workspace = true
 arcbox-transport.workspace = true
 connectrpc = { version = "0.8.1", features = ["axum"], git = "https://github.com/connectrpc/connect-rust", rev = "c5c1a6faa5d7f4d681662731db61e1fbe7796eec" }
 hyper-util = { version = "0.1.20", features = ["server", "server-auto", "server-graceful", "tokio", "http1", "http2", "service"] }
 hyper = { workspace = true, features = ["server", "http1", "http2"] }
 connectrpc-reflection = { git = "https://github.com/connectrpc/connect-rust", rev = "c5c1a6faa5d7f4d681662731db61e1fbe7796eec", version = "0.8.0" }
+arcbox-connect = { version = "0.6.0", path = "../../rpc/arcbox-connect" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 arcbox-route.workspace = true
@@ -63,7 +63,6 @@ gic = ["arcbox-core/gic"]
 workspace = true
 
 [dev-dependencies]
-arcbox-connect = { path = "../../rpc/arcbox-connect" }
 arcbox-grpc.workspace = true
 arcbox-protocol.workspace = true
 connectrpc = { git = "https://github.com/connectrpc/connect-rust", rev = "c5c1a6faa5d7f4d681662731db61e1fbe7796eec", features = ["client"] }

--- a/app/arcbox-daemon/Cargo.toml
+++ b/app/arcbox-daemon/Cargo.toml
@@ -41,7 +41,7 @@ connectrpc = { version = "0.8.1", features = ["axum"], git = "https://github.com
 hyper-util = { version = "0.1.20", features = ["server", "server-auto", "server-graceful", "tokio", "http1", "http2", "service"] }
 hyper = { workspace = true, features = ["server", "http1", "http2"] }
 connectrpc-reflection = { git = "https://github.com/connectrpc/connect-rust", rev = "c5c1a6faa5d7f4d681662731db61e1fbe7796eec", version = "0.8.0" }
-arcbox-connect = { version = "0.6.0", path = "../../rpc/arcbox-connect" }
+arcbox-connect.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 arcbox-route.workspace = true

--- a/app/arcbox-daemon/src/control_plane.rs
+++ b/app/arcbox-daemon/src/control_plane.rs
@@ -98,10 +98,12 @@ pub fn bind(socket_path: &std::path::Path) -> Result<UnixListener> {
 /// The descriptor set is `arcbox-connect`'s own — emitted by the same
 /// build script that generates the served types, so it tracks the
 /// GENERATED surface exactly. That is deliberately a superset of the
-/// served one: reflection also advertises the schema-only `AgentService`,
-/// the unregistered Container/Image services, and (off macOS) the
-/// cfg-gated `MacosService` — the same superset the prost-built set
-/// always advertised.
+/// served one — reflection advertises every service the protos declare:
+/// the schema-only `AgentService`, the never-implemented Container,
+/// Image, Network, and Volume services, and (off macOS) the cfg-gated
+/// `MacosService`. A reflected service 404ing on every format is one of
+/// these, not a router bug. The prost-built set advertised the same
+/// superset.
 ///
 /// # Errors
 ///

--- a/app/arcbox-daemon/src/control_plane.rs
+++ b/app/arcbox-daemon/src/control_plane.rs
@@ -107,7 +107,7 @@ pub fn connect_router(
     system: arcbox_api::SystemServiceImpl,
 ) -> Result<connectrpc::Router> {
     let reflector = connectrpc_reflection::Reflector::from_descriptor_set_bytes(
-        arcbox_grpc::FILE_DESCRIPTOR_SET,
+        arcbox_connect::FILE_DESCRIPTOR_SET,
     )
     .context("parsing the embedded file descriptor set for reflection")?;
     Ok(connectrpc_reflection::install(

--- a/app/arcbox-daemon/src/control_plane.rs
+++ b/app/arcbox-daemon/src/control_plane.rs
@@ -96,8 +96,12 @@ pub fn bind(socket_path: &std::path::Path) -> Result<UnixListener> {
 /// the services themselves.
 ///
 /// The descriptor set is `arcbox-connect`'s own — emitted by the same
-/// build script that generates the served types, so the reflected surface
-/// cannot drift from the implemented one.
+/// build script that generates the served types, so it tracks the
+/// GENERATED surface exactly. That is deliberately a superset of the
+/// served one: reflection also advertises the schema-only `AgentService`,
+/// the unregistered Container/Image services, and (off macOS) the
+/// cfg-gated `MacosService` — the same superset the prost-built set
+/// always advertised.
 ///
 /// # Errors
 ///

--- a/app/arcbox-daemon/src/control_plane.rs
+++ b/app/arcbox-daemon/src/control_plane.rs
@@ -95,8 +95,9 @@ pub fn bind(socket_path: &std::path::Path) -> Result<UnixListener> {
 /// calls are unaffected, which is why `curl --unix-socket` still works for
 /// the services themselves.
 ///
-/// The descriptor set is standard protobuf wire bytes, so the same one
-/// `arcbox-grpc` emits for its prost build describes every service here.
+/// The descriptor set is `arcbox-connect`'s own — emitted by the same
+/// build script that generates the served types, so the reflected surface
+/// cannot drift from the implemented one.
 ///
 /// # Errors
 ///

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -38,8 +38,6 @@ command-group = { version = "5.0.1", features = ["with-tokio"] }
 tokio-util = { version = "0.7.18", features = ["rt"] }
 bollard = "0.21.0"
 hyper-util = "0.1"
-arcbox-grpc.workspace = true
-arcbox-protocol.workspace = true
 arcbox-constants.workspace = true
 russh = { version = "0.62.1", default-features = false, features = ["aws-lc-rs", "flate2"] }
 thiserror.workspace = true
@@ -48,6 +46,9 @@ libc.workspace = true
 sha2.workspace = true
 reqwest = { version = "0.13.4", default-features = false, features = ["rustls"] }
 uuid = { workspace = true }
+arcbox-connect = { version = "0.6.0", path = "../../rpc/arcbox-connect" }
+connectrpc = { git = "https://github.com/connectrpc/connect-rust", rev = "c5c1a6faa5d7f4d681662731db61e1fbe7796eec", version = "0.8.1", features = ["client"] }
+hyper.workspace = true
 
 [lints]
 workspace = true
@@ -56,5 +57,7 @@ workspace = true
 keyring = "4"
 
 [dev-dependencies]
+arcbox-grpc.workspace = true
+arcbox-protocol.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }

--- a/fleet/arcbox-fleet-agent/Cargo.toml
+++ b/fleet/arcbox-fleet-agent/Cargo.toml
@@ -46,9 +46,8 @@ libc.workspace = true
 sha2.workspace = true
 reqwest = { version = "0.13.4", default-features = false, features = ["rustls"] }
 uuid = { workspace = true }
-arcbox-connect = { version = "0.6.0", path = "../../rpc/arcbox-connect" }
+arcbox-connect.workspace = true
 connectrpc = { git = "https://github.com/connectrpc/connect-rust", rev = "c5c1a6faa5d7f4d681662731db61e1fbe7796eec", version = "0.8.1", features = ["client"] }
-hyper.workspace = true
 
 [lints]
 workspace = true

--- a/fleet/arcbox-fleet-agent/src/control/image.rs
+++ b/fleet/arcbox-fleet-agent/src/control/image.rs
@@ -196,6 +196,7 @@ impl FleetImageServiceTrait for ImageService {
                                         ))
                                     })?;
                                     let Some(progress) = progress else { break };
+                                    let progress = progress.to_owned_message();
                                     yield event(kind, &progress.stage, "pulling", progress.fraction);
                                 }
                                 // A pull through a direct dial leaves a daemon that

--- a/fleet/arcbox-fleet-agent/src/vm.rs
+++ b/fleet/arcbox-fleet-agent/src/vm.rs
@@ -26,14 +26,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
-use arcbox_grpc::MacosServiceClient;
-use arcbox_protocol::v1::{
-    CreateMacosMachineRequest, Empty, InspectMacosMachineRequest, MacosImageSummary,
-    RemoveMacosMachineRequest, StartMacosMachineRequest,
+use arcbox_connect::v1::{
+    CreateMacosMachineRequest, Empty, InspectMacosMachineRequest, MacosImagePullRequest,
+    MacosImageSummary, MacosServiceClient, RemoveMacosMachineRequest, StartMacosMachineRequest,
 };
+use connectrpc::Protocol;
+use connectrpc::client::{ClientConfig, Http2Connection, SharedHttp2Connection};
 use russh::client::{Config as SshConfig, Handle as SshHandle};
 use russh::{ChannelMsg, Disconnect};
-use tonic::transport::Channel;
 use tracing::{debug, info, warn};
 
 use crate::host;
@@ -44,6 +44,17 @@ const GUEST_SSH_USER: &str = "admin";
 const GUEST_SSH_PASSWORD: &str = "admin";
 const GUEST_RUNNER_SCRIPT: &str = "/Users/admin/actions-runner/run.sh";
 const SSH_PORT: u16 = 22;
+
+/// Concurrent in-flight requests the daemon transport will buffer — a
+/// couple of unary calls plus one progress stream never queue.
+const TRANSPORT_BUFFER: usize = 32;
+
+/// Progress stream from `MacosService.ImagePull`, concretized for the
+/// daemon transport below.
+pub type PullStream = connectrpc::client::ServerStream<
+    hyper::body::Incoming,
+    arcbox_connect::v1::__buffa::view::MacosImagePullEventView<'static>,
+>;
 
 /// Budget for a freshly started guest to acquire its DHCP lease and answer
 /// SSH. First boots take minutes; the DHCP lease appears well before
@@ -78,7 +89,7 @@ fn stream_name(reference: &str) -> &str {
 /// Runs darwin jobs in disposable macOS guests via the local arcbox-daemon.
 #[derive(Clone)]
 pub struct VmRunner {
-    client: MacosServiceClient<Channel>,
+    client: MacosServiceClient<SharedHttp2Connection>,
 }
 
 impl VmRunner {
@@ -114,10 +125,17 @@ impl VmRunner {
     /// what that pull is about to fix, so demanding the full readiness
     /// probe first would be circular.
     pub async fn connect(daemon_socket: &Path) -> Result<Self> {
-        let channel = crate::control::client::connect(daemon_socket).await?;
-        let mut client = MacosServiceClient::new(channel);
+        // Speak the gRPC protocol: the daemon's Connect router answers it,
+        // and so does the tonic mock daemon in tests — which thereby stays
+        // an independent-implementation interop check.
+        let authority = "http://localhost".parse().expect("static authority parses");
+        let transport =
+            Http2Connection::lazy_unix(daemon_socket, authority).shared(TRANSPORT_BUFFER);
+        let config = ClientConfig::new("http://localhost".parse().expect("static base URI parses"))
+            .with_protocol(Protocol::Grpc);
+        let client = MacosServiceClient::new(transport, config);
         client
-            .image_list(Empty {})
+            .image_list(Empty::default())
             .await
             .context("daemon does not serve macOS guests (MacosService.ImageList failed)")?;
         Ok(Self { client })
@@ -127,9 +145,9 @@ impl VmRunner {
     /// names (the control socket is a per-host singleton), so anything
     /// matching is an orphan from a previous process.
     async fn sweep_leftovers(&self) {
-        let mut client = self.client.clone();
-        let machines = match client.list(Empty {}).await {
-            Ok(response) => response.into_inner().machines,
+        let client = self.client.clone();
+        let machines = match client.list(Empty::default()).await {
+            Ok(response) => response.into_owned().machines,
             Err(e) => {
                 warn!(error = %e, "listing leftover fleet guests failed");
                 return;
@@ -138,7 +156,7 @@ impl VmRunner {
         for machine in machines {
             if machine.name.starts_with("fleet-") {
                 warn!(name = %machine.name, "removing leftover fleet guest");
-                remove_vm(&mut client, &machine.name).await;
+                remove_vm(&client, &machine.name).await;
             }
         }
     }
@@ -147,8 +165,8 @@ impl VmRunner {
     /// idempotent. Remove-before-bind ahead of a create, and the cleanup
     /// when cancellation interrupts [`start`](Self::start) mid-flight.
     pub async fn remove_job_vm(&self, job_id: &str) {
-        let mut client = self.client.clone();
-        remove_vm(&mut client, &machine_name(job_id)).await;
+        let client = self.client.clone();
+        remove_vm(&client, &machine_name(job_id)).await;
     }
 
     /// Pull `reference` through the daemon, returning its progress stream
@@ -156,19 +174,17 @@ impl VmRunner {
     /// this to converge `macos_runner_image` onto its target; a pull the
     /// daemon already has registered completes immediately, so
     /// re-preparation is cheap when nothing changed.
-    pub async fn pull(
-        &self,
-        reference: &str,
-    ) -> Result<tonic::Streaming<arcbox_protocol::v1::MacosImagePullEvent>> {
-        let mut client = self.client.clone();
-        let stream = client
-            .image_pull(arcbox_protocol::v1::MacosImagePullRequest {
+    pub async fn pull(&self, reference: &str) -> Result<PullStream> {
+        let stream = self
+            .client
+            .image_pull(MacosImagePullRequest {
                 reference: reference.to_owned(),
                 manifest_url: String::new(),
+                ..Default::default()
             })
             .await
             .with_context(|| format!("pulling macOS image '{reference}' through the daemon"))?;
-        Ok(stream.into_inner())
+        Ok(stream)
     }
 
     /// Provision a guest for `spec` and start the runner in it, returning a
@@ -196,11 +212,11 @@ impl VmRunner {
     /// provision→ssh→exec→destroy cycle without a real runner invocation.
     async fn start_with_command(&self, spec: &RunSpec<'_>, command: &str) -> Result<RunningVm> {
         let name = machine_name(spec.job_id);
-        let mut client = self.client.clone();
+        let client = self.client.clone();
 
         // The name is deterministic per job, so a redelivery after a crash
         // that left an orphan would otherwise collide on create.
-        remove_vm(&mut client, &name).await;
+        remove_vm(&client, &name).await;
 
         let image = self.installed_image(spec.runner_image).await?;
         let (cpus, memory_mib) = guest_size(&image, host::cpu_cores(), host::mem_mib());
@@ -210,6 +226,7 @@ impl VmRunner {
                 image: image.name.clone(),
                 cpus,
                 memory_mib,
+                ..Default::default()
             })
             .await
             .context("creating macOS guest")?;
@@ -217,7 +234,10 @@ impl VmRunner {
         // Everything from here on owns a guest; tear it down on any error.
         let provisioned = async {
             client
-                .start(StartMacosMachineRequest { name: name.clone() })
+                .start(StartMacosMachineRequest {
+                    name: name.clone(),
+                    ..Default::default()
+                })
                 .await
                 .context("starting macOS guest (a two-guest license-cap refusal lands here)")?;
 
@@ -245,7 +265,7 @@ impl VmRunner {
         .await;
 
         if provisioned.is_err() {
-            remove_vm(&mut client, &name).await;
+            remove_vm(&client, &name).await;
         }
         provisioned
     }
@@ -254,12 +274,12 @@ impl VmRunner {
     /// minimums. Not being installed is a per-job failure (reject), not a
     /// backend fault: the image may have been removed since the probe.
     async fn installed_image(&self, reference: &str) -> Result<MacosImageSummary> {
-        let mut client = self.client.clone();
+        let client = self.client.clone();
         let images = client
-            .image_list(Empty {})
+            .image_list(Empty::default())
             .await
             .context("listing daemon macOS images")?
-            .into_inner()
+            .into_owned()
             .images;
         images
             .into_iter()
@@ -269,15 +289,16 @@ impl VmRunner {
 
     /// Poll `Inspect` until the guest reports its DHCP-lease address.
     async fn await_ip(&self, name: &str, deadline: tokio::time::Instant) -> Result<String> {
-        let mut client = self.client.clone();
+        let client = self.client.clone();
         loop {
             let info = client
                 .inspect(InspectMacosMachineRequest {
                     name: name.to_owned(),
+                    ..Default::default()
                 })
                 .await
                 .context("inspecting macOS guest")?
-                .into_inner();
+                .into_owned();
             if !info.ip_address.is_empty() {
                 return Ok(info.ip_address);
             }
@@ -367,7 +388,7 @@ impl russh::client::Handler for SshClient {
 /// caller's bookkeeping settles only after the guest is actually gone. The
 /// embedded [`VmGuard`] is a panic safety net, not the teardown path.
 pub struct RunningVm {
-    client: MacosServiceClient<Channel>,
+    client: MacosServiceClient<SharedHttp2Connection>,
     guard: VmGuard,
     name: String,
     ssh: SshHandle<SshClient>,
@@ -400,7 +421,7 @@ impl RunningVm {
     /// failed loudly in the log.
     pub async fn destroy(self) {
         let Self {
-            mut client,
+            client,
             guard,
             name,
             ssh,
@@ -409,24 +430,30 @@ impl RunningVm {
         guard.defuse();
         drop(channel);
         let _ = ssh.disconnect(Disconnect::ByApplication, "", "en").await;
-        remove_vm(&mut client, &name).await;
+        remove_vm(&client, &name).await;
     }
 }
 
 /// Force-remove a guest, awaited and idempotent: "not found" is the normal
 /// no-leftover case, anything else is logged — the job itself already
 /// concluded, so removal failures must not fail the caller.
-async fn remove_vm(client: &mut MacosServiceClient<Channel>, name: &str) {
+async fn remove_vm(client: &MacosServiceClient<SharedHttp2Connection>, name: &str) {
     let request = RemoveMacosMachineRequest {
         name: name.to_owned(),
         force: true,
+        ..Default::default()
     };
     match client.remove(request).await {
         Ok(_) => {}
-        Err(status) if status.code() == tonic::Code::NotFound => {}
+        Err(status) if status.code == connectrpc::ErrorCode::NotFound => {}
         // The daemon maps not-found to Internal today; match on message
         // until it grows structured codes.
-        Err(status) if status.message().contains("not found") => {}
+        Err(status)
+            if status
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("not found") => {}
         Err(status) => warn!(guest = name, error = %status, "failed to remove macOS guest"),
     }
 }
@@ -438,13 +465,13 @@ async fn remove_vm(client: &mut MacosServiceClient<Channel>, name: &str) {
 /// cannot await); it must never be the path a correctness guarantee rides
 /// on.
 struct VmGuard {
-    client: MacosServiceClient<Channel>,
+    client: MacosServiceClient<SharedHttp2Connection>,
     name: String,
     defused: bool,
 }
 
 impl VmGuard {
-    fn new(client: MacosServiceClient<Channel>, name: String) -> Self {
+    fn new(client: MacosServiceClient<SharedHttp2Connection>, name: String) -> Self {
         Self {
             client,
             name,
@@ -463,10 +490,10 @@ impl Drop for VmGuard {
         if self.defused {
             return;
         }
-        let mut client = self.client.clone();
+        let client = self.client.clone();
         let name = std::mem::take(&mut self.name);
         tokio::spawn(async move {
-            remove_vm(&mut client, &name).await;
+            remove_vm(&client, &name).await;
         });
     }
 }

--- a/fleet/arcbox-fleet-agent/src/vm.rs
+++ b/fleet/arcbox-fleet-agent/src/vm.rs
@@ -27,8 +27,9 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use arcbox_connect::v1::{
-    CreateMacosMachineRequest, Empty, InspectMacosMachineRequest, MacosImagePullRequest,
-    MacosImageSummary, MacosServiceClient, RemoveMacosMachineRequest, StartMacosMachineRequest,
+    CreateMacosMachineRequest, Empty, InspectMacosMachineRequest, MacosImagePullEvent,
+    MacosImagePullRequest, MacosImageSummary, MacosServiceClient, RemoveMacosMachineRequest,
+    StartMacosMachineRequest,
 };
 use connectrpc::Protocol;
 use connectrpc::client::{ClientConfig, Http2Connection, SharedHttp2Connection};
@@ -50,10 +51,10 @@ const SSH_PORT: u16 = 22;
 const TRANSPORT_BUFFER: usize = 32;
 
 /// Progress stream from `MacosService.ImagePull`, concretized for the
-/// daemon transport below.
+/// daemon transport below via the public associated types.
 pub type PullStream = connectrpc::client::ServerStream<
-    hyper::body::Incoming,
-    arcbox_connect::v1::__buffa::view::MacosImagePullEventView<'static>,
+    <SharedHttp2Connection as connectrpc::client::ClientTransport>::ResponseBody,
+    <MacosImagePullEvent as connectrpc::HasMessageView>::View<'static>,
 >;
 
 /// Budget for a freshly started guest to acquire its DHCP lease and answer

--- a/rpc/AGENTS.md
+++ b/rpc/AGENTS.md
@@ -30,12 +30,13 @@ This file is only the non-obvious operational knowledge.
   speaks Connect only, and `tonic` is absent from its dependency tree.)
   - `connectrpc` is bound to `buffa::Message`, and since CORE-73 the buffa
     types in `arcbox-connect` are the ONE runtime representation: daemon
-    handlers, `abctl`, and both ends of the vsock wire. The prost twins in
-    `arcbox-protocol` are still generated for the tonic test clients, the
-    reflection descriptor set, and one production consumer: the fleet agent
-    (`fleet/arcbox-fleet-agent/src/vm.rs`) drives the daemon's gRPC endpoint
-    with them, deliberately kept on tonic. The two codegens emit identical
-    bytes, which is what lets a prost peer talk to the buffa server.
+    handlers, `abctl`, the fleet agent's daemon client, reflection's
+    descriptor set, and both ends of the vsock wire. The prost twins in
+    `arcbox-protocol` are still generated, but ONLY test support consumes
+    them: the tonic test clients (daemon/e2e wire-format proofs) and the
+    fleet agent's tonic mock daemon. The two codegens emit identical
+    bytes, which is what lets a prost test peer prove the buffa server's
+    wire format.
   - Reflection is served by `connectrpc-reflection` from the whole daemon's
     descriptor set. It answers `501` over HTTP/1.1 Connect because
     `ServerReflectionInfo` is bidi-streaming and Connect carries bidi only

--- a/rpc/arcbox-connect/src/lib.rs
+++ b/rpc/arcbox-connect/src/lib.rs
@@ -13,14 +13,14 @@
 //! `aarch64-unknown-linux-musl` (base `connectrpc` is transport-free) and
 //! must stay musl-clean for the guest agent's sake.
 //!
-//! The prost twins in `arcbox-protocol` remain as test support — the
-//! daemon/e2e tonic clients that prove the gRPC wire format still answers,
-//! and the reflection FILE_DESCRIPTOR_SET — plus one production consumer:
-//! the fleet agent (`fleet/arcbox-fleet-agent/src/vm.rs`) drives the
-//! daemon's gRPC endpoint with them, deliberately kept on tonic. buffa and
-//! prost encode identical protobuf bytes, so those mixed-codec peers
-//! interoperate; both representations are generated from the same `.proto`
-//! sources and therefore cannot drift.
+//! The fleet agent's daemon client and reflection's descriptor set (see
+//! [`FILE_DESCRIPTOR_SET`]) use these types too. The prost twins in
+//! `arcbox-protocol` remain ONLY as test support: the daemon/e2e tonic
+//! clients that prove the gRPC wire format still answers, and the fleet
+//! agent's tonic mock daemon. buffa and prost encode identical protobuf
+//! bytes, so those mixed-codec test peers interoperate; both
+//! representations are generated from the same `.proto` sources and
+//! therefore cannot drift.
 
 connectrpc::include_generated!();
 

--- a/rpc/arcbox-connect/src/lib.rs
+++ b/rpc/arcbox-connect/src/lib.rs
@@ -33,3 +33,10 @@ pub use arcbox::sandbox::v1 as sandbox_v1;
 /// The daemon's own package, under the same short alias `arcbox-protocol`
 /// uses for its prost twin (CORE-68).
 pub use arcbox::v1;
+
+/// The compiled `FileDescriptorSet` covering every ArcBox-owned proto
+/// (all thirteen files plus their imports, with source info), produced by
+/// this crate's build script. The daemon feeds it to reflection, so the
+/// reflected surface is exactly the surface this crate generates.
+pub const FILE_DESCRIPTOR_SET: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/arcbox_connect.protoset"));


### PR DESCRIPTION
Closes out the two remaining production prost/arcbox-grpc consumers identified after CORE-73, and records the fleet decision.

**Commit 1 — reflection.** `arcbox-connect`'s build script already produces a full FileDescriptorSet (the protoc-compat fix); export it and feed reflection from it, so the reflected surface is exactly the generated surface. `arcbox-grpc` leaves the daemon's runtime deps (dev-dep test clients stay). Reflection tests green against the new set.

**Commit 2 — fleet's daemon client.** `vm.rs` was the workspace's last production consumer of `arcbox-grpc`/`arcbox-protocol`. It now uses the `arcbox-connect` connectrpc client speaking the **gRPC protocol** over the lazy unix-socket transport — so the tonic mock daemon in tests answers unchanged and doubles as an independent-implementation interop check (132 bin tests green). `arcbox-grpc`/`arcbox-protocol` drop to dev-dependencies.

**Deliberately NOT migrated** (decision record): the gateway and `attach.rs` stay on tonic — no product driver (M2M contract, no browser/SDK consumers), no type seam (platform is natively single-typed prost), and the Attach reconnect logic is availability-critical. Revisit only if fleet APIs ever need browser/SDK-direct access.

`rpc/AGENTS.md`'s surviving-consumers bullet updated to the new truth ("only test support consumes the prost twins") — ⚠️ **AGENTS.md hunk needs human approval**.

Note: `fleet-agent` integration test `unenrolled_agent_reports_status_and_rejects_drain` fails identically on clean master on this dev machine (environmental capability probe) — pre-existing, unrelated.

Validated (exit codes checked): workspace clippy `-D warnings` --all-targets, `cargo test -p arcbox-fleet-agent --bins` (132), `cargo test -p arcbox-daemon` (35, incl. reflection + wire-format proofs), guest musl check, `cargo fmt --check`.