### PR TITLE
feat(rpc): SDK-prerequisite proto increments (CORE-58/CORE-21/CORE-62)

### DIFF
--- a/app/arcbox-api/src/connect/control.rs
+++ b/app/arcbox-api/src/connect/control.rs
@@ -117,6 +117,54 @@ impl pb::SandboxService for SandboxServiceImpl {
         Response::ok(Empty::default())
     }
 
+    /// Contract-only stub (CORE-58 phase 1): pause/auto-pause lands with
+    /// CORE-21.
+    async fn pause(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::PauseSandboxRequest>,
+    ) -> ServiceResult<Empty> {
+        Err(ConnectError::unimplemented(
+            "sandbox pause is not implemented yet (CORE-21)",
+        ))
+    }
+
+    /// Contract-only stub (CORE-58 phase 1): resume lands with CORE-21.
+    async fn resume(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ResumeSandboxRequest>,
+    ) -> ServiceResult<Empty> {
+        Err(ConnectError::unimplemented(
+            "sandbox resume is not implemented yet (CORE-21)",
+        ))
+    }
+
+    /// Contract-only stub (CORE-58 phase 1): the TTL wire-up lands with
+    /// CORE-60 (the daemon-side mechanism already exists), the idle
+    /// knobs with CORE-21.
+    async fn set_lifecycle(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::SetLifecycleRequest>,
+    ) -> ServiceResult<Empty> {
+        Err(ConnectError::unimplemented(
+            "sandbox lifecycle updates are not implemented yet (CORE-60/CORE-21)",
+        ))
+    }
+
+    /// Contract-only stub (CORE-58 phase 1): served for real with
+    /// CORE-13 (nested-virt fail-fast).
+    async fn get_capabilities(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::GetCapabilitiesRequest>,
+    ) -> ServiceResult<pb::GetCapabilitiesResponse> {
+        Err(ConnectError::unimplemented(
+            "capability reporting is not implemented yet (CORE-13)",
+        ))
+    }
+
     async fn inspect(
         &self,
         ctx: RequestContext,

--- a/app/arcbox-api/src/connect/filesystem.rs
+++ b/app/arcbox-api/src/connect/filesystem.rs
@@ -125,4 +125,76 @@ impl pb::SandboxFilesystemService for SandboxFilesystemServiceImpl {
             .map_err(ApiError::from)?;
         Response::ok(Empty::default())
     }
+
+    /// Contract-only stub (CORE-58 phase 1): the path verbs land with
+    /// CORE-62 (guest-agent implementation).
+    async fn stat(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::StatFileRequest>,
+    ) -> ServiceResult<pb::FileStat> {
+        Err(ConnectError::unimplemented(
+            "stat is not implemented yet (CORE-62)",
+        ))
+    }
+
+    /// Contract-only stub (CORE-58 phase 1): the path verbs land with
+    /// CORE-62 (guest-agent implementation).
+    async fn list_dir(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ListDirRequest>,
+    ) -> ServiceResult<pb::ListDirResponse> {
+        Err(ConnectError::unimplemented(
+            "list_dir is not implemented yet (CORE-62)",
+        ))
+    }
+
+    /// Contract-only stub (CORE-58 phase 1): the path verbs land with
+    /// CORE-62 (guest-agent implementation).
+    async fn make_dir(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::MakeDirRequest>,
+    ) -> ServiceResult<Empty> {
+        Err(ConnectError::unimplemented(
+            "make_dir is not implemented yet (CORE-62)",
+        ))
+    }
+
+    /// Contract-only stub (CORE-58 phase 1): the path verbs land with
+    /// CORE-62 (guest-agent implementation).
+    async fn remove(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::RemoveEntryRequest>,
+    ) -> ServiceResult<Empty> {
+        Err(ConnectError::unimplemented(
+            "remove is not implemented yet (CORE-62)",
+        ))
+    }
+
+    /// Contract-only stub (CORE-58 phase 1): the path verbs land with
+    /// CORE-62 (guest-agent implementation).
+    async fn r#move(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::MoveEntryRequest>,
+    ) -> ServiceResult<Empty> {
+        Err(ConnectError::unimplemented(
+            "move is not implemented yet (CORE-62)",
+        ))
+    }
+
+    /// Contract-only stub (CORE-58 phase 1): the path verbs land with
+    /// CORE-62 (guest-agent implementation).
+    async fn watch_dir(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::WatchDirRequest>,
+    ) -> ServiceResult<ServiceStream<pb::WatchDirResponse>> {
+        Err(ConnectError::unimplemented(
+            "watch_dir is not implemented yet (CORE-62)",
+        ))
+    }
 }

--- a/app/arcbox-api/src/connect/mod.rs
+++ b/app/arcbox-api/src/connect/mod.rs
@@ -8,6 +8,7 @@
 //! processes:
 //!
 //! - [`control`] — sandbox lifecycle, events, published ports
+//! - [`template`] — the template catalog (control plane, CORE-21)
 //! - [`process`] — executions (data plane)
 //! - [`filesystem`] — file transfer (data plane)
 //! - [`snapshot`] — checkpoint / restore
@@ -35,6 +36,7 @@ mod sandbox_locks;
 mod snapshot;
 mod stats;
 mod system;
+mod template;
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -61,6 +63,7 @@ pub use sandbox_cleanup::{
 pub use snapshot::SandboxSnapshotServiceImpl;
 pub use stats::StatsServiceImpl;
 pub use system::{SetupState, SystemServiceImpl};
+pub use template::TemplateServiceImpl;
 
 /// Shared handle to a runtime that may not be initialized yet.
 ///
@@ -218,6 +221,7 @@ pub fn router(runtime: SharedRuntime) -> connectrpc::Router {
             clone(),
             Arc::clone(&sandbox_operations),
         )))
+        .add_service(Arc::new(TemplateServiceImpl::new()))
         // The daemon's own services, all on Connect since CORE-68.
         .add_service(Arc::new(IconServiceImpl::new()))
         .add_service(Arc::new(StatsServiceImpl::new(clone())))

--- a/app/arcbox-api/src/connect/process.rs
+++ b/app/arcbox-api/src/connect/process.rs
@@ -201,4 +201,28 @@ impl pb::SandboxProcessService for SandboxProcessServiceImpl {
             .map_err(ApiError::from)?;
         Response::ok(execution)
     }
+
+    /// Contract-only stub (CORE-58 phase 1): execution discovery lands
+    /// with CORE-58 phase 2 (guest-agent enumeration).
+    async fn list_executions(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ListExecutionsRequest>,
+    ) -> ServiceResult<pb::ListExecutionsResponse> {
+        Err(ConnectError::unimplemented(
+            "execution listing is not implemented yet (CORE-58 phase 2)",
+        ))
+    }
+
+    /// Contract-only stub (CORE-58 phase 1): the guest-agent listen-table
+    /// watch lands with CORE-58 phase 2.
+    async fn wait_for_port(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::WaitForPortRequest>,
+    ) -> ServiceResult<Empty> {
+        Err(ConnectError::unimplemented(
+            "port readiness waits are not implemented yet (CORE-58 phase 2)",
+        ))
+    }
 }

--- a/app/arcbox-api/src/connect/template.rs
+++ b/app/arcbox-api/src/connect/template.rs
@@ -1,0 +1,86 @@
+//! Sandbox template catalog service — control plane (CORE-21).
+
+use arcbox_connect::sandbox_v1 as pb;
+use buffa_types::google::protobuf::Empty;
+use connectrpc::{ConnectError, RequestContext, ServiceRequest, ServiceResult};
+
+/// Template service implementation.
+///
+/// Contract-only stub (CORE-58 phase 1): every method answers
+/// UNIMPLEMENTED until the template catalog lands with CORE-21. Build
+/// additionally depends on the rootfs pipeline (CORE-5) and, for
+/// pre-warmed snapshots, FC 1.16 network overrides (CORE-16).
+#[derive(Default)]
+pub struct TemplateServiceImpl;
+
+impl TemplateServiceImpl {
+    /// Creates a new template service.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[allow(
+    refining_impl_trait,
+    reason = "the trait returns `impl Encodable<M>`; naming the concrete body \
+              type is strictly more informative and these impls are registered on a \
+              Router rather than named by callers"
+)]
+impl pb::TemplateService for TemplateServiceImpl {
+    /// Contract-only stub: the build pipeline lands with CORE-21
+    /// (gated on CORE-5 rootfs builds and CORE-16 for `prewarm`).
+    async fn build(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::BuildTemplateRequest>,
+    ) -> ServiceResult<pb::Template> {
+        Err(ConnectError::unimplemented(
+            "template build is not implemented yet (CORE-21; build pipeline CORE-5/CORE-16)",
+        ))
+    }
+
+    /// Contract-only stub: the template catalog lands with CORE-21.
+    async fn publish(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::PublishTemplateRequest>,
+    ) -> ServiceResult<pb::Template> {
+        Err(ConnectError::unimplemented(
+            "template publish is not implemented yet (CORE-21)",
+        ))
+    }
+
+    /// Contract-only stub: the template catalog lands with CORE-21.
+    async fn get(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::GetTemplateRequest>,
+    ) -> ServiceResult<pb::Template> {
+        Err(ConnectError::unimplemented(
+            "template get is not implemented yet (CORE-21)",
+        ))
+    }
+
+    /// Contract-only stub: the template catalog lands with CORE-21.
+    async fn list(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ListTemplatesRequest>,
+    ) -> ServiceResult<pb::ListTemplatesResponse> {
+        Err(ConnectError::unimplemented(
+            "template list is not implemented yet (CORE-21)",
+        ))
+    }
+
+    /// Contract-only stub: the template catalog lands with CORE-21.
+    async fn delete(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::DeleteTemplateRequest>,
+    ) -> ServiceResult<Empty> {
+        Err(ConnectError::unimplemented(
+            "template delete is not implemented yet (CORE-21)",
+        ))
+    }
+}

--- a/app/arcbox-cli/src/commands/sandbox.rs
+++ b/app/arcbox-cli/src/commands/sandbox.rs
@@ -349,6 +349,8 @@ pub(super) fn state_name(state: SandboxState) -> &'static str {
         SandboxState::Stopping => "stopping",
         SandboxState::Stopped => "stopped",
         SandboxState::Failed => "failed",
+        SandboxState::Pausing => "pausing",
+        SandboxState::Paused => "paused",
     }
 }
 
@@ -361,8 +363,11 @@ fn parse_state(value: &str) -> Result<SandboxState> {
         "stopping" => SandboxState::Stopping,
         "stopped" => SandboxState::Stopped,
         "failed" => SandboxState::Failed,
+        "pausing" => SandboxState::Pausing,
+        "paused" => SandboxState::Paused,
         other => anyhow::bail!(
-            "unknown state '{other}' (expected starting/ready/running/stopping/stopped/failed)"
+            "unknown state '{other}' (expected starting/ready/running/stopping/\
+             stopped/failed/pausing/paused)"
         ),
     })
 }
@@ -378,9 +383,13 @@ fn parse_event_kind(value: &str) -> Result<SandboxEventKind> {
         "stopped" => SandboxEventKind::Stopped,
         "failed" => SandboxEventKind::Failed,
         "removed" => SandboxEventKind::Removed,
+        "pausing" => SandboxEventKind::Pausing,
+        "paused" => SandboxEventKind::Paused,
+        "resumed" => SandboxEventKind::Resumed,
         other => anyhow::bail!(
             "unknown event kind '{other}' (expected \
-             created/ready/running/idle/stopping/stopped/failed/removed)"
+             created/ready/running/idle/stopping/stopped/failed/removed/\
+             pausing/paused/resumed)"
         ),
     })
 }
@@ -397,6 +406,9 @@ fn event_kind_name(kind: SandboxEventKind) -> &'static str {
         SandboxEventKind::Stopped => "stopped",
         SandboxEventKind::Failed => "failed",
         SandboxEventKind::Removed => "removed",
+        SandboxEventKind::Pausing => "pausing",
+        SandboxEventKind::Paused => "paused",
+        SandboxEventKind::Resumed => "resumed",
     }
 }
 

--- a/app/arcbox-daemon/src/control_plane.rs
+++ b/app/arcbox-daemon/src/control_plane.rs
@@ -346,6 +346,9 @@ mod tests {
             "arcbox.v1.KubernetesService/Status",
             "arcbox.v1.MigrationService/RunMigration",
             "arcbox.v1.MachineService/ExecSession",
+            // Post-migration additions live under the same guarantee: a
+            // service missing from the router 404s and fails nowhere else.
+            "arcbox.sandbox.v1.TemplateService/Get",
             #[cfg(target_os = "macos")]
             "arcbox.v1.MacosService/List",
         ] {

--- a/docs/sandbox-api.md
+++ b/docs/sandbox-api.md
@@ -133,6 +133,7 @@ Key fields:
 | `limits.vcpus` / `limits.memory_mib` | 0 → daemon defaults (1 vCPU, 512 MiB) |
 | `template` | opaque reference to what boots — see **Templates** below |
 | `cmd`, `env`, `working_dir`, `user` | initial workload launched automatically once ready; exit returns the sandbox to `READY` with an `IDLE` event |
+| `no_default_cmd`, `no_default_env` | explicit-empty overrides of a catalog template's default cmd/env — proto3 repeated/map fields cannot distinguish omitted from empty (CORE-21, contract-only today) |
 | `network.mode` | `NETWORK_MODE_ENABLED` (default, IP from 172.20.0.0/16) or `NETWORK_MODE_NONE` |
 | `ttl_seconds` | hard maximum lifetime from creation (not reset by activity; re-armable via `SetLifecycle`); always destroys |
 | `idle_timeout_seconds`, `on_idle` | idle reaping: `KILL` (default) or `PAUSE` after inactivity (CORE-21, contract-only today) |
@@ -153,6 +154,14 @@ Anything else is rejected with `INVALID_ARGUMENT` — a bare
 `name[:version]` addresses the template catalog (`TemplateService`,
 CORE-21; contract-only today), so it is never guessed at as an image
 reference.
+
+Catalog templates carry defaults (`limits`, `cmd`, `env`,
+`exposed_ports`, `ready_probe`). A create request overrides them
+field-wise: a set `limits` replaces the default limits, a non-empty
+`cmd` replaces the default cmd, and `env` merges per key with the
+request winning. `no_default_cmd` / `no_default_env` express the
+explicitly-empty case that proto3 repeated/map shape cannot
+(`exposed_ports` and `ready_probe` have no per-create counterpart).
 
 A `docker:` template is resolved **inside the VM**: the guest exports the
 image from its own dockerd, converts it to ext4, and caches the result

--- a/docs/sandbox-api.md
+++ b/docs/sandbox-api.md
@@ -157,9 +157,11 @@ reference.
 
 Catalog templates carry defaults (`limits`, `cmd`, `env`,
 `exposed_ports`, `ready_probe`). A create request overrides them
-field-wise: a set `limits` replaces the default limits, a non-empty
-`cmd` replaces the default cmd, and `env` merges per key with the
-request winning. `no_default_cmd` / `no_default_env` express the
+field-wise: a set `limits` replaces the default limits wholesale — a
+zero `vcpus`/`memory_mib` inside it means the *daemon* default for that
+resource, never a per-field fall-through to the template (the scalars
+have no presence) — a non-empty `cmd` replaces the default cmd, and
+`env` merges per key with the request winning. `no_default_cmd` / `no_default_env` express the
 explicitly-empty case that proto3 repeated/map shape cannot
 (`exposed_ports` and `ready_probe` have no per-create counterpart).
 

--- a/docs/sandbox-api.md
+++ b/docs/sandbox-api.md
@@ -15,9 +15,11 @@ seam (CORE-57):
 | File | Service | Plane |
 |---|---|---|
 | `sandbox.proto` | `SandboxService` | control — lifecycle, events, published ports |
+| `template.proto` | `TemplateService` | control — the template catalog (CORE-21, contract-only) |
 | `process.proto` | `SandboxProcessService` | data — executions |
-| `filesystem.proto` | `SandboxFilesystemService` | data — file transfer |
+| `filesystem.proto` | `SandboxFilesystemService` | data — file transfer + path verbs |
 | `snapshot.proto` | `SandboxSnapshotService` | checkpoint / restore |
+| `errors.proto` | — | the `ErrorCode` registry / `ErrorInfo` detail |
 
 The split is what lets a deployment put the two planes in different places:
 control-plane calls address a fleet and can be served by a multi-tenant
@@ -73,14 +75,30 @@ Sandbox V1" (`image`, `mounts`, `ssh_public_key`) are rejected with
 `FAILED_PRECONDITION` rather than silently ignored, and will gain
 behavior in later releases without a wire break.
 
+**Contract-only additions (CORE-58 phase 1).** The SDK-prerequisite
+surface is on the wire ahead of its implementation; these RPCs answer
+`UNIMPLEMENTED` today, each naming its follow-up issue:
+
+- `TemplateService` (`template.proto`) — the template catalog (CORE-21;
+  Build additionally gated on CORE-5/CORE-16).
+- `SandboxService.Pause/Resume` (CORE-21), `SetLifecycle` (CORE-60 /
+  CORE-21), `GetCapabilities` (CORE-13).
+- `SandboxProcessService.ListExecutions/WaitForPort` (CORE-58 phase 2).
+- The `SandboxFilesystemService` path verbs — `Stat`, `ListDir`,
+  `MakeDir`, `Remove`, `Move`, `WatchDir` (CORE-62).
+- `errors.proto` — the `ErrorCode` registry; handlers attach `ErrorInfo`
+  as a Connect error detail in a follow-up phase (CORE-58).
+
 ## Sandbox state machine
 
 ```
 STARTING ──► READY ──► RUNNING ──► READY   (execution exited; IDLE event)
                │          │
-               └──────────┴──► STOPPING ──► STOPPED
-                                    │
-                                 FAILED
+               ├──────────┴──► STOPPING ──► STOPPED
+               │          │
+               ├──────────┴──► PAUSING ──► PAUSED ──(Resume)──► STARTING  (same ID)
+               │          │
+               └──────────┴──► FAILED   (error + failed_at set)
 ```
 
 States are the `SandboxState` enum (`SANDBOX_STATE_*`); events carry the
@@ -88,9 +106,15 @@ States are the `SandboxState` enum (`SANDBOX_STATE_*`); events carry the
 
 - A sandbox is **not destroyed** when its execution exits — it returns to
   `READY` and accepts further `StartExecution` calls.
-- Destruction happens via `Stop`/`Remove` or `ttl_seconds` expiry.
+- Destruction happens via `Stop`/`Remove`, `ttl_seconds` (hard maximum
+  lifetime) expiry, or `idle_timeout_seconds` expiry with the default
+  `KILL` policy; `on_idle: PAUSE` checkpoints instead (CORE-21,
+  contract-only today).
 - `stopped` sandboxes have released their TAP/IP, CoW device, and chroot;
   only the inspectable record and logs remain until `Remove`.
+- `paused` sandboxes keep their record **and** an on-disk checkpoint
+  (`storage_bytes`) under the same ID; data-plane calls resume them
+  transparently, `Inspect`/`List` never do.
 
 ## SandboxService
 
@@ -110,7 +134,8 @@ Key fields:
 | `template` | opaque reference to what boots — see **Templates** below |
 | `cmd`, `env`, `working_dir`, `user` | initial workload launched automatically once ready; exit returns the sandbox to `READY` with an `IDLE` event |
 | `network.mode` | `NETWORK_MODE_ENABLED` (default, IP from 172.20.0.0/16) or `NETWORK_MODE_NONE` |
-| `ttl_seconds` | auto-destroy timer from creation (not reset by activity) |
+| `ttl_seconds` | hard maximum lifetime from creation (not reset by activity; re-armable via `SetLifecycle`); always destroys |
+| `idle_timeout_seconds`, `on_idle` | idle reaping: `KILL` (default) or `PAUSE` after inactivity (CORE-21, contract-only today) |
 | `mounts`, `ssh_public_key` | **rejected in V1** with `FAILED_PRECONDITION` (see Proto stability) |
 
 ### Templates
@@ -124,9 +149,10 @@ crosses the API (CORE-54). Local mode accepts:
 | `""` | the built-in minimal image (busybox + init), built on first use |
 | `"docker:<ref>"` | a Docker image in the guest's own image store |
 
-Anything else is rejected with `INVALID_ARGUMENT` — a bare name is
-reserved for the cloud template registry (CORE-21), so it is never
-guessed at as an image reference.
+Anything else is rejected with `INVALID_ARGUMENT` — a bare
+`name[:version]` addresses the template catalog (`TemplateService`,
+CORE-21; contract-only today), so it is never guessed at as an image
+reference.
 
 A `docker:` template is resolved **inside the VM**: the guest exports the
 image from its own dockerd, converts it to ext4, and caches the result

--- a/docs/sandbox-api.md
+++ b/docs/sandbox-api.md
@@ -157,11 +157,12 @@ reference.
 
 Catalog templates carry defaults (`limits`, `cmd`, `env`,
 `exposed_ports`, `ready_probe`). A create request overrides them
-field-wise: a set `limits` replaces the default limits wholesale — a
-zero `vcpus`/`memory_mib` inside it means the *daemon* default for that
-resource, never a per-field fall-through to the template (the scalars
-have no presence) — a non-empty `cmd` replaces the default cmd, and
-`env` merges per key with the request winning. `no_default_cmd` / `no_default_env` express the
+field-wise: a set `limits` replaces the default limits wholesale, a
+non-empty `cmd` replaces the default cmd, and `env` merges per key with
+the request winning. Inside a set `limits`, a zero `vcpus` or
+`memory_mib` means the *daemon* default for that resource — never a
+per-field fall-through to the template, since the scalars have no
+presence. `no_default_cmd` / `no_default_env` express the
 explicitly-empty case that proto3 repeated/map shape cannot
 (`exposed_ports` and `ready_probe` have no per-create counterpart).
 

--- a/guest/arcbox-agent/src/sandbox/convert.rs
+++ b/guest/arcbox-agent/src/sandbox/convert.rs
@@ -111,6 +111,10 @@ pub(super) fn state_filter(state: sandbox_v1::SandboxState) -> Option<&'static s
         sandbox_v1::SandboxState::Stopping => Some("stopping"),
         sandbox_v1::SandboxState::Stopped => Some("stopped"),
         sandbox_v1::SandboxState::Failed => Some("failed"),
+        // Pause states (CORE-21): the manager cannot produce them yet, so
+        // the filter matches nothing until pause lands guest-side.
+        sandbox_v1::SandboxState::Pausing => Some("pausing"),
+        sandbox_v1::SandboxState::Paused => Some("paused"),
     }
 }
 

--- a/rpc/arcbox-connect/build.rs
+++ b/rpc/arcbox-connect/build.rs
@@ -29,6 +29,7 @@ fn main() {
         "arcbox/sandbox/v1/process.proto",
         "arcbox/sandbox/v1/filesystem.proto",
         "arcbox/sandbox/v1/snapshot.proto",
+        "arcbox/sandbox/v1/template.proto",
         "arcbox/sandbox/v1/errors.proto",
     ];
 

--- a/rpc/arcbox-connect/build.rs
+++ b/rpc/arcbox-connect/build.rs
@@ -29,6 +29,7 @@ fn main() {
         "arcbox/sandbox/v1/process.proto",
         "arcbox/sandbox/v1/filesystem.proto",
         "arcbox/sandbox/v1/snapshot.proto",
+        "arcbox/sandbox/v1/errors.proto",
     ];
 
     // Run protoc ourselves and hand connectrpc-build the descriptor set:

--- a/rpc/arcbox-connect/src/lib.rs
+++ b/rpc/arcbox-connect/src/lib.rs
@@ -35,8 +35,9 @@ pub use arcbox::sandbox::v1 as sandbox_v1;
 pub use arcbox::v1;
 
 /// The compiled `FileDescriptorSet` covering every ArcBox-owned proto
-/// (all thirteen files plus their imports, with source info), produced by
-/// this crate's build script. The daemon feeds it to reflection, so the
-/// reflected surface is exactly the surface this crate generates.
+/// (every file in the build script's list plus imports, with source
+/// info), produced by this crate's build script. The daemon feeds it to
+/// reflection, so the reflected surface is exactly the surface this
+/// crate generates.
 pub const FILE_DESCRIPTOR_SET: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/arcbox_connect.protoset"));

--- a/rpc/arcbox-grpc/build.rs
+++ b/rpc/arcbox-grpc/build.rs
@@ -22,6 +22,7 @@ fn main() {
         "../arcbox-protocol/proto/arcbox/sandbox/v1/process.proto",
         "../arcbox-protocol/proto/arcbox/sandbox/v1/filesystem.proto",
         "../arcbox-protocol/proto/arcbox/sandbox/v1/snapshot.proto",
+        "../arcbox-protocol/proto/arcbox/sandbox/v1/errors.proto",
         "../arcbox-protocol/proto/stats.proto",
     ];
 

--- a/rpc/arcbox-grpc/build.rs
+++ b/rpc/arcbox-grpc/build.rs
@@ -22,6 +22,7 @@ fn main() {
         "../arcbox-protocol/proto/arcbox/sandbox/v1/process.proto",
         "../arcbox-protocol/proto/arcbox/sandbox/v1/filesystem.proto",
         "../arcbox-protocol/proto/arcbox/sandbox/v1/snapshot.proto",
+        "../arcbox-protocol/proto/arcbox/sandbox/v1/template.proto",
         "../arcbox-protocol/proto/arcbox/sandbox/v1/errors.proto",
         "../arcbox-protocol/proto/stats.proto",
     ];

--- a/rpc/arcbox-grpc/src/lib.rs
+++ b/rpc/arcbox-grpc/src/lib.rs
@@ -62,6 +62,7 @@ pub mod v1 {
 /// deployment can serve the control plane from a multi-tenant front door
 /// and the data plane from whatever is co-located with the sandbox:
 /// - SandboxService - control plane: lifecycle, events, published ports
+/// - TemplateService - control plane: the template catalog (CORE-21)
 /// - SandboxProcessService - data plane: executions (exec family)
 /// - SandboxFilesystemService - data plane: file transfer
 /// - SandboxSnapshotService - checkpoint and restore
@@ -76,6 +77,7 @@ pub use sandbox_v1::sandbox_filesystem_service_client::SandboxFilesystemServiceC
 pub use sandbox_v1::sandbox_process_service_client::SandboxProcessServiceClient;
 pub use sandbox_v1::sandbox_service_client::SandboxServiceClient;
 pub use sandbox_v1::sandbox_snapshot_service_client::SandboxSnapshotServiceClient;
+pub use sandbox_v1::template_service_client::TemplateServiceClient;
 pub use v1::agent_service_client::AgentServiceClient;
 pub use v1::icon_service_client::IconServiceClient;
 pub use v1::machine_service_client::MachineServiceClient;
@@ -94,6 +96,7 @@ pub use sandbox_v1::sandbox_service_server::{SandboxService, SandboxServiceServe
 pub use sandbox_v1::sandbox_snapshot_service_server::{
     SandboxSnapshotService, SandboxSnapshotServiceServer,
 };
+pub use sandbox_v1::template_service_server::{TemplateService, TemplateServiceServer};
 pub use v1::agent_service_server::{AgentService, AgentServiceServer};
 pub use v1::icon_service_server::{IconService, IconServiceServer};
 pub use v1::machine_service_server::{MachineService, MachineServiceServer};

--- a/rpc/arcbox-protocol/build.rs
+++ b/rpc/arcbox-protocol/build.rs
@@ -32,6 +32,7 @@ fn main() {
         "proto/arcbox/sandbox/v1/process.proto",
         "proto/arcbox/sandbox/v1/filesystem.proto",
         "proto/arcbox/sandbox/v1/snapshot.proto",
+        "proto/arcbox/sandbox/v1/template.proto",
         "proto/arcbox/sandbox/v1/errors.proto",
         "proto/stats.proto",
     ];

--- a/rpc/arcbox-protocol/build.rs
+++ b/rpc/arcbox-protocol/build.rs
@@ -32,6 +32,7 @@ fn main() {
         "proto/arcbox/sandbox/v1/process.proto",
         "proto/arcbox/sandbox/v1/filesystem.proto",
         "proto/arcbox/sandbox/v1/snapshot.proto",
+        "proto/arcbox/sandbox/v1/errors.proto",
         "proto/stats.proto",
     ];
 

--- a/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/errors.proto
+++ b/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/errors.proto
@@ -1,0 +1,88 @@
+// Sandbox error registry (CORE-58).
+//
+// One machine-readable error code registry for the whole sandbox surface.
+// `ErrorInfo` rides as a Connect error detail on every daemon error, so
+// SDKs derive their exception hierarchies from this single enum — one
+// registry, per-language mappings generated from it, zero drift.
+//
+// `suggestion` is an actionable, human/LLM-readable fix ("run `abctl
+// daemon start`") that agent frameworks surface directly; `context`
+// carries structured facts about the failure (which timeout fired, the
+// limit that was exceeded, the state that was observed) so messages can
+// be rendered SDK-side in the caller's own parameter vocabulary.
+//
+// This file defines the contract only; daemon handlers attach `ErrorInfo`
+// in a follow-up phase (CORE-58).
+
+syntax = "proto3";
+
+package arcbox.sandbox.v1;
+
+// Machine-readable cause of a sandbox API error.
+//
+// Values are append-only: SDKs map unknown codes to their base error
+// class, so retiring or renumbering a value silently reclassifies errors
+// for older clients.
+enum ErrorCode {
+    ERROR_CODE_UNSPECIFIED = 0;
+    // The addressed sandbox does not exist.
+    ERROR_CODE_SANDBOX_NOT_FOUND = 1;
+    // The addressed template does not exist.
+    ERROR_CODE_TEMPLATE_NOT_FOUND = 2;
+    // The addressed execution does not exist.
+    ERROR_CODE_EXECUTION_NOT_FOUND = 3;
+    // The addressed path does not exist inside the sandbox.
+    ERROR_CODE_FILE_NOT_FOUND = 4;
+    // The sandbox is PAUSED and this call did not resume it. Data-plane
+    // calls resume a paused sandbox transparently (CORE-21), so this
+    // surfaces only where resume does not apply: on control-plane calls,
+    // or when the caller opted out of transparent resume (the reserved
+    // `x-arcbox-no-auto-resume` header — see sandbox.proto `Resume`).
+    ERROR_CODE_SANDBOX_PAUSED = 5;
+    // The sandbox exists but is not READY for this operation
+    // (e.g. still STARTING).
+    ERROR_CODE_SANDBOX_NOT_READY = 6;
+    // The sandbox is in FAILED state; context carries the failure reason.
+    ERROR_CODE_SANDBOX_FAILED = 7;
+    // The sandbox's hard maximum lifetime (`ttl_seconds`) expired and the
+    // daemon destroyed it.
+    ERROR_CODE_TTL_EXPIRED = 8;
+    // A per-command timeout fired and the process group was killed.
+    ERROR_CODE_COMMAND_TIMEOUT = 9;
+    // This host cannot run sandboxes (no nested virtualization).
+    // See SandboxService.GetCapabilities (CORE-13 fail-fast).
+    ERROR_CODE_NESTED_VIRT_UNSUPPORTED = 10;
+    // The template reference could not be resolved or is malformed.
+    ERROR_CODE_TEMPLATE_INVALID = 11;
+    // A file transfer exceeded the per-file size cap; context carries
+    // the limit.
+    ERROR_CODE_FILE_TOO_LARGE = 12;
+    // Stdin was already closed for this execution.
+    ERROR_CODE_STDIN_CLOSED = 13;
+    // The operation requires a TTY execution (e.g. terminal resize).
+    ERROR_CODE_TTY_REQUIRED = 14;
+    // The requested host port is already bound.
+    ERROR_CODE_PORT_IN_USE = 15;
+    // Authentication is required. Reserved for the remote tier (CORE-63).
+    ERROR_CODE_AUTH_REQUIRED = 16;
+    // The client and daemon protocol levels are incompatible; the
+    // suggestion names which side to upgrade.
+    ERROR_CODE_PROTOCOL_MISMATCH = 17;
+    // The host is out of a resource (memory, disk, sandbox slots).
+    ERROR_CODE_RESOURCE_EXHAUSTED_HOST = 18;
+}
+
+// Structured detail attached to sandbox API errors.
+//
+// Carried as a Connect error detail; the transport status code stays the
+// coarse routing signal while this message carries the precise cause.
+message ErrorInfo {
+    // Machine-readable cause.
+    ErrorCode code = 1;
+    // Actionable fix, phrased for direct display ("run `abctl daemon
+    // start`"). Agent frameworks surface this to the LLM verbatim.
+    string suggestion = 2;
+    // Structured facts about the failure: which timeout knob fired, the
+    // limit that was exceeded, the state that was observed, and so on.
+    map<string, string> context = 3;
+}

--- a/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/filesystem.proto
+++ b/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/filesystem.proto
@@ -1,20 +1,25 @@
 // Sandbox filesystem data plane.
 //
-// File transfer in and out of a running sandbox. **Data plane**: the calls
-// carry file bytes and address one specific sandbox, so they are served by
-// whatever is co-located with it rather than routed through the
-// control-plane entry point. See `sandbox.proto` for the control plane.
+// File transfer and path operations inside a running sandbox. **Data
+// plane**: the calls carry file bytes and address one specific sandbox,
+// so they are served by whatever is co-located with it rather than
+// routed through the control-plane entry point. See `sandbox.proto` for
+// the control plane.
 //
-// Directory operations (stat, list, mkdir, move, remove, watch) are not here
-// yet — the surface is whole-file-only in V1 (CORE-62).
+// Every verb is a real RPC into the guest agent — never a shelled-out
+// `ls`/`stat` parse. The path verbs (CORE-62) are contract-only until
+// the guest side lands; whole-file read/write are live.
 
 syntax = "proto3";
 
 package arcbox.sandbox.v1;
 
+import "arcbox/sandbox/v1/sandbox.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 
-// SandboxFilesystemService moves files in and out of a sandbox.
+// SandboxFilesystemService moves files in and out of a sandbox and
+// operates on its paths.
 service SandboxFilesystemService {
     // Read a file from inside a sandbox as a stream of chunks.
     // The final chunk has done == true. The sandbox must be alive
@@ -26,6 +31,31 @@ service SandboxFilesystemService {
     // subsequent messages stream `chunk` payloads, the last one with
     // done == true. Limited to 256 MiB per file.
     rpc WriteFile(stream WriteFileRequest) returns (google.protobuf.Empty);
+
+    // Return metadata for one path. Symlinks are reported, not followed.
+    rpc Stat(StatFileRequest) returns (FileStat);
+
+    // List a directory's entries, non-recursively. Every entry carries
+    // a full FileStat, so no per-entry Stat round-trips are needed.
+    rpc ListDir(ListDirRequest) returns (ListDirResponse);
+
+    // Create a directory, including missing parents (`mkdir -p`
+    // semantics — never the non-recursive trap). Succeeds when the
+    // directory already exists.
+    rpc MakeDir(MakeDirRequest) returns (google.protobuf.Empty);
+
+    // Remove a file, symlink, or directory. A non-empty directory
+    // requires `recursive`.
+    rpc Remove(RemoveEntryRequest) returns (google.protobuf.Empty);
+
+    // Rename / move a file or directory within the sandbox.
+    rpc Move(MoveEntryRequest) returns (google.protobuf.Empty);
+
+    // Stream filesystem events under a path — push-based, never a
+    // polling fallback. KeepAlive frames are interleaved while idle so
+    // proxies do not cut the connection; the stream ends only on
+    // cancellation or sandbox stop.
+    rpc WatchDir(WatchDirRequest) returns (stream WatchDirResponse);
 }
 
 // Request to read a file from a sandbox.
@@ -61,5 +91,136 @@ message WriteFileRequest {
         WriteFileOpen open = 1;
         // File content chunk; the last one has done == true.
         FileChunk chunk = 2;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Path verbs (CORE-62)
+// ---------------------------------------------------------------------------
+
+// What kind of filesystem object a path is.
+enum FileKind {
+    FILE_KIND_UNSPECIFIED = 0;
+    // Regular file.
+    FILE_KIND_FILE = 1;
+    FILE_KIND_DIRECTORY = 2;
+    FILE_KIND_SYMLINK = 3;
+    // Device node, FIFO, or socket.
+    FILE_KIND_OTHER = 4;
+}
+
+// Metadata of one filesystem entry.
+message FileStat {
+    // Base name of the entry (the final path component).
+    string name = 1;
+    // Kind of entry (symlinks are reported as SYMLINK, not followed).
+    FileKind kind = 2;
+    // Size in bytes (regular files; 0 otherwise).
+    uint64 size = 3;
+    // Unix permission bits (the low 12 bits of st_mode).
+    uint32 mode = 4;
+    // Last modification time.
+    google.protobuf.Timestamp modified_at = 5;
+    // Owning user ID.
+    uint32 uid = 6;
+    // Owning group ID.
+    uint32 gid = 7;
+    // Symlink target (set only when kind == SYMLINK).
+    string symlink_target = 8;
+}
+
+// Request to stat a path.
+message StatFileRequest {
+    // Sandbox ID.
+    string id = 1;
+    // Absolute path inside the sandbox rootfs.
+    string path = 2;
+}
+
+// Request to list a directory.
+message ListDirRequest {
+    // Sandbox ID.
+    string id = 1;
+    // Absolute directory path inside the sandbox rootfs.
+    string path = 2;
+}
+
+// Response to ListDir.
+message ListDirResponse {
+    // Directory entries, each with full metadata.
+    repeated FileStat entries = 1;
+}
+
+// Request to create a directory.
+message MakeDirRequest {
+    // Sandbox ID.
+    string id = 1;
+    // Absolute directory path to create (missing parents are created).
+    string path = 2;
+    // Unix permission bits for created directories (0 = 0755).
+    uint32 mode = 3;
+}
+
+// Request to remove a filesystem entry.
+message RemoveEntryRequest {
+    // Sandbox ID.
+    string id = 1;
+    // Absolute path to remove.
+    string path = 2;
+    // Remove directories and their contents recursively. Without it a
+    // non-empty directory fails with FAILED_PRECONDITION.
+    bool recursive = 3;
+}
+
+// Request to rename / move a filesystem entry.
+message MoveEntryRequest {
+    // Sandbox ID.
+    string id = 1;
+    // Absolute source path.
+    string from_path = 2;
+    // Absolute destination path.
+    string to_path = 3;
+}
+
+// Request to watch a path for filesystem events.
+message WatchDirRequest {
+    // Sandbox ID.
+    string id = 1;
+    // Absolute path to watch (a directory).
+    string path = 2;
+    // Also watch subdirectories.
+    bool recursive = 3;
+}
+
+// Kind of a filesystem event.
+enum FsEventKind {
+    FS_EVENT_KIND_UNSPECIFIED = 0;
+    // An entry was created.
+    FS_EVENT_KIND_CREATED = 1;
+    // An entry's content or metadata changed.
+    FS_EVENT_KIND_MODIFIED = 2;
+    // An entry was removed.
+    FS_EVENT_KIND_REMOVED = 3;
+    // An entry was renamed within the watched tree.
+    FS_EVENT_KIND_RENAMED = 4;
+}
+
+// One filesystem event.
+message FsEvent {
+    // What happened.
+    FsEventKind kind = 1;
+    // Absolute path of the affected entry (the old path for RENAMED).
+    string path = 2;
+    // New absolute path (set only for RENAMED).
+    string renamed_to = 3;
+}
+
+// One frame of a WatchDir stream.
+message WatchDirResponse {
+    oneof payload {
+        // A filesystem event.
+        FsEvent event = 1;
+        // Idle-stream keepalive; carries no data.
+        KeepAlive keep_alive = 2;
     }
 }

--- a/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/process.proto
+++ b/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/process.proto
@@ -61,6 +61,18 @@ service SandboxProcessService {
     // state (a zero timeout polls). The exit status distinguishes a normal
     // exit code from death by signal.
     rpc WaitExecution(WaitExecutionRequest) returns (Execution);
+
+    // List a sandbox's executions, running and exited, so a client can
+    // rediscover processes it no longer holds handles to — after losing
+    // its connection, or across an auto-pause/resume cycle. Executions
+    // are retained for the life of their sandbox.
+    rpc ListExecutions(ListExecutionsRequest) returns (ListExecutionsResponse);
+
+    // Wait until something inside the sandbox listens on the given TCP
+    // port, or fail with DEADLINE_EXCEEDED when the timeout elapses. The
+    // guest agent watches the listen table directly — clients never
+    // poll with shelled-out probes.
+    rpc WaitForPort(WaitForPortRequest) returns (google.protobuf.Empty);
 }
 
 // ---------------------------------------------------------------------------
@@ -268,5 +280,28 @@ message WaitExecutionRequest {
     string execution_id = 2;
     // Give up after this many seconds and return the current state
     // (0 = return immediately — a poll).
+    uint32 timeout_seconds = 3;
+}
+
+// Request to list a sandbox's executions.
+message ListExecutionsRequest {
+    // Sandbox whose executions to list.
+    string sandbox_id = 1;
+}
+
+// Response to ListExecutions.
+message ListExecutionsResponse {
+    // Every retained execution, running and exited.
+    repeated Execution executions = 1;
+}
+
+// Request to wait for a listening TCP port inside a sandbox.
+message WaitForPortRequest {
+    // Sandbox to watch.
+    string sandbox_id = 1;
+    // TCP port a workload is expected to listen on.
+    uint32 port = 2;
+    // Give up after this many seconds with DEADLINE_EXCEEDED
+    // (0 = daemon default of 30 s).
     uint32 timeout_seconds = 3;
 }

--- a/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/sandbox.proto
+++ b/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/sandbox.proto
@@ -42,6 +42,39 @@ service SandboxService {
     // Forcibly destroy a sandbox and release all resources immediately.
     rpc Remove(RemoveSandboxRequest) returns (google.protobuf.Empty);
 
+    // Pause a sandbox: checkpoint it to disk under the same ID, then
+    // release its runtime resources (VM, network, CoW overlay). The
+    // record survives as PAUSED and Resume restores it in place — the
+    // origin VM is gone by construction, which sidesteps the direct-mode
+    // relocation constraint documented in `snapshot.proto` (CORE-21).
+    // Returns once the sandbox reaches PAUSED; requires READY (no active
+    // execution). Trades RAM for disk: a paused sandbox keeps paying
+    // `storage_bytes` until removed.
+    rpc Pause(PauseSandboxRequest) returns (google.protobuf.Empty);
+
+    // Resume a PAUSED sandbox in place under the same ID; returns once
+    // it is READY again. Explicit resume is for control-plane callers:
+    // data-plane RPCs (executions, files) targeting a PAUSED sandbox
+    // resume it transparently before proceeding, so clients see a
+    // latency blip rather than an error. Callers that want the honest
+    // state machine instead set the reserved `x-arcbox-no-auto-resume`
+    // request header (not yet honored) and receive SANDBOX_PAUSED
+    // (`errors.proto`). Inspect and List never resume.
+    rpc Resume(ResumeSandboxRequest) returns (google.protobuf.Empty);
+
+    // Replace a sandbox's lifecycle deadlines: the hard maximum lifetime
+    // (`ttl_seconds`, re-armed from now — CORE-60) and/or the idle
+    // timeout and its policy. Fields left unset are unchanged.
+    rpc SetLifecycle(SetLifecycleRequest) returns (google.protobuf.Empty);
+
+    // Report what this daemon can do: version, sandbox protocol level,
+    // feature flags, and whether nested virtualization is available.
+    // Serves the SDK's lazy version handshake and the fail-fast
+    // capability check (CORE-13): creating a sandbox on an unsupported
+    // host fails immediately with NESTED_VIRT_UNSUPPORTED instead of a
+    // boot that wedges.
+    rpc GetCapabilities(GetCapabilitiesRequest) returns (GetCapabilitiesResponse);
+
     // Return the current state and metadata of a sandbox.
     rpc Inspect(InspectSandboxRequest) returns (SandboxInfo);
 
@@ -72,9 +105,11 @@ service SandboxService {
 //
 //   STARTING ──► READY ──► RUNNING ──► READY  (execution exited, sandbox alive)
 //                  │          │
-//                  └──────────┴──► STOPPING ──► STOPPED
-//                                       │
-//                                    FAILED
+//                  ├──────────┴──► STOPPING ──► STOPPED
+//                  │          │
+//                  ├──────────┴──► PAUSING ──► PAUSED ──(Resume)──► STARTING  (same ID)
+//                  │          │
+//                  └──────────┴──► FAILED  (error reason set)
 enum SandboxState {
     SANDBOX_STATE_UNSPECIFIED = 0;
     // Firecracker process spawned; VM still booting.
@@ -89,6 +124,11 @@ enum SandboxState {
     SANDBOX_STATE_STOPPED = 5;
     // Unrecoverable error occurred.
     SANDBOX_STATE_FAILED = 6;
+    // Pause in progress: checkpointing state, then releasing the VM.
+    SANDBOX_STATE_PAUSING = 7;
+    // Checkpointed to disk; runtime resources released. The record and
+    // snapshot survive under the same ID until Resume or Remove.
+    SANDBOX_STATE_PAUSED = 8;
 }
 
 // Kind of a sandbox lifecycle event.
@@ -112,6 +152,29 @@ enum SandboxEventKind {
     SANDBOX_EVENT_KIND_FAILED = 7;
     // Sandbox deleted.
     SANDBOX_EVENT_KIND_REMOVED = 8;
+    // Pause started — whether client-driven (Pause) or automated (idle
+    // timeout with a PAUSE policy); automation must be visible, so the
+    // idle detector emits the same events. Attributes carry "reason"
+    // ("pause" or "idle_timeout").
+    SANDBOX_EVENT_KIND_PAUSING = 9;
+    // Checkpoint complete; runtime resources released.
+    SANDBOX_EVENT_KIND_PAUSED = 10;
+    // Resume completed — explicit or transparent (a data-plane call to a
+    // paused sandbox); sandbox READY again under the same ID. Attributes
+    // carry "reason" ("resume" or "auto_resume").
+    SANDBOX_EVENT_KIND_RESUMED = 11;
+}
+
+// What the daemon does when a sandbox's idle timeout expires.
+enum IdleAction {
+    // Daemon default (currently KILL; auto-pause is opt-in).
+    IDLE_ACTION_UNSPECIFIED = 0;
+    // Destroy the sandbox and release all resources (Remove semantics).
+    IDLE_ACTION_KILL = 1;
+    // Pause: checkpoint to disk under the same ID and release the VM.
+    // Trades RAM for disk — the sandbox reports `storage_bytes` until
+    // resumed or removed.
+    IDLE_ACTION_PAUSE = 2;
 }
 
 // Sandbox network mode.
@@ -218,9 +281,14 @@ message CreateSandboxRequest {
     NetworkSpec network = 13;
 
     // --- Lifecycle ---
-    // Sandbox auto-destruction timeout in seconds (0 = no limit).
-    // The timer starts from the moment the sandbox is created and is not
-    // reset by workload activity.
+    // Two independent lifecycle knobs exist; never conflate them:
+    // `ttl_seconds` is the hard maximum lifetime, `idle_timeout_seconds`
+    // reacts to inactivity.
+    //
+    // Hard maximum lifetime in seconds (0 = no limit). On expiry the
+    // sandbox is always destroyed — pausing does not apply. The deadline
+    // starts at creation and is not reset by workload activity;
+    // SetLifecycle replaces it with a fresh deadline from now (CORE-60).
     uint32 ttl_seconds = 14;
 
     // --- Provisioning ---
@@ -241,6 +309,16 @@ message CreateSandboxRequest {
     // Cloud mode resolves names against the tenant's template registry.
     // Anything else is rejected with INVALID_ARGUMENT.
     string template = 17;
+
+    // Apply `on_idle` after this many seconds without a running
+    // execution (0 = no idle detection). Re-armed every time the
+    // workload goes idle; distinct from `ttl_seconds`, which caps total
+    // lifetime regardless of activity (CORE-21).
+    uint32 idle_timeout_seconds = 18;
+
+    // What to do when the idle timeout expires (UNSPECIFIED = the
+    // daemon default, currently KILL).
+    IdleAction on_idle = 19;
 }
 
 // Response to CreateSandbox.
@@ -277,6 +355,69 @@ message RemoveSandboxRequest {
 }
 
 // ---------------------------------------------------------------------------
+// Pause / Resume / lifecycle
+// ---------------------------------------------------------------------------
+
+// Request to pause a sandbox.
+message PauseSandboxRequest {
+    // Sandbox ID.
+    string id = 1;
+}
+
+// Request to resume a paused sandbox.
+message ResumeSandboxRequest {
+    // Sandbox ID.
+    string id = 1;
+}
+
+// Request to replace a sandbox's lifecycle deadlines. Absent fields are
+// left unchanged, so each knob can be adjusted independently.
+message SetLifecycleRequest {
+    // Sandbox ID.
+    string id = 1;
+    // Replace the hard maximum lifetime: expire this many seconds from
+    // now (0 = remove the limit).
+    optional uint32 ttl_seconds = 2;
+    // Replace the idle timeout (0 = disable idle detection).
+    optional uint32 idle_timeout_seconds = 3;
+    // Replace the idle policy (UNSPECIFIED = leave unchanged).
+    IdleAction on_idle = 4;
+}
+
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+// Request for the daemon's sandbox capabilities.
+message GetCapabilitiesRequest {}
+
+// What this daemon can do. SDKs fetch it lazily once per process and
+// fail fast with an actionable error instead of probing per call.
+message GetCapabilitiesResponse {
+    // Daemon version string (informational).
+    string daemon_version = 1;
+    // Sandbox API protocol level. SDKs compare it against their floor
+    // and raise a mismatch error with an upgrade suggestion
+    // (PROTOCOL_MISMATCH in `errors.proto`) instead of sprinkling
+    // version checks at call sites.
+    uint32 protocol = 2;
+    // Named feature flags for capabilities that postdate `protocol`.
+    repeated string features = 3;
+    // Whether this host can run sandboxes at all (CORE-13).
+    NestedVirtCapability nested_virt = 4;
+}
+
+// Nested-virtualization support on this host.
+message NestedVirtCapability {
+    // True when sandboxes can run (M3+ hardware, VZ backend).
+    bool supported = 1;
+    // Why not, when unsupported — the daemon's authoritative reason
+    // (chip generation vs backend), surfaced verbatim in
+    // NESTED_VIRT_UNSUPPORTED errors.
+    string reason = 2;
+}
+
+// ---------------------------------------------------------------------------
 // Inspect / List
 // ---------------------------------------------------------------------------
 
@@ -309,6 +450,24 @@ message SandboxInfo {
     ExitStatus last_exit_status = 9;
     // Human-readable error message (only set when state == FAILED).
     string error = 10;
+    // Template reference the sandbox was created from (as passed to
+    // Create; empty = the built-in minimal template).
+    string template = 11;
+    // When the hard maximum lifetime fires (unset = no limit). Replaced
+    // by SetLifecycle.
+    google.protobuf.Timestamp ttl_deadline = 12;
+    // Idle timeout in seconds (0 = no idle detection).
+    uint32 idle_timeout_seconds = 13;
+    // Action applied when the idle timeout expires.
+    IdleAction on_idle = 14;
+    // When the sandbox reached PAUSED (unset unless paused).
+    google.protobuf.Timestamp paused_at = 15;
+    // When the sandbox reached FAILED (unset otherwise; `error` carries
+    // the reason).
+    google.protobuf.Timestamp failed_at = 16;
+    // On-disk footprint of the sandbox's retained state (checkpoint +
+    // disk overlay). Paused sandboxes keep paying this until removed.
+    uint64 storage_bytes = 17;
 }
 
 // Network details of a sandbox.
@@ -342,6 +501,9 @@ message ListSandboxesResponse {
 }
 
 // Lightweight sandbox summary for List.
+//
+// Carries the state timestamps and retention cost so a listing shows
+// lifecycle truth without an Inspect per row.
 message SandboxSummary {
     // Sandbox ID.
     string id = 1;
@@ -353,6 +515,14 @@ message SandboxSummary {
     string ip_address = 4;
     // Creation time.
     google.protobuf.Timestamp created_at = 5;
+    // When the sandbox first became READY (unset if not yet).
+    google.protobuf.Timestamp ready_at = 6;
+    // When the sandbox reached PAUSED (unset unless paused).
+    google.protobuf.Timestamp paused_at = 7;
+    // When the sandbox reached FAILED (unset otherwise).
+    google.protobuf.Timestamp failed_at = 8;
+    // On-disk footprint of retained state; nonzero for paused sandboxes.
+    uint64 storage_bytes = 9;
 }
 
 // ---------------------------------------------------------------------------

--- a/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/sandbox.proto
+++ b/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/sandbox.proto
@@ -257,16 +257,32 @@ message CreateSandboxRequest {
     reserved "kernel", "rootfs", "boot_args", "image";
 
     // --- Resources ---
+    // Unset = the template's default limits, if any, else daemon
+    // defaults. Set = replaces the template default wholesale.
     ResourceLimits limits = 6;
 
     // --- Initial workload (optional) ---
     // Initial command launched automatically after boot.
-    // Empty = sandbox enters READY without running anything.
+    // Empty = inherit the template's default cmd, if any; otherwise the
+    // sandbox enters READY without running anything. Non-empty =
+    // replaces the template default.
     // When this process exits the sandbox transitions back to READY
     // (NOT destroyed) and continues accepting executions.
     repeated string cmd = 8;
-    // Environment variables for the initial command.
+    // Suppress the template's default cmd: enter READY without running
+    // anything even when the template defines one. proto3 repeated
+    // fields cannot express "explicitly empty", so this flag carries the
+    // presence `cmd` cannot. Rejected with INVALID_ARGUMENT alongside a
+    // non-empty `cmd`.
+    bool no_default_cmd = 20;
+    // Environment variables for the initial command, merged over the
+    // template's default env (per key, this request wins).
     map<string, string> env = 9;
+    // Start the initial command from exactly `env`, discarding the
+    // template's default env instead of merging over it (the map
+    // counterpart of `no_default_cmd`; to unset a single default key,
+    // set this and supply the full desired map).
+    bool no_default_env = 21;
     // Working directory for the initial command.
     string working_dir = 10;
     // User to run the initial command as.
@@ -305,7 +321,7 @@ message CreateSandboxRequest {
     //   "name[:version]" — a template from the catalog (`template.proto`,
     //                      CORE-21); a bare name resolves to the newest
     //                      published version. Template defaults apply
-    //                      unless overridden by the fields above.
+    //                      per the override rules on the fields above.
     // Cloud mode resolves names against the tenant's template registry.
     // Anything else is rejected with INVALID_ARGUMENT.
     string template = 17;

--- a/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/sandbox.proto
+++ b/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/sandbox.proto
@@ -230,13 +230,16 @@ message CreateSandboxRequest {
 
     reserved 16;
 
-    // Opaque reference to what boots inside the sandbox. Local mode accepts:
-    //   ""             — the built-in minimal template (busybox + init)
-    //   "docker:<ref>" — a local Docker image reference, resolved and
-    //                    converted inside the VM
-    // Cloud mode resolves names against the tenant's template registry;
-    // first-class templates are designed in CORE-21. Anything else is
-    // rejected with INVALID_ARGUMENT.
+    // Reference to what boots inside the sandbox:
+    //   ""               — the built-in minimal template (busybox + init)
+    //   "docker:<ref>"   — a local Docker image reference, resolved and
+    //                      converted inside the VM
+    //   "name[:version]" — a template from the catalog (`template.proto`,
+    //                      CORE-21); a bare name resolves to the newest
+    //                      published version. Template defaults apply
+    //                      unless overridden by the fields above.
+    // Cloud mode resolves names against the tenant's template registry.
+    // Anything else is rejected with INVALID_ARGUMENT.
     string template = 17;
 }
 

--- a/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/sandbox.proto
+++ b/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/sandbox.proto
@@ -258,7 +258,11 @@ message CreateSandboxRequest {
 
     // --- Resources ---
     // Unset = the template's default limits, if any, else daemon
-    // defaults. Set = replaces the template default wholesale.
+    // defaults. Set = replaces the template default wholesale: a zero
+    // subfield (vcpus, memory_mib) inside a set message means the DAEMON
+    // default for that resource — the template's value does not shine
+    // through per-field. Precision costs message presence, which the
+    // subfields (plain proto3 scalars) do not have.
     ResourceLimits limits = 6;
 
     // --- Initial workload (optional) ---

--- a/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/sandbox.proto
+++ b/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/sandbox.proto
@@ -380,8 +380,9 @@ message SetLifecycleRequest {
     optional uint32 ttl_seconds = 2;
     // Replace the idle timeout (0 = disable idle detection).
     optional uint32 idle_timeout_seconds = 3;
-    // Replace the idle policy (UNSPECIFIED = leave unchanged).
-    IdleAction on_idle = 4;
+    // Replace the idle policy (absent = leave unchanged; UNSPECIFIED =
+    // restore the daemon default).
+    optional IdleAction on_idle = 4;
 }
 
 // ---------------------------------------------------------------------------

--- a/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/template.proto
+++ b/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/template.proto
@@ -77,7 +77,11 @@ message Template {
 }
 
 // Default configuration a template applies to sandboxes created from it.
-// Every field can be overridden per sandbox in CreateSandboxRequest.
+// `limits`, `cmd`, and `env` can be overridden per sandbox — the
+// override/merge rules, including the `no_default_cmd`/`no_default_env`
+// explicit-empty flags, live on the CreateSandboxRequest fields.
+// `exposed_ports` and `ready_probe` have no per-create counterpart and
+// apply as-is.
 message TemplateDefaults {
     // Default resource limits.
     ResourceLimits limits = 1;

--- a/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/template.proto
+++ b/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/template.proto
@@ -1,0 +1,184 @@
+// Sandbox template catalog (CORE-21).
+//
+// A template is a named, versioned, reproducible base for sandboxes: a
+// built rootfs plus a default-config bundle (resources, startup command,
+// env, exposed ports, ready probe), optionally paired with a pre-warmed
+// boot-to-ready snapshot for sub-second starts. Templates are what users
+// author and share ("code-interpreter", "web-scraper", ...);
+// `CreateSandboxRequest.template` resolves `name[:version]` references
+// against this catalog.
+//
+// Control plane: the catalog addresses the fleet, not one sandbox.
+// Checkpoint/restore of a *live* sandbox stays in `snapshot.proto`;
+// promoting a checkpoint into a reusable template goes through
+// `Build` with a `snapshot_id` source.
+
+syntax = "proto3";
+
+package arcbox.sandbox.v1;
+
+import "arcbox/sandbox/v1/sandbox.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+// TemplateService manages the template catalog. Control plane.
+//
+// Contract-only in CORE-58 phase 1: the daemon answers UNIMPLEMENTED
+// until the catalog lands with CORE-21. Build additionally depends on the
+// rootfs pipeline (CORE-5) and, for pre-warmed snapshots, FC 1.16
+// network overrides (CORE-16).
+service TemplateService {
+    // Build a template from a source and register it in the catalog.
+    // Blocks until the build completes; a streaming progress variant can
+    // be added additively later. The result is an unpublished draft
+    // addressed as `name` until Publish freezes a version.
+    rpc Build(BuildTemplateRequest) returns (Template);
+
+    // Freeze the template's current content as an immutable version.
+    // Bare-name references then resolve to the newest published version.
+    rpc Publish(PublishTemplateRequest) returns (Template);
+
+    // Resolve a `name[:version]` reference to its template.
+    rpc Get(GetTemplateRequest) returns (Template);
+
+    // List templates, optionally filtered by labels. Paginated.
+    rpc List(ListTemplatesRequest) returns (ListTemplatesResponse);
+
+    // Delete a template version — or, for a bare-name reference, the
+    // template with all its versions — and its on-disk artifacts.
+    // Sandboxes already created from it are unaffected.
+    rpc Delete(DeleteTemplateRequest) returns (google.protobuf.Empty);
+}
+
+// A template: named, versioned, reproducible sandbox base.
+message Template {
+    // Template name, unique in the catalog.
+    string name = 1;
+    // Published version this record describes (empty = unpublished draft).
+    string version = 2;
+    // Content digest pinning this version's artifacts.
+    string digest = 3;
+    // Reference to the built rootfs image in the rootfs cache.
+    string rootfs_ref = 4;
+    // Pre-warmed boot-to-ready snapshot (empty = cold boot from
+    // `rootfs_ref`). Not a oneof with `rootfs_ref`: a built rootfs and
+    // its pre-warmed snapshot compose — creating from this template
+    // restores the snapshot for sub-second READY (CORE-16).
+    string warm_snapshot_id = 5;
+    // Defaults applied to sandboxes created from this template.
+    TemplateDefaults defaults = 6;
+    // Creation time of this version.
+    google.protobuf.Timestamp created_at = 7;
+    // Arbitrary key-value metadata (filterable in List).
+    map<string, string> labels = 8;
+    // On-disk footprint of this version's artifacts (rootfs + warm
+    // snapshot).
+    uint64 size_bytes = 9;
+}
+
+// Default configuration a template applies to sandboxes created from it.
+// Every field can be overridden per sandbox in CreateSandboxRequest.
+message TemplateDefaults {
+    // Default resource limits.
+    ResourceLimits limits = 1;
+    // Default initial command (see CreateSandboxRequest.cmd).
+    repeated string cmd = 2;
+    // Default environment for the initial command.
+    map<string, string> env = 3;
+    // Ports the workload is expected to listen on; clients may expose
+    // them without knowing the workload.
+    repeated uint32 exposed_ports = 4;
+    // How to decide the sandbox is ready for use (unset = READY as soon
+    // as the VM accepts executions).
+    ReadyProbe ready_probe = 5;
+}
+
+// Readiness probe run inside a sandbox after boot.
+message ReadyProbe {
+    oneof probe {
+        // Ready when something inside the sandbox listens on this TCP
+        // port.
+        uint32 port = 1;
+        // Ready when this command exits 0.
+        CommandProbe command = 2;
+    }
+    // Give up after this many seconds and mark the sandbox FAILED
+    // (0 = daemon default).
+    uint32 timeout_seconds = 3;
+}
+
+// Command form of a ReadyProbe.
+message CommandProbe {
+    // Command and arguments to run inside the sandbox.
+    repeated string cmd = 1;
+}
+
+// Request to build a template.
+message BuildTemplateRequest {
+    // Template name to register the result under.
+    string name = 1;
+
+    // What to build the rootfs from.
+    oneof source {
+        // A local Docker image reference, converted to a rootfs via the
+        // in-guest OCI pipeline (CORE-5).
+        string docker_ref = 2;
+        // Inline Dockerfile content, built in-guest then converted
+        // (CORE-5).
+        string dockerfile = 3;
+        // Promote an existing checkpoint (snapshot.proto) into a
+        // template: no build runs, and the checkpoint becomes the
+        // template's warm snapshot.
+        string snapshot_id = 4;
+    }
+
+    // Defaults for sandboxes created from this template.
+    TemplateDefaults defaults = 5;
+    // Labels for the template.
+    map<string, string> labels = 6;
+    // Also boot the built rootfs once and checkpoint it at READY, so the
+    // template carries a warm snapshot (requires CORE-16; ignored for
+    // `snapshot_id` sources, which are warm by construction).
+    bool prewarm = 7;
+}
+
+// Request to publish a template version.
+message PublishTemplateRequest {
+    // Template name.
+    string name = 1;
+    // Version to freeze the current draft content as (e.g. "1.2.0").
+    string version = 2;
+}
+
+// Request to resolve a template reference.
+message GetTemplateRequest {
+    // `name` or `name:version`. A bare name resolves to the newest
+    // published version, or the draft when nothing is published.
+    string reference = 1;
+}
+
+// Request to list templates.
+message ListTemplatesRequest {
+    // Filter by labels (all key-value pairs must match).
+    map<string, string> labels = 1;
+    // Maximum entries per page (0 = server default of 100; capped at
+    // 1000).
+    uint32 page_size = 2;
+    // Continuation token from a previous response (empty = first page).
+    string page_token = 3;
+}
+
+// Response to ListTemplates.
+message ListTemplatesResponse {
+    // One entry per template version (drafts included).
+    repeated Template templates = 1;
+    // Token for the next page; empty when this is the last page.
+    string next_page_token = 2;
+}
+
+// Request to delete a template.
+message DeleteTemplateRequest {
+    // `name` (delete the template and all its versions) or
+    // `name:version` (delete one version).
+    string reference = 1;
+}

--- a/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
@@ -1017,3 +1017,131 @@ pub struct DeleteSnapshotRequest {
     #[prost(string, tag = "1")]
     pub snapshot_id: ::prost::alloc::string::String,
 }
+/// Structured detail attached to sandbox API errors.
+///
+/// Carried as a Connect error detail; the transport status code stays the
+/// coarse routing signal while this message carries the precise cause.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ErrorInfo {
+    /// Machine-readable cause.
+    #[prost(enumeration = "ErrorCode", tag = "1")]
+    pub code: i32,
+    /// Actionable fix, phrased for direct display ("run `abctl daemon
+    /// start`"). Agent frameworks surface this to the LLM verbatim.
+    #[prost(string, tag = "2")]
+    pub suggestion: ::prost::alloc::string::String,
+    /// Structured facts about the failure: which timeout knob fired, the
+    /// limit that was exceeded, the state that was observed, and so on.
+    #[prost(map = "string, string", tag = "3")]
+    pub context:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+}
+/// Machine-readable cause of a sandbox API error.
+///
+/// Values are append-only: SDKs map unknown codes to their base error
+/// class, so retiring or renumbering a value silently reclassifies errors
+/// for older clients.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ErrorCode {
+    Unspecified = 0,
+    /// The addressed sandbox does not exist.
+    SandboxNotFound = 1,
+    /// The addressed template does not exist.
+    TemplateNotFound = 2,
+    /// The addressed execution does not exist.
+    ExecutionNotFound = 3,
+    /// The addressed path does not exist inside the sandbox.
+    FileNotFound = 4,
+    /// The sandbox is PAUSED and this call did not resume it. Data-plane
+    /// calls resume a paused sandbox transparently (CORE-21), so this
+    /// surfaces only where resume does not apply: on control-plane calls,
+    /// or when the caller opted out of transparent resume (the reserved
+    /// `x-arcbox-no-auto-resume` header — see sandbox.proto `Resume`).
+    SandboxPaused = 5,
+    /// The sandbox exists but is not READY for this operation
+    /// (e.g. still STARTING).
+    SandboxNotReady = 6,
+    /// The sandbox is in FAILED state; context carries the failure reason.
+    SandboxFailed = 7,
+    /// The sandbox's hard maximum lifetime (`ttl_seconds`) expired and the
+    /// daemon destroyed it.
+    TtlExpired = 8,
+    /// A per-command timeout fired and the process group was killed.
+    CommandTimeout = 9,
+    /// This host cannot run sandboxes (no nested virtualization).
+    /// See SandboxService.GetCapabilities (CORE-13 fail-fast).
+    NestedVirtUnsupported = 10,
+    /// The template reference could not be resolved or is malformed.
+    TemplateInvalid = 11,
+    /// A file transfer exceeded the per-file size cap; context carries
+    /// the limit.
+    FileTooLarge = 12,
+    /// Stdin was already closed for this execution.
+    StdinClosed = 13,
+    /// The operation requires a TTY execution (e.g. terminal resize).
+    TtyRequired = 14,
+    /// The requested host port is already bound.
+    PortInUse = 15,
+    /// Authentication is required. Reserved for the remote tier (CORE-63).
+    AuthRequired = 16,
+    /// The client and daemon protocol levels are incompatible; the
+    /// suggestion names which side to upgrade.
+    ProtocolMismatch = 17,
+    /// The host is out of a resource (memory, disk, sandbox slots).
+    ResourceExhaustedHost = 18,
+}
+impl ErrorCode {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "ERROR_CODE_UNSPECIFIED",
+            Self::SandboxNotFound => "ERROR_CODE_SANDBOX_NOT_FOUND",
+            Self::TemplateNotFound => "ERROR_CODE_TEMPLATE_NOT_FOUND",
+            Self::ExecutionNotFound => "ERROR_CODE_EXECUTION_NOT_FOUND",
+            Self::FileNotFound => "ERROR_CODE_FILE_NOT_FOUND",
+            Self::SandboxPaused => "ERROR_CODE_SANDBOX_PAUSED",
+            Self::SandboxNotReady => "ERROR_CODE_SANDBOX_NOT_READY",
+            Self::SandboxFailed => "ERROR_CODE_SANDBOX_FAILED",
+            Self::TtlExpired => "ERROR_CODE_TTL_EXPIRED",
+            Self::CommandTimeout => "ERROR_CODE_COMMAND_TIMEOUT",
+            Self::NestedVirtUnsupported => "ERROR_CODE_NESTED_VIRT_UNSUPPORTED",
+            Self::TemplateInvalid => "ERROR_CODE_TEMPLATE_INVALID",
+            Self::FileTooLarge => "ERROR_CODE_FILE_TOO_LARGE",
+            Self::StdinClosed => "ERROR_CODE_STDIN_CLOSED",
+            Self::TtyRequired => "ERROR_CODE_TTY_REQUIRED",
+            Self::PortInUse => "ERROR_CODE_PORT_IN_USE",
+            Self::AuthRequired => "ERROR_CODE_AUTH_REQUIRED",
+            Self::ProtocolMismatch => "ERROR_CODE_PROTOCOL_MISMATCH",
+            Self::ResourceExhaustedHost => "ERROR_CODE_RESOURCE_EXHAUSTED_HOST",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "ERROR_CODE_UNSPECIFIED" => Some(Self::Unspecified),
+            "ERROR_CODE_SANDBOX_NOT_FOUND" => Some(Self::SandboxNotFound),
+            "ERROR_CODE_TEMPLATE_NOT_FOUND" => Some(Self::TemplateNotFound),
+            "ERROR_CODE_EXECUTION_NOT_FOUND" => Some(Self::ExecutionNotFound),
+            "ERROR_CODE_FILE_NOT_FOUND" => Some(Self::FileNotFound),
+            "ERROR_CODE_SANDBOX_PAUSED" => Some(Self::SandboxPaused),
+            "ERROR_CODE_SANDBOX_NOT_READY" => Some(Self::SandboxNotReady),
+            "ERROR_CODE_SANDBOX_FAILED" => Some(Self::SandboxFailed),
+            "ERROR_CODE_TTL_EXPIRED" => Some(Self::TtlExpired),
+            "ERROR_CODE_COMMAND_TIMEOUT" => Some(Self::CommandTimeout),
+            "ERROR_CODE_NESTED_VIRT_UNSUPPORTED" => Some(Self::NestedVirtUnsupported),
+            "ERROR_CODE_TEMPLATE_INVALID" => Some(Self::TemplateInvalid),
+            "ERROR_CODE_FILE_TOO_LARGE" => Some(Self::FileTooLarge),
+            "ERROR_CODE_STDIN_CLOSED" => Some(Self::StdinClosed),
+            "ERROR_CODE_TTY_REQUIRED" => Some(Self::TtyRequired),
+            "ERROR_CODE_PORT_IN_USE" => Some(Self::PortInUse),
+            "ERROR_CODE_AUTH_REQUIRED" => Some(Self::AuthRequired),
+            "ERROR_CODE_PROTOCOL_MISMATCH" => Some(Self::ProtocolMismatch),
+            "ERROR_CODE_RESOURCE_EXHAUSTED_HOST" => Some(Self::ResourceExhaustedHost),
+            _ => None,
+        }
+    }
+}

--- a/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
@@ -92,9 +92,14 @@ pub struct CreateSandboxRequest {
     #[prost(message, optional, tag = "13")]
     pub network: ::core::option::Option<NetworkSpec>,
     /// --- Lifecycle ---
-    /// Sandbox auto-destruction timeout in seconds (0 = no limit).
-    /// The timer starts from the moment the sandbox is created and is not
-    /// reset by workload activity.
+    /// Two independent lifecycle knobs exist; never conflate them:
+    /// `ttl_seconds` is the hard maximum lifetime, `idle_timeout_seconds`
+    /// reacts to inactivity.
+    ///
+    /// Hard maximum lifetime in seconds (0 = no limit). On expiry the
+    /// sandbox is always destroyed — pausing does not apply. The deadline
+    /// starts at creation and is not reset by workload activity;
+    /// SetLifecycle replaces it with a fresh deadline from now (CORE-60).
     #[prost(uint32, tag = "14")]
     pub ttl_seconds: u32,
     /// --- Provisioning ---
@@ -114,6 +119,16 @@ pub struct CreateSandboxRequest {
     /// Anything else is rejected with INVALID_ARGUMENT.
     #[prost(string, tag = "17")]
     pub template: ::prost::alloc::string::String,
+    /// Apply `on_idle` after this many seconds without a running
+    /// execution (0 = no idle detection). Re-armed every time the
+    /// workload goes idle; distinct from `ttl_seconds`, which caps total
+    /// lifetime regardless of activity (CORE-21).
+    #[prost(uint32, tag = "18")]
+    pub idle_timeout_seconds: u32,
+    /// What to do when the idle timeout expires (UNSPECIFIED = the
+    /// daemon default, currently KILL).
+    #[prost(enumeration = "IdleAction", tag = "19")]
+    pub on_idle: i32,
 }
 /// Response to CreateSandbox.
 /// Returned immediately; the sandbox may still be booting (state STARTING).
@@ -150,6 +165,73 @@ pub struct RemoveSandboxRequest {
     /// Force removal even if the sandbox is in RUNNING state.
     #[prost(bool, tag = "2")]
     pub force: bool,
+}
+/// Request to pause a sandbox.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct PauseSandboxRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+}
+/// Request to resume a paused sandbox.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ResumeSandboxRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+}
+/// Request to replace a sandbox's lifecycle deadlines. Absent fields are
+/// left unchanged, so each knob can be adjusted independently.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SetLifecycleRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Replace the hard maximum lifetime: expire this many seconds from
+    /// now (0 = remove the limit).
+    #[prost(uint32, optional, tag = "2")]
+    pub ttl_seconds: ::core::option::Option<u32>,
+    /// Replace the idle timeout (0 = disable idle detection).
+    #[prost(uint32, optional, tag = "3")]
+    pub idle_timeout_seconds: ::core::option::Option<u32>,
+    /// Replace the idle policy (UNSPECIFIED = leave unchanged).
+    #[prost(enumeration = "IdleAction", tag = "4")]
+    pub on_idle: i32,
+}
+/// Request for the daemon's sandbox capabilities.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetCapabilitiesRequest {}
+/// What this daemon can do. SDKs fetch it lazily once per process and
+/// fail fast with an actionable error instead of probing per call.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetCapabilitiesResponse {
+    /// Daemon version string (informational).
+    #[prost(string, tag = "1")]
+    pub daemon_version: ::prost::alloc::string::String,
+    /// Sandbox API protocol level. SDKs compare it against their floor
+    /// and raise a mismatch error with an upgrade suggestion
+    /// (PROTOCOL_MISMATCH in `errors.proto`) instead of sprinkling
+    /// version checks at call sites.
+    #[prost(uint32, tag = "2")]
+    pub protocol: u32,
+    /// Named feature flags for capabilities that postdate `protocol`.
+    #[prost(string, repeated, tag = "3")]
+    pub features: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Whether this host can run sandboxes at all (CORE-13).
+    #[prost(message, optional, tag = "4")]
+    pub nested_virt: ::core::option::Option<NestedVirtCapability>,
+}
+/// Nested-virtualization support on this host.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct NestedVirtCapability {
+    /// True when sandboxes can run (M3+ hardware, VZ backend).
+    #[prost(bool, tag = "1")]
+    pub supported: bool,
+    /// Why not, when unsupported — the daemon's authoritative reason
+    /// (chip generation vs backend), surfaced verbatim in
+    /// NESTED_VIRT_UNSUPPORTED errors.
+    #[prost(string, tag = "2")]
+    pub reason: ::prost::alloc::string::String,
 }
 /// Request to inspect a sandbox.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -193,6 +275,31 @@ pub struct SandboxInfo {
     /// Human-readable error message (only set when state == FAILED).
     #[prost(string, tag = "10")]
     pub error: ::prost::alloc::string::String,
+    /// Template reference the sandbox was created from (as passed to
+    /// Create; empty = the built-in minimal template).
+    #[prost(string, tag = "11")]
+    pub template: ::prost::alloc::string::String,
+    /// When the hard maximum lifetime fires (unset = no limit). Replaced
+    /// by SetLifecycle.
+    #[prost(message, optional, tag = "12")]
+    pub ttl_deadline: ::core::option::Option<::pbjson_types::Timestamp>,
+    /// Idle timeout in seconds (0 = no idle detection).
+    #[prost(uint32, tag = "13")]
+    pub idle_timeout_seconds: u32,
+    /// Action applied when the idle timeout expires.
+    #[prost(enumeration = "IdleAction", tag = "14")]
+    pub on_idle: i32,
+    /// When the sandbox reached PAUSED (unset unless paused).
+    #[prost(message, optional, tag = "15")]
+    pub paused_at: ::core::option::Option<::pbjson_types::Timestamp>,
+    /// When the sandbox reached FAILED (unset otherwise; `error` carries
+    /// the reason).
+    #[prost(message, optional, tag = "16")]
+    pub failed_at: ::core::option::Option<::pbjson_types::Timestamp>,
+    /// On-disk footprint of the sandbox's retained state (checkpoint +
+    /// disk overlay). Paused sandboxes keep paying this until removed.
+    #[prost(uint64, tag = "17")]
+    pub storage_bytes: u64,
 }
 /// Network details of a sandbox.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -231,6 +338,9 @@ pub struct ListSandboxesResponse {
     pub next_page_token: ::prost::alloc::string::String,
 }
 /// Lightweight sandbox summary for List.
+///
+/// Carries the state timestamps and retention cost so a listing shows
+/// lifecycle truth without an Inspect per row.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SandboxSummary {
     /// Sandbox ID.
@@ -249,6 +359,18 @@ pub struct SandboxSummary {
     /// Creation time.
     #[prost(message, optional, tag = "5")]
     pub created_at: ::core::option::Option<::pbjson_types::Timestamp>,
+    /// When the sandbox first became READY (unset if not yet).
+    #[prost(message, optional, tag = "6")]
+    pub ready_at: ::core::option::Option<::pbjson_types::Timestamp>,
+    /// When the sandbox reached PAUSED (unset unless paused).
+    #[prost(message, optional, tag = "7")]
+    pub paused_at: ::core::option::Option<::pbjson_types::Timestamp>,
+    /// When the sandbox reached FAILED (unset otherwise).
+    #[prost(message, optional, tag = "8")]
+    pub failed_at: ::core::option::Option<::pbjson_types::Timestamp>,
+    /// On-disk footprint of retained state; nonzero for paused sandboxes.
+    #[prost(uint64, tag = "9")]
+    pub storage_bytes: u64,
 }
 /// Request to subscribe to sandbox lifecycle events.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -341,9 +463,11 @@ pub struct UnexposePortRequest {
 ///
 ///    STARTING ──► READY ──► RUNNING ──► READY  (execution exited, sandbox alive)
 ///                   │          │
-///                   └──────────┴──► STOPPING ──► STOPPED
-///                                        │
-///                                     FAILED
+///                   ├──────────┴──► STOPPING ──► STOPPED
+///                   │          │
+///                   ├──────────┴──► PAUSING ──► PAUSED ──(Resume)──► STARTING  (same ID)
+///                   │          │
+///                   └──────────┴──► FAILED  (error reason set)
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum SandboxState {
@@ -360,6 +484,11 @@ pub enum SandboxState {
     Stopped = 5,
     /// Unrecoverable error occurred.
     Failed = 6,
+    /// Pause in progress: checkpointing state, then releasing the VM.
+    Pausing = 7,
+    /// Checkpointed to disk; runtime resources released. The record and
+    /// snapshot survive under the same ID until Resume or Remove.
+    Paused = 8,
 }
 impl SandboxState {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -375,6 +504,8 @@ impl SandboxState {
             Self::Stopping => "SANDBOX_STATE_STOPPING",
             Self::Stopped => "SANDBOX_STATE_STOPPED",
             Self::Failed => "SANDBOX_STATE_FAILED",
+            Self::Pausing => "SANDBOX_STATE_PAUSING",
+            Self::Paused => "SANDBOX_STATE_PAUSED",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -387,6 +518,8 @@ impl SandboxState {
             "SANDBOX_STATE_STOPPING" => Some(Self::Stopping),
             "SANDBOX_STATE_STOPPED" => Some(Self::Stopped),
             "SANDBOX_STATE_FAILED" => Some(Self::Failed),
+            "SANDBOX_STATE_PAUSING" => Some(Self::Pausing),
+            "SANDBOX_STATE_PAUSED" => Some(Self::Paused),
             _ => None,
         }
     }
@@ -414,6 +547,17 @@ pub enum SandboxEventKind {
     Failed = 7,
     /// Sandbox deleted.
     Removed = 8,
+    /// Pause started — whether client-driven (Pause) or automated (idle
+    /// timeout with a PAUSE policy); automation must be visible, so the
+    /// idle detector emits the same events. Attributes carry "reason"
+    /// ("pause" or "idle_timeout").
+    Pausing = 9,
+    /// Checkpoint complete; runtime resources released.
+    Paused = 10,
+    /// Resume completed — explicit or transparent (a data-plane call to a
+    /// paused sandbox); sandbox READY again under the same ID. Attributes
+    /// carry "reason" ("resume" or "auto_resume").
+    Resumed = 11,
 }
 impl SandboxEventKind {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -431,6 +575,9 @@ impl SandboxEventKind {
             Self::Stopped => "SANDBOX_EVENT_KIND_STOPPED",
             Self::Failed => "SANDBOX_EVENT_KIND_FAILED",
             Self::Removed => "SANDBOX_EVENT_KIND_REMOVED",
+            Self::Pausing => "SANDBOX_EVENT_KIND_PAUSING",
+            Self::Paused => "SANDBOX_EVENT_KIND_PAUSED",
+            Self::Resumed => "SANDBOX_EVENT_KIND_RESUMED",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -445,6 +592,44 @@ impl SandboxEventKind {
             "SANDBOX_EVENT_KIND_STOPPED" => Some(Self::Stopped),
             "SANDBOX_EVENT_KIND_FAILED" => Some(Self::Failed),
             "SANDBOX_EVENT_KIND_REMOVED" => Some(Self::Removed),
+            "SANDBOX_EVENT_KIND_PAUSING" => Some(Self::Pausing),
+            "SANDBOX_EVENT_KIND_PAUSED" => Some(Self::Paused),
+            "SANDBOX_EVENT_KIND_RESUMED" => Some(Self::Resumed),
+            _ => None,
+        }
+    }
+}
+/// What the daemon does when a sandbox's idle timeout expires.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum IdleAction {
+    /// Daemon default (currently KILL; auto-pause is opt-in).
+    Unspecified = 0,
+    /// Destroy the sandbox and release all resources (Remove semantics).
+    Kill = 1,
+    /// Pause: checkpoint to disk under the same ID and release the VM.
+    /// Trades RAM for disk — the sandbox reports `storage_bytes` until
+    /// resumed or removed.
+    Pause = 2,
+}
+impl IdleAction {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "IDLE_ACTION_UNSPECIFIED",
+            Self::Kill => "IDLE_ACTION_KILL",
+            Self::Pause => "IDLE_ACTION_PAUSE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "IDLE_ACTION_UNSPECIFIED" => Some(Self::Unspecified),
+            "IDLE_ACTION_KILL" => Some(Self::Kill),
+            "IDLE_ACTION_PAUSE" => Some(Self::Pause),
             _ => None,
         }
     }

--- a/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
@@ -102,13 +102,16 @@ pub struct CreateSandboxRequest {
     /// FAILED_PRECONDITION. Use executions for interactive access.
     #[prost(string, optional, tag = "15")]
     pub ssh_public_key: ::core::option::Option<::prost::alloc::string::String>,
-    /// Opaque reference to what boots inside the sandbox. Local mode accepts:
-    ///    ""             — the built-in minimal template (busybox + init)
-    ///    "docker:<ref>" — a local Docker image reference, resolved and
-    ///                     converted inside the VM
-    /// Cloud mode resolves names against the tenant's template registry;
-    /// first-class templates are designed in CORE-21. Anything else is
-    /// rejected with INVALID_ARGUMENT.
+    /// Reference to what boots inside the sandbox:
+    ///    ""               — the built-in minimal template (busybox + init)
+    ///    "docker:<ref>"   — a local Docker image reference, resolved and
+    ///                       converted inside the VM
+    ///    "name\[:version\]" — a template from the catalog (`template.proto`,
+    ///                       CORE-21); a bare name resolves to the newest
+    ///                       published version. Template defaults apply
+    ///                       unless overridden by the fields above.
+    /// Cloud mode resolves names against the tenant's template registry.
+    /// Anything else is rejected with INVALID_ARGUMENT.
     #[prost(string, tag = "17")]
     pub template: ::prost::alloc::string::String,
 }
@@ -1016,6 +1019,188 @@ pub struct DeleteSnapshotRequest {
     /// Snapshot ID.
     #[prost(string, tag = "1")]
     pub snapshot_id: ::prost::alloc::string::String,
+}
+/// A template: named, versioned, reproducible sandbox base.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Template {
+    /// Template name, unique in the catalog.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Published version this record describes (empty = unpublished draft).
+    #[prost(string, tag = "2")]
+    pub version: ::prost::alloc::string::String,
+    /// Content digest pinning this version's artifacts.
+    #[prost(string, tag = "3")]
+    pub digest: ::prost::alloc::string::String,
+    /// Reference to the built rootfs image in the rootfs cache.
+    #[prost(string, tag = "4")]
+    pub rootfs_ref: ::prost::alloc::string::String,
+    /// Pre-warmed boot-to-ready snapshot (empty = cold boot from
+    /// `rootfs_ref`). Not a oneof with `rootfs_ref`: a built rootfs and
+    /// its pre-warmed snapshot compose — creating from this template
+    /// restores the snapshot for sub-second READY (CORE-16).
+    #[prost(string, tag = "5")]
+    pub warm_snapshot_id: ::prost::alloc::string::String,
+    /// Defaults applied to sandboxes created from this template.
+    #[prost(message, optional, tag = "6")]
+    pub defaults: ::core::option::Option<TemplateDefaults>,
+    /// Creation time of this version.
+    #[prost(message, optional, tag = "7")]
+    pub created_at: ::core::option::Option<::pbjson_types::Timestamp>,
+    /// Arbitrary key-value metadata (filterable in List).
+    #[prost(map = "string, string", tag = "8")]
+    pub labels:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// On-disk footprint of this version's artifacts (rootfs + warm
+    /// snapshot).
+    #[prost(uint64, tag = "9")]
+    pub size_bytes: u64,
+}
+/// Default configuration a template applies to sandboxes created from it.
+/// Every field can be overridden per sandbox in CreateSandboxRequest.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TemplateDefaults {
+    /// Default resource limits.
+    #[prost(message, optional, tag = "1")]
+    pub limits: ::core::option::Option<ResourceLimits>,
+    /// Default initial command (see CreateSandboxRequest.cmd).
+    #[prost(string, repeated, tag = "2")]
+    pub cmd: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Default environment for the initial command.
+    #[prost(map = "string, string", tag = "3")]
+    pub env:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// Ports the workload is expected to listen on; clients may expose
+    /// them without knowing the workload.
+    #[prost(uint32, repeated, tag = "4")]
+    pub exposed_ports: ::prost::alloc::vec::Vec<u32>,
+    /// How to decide the sandbox is ready for use (unset = READY as soon
+    /// as the VM accepts executions).
+    #[prost(message, optional, tag = "5")]
+    pub ready_probe: ::core::option::Option<ReadyProbe>,
+}
+/// Readiness probe run inside a sandbox after boot.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ReadyProbe {
+    /// Give up after this many seconds and mark the sandbox FAILED
+    /// (0 = daemon default).
+    #[prost(uint32, tag = "3")]
+    pub timeout_seconds: u32,
+    #[prost(oneof = "ready_probe::Probe", tags = "1, 2")]
+    pub probe: ::core::option::Option<ready_probe::Probe>,
+}
+/// Nested message and enum types in `ReadyProbe`.
+pub mod ready_probe {
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum Probe {
+        /// Ready when something inside the sandbox listens on this TCP
+        /// port.
+        #[prost(uint32, tag = "1")]
+        Port(u32),
+        /// Ready when this command exits 0.
+        #[prost(message, tag = "2")]
+        Command(super::CommandProbe),
+    }
+}
+/// Command form of a ReadyProbe.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct CommandProbe {
+    /// Command and arguments to run inside the sandbox.
+    #[prost(string, repeated, tag = "1")]
+    pub cmd: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Request to build a template.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BuildTemplateRequest {
+    /// Template name to register the result under.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Defaults for sandboxes created from this template.
+    #[prost(message, optional, tag = "5")]
+    pub defaults: ::core::option::Option<TemplateDefaults>,
+    /// Labels for the template.
+    #[prost(map = "string, string", tag = "6")]
+    pub labels:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// Also boot the built rootfs once and checkpoint it at READY, so the
+    /// template carries a warm snapshot (requires CORE-16; ignored for
+    /// `snapshot_id` sources, which are warm by construction).
+    #[prost(bool, tag = "7")]
+    pub prewarm: bool,
+    /// What to build the rootfs from.
+    #[prost(oneof = "build_template_request::Source", tags = "2, 3, 4")]
+    pub source: ::core::option::Option<build_template_request::Source>,
+}
+/// Nested message and enum types in `BuildTemplateRequest`.
+pub mod build_template_request {
+    /// What to build the rootfs from.
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum Source {
+        /// A local Docker image reference, converted to a rootfs via the
+        /// in-guest OCI pipeline (CORE-5).
+        #[prost(string, tag = "2")]
+        DockerRef(::prost::alloc::string::String),
+        /// Inline Dockerfile content, built in-guest then converted
+        /// (CORE-5).
+        #[prost(string, tag = "3")]
+        Dockerfile(::prost::alloc::string::String),
+        /// Promote an existing checkpoint (snapshot.proto) into a
+        /// template: no build runs, and the checkpoint becomes the
+        /// template's warm snapshot.
+        #[prost(string, tag = "4")]
+        SnapshotId(::prost::alloc::string::String),
+    }
+}
+/// Request to publish a template version.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct PublishTemplateRequest {
+    /// Template name.
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Version to freeze the current draft content as (e.g. "1.2.0").
+    #[prost(string, tag = "2")]
+    pub version: ::prost::alloc::string::String,
+}
+/// Request to resolve a template reference.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetTemplateRequest {
+    /// `name` or `name:version`. A bare name resolves to the newest
+    /// published version, or the draft when nothing is published.
+    #[prost(string, tag = "1")]
+    pub reference: ::prost::alloc::string::String,
+}
+/// Request to list templates.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListTemplatesRequest {
+    /// Filter by labels (all key-value pairs must match).
+    #[prost(map = "string, string", tag = "1")]
+    pub labels:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// Maximum entries per page (0 = server default of 100; capped at
+    /// 1000).
+    #[prost(uint32, tag = "2")]
+    pub page_size: u32,
+    /// Continuation token from a previous response (empty = first page).
+    #[prost(string, tag = "3")]
+    pub page_token: ::prost::alloc::string::String,
+}
+/// Response to ListTemplates.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListTemplatesResponse {
+    /// One entry per template version (drafts included).
+    #[prost(message, repeated, tag = "1")]
+    pub templates: ::prost::alloc::vec::Vec<Template>,
+    /// Token for the next page; empty when this is the last page.
+    #[prost(string, tag = "2")]
+    pub next_page_token: ::prost::alloc::string::String,
+}
+/// Request to delete a template.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct DeleteTemplateRequest {
+    /// `name` (delete the template and all its versions) or
+    /// `name:version` (delete one version).
+    #[prost(string, tag = "1")]
+    pub reference: ::prost::alloc::string::String,
 }
 /// Structured detail attached to sandbox API errors.
 ///

--- a/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
@@ -929,6 +929,34 @@ pub struct WaitExecutionRequest {
     #[prost(uint32, tag = "3")]
     pub timeout_seconds: u32,
 }
+/// Request to list a sandbox's executions.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ListExecutionsRequest {
+    /// Sandbox whose executions to list.
+    #[prost(string, tag = "1")]
+    pub sandbox_id: ::prost::alloc::string::String,
+}
+/// Response to ListExecutions.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListExecutionsResponse {
+    /// Every retained execution, running and exited.
+    #[prost(message, repeated, tag = "1")]
+    pub executions: ::prost::alloc::vec::Vec<Execution>,
+}
+/// Request to wait for a listening TCP port inside a sandbox.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct WaitForPortRequest {
+    /// Sandbox to watch.
+    #[prost(string, tag = "1")]
+    pub sandbox_id: ::prost::alloc::string::String,
+    /// TCP port a workload is expected to listen on.
+    #[prost(uint32, tag = "2")]
+    pub port: u32,
+    /// Give up after this many seconds with DEADLINE_EXCEEDED
+    /// (0 = daemon default of 30 s).
+    #[prost(uint32, tag = "3")]
+    pub timeout_seconds: u32,
+}
 /// Lifecycle state of an execution.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
@@ -64,19 +64,37 @@ pub struct CreateSandboxRequest {
     pub labels:
         ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// --- Resources ---
+    /// Unset = the template's default limits, if any, else daemon
+    /// defaults. Set = replaces the template default wholesale.
     #[prost(message, optional, tag = "6")]
     pub limits: ::core::option::Option<ResourceLimits>,
     /// --- Initial workload (optional) ---
     /// Initial command launched automatically after boot.
-    /// Empty = sandbox enters READY without running anything.
+    /// Empty = inherit the template's default cmd, if any; otherwise the
+    /// sandbox enters READY without running anything. Non-empty =
+    /// replaces the template default.
     /// When this process exits the sandbox transitions back to READY
     /// (NOT destroyed) and continues accepting executions.
     #[prost(string, repeated, tag = "8")]
     pub cmd: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// Environment variables for the initial command.
+    /// Suppress the template's default cmd: enter READY without running
+    /// anything even when the template defines one. proto3 repeated
+    /// fields cannot express "explicitly empty", so this flag carries the
+    /// presence `cmd` cannot. Rejected with INVALID_ARGUMENT alongside a
+    /// non-empty `cmd`.
+    #[prost(bool, tag = "20")]
+    pub no_default_cmd: bool,
+    /// Environment variables for the initial command, merged over the
+    /// template's default env (per key, this request wins).
     #[prost(map = "string, string", tag = "9")]
     pub env:
         ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// Start the initial command from exactly `env`, discarding the
+    /// template's default env instead of merging over it (the map
+    /// counterpart of `no_default_cmd`; to unset a single default key,
+    /// set this and supply the full desired map).
+    #[prost(bool, tag = "21")]
+    pub no_default_env: bool,
     /// Working directory for the initial command.
     #[prost(string, tag = "10")]
     pub working_dir: ::prost::alloc::string::String,
@@ -114,7 +132,7 @@ pub struct CreateSandboxRequest {
     ///    "name\[:version\]" — a template from the catalog (`template.proto`,
     ///                       CORE-21); a bare name resolves to the newest
     ///                       published version. Template defaults apply
-    ///                       unless overridden by the fields above.
+    ///                       per the override rules on the fields above.
     /// Cloud mode resolves names against the tenant's template registry.
     /// Anything else is rejected with INVALID_ARGUMENT.
     #[prost(string, tag = "17")]
@@ -1488,7 +1506,11 @@ pub struct Template {
     pub size_bytes: u64,
 }
 /// Default configuration a template applies to sandboxes created from it.
-/// Every field can be overridden per sandbox in CreateSandboxRequest.
+/// `limits`, `cmd`, and `env` can be overridden per sandbox — the
+/// override/merge rules, including the `no_default_cmd`/`no_default_env`
+/// explicit-empty flags, live on the CreateSandboxRequest fields.
+/// `exposed_ports` and `ready_probe` have no per-create counterpart and
+/// apply as-is.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TemplateDefaults {
     /// Default resource limits.

--- a/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
@@ -1119,6 +1119,223 @@ pub mod write_file_request {
         Chunk(super::FileChunk),
     }
 }
+/// Metadata of one filesystem entry.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct FileStat {
+    /// Base name of the entry (the final path component).
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    /// Kind of entry (symlinks are reported as SYMLINK, not followed).
+    #[prost(enumeration = "FileKind", tag = "2")]
+    pub kind: i32,
+    /// Size in bytes (regular files; 0 otherwise).
+    #[prost(uint64, tag = "3")]
+    pub size: u64,
+    /// Unix permission bits (the low 12 bits of st_mode).
+    #[prost(uint32, tag = "4")]
+    pub mode: u32,
+    /// Last modification time.
+    #[prost(message, optional, tag = "5")]
+    pub modified_at: ::core::option::Option<::pbjson_types::Timestamp>,
+    /// Owning user ID.
+    #[prost(uint32, tag = "6")]
+    pub uid: u32,
+    /// Owning group ID.
+    #[prost(uint32, tag = "7")]
+    pub gid: u32,
+    /// Symlink target (set only when kind == SYMLINK).
+    #[prost(string, tag = "8")]
+    pub symlink_target: ::prost::alloc::string::String,
+}
+/// Request to stat a path.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct StatFileRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Absolute path inside the sandbox rootfs.
+    #[prost(string, tag = "2")]
+    pub path: ::prost::alloc::string::String,
+}
+/// Request to list a directory.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ListDirRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Absolute directory path inside the sandbox rootfs.
+    #[prost(string, tag = "2")]
+    pub path: ::prost::alloc::string::String,
+}
+/// Response to ListDir.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListDirResponse {
+    /// Directory entries, each with full metadata.
+    #[prost(message, repeated, tag = "1")]
+    pub entries: ::prost::alloc::vec::Vec<FileStat>,
+}
+/// Request to create a directory.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct MakeDirRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Absolute directory path to create (missing parents are created).
+    #[prost(string, tag = "2")]
+    pub path: ::prost::alloc::string::String,
+    /// Unix permission bits for created directories (0 = 0755).
+    #[prost(uint32, tag = "3")]
+    pub mode: u32,
+}
+/// Request to remove a filesystem entry.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct RemoveEntryRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Absolute path to remove.
+    #[prost(string, tag = "2")]
+    pub path: ::prost::alloc::string::String,
+    /// Remove directories and their contents recursively. Without it a
+    /// non-empty directory fails with FAILED_PRECONDITION.
+    #[prost(bool, tag = "3")]
+    pub recursive: bool,
+}
+/// Request to rename / move a filesystem entry.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct MoveEntryRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Absolute source path.
+    #[prost(string, tag = "2")]
+    pub from_path: ::prost::alloc::string::String,
+    /// Absolute destination path.
+    #[prost(string, tag = "3")]
+    pub to_path: ::prost::alloc::string::String,
+}
+/// Request to watch a path for filesystem events.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct WatchDirRequest {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// Absolute path to watch (a directory).
+    #[prost(string, tag = "2")]
+    pub path: ::prost::alloc::string::String,
+    /// Also watch subdirectories.
+    #[prost(bool, tag = "3")]
+    pub recursive: bool,
+}
+/// One filesystem event.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct FsEvent {
+    /// What happened.
+    #[prost(enumeration = "FsEventKind", tag = "1")]
+    pub kind: i32,
+    /// Absolute path of the affected entry (the old path for RENAMED).
+    #[prost(string, tag = "2")]
+    pub path: ::prost::alloc::string::String,
+    /// New absolute path (set only for RENAMED).
+    #[prost(string, tag = "3")]
+    pub renamed_to: ::prost::alloc::string::String,
+}
+/// One frame of a WatchDir stream.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct WatchDirResponse {
+    #[prost(oneof = "watch_dir_response::Payload", tags = "1, 2")]
+    pub payload: ::core::option::Option<watch_dir_response::Payload>,
+}
+/// Nested message and enum types in `WatchDirResponse`.
+pub mod watch_dir_response {
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum Payload {
+        /// A filesystem event.
+        #[prost(message, tag = "1")]
+        Event(super::FsEvent),
+        /// Idle-stream keepalive; carries no data.
+        #[prost(message, tag = "2")]
+        KeepAlive(super::KeepAlive),
+    }
+}
+/// What kind of filesystem object a path is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum FileKind {
+    Unspecified = 0,
+    /// Regular file.
+    File = 1,
+    Directory = 2,
+    Symlink = 3,
+    /// Device node, FIFO, or socket.
+    Other = 4,
+}
+impl FileKind {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "FILE_KIND_UNSPECIFIED",
+            Self::File => "FILE_KIND_FILE",
+            Self::Directory => "FILE_KIND_DIRECTORY",
+            Self::Symlink => "FILE_KIND_SYMLINK",
+            Self::Other => "FILE_KIND_OTHER",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "FILE_KIND_UNSPECIFIED" => Some(Self::Unspecified),
+            "FILE_KIND_FILE" => Some(Self::File),
+            "FILE_KIND_DIRECTORY" => Some(Self::Directory),
+            "FILE_KIND_SYMLINK" => Some(Self::Symlink),
+            "FILE_KIND_OTHER" => Some(Self::Other),
+            _ => None,
+        }
+    }
+}
+/// Kind of a filesystem event.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum FsEventKind {
+    Unspecified = 0,
+    /// An entry was created.
+    Created = 1,
+    /// An entry's content or metadata changed.
+    Modified = 2,
+    /// An entry was removed.
+    Removed = 3,
+    /// An entry was renamed within the watched tree.
+    Renamed = 4,
+}
+impl FsEventKind {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "FS_EVENT_KIND_UNSPECIFIED",
+            Self::Created => "FS_EVENT_KIND_CREATED",
+            Self::Modified => "FS_EVENT_KIND_MODIFIED",
+            Self::Removed => "FS_EVENT_KIND_REMOVED",
+            Self::Renamed => "FS_EVENT_KIND_RENAMED",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "FS_EVENT_KIND_UNSPECIFIED" => Some(Self::Unspecified),
+            "FS_EVENT_KIND_CREATED" => Some(Self::Created),
+            "FS_EVENT_KIND_MODIFIED" => Some(Self::Modified),
+            "FS_EVENT_KIND_REMOVED" => Some(Self::Removed),
+            "FS_EVENT_KIND_RENAMED" => Some(Self::Renamed),
+            _ => None,
+        }
+    }
+}
 /// Request to checkpoint a sandbox.
 /// The sandbox must be in READY state (no active execution).
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
@@ -194,9 +194,10 @@ pub struct SetLifecycleRequest {
     /// Replace the idle timeout (0 = disable idle detection).
     #[prost(uint32, optional, tag = "3")]
     pub idle_timeout_seconds: ::core::option::Option<u32>,
-    /// Replace the idle policy (UNSPECIFIED = leave unchanged).
-    #[prost(enumeration = "IdleAction", tag = "4")]
-    pub on_idle: i32,
+    /// Replace the idle policy (absent = leave unchanged; UNSPECIFIED =
+    /// restore the daemon default).
+    #[prost(enumeration = "IdleAction", optional, tag = "4")]
+    pub on_idle: ::core::option::Option<i32>,
 }
 /// Request for the daemon's sandbox capabilities.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
@@ -65,7 +65,11 @@ pub struct CreateSandboxRequest {
         ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// --- Resources ---
     /// Unset = the template's default limits, if any, else daemon
-    /// defaults. Set = replaces the template default wholesale.
+    /// defaults. Set = replaces the template default wholesale: a zero
+    /// subfield (vcpus, memory_mib) inside a set message means the DAEMON
+    /// default for that resource — the template's value does not shine
+    /// through per-field. Precision costs message presence, which the
+    /// subfields (plain proto3 scalars) do not have.
     #[prost(message, optional, tag = "6")]
     pub limits: ::core::option::Option<ResourceLimits>,
     /// --- Initial workload (optional) ---

--- a/rpc/arcbox-protocol/src/generated/mod.rs
+++ b/rpc/arcbox-protocol/src/generated/mod.rs
@@ -28,6 +28,7 @@ pub mod arcbox_v1;
 /// - `process.proto` - data plane: the execution (exec) family
 /// - `filesystem.proto` - data plane: file transfer and path verbs
 /// - `snapshot.proto` - checkpoint / restore
+/// - `template.proto` - the template catalog (CORE-21)
 /// - `errors.proto` - the error-code registry (`ErrorInfo` detail)
 #[path = "arcbox.sandbox.v1.rs"]
 pub mod arcbox_sandbox_v1;

--- a/rpc/arcbox-protocol/src/generated/mod.rs
+++ b/rpc/arcbox-protocol/src/generated/mod.rs
@@ -22,11 +22,12 @@ pub mod arcbox_v1;
 
 /// All protocol buffer types from the `arcbox.sandbox.v1` package.
 ///
-/// prost emits one module per package, so the four proto files that make up
+/// prost emits one module per package, so the proto files that make up
 /// the sandbox API land here together:
 /// - `sandbox.proto` - control plane: lifecycle, events, published ports
 /// - `process.proto` - data plane: the execution (exec) family
-/// - `filesystem.proto` - data plane: file transfer
+/// - `filesystem.proto` - data plane: file transfer and path verbs
 /// - `snapshot.proto` - checkpoint / restore
+/// - `errors.proto` - the error-code registry (`ErrorInfo` detail)
 #[path = "arcbox.sandbox.v1.rs"]
 pub mod arcbox_sandbox_v1;


### PR DESCRIPTION
SDK-prerequisite proto increments for the sandbox surface, per the signed-off CORE-58 API design doc with the CORE-21 divergences resolved mid-flight from the issue body. **Contract only**: no daemon/guest behavior changes; every new RPC answers `UNIMPLEMENTED` with a doc comment naming its follow-up issue. All changes are additive on the `buf breaking`-exempt `arcbox.sandbox.v1` surface; no other proto is touched.

## The deltas (design doc §9, as amended by CORE-21)

1. **`template.proto` (new)** — `TemplateService` at full CORE-21 shape: `Build` (Dockerfile / OCI ref / snapshot promotion, gated on CORE-5/CORE-16), `Publish` for `name[:version]` addressing (`version` + `digest`), `Get`/`List`/`Delete` by reference; `warm_snapshot_id` **alongside** `rootfs_ref` (composing, not a oneof); `TemplateDefaults` bundle (`ResourceLimits`, `cmd`, `env`, `exposed_ports`, `ready_probe`).
2. `SandboxService.Pause` / `Resume` — same-ID checkpoint/restore; in-place resume sidesteps the direct-mode relocation constraint documented in `snapshot.proto`.
3. `SandboxState` += `PAUSING`/`PAUSED`; `SandboxEventKind` += `PAUSING`/`PAUSED`/`RESUMED` (automated transitions stay visible).
4. `SandboxService.SetLifecycle` — replaces the doc's `SetTtl`; re-arms the hard lifetime from now (CORE-60) and/or replaces the idle knobs, each independently (`optional` fields).
5. `CreateSandboxRequest.idle_timeout_seconds` + `on_idle` (`IdleAction KILL|PAUSE`) — the CORE-21 dual-knob model; replaces the doc's `on_ttl_expiry`.
6. `SandboxInfo` += `template`, `ttl_deadline`, `idle_timeout_seconds`, `on_idle`, `paused_at`, `failed_at`, `storage_bytes`; `SandboxSummary` += `ready_at`/`paused_at`/`failed_at`, `storage_bytes`.
7. `SandboxService.GetCapabilities` — `daemon_version`, `protocol`, `features[]`, `nested_virt {supported, reason}` (CORE-13 fail-fast).
8. **`errors.proto` (new)** — the `ErrorCode` registry (19 values) + `ErrorInfo {code, suggestion, context}` Connect error detail.
9. `SandboxProcessService.ListExecutions` — re-attach discovery across lost connections / auto-pause.
10. `SandboxProcessService.WaitForPort` — guest-agent listen-table wait, never a shelled-out probe.
11. **`filesystem.proto` (CORE-62)** — `Stat`, `ListDir`, `MakeDir` (mkdir -p), `Remove` (recursive flag), `Move`, `WatchDir` (server-streaming, KeepAlive-bearing) + `FileStat`/`FsEvent`.
12. `ttl_seconds` semantics clarified (meaning change on the exempt surface, flagged for abctl + desktop review): hard **maximum lifetime**, always destroys, never pauses; re-armable via `SetLifecycle`; still not reset by workload activity.
13. `SandboxSnapshotService` — untouched; template promotion goes through `TemplateService.Build{snapshot_id}`.

Transparent resume is specified **daemon-side** (data-plane RPCs auto-resume; `Inspect`/`List` never do), with the `x-arcbox-no-auto-resume` opt-out header reserved in comments; `ERROR_CODE_SANDBOX_PAUSED` documents exactly when it can surface.

## Deviations from the design doc (with rationale)

- **CORE-21 issue wins over the doc where they diverge** (per the doc's own source caveat): dual-knob timeouts instead of `ttl + on_ttl_expiry`, full Template (versioning/Publish/Build/defaults) instead of the lean `{name, source, created_at, labels, size_bytes}`, daemon-side transparent resume instead of SDK-side.
- **`ttl_seconds` keeps its name** (not renamed to `max_lifetime_seconds`): the field already means hard-destroy, and a wire-field rename would cascade into the guest agent's create-key idempotency derivation — behavior-adjacent churn a contract-only branch must avoid. Doc comments now state the dual-knob model explicitly.
- **Enum value names carry proto prefixes** (`ERROR_CODE_*`, `IDLE_ACTION_*`, …) per the package's existing lint convention; the doc's bare names are the SDK-side spellings.
- **Snapshot promotion is a `Build` source** (`snapshot_id` in the source oneof) rather than a separate Create verb — one creation verb, and a promoted checkpoint is warm by construction.
- **`Build` is unary** (blocks until built); a streaming progress variant can be added additively later.

## Plumbing (per rpc/AGENTS.md checklists)

- Both new files registered in all **three** build arrays (`arcbox-connect`, `arcbox-protocol`, `arcbox-grpc`); prost output regenerated and committed; buffa/tonic regenerate from build.rs.
- `TemplateServiceImpl` registered on `arcbox_api::connect::router` and pinned by the `control_plane.rs` registration test; tonic client/server re-exported from `arcbox-grpc`.
- `abctl` and the guest agent's enum maps learned the new `SandboxState`/`SandboxEventKind` variants.
- `docs/sandbox-api.md` updated (state machine, lifecycle knobs, contract-only inventory).

## Gates (all exit 0)

- `cargo check --workspace --exclude arcbox-agent --all-targets`
- `cargo clippy --workspace --exclude arcbox-agent --all-targets -- -D warnings`
- `cargo test -p arcbox-protocol -p arcbox-connect -p arcbox-api -p arcbox-daemon`
- `cargo check -p arcbox-agent --target aarch64-unknown-linux-musl`
- `buf breaking rpc/arcbox-protocol/proto --against '.git#branch=origin/master,subdir=rpc/arcbox-protocol/proto'`
- `cargo fmt --all --check`
