### PR TITLE
fix(sdk): stop connect() from waiting on READY for a PAUSING sandbox

### DIFF
--- a/sdk/typescript/src/sandbox.ts
+++ b/sdk/typescript/src/sandbox.ts
@@ -1,6 +1,7 @@
 import type { Client } from "@connectrpc/connect";
 import { createClient } from "@connectrpc/connect";
 import { noop } from "foxts/noop";
+import { wait } from "foxts/wait";
 
 import { Commands } from "./commands.js";
 import type { ConnectionOptions } from "./connection.js";
@@ -76,6 +77,12 @@ export interface ListSandboxesOptions {
 }
 
 type SandboxClient = Client<typeof SandboxService>;
+
+/**
+ * How often {@link ArcBox.connect} re-inspects a PAUSING sandbox. No
+ * lifecycle event marks the PAUSING→PAUSED edge, so it is polled out.
+ */
+const PAUSE_SETTLE_POLL_MS = 500;
 
 /**
  * Client entry point. Holds one resolved connection; every handle it
@@ -167,13 +174,23 @@ export class ArcBox {
 
   /**
    * Attach to an existing sandbox. A PAUSED sandbox is resumed (resume
-   * completes once it is READY again); a STARTING one is waited for. A
-   * terminal state is a typed error carrying the observed state.
-   * Connecting never touches the sandbox's lifecycle deadlines.
+   * completes once it is READY again); a PAUSING one settles to PAUSED
+   * first, then resumes; a STARTING one is waited for. A terminal state
+   * is a typed error carrying the observed state. Connecting never
+   * touches the sandbox's lifecycle deadlines.
    */
   async connect(id: string): Promise<Sandbox> {
     try {
-      const info = await this.#client.inspect({ id }, unaryOptions(this.#ctx));
+      let info = await this.#client.inspect({ id }, unaryOptions(this.#ctx));
+      // A pausing sandbox's next stop is PAUSED — never READY — so
+      // waiting on readiness events would park forever. Poll the
+      // checkpoint out, then route on whatever state it settled in.
+      while (info.state === SandboxStateProto.PAUSING) {
+        // eslint-disable-next-line no-await-in-loop -- sequential by design: each re-inspect waits out the poll interval
+        await wait(PAUSE_SETTLE_POLL_MS);
+        // eslint-disable-next-line no-await-in-loop -- sequential by design: the settled state decides the route
+        info = await this.#client.inspect({ id }, unaryOptions(this.#ctx));
+      }
       switch (info.state) {
         case SandboxStateProto.READY:
         case SandboxStateProto.RUNNING:
@@ -183,8 +200,7 @@ export class ArcBox {
           // takes as long as it takes, and the RPC returns once READY.
           await this.#client.resume({ id });
           return new Sandbox(this.#ctx, id);
-        case SandboxStateProto.STARTING:
-        case SandboxStateProto.PAUSING: {
+        case SandboxStateProto.STARTING: {
           const abort = new AbortController();
           try {
             const stream = this.#client.events(

--- a/sdk/typescript/src/sandbox.ts
+++ b/sdk/typescript/src/sandbox.ts
@@ -79,8 +79,11 @@ export interface ListSandboxesOptions {
 type SandboxClient = Client<typeof SandboxService>;
 
 /**
- * How often {@link ArcBox.connect} re-inspects a PAUSING sandbox. No
- * lifecycle event marks the PAUSING→PAUSED edge, so it is polled out.
+ * How often {@link ArcBox.connect} re-inspects a PAUSING sandbox.
+ * `SANDBOX_EVENT_KIND_PAUSED` names this edge in the proto, but the
+ * daemon does not emit it yet (Pause/Resume are CORE-21 stubs), so the
+ * checkpoint is polled out instead. Once it is emitted, this poll
+ * should become an event wait.
  */
 const PAUSE_SETTLE_POLL_MS = 500;
 

--- a/sdk/typescript/test/connect.test.ts
+++ b/sdk/typescript/test/connect.test.ts
@@ -12,15 +12,25 @@ import { createRouterTransport } from "@connectrpc/connect";
 import { describe, expect, it } from "vitest";
 
 import {
+  KeepAliveSchema,
   SandboxInfoSchema,
   SandboxService,
   SandboxState as SandboxStateProto,
+  WatchEventsResponseSchema,
 } from "../src/gen/arcbox/sandbox/v1/sandbox_pb.js";
 import { ArcBox } from "../src/sandbox.js";
 
-/** Serves Inspect from a state script and records Resume calls. */
+/** Serves Inspect from a state script, counting every call it answers. */
 class MockLifecycle {
   resumes = 0;
+  /**
+   * The settle poll is witnessed by this count: `resume` rewrites
+   * `states` unconditionally, so the post-state is `[READY]` whether or
+   * not a second Inspect ever ran.
+   */
+  inspects = 0;
+  /** Readiness subscriptions opened. A PAUSING connect must open none. */
+  eventStreams = 0;
 
   /** Consumed one per Inspect; the last entry repeats. */
   constructor(public states: SandboxStateProto[]) {}
@@ -29,6 +39,7 @@ class MockLifecycle {
     return createRouterTransport(({ service }) => {
       service(SandboxService, {
         inspect: () => {
+          this.inspects += 1;
           const state = this.states[0] ?? SandboxStateProto.UNSPECIFIED;
           if (this.states.length > 1) {
             this.states = this.states.slice(1);
@@ -40,6 +51,18 @@ class MockLifecycle {
           this.states = [SandboxStateProto.READY];
           return create(EmptySchema);
         },
+        // What the daemon serves a pausing sandbox: keepalives and no
+        // state change, because READY is not where it is headed. The
+        // real stream never ends; ending it here makes a connect that
+        // wrongly waits on readiness fail fast, and say why, instead of
+        // hanging until the suite's timeout.
+        // eslint-disable-next-line @typescript-eslint/require-await -- a server-streaming handler is an async generator; this double serves from memory and has nothing to await
+        events: async function* (this: MockLifecycle) {
+          this.eventStreams += 1;
+          yield create(WatchEventsResponseSchema, {
+            payload: { case: "keepAlive", value: create(KeepAliveSchema) },
+          });
+        }.bind(this),
       });
     });
   }
@@ -50,10 +73,13 @@ function connectAgainst(daemon: MockLifecycle): ArcBox {
 }
 
 describe("ArcBox.connect lifecycle routing", () => {
-  it("resumes a PAUSED sandbox", async () => {
+  it("resumes a PAUSED sandbox without re-inspecting", async () => {
     const daemon = new MockLifecycle([SandboxStateProto.PAUSED]);
     const sandbox = await connectAgainst(daemon).connect("sb-1");
     expect(sandbox.id).toBe("sb-1");
+    // The negative that gives the PAUSING count below its meaning: an
+    // already-settled state routes off the first Inspect.
+    expect(daemon.inspects).toBe(1);
     expect(daemon.resumes).toBe(1);
   });
 
@@ -64,9 +90,12 @@ describe("ArcBox.connect lifecycle routing", () => {
     ]);
     const sandbox = await connectAgainst(daemon).connect("sb-1");
     expect(sandbox.id).toBe("sb-1");
-    // The checkpoint was polled out (a second Inspect ran) and exactly
-    // one Resume followed — not a readiness-event wait that never ends.
-    expect(daemon.states).toEqual([SandboxStateProto.READY]);
+    // The checkpoint was polled out — a second Inspect ran — and exactly
+    // one Resume followed. No readiness subscription was ever opened:
+    // that is the regression, since READY is not where a pausing
+    // sandbox is headed.
+    expect(daemon.inspects).toBe(2);
+    expect(daemon.eventStreams).toBe(0);
     expect(daemon.resumes).toBe(1);
   });
 });

--- a/sdk/typescript/test/connect.test.ts
+++ b/sdk/typescript/test/connect.test.ts
@@ -1,0 +1,72 @@
+// connect() lifecycle routing against a mock daemon.
+//
+// The PAUSING case is the regression that matters: a pausing sandbox's
+// next stop is PAUSED — never READY — so connect must poll the
+// checkpoint out and then resume, not wait on readiness events that
+// cannot arrive.
+
+import { create } from "@bufbuild/protobuf";
+import { EmptySchema } from "@bufbuild/protobuf/wkt";
+import type { Transport } from "@connectrpc/connect";
+import { createRouterTransport } from "@connectrpc/connect";
+import { describe, expect, it } from "vitest";
+
+import {
+  SandboxInfoSchema,
+  SandboxService,
+  SandboxState as SandboxStateProto,
+} from "../src/gen/arcbox/sandbox/v1/sandbox_pb.js";
+import { ArcBox } from "../src/sandbox.js";
+
+/** Serves Inspect from a state script and records Resume calls. */
+class MockLifecycle {
+  resumes = 0;
+
+  /** Consumed one per Inspect; the last entry repeats. */
+  constructor(public states: SandboxStateProto[]) {}
+
+  transport(): Transport {
+    return createRouterTransport(({ service }) => {
+      service(SandboxService, {
+        inspect: () => {
+          const state = this.states[0] ?? SandboxStateProto.UNSPECIFIED;
+          if (this.states.length > 1) {
+            this.states = this.states.slice(1);
+          }
+          return create(SandboxInfoSchema, { id: "sb-1", state });
+        },
+        resume: () => {
+          this.resumes += 1;
+          this.states = [SandboxStateProto.READY];
+          return create(EmptySchema);
+        },
+      });
+    });
+  }
+}
+
+function connectAgainst(daemon: MockLifecycle): ArcBox {
+  return new ArcBox({ transport: daemon.transport() });
+}
+
+describe("ArcBox.connect lifecycle routing", () => {
+  it("resumes a PAUSED sandbox", async () => {
+    const daemon = new MockLifecycle([SandboxStateProto.PAUSED]);
+    const sandbox = await connectAgainst(daemon).connect("sb-1");
+    expect(sandbox.id).toBe("sb-1");
+    expect(daemon.resumes).toBe(1);
+  });
+
+  it("settles a PAUSING sandbox to PAUSED, then resumes", async () => {
+    const daemon = new MockLifecycle([
+      SandboxStateProto.PAUSING,
+      SandboxStateProto.PAUSED,
+    ]);
+    const sandbox = await connectAgainst(daemon).connect("sb-1");
+    expect(sandbox.id).toBe("sb-1");
+    // The checkpoint was polled out (a second Inspect ran) and exactly
+    // one Resume followed — not a readiness-event wait that never ends.
+    expect(daemon.states).toEqual([SandboxStateProto.READY]);
+    expect(daemon.resumes).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

A PAUSING sandbox's next stop is PAUSED — never READY — and no lifecycle event marks the PAUSING→PAUSED edge. The TS SDK routed PAUSING into the readiness-event wait, which parked `connect()` forever on a keepalive-fed Events stream.

Fix: poll the checkpoint out via Inspect (500 ms cadence), then route on the settled state — PAUSED resumes as before, READY/RUNNING returns, terminal states throw `SandboxStateError`. STARTING keeps the event wait.

This is the TypeScript twin of the Python fix (78e04915 on `feat/sdk-python`), where the shared routing bug was first reported on review and fixed; that commit noted the TS SDK inherits it and would be fixed separately — this PR.

## Test

`test/connect.test.ts` mirrors the Python `test_connect.py`: a mock daemon (connect-es `createRouterTransport`) serves Inspect from a state script and records Resume calls.

- `resumes a PAUSED sandbox` — baseline routing.
- `settles a PAUSING sandbox to PAUSED, then resumes` — the regression: asserts the checkpoint was polled out (a second Inspect consumed the script) and exactly one Resume followed, instead of a readiness-event wait that can never end.

## Gates

- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test` ✅ (38 passed, 1 e2e skipped)
- `npx tsc --noEmit` ✅
- `npm run build` ✅