### PR TITLE
perf(sandbox): cold-start probe + restore fast path round 1

### DIFF
--- a/tests/e2e/tests/sandbox_coldstart.rs
+++ b/tests/e2e/tests/sandbox_coldstart.rs
@@ -1,0 +1,656 @@
+//! Sandbox cold-start bench: `Create` → `READY` over N serial iterations.
+//!
+//! Measures the user-visible cold start of a sandbox — the wall time from
+//! the `Create` RPC leaving the client until the `READY` lifecycle event
+//! arrives back — against one already-warm daemon, so the System VM boot
+//! is excluded and only the nested Firecracker microVM start is timed.
+//!
+//! Readiness is taken from the `Events` stream, subscribed *before* the
+//! first `Create`, rather than the smoke test's 500ms `Inspect` poll: at
+//! the sub-second scale this bench targets, a 500ms poll interval is the
+//! measurement.
+//!
+//! Requires nested virtualization (VZ backend, Apple Silicon M3+ with
+//! macOS 15+). Run:
+//!
+//! ```console
+//! cargo test -p arcbox-e2e --test sandbox_coldstart -- --ignored --nocapture
+//! ```
+//!
+//! Knobs: `ARCBOX_COLDSTART_ITERS` (default 10), `ARCBOX_COLDSTART_VCPUS`
+//! (1), `ARCBOX_COLDSTART_MEMORY_MIB` (512), `SKIP_BUILD`, `KEEP_TEST_DIR`.
+
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle, connect_unix};
+use arcbox_e2e::metrics::RunMetrics;
+use arcbox_e2e::{env_flag, repo_root};
+use arcbox_grpc::sandbox_v1::sandbox_process_service_client::SandboxProcessServiceClient;
+use arcbox_grpc::sandbox_v1::sandbox_service_client::SandboxServiceClient;
+use arcbox_grpc::sandbox_v1::sandbox_snapshot_service_client::SandboxSnapshotServiceClient;
+use arcbox_protocol::sandbox_v1::{
+    AttachExecutionRequest, CheckpointRequest, CreateSandboxRequest, NetworkMode, NetworkSpec,
+    RemoveSandboxRequest, ResourceLimits, RestoreRequest, SandboxEventKind, SandboxEventsRequest,
+    SandboxState, StartExecutionRequest, StdioChannel, execution_event, exit_status,
+    watch_events_response,
+};
+use tonic::Streaming;
+use tonic::transport::Channel;
+use tracing::{info, warn};
+
+/// Generous ceiling for daemon startup (asset staging + VM boot + agent).
+const DAEMON_READY_TIMEOUT: Duration = Duration::from_secs(240);
+/// Ceiling for one sandbox to reach READY. The first iteration may build
+/// the default template inside the guest, so this is far above the steady
+/// state it measures.
+const SANDBOX_READY_TIMEOUT: Duration = Duration::from_secs(180);
+
+#[test]
+#[ignore = "requires nested virtualization (VZ on M3+), boot assets, and a signed daemon"]
+fn sandbox_coldstart() -> Result<()> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_test_writer()
+        .try_init();
+
+    let iters = env_usize("ARCBOX_COLDSTART_ITERS", 10);
+    let vcpus = env_usize("ARCBOX_COLDSTART_VCPUS", 1) as u32;
+    let memory_mib = env_usize("ARCBOX_COLDSTART_MEMORY_MIB", 512) as u64;
+
+    if !env_flag("SKIP_BUILD") {
+        arcbox_e2e::sandbox::build_binaries()?;
+    }
+
+    let root = repo_root();
+    let version = resolve_boot_version(&root)?;
+    let temp_dir = tempfile::Builder::new()
+        .prefix("arcbox-sandbox-coldstart-")
+        .tempdir()
+        .context("creating bench directory")?;
+    let data_dir = temp_dir.path().to_owned();
+    stage_dev_boot_assets(&root, &data_dir, &version)?;
+
+    let mut metrics = RunMetrics::new("sandbox_coldstart", Some("vz"));
+    let result = run_bench(
+        &root,
+        &data_dir,
+        &version,
+        &mut metrics,
+        Params {
+            iters,
+            vcpus,
+            memory_mib,
+        },
+    );
+    metrics.passed = result.is_ok();
+    match metrics.write(Some(&data_dir)) {
+        Ok(paths) => {
+            for path in paths {
+                info!(path = %path.display(), "run metrics written");
+            }
+        }
+        Err(error) => warn!("writing run metrics failed: {error:#}"),
+    }
+
+    if result.is_err() || env_flag("KEEP_TEST_DIR") {
+        let path = temp_dir.keep();
+        warn!(path = %path.display(), "preserving test directory");
+    }
+    result
+}
+
+struct Params {
+    iters: usize,
+    vcpus: u32,
+    memory_mib: u64,
+}
+
+fn run_bench(
+    root: &std::path::Path,
+    data_dir: &std::path::Path,
+    version: &str,
+    metrics: &mut RunMetrics,
+    params: Params,
+) -> Result<()> {
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: data_dir.to_owned(),
+        args: vec![],
+        env: vec![
+            ("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version.to_owned()),
+            ("ARCBOX_VM_BACKEND".to_owned(), "vz".to_owned()),
+        ],
+    })?;
+
+    let ready_started = Instant::now();
+    daemon.wait_ready_blocking(DAEMON_READY_TIMEOUT)?;
+    let daemon_ready = ready_started.elapsed();
+    metrics.record("daemon_ready", daemon_ready.as_secs_f64());
+    info!(seconds = daemon_ready.as_secs_f64(), "daemon ready");
+
+    let socket = daemon.grpc_socket();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building bench runtime")?;
+
+    let bench = rt.block_on(async {
+        let channel = connect_unix(&socket).await?;
+        drive(channel, metrics, params).await
+    });
+
+    match daemon.shutdown() {
+        Ok(status) => info!(%status, "daemon stopped"),
+        Err(error) => warn!("daemon shutdown failed: {error:#}"),
+    }
+
+    bench
+}
+
+/// One iteration's timings.
+struct Sample {
+    /// `Create` RPC call → response (the sandbox is STARTING at this point).
+    create_rpc: Duration,
+    /// `Create` call → `READY` event: the cold start itself.
+    ready: Duration,
+    /// `Create` call → stdout of the first command. READY claims the
+    /// sandbox accepts executions; this is what makes that claim
+    /// falsifiable, and is the number an SDK user actually waits out.
+    first_exec: Duration,
+    /// The same command again on the already-warm sandbox. Splits the gap
+    /// after READY into "the sandbox was not yet executable" (first ≫
+    /// second) and "every execution costs this" (first ≈ second).
+    second_exec: Duration,
+    /// Guest `/proc/uptime` sampled by the first command: how long the
+    /// microVM kernel had been up when the first exec landed. Splits the
+    /// create→exec gap into host-side cost (create→exec minus uptime) and
+    /// in-guest boot (uptime minus the exec round-trip itself).
+    guest_uptime: Option<f64>,
+    /// `Remove` RPC call → response.
+    remove: Duration,
+}
+
+async fn drive(channel: Channel, metrics: &mut RunMetrics, params: Params) -> Result<()> {
+    let mut client = SandboxServiceClient::new(channel.clone());
+    let mut processes = SandboxProcessServiceClient::new(channel.clone());
+    let mut snapshots = SandboxSnapshotServiceClient::new(channel);
+
+    // Subscribed before the first Create so no READY can be missed. Kind is
+    // left unfiltered: a FAILED frame is what turns a hung bench into a
+    // reported cause.
+    let mut events = client
+        .events(with_machine(SandboxEventsRequest::default()))
+        .await
+        .context("Events subscribe failed")?
+        .into_inner();
+
+    for (label, mode) in [
+        ("networked", NetworkMode::Enabled),
+        ("no-network", NetworkMode::None),
+    ] {
+        let mut samples = Vec::with_capacity(params.iters);
+        for i in 0..params.iters {
+            let id = format!("cold-{label}-{i}");
+            // dmesg on the second iteration: a steady-state boot timeline,
+            // not the one-time-cost first boot.
+            let sample = one_cycle(
+                &mut client,
+                &mut processes,
+                &mut events,
+                &id,
+                mode,
+                &params,
+                i == 1,
+            )
+            .await?;
+            log_sample(label, i, &sample);
+            samples.push(sample);
+        }
+        report(label, &samples, metrics);
+    }
+
+    // -- Restore group: the snapshot-resume path -------------------------
+    // One warm networked template is checkpointed once; each iteration then
+    // restores a clone with a fresh TAP (`network_override`) while the
+    // template keeps running — the E2B-style "resume, don't boot" shape.
+    let template_id = "cold-template";
+    one_template(
+        &mut client,
+        &mut processes,
+        &mut events,
+        template_id,
+        &params,
+    )
+    .await?;
+    let checkpoint_started = Instant::now();
+    let snapshot_id = snapshots
+        .checkpoint(with_machine(CheckpointRequest {
+            sandbox_id: template_id.to_owned(),
+            name: "coldstart-bench".into(),
+            ..Default::default()
+        }))
+        .await
+        .context("Checkpoint failed")?
+        .into_inner()
+        .snapshot_id;
+    info!(
+        %snapshot_id,
+        checkpoint_ms = checkpoint_started.elapsed().as_millis(),
+        "template checkpointed"
+    );
+
+    let mut samples = Vec::with_capacity(params.iters);
+    for i in 0..params.iters {
+        let id = format!("cold-restore-{i}");
+        let sample = one_restore_cycle(
+            &mut client,
+            &mut processes,
+            &mut snapshots,
+            &id,
+            &snapshot_id,
+        )
+        .await?;
+        log_sample("restore", i, &sample);
+        samples.push(sample);
+    }
+    report("restore", &samples, metrics);
+
+    client
+        .remove(with_machine(RemoveSandboxRequest {
+            id: template_id.to_owned(),
+            force: true,
+        }))
+        .await
+        .context("Remove template failed")?;
+
+    Ok(())
+}
+
+/// Create the warm template the restore group snapshots: booted, one
+/// execution completed so the exec path is warm in the captured memory.
+async fn one_template(
+    client: &mut SandboxServiceClient<Channel>,
+    processes: &mut SandboxProcessServiceClient<Channel>,
+    events: &mut Streaming<arcbox_protocol::sandbox_v1::WatchEventsResponse>,
+    id: &str,
+    params: &Params,
+) -> Result<()> {
+    client
+        .create(with_machine(CreateSandboxRequest {
+            id: id.to_owned(),
+            limits: Some(ResourceLimits {
+                vcpus: params.vcpus,
+                memory_mib: params.memory_mib,
+            }),
+            network: Some(NetworkSpec {
+                mode: NetworkMode::Enabled.into(),
+            }),
+            ..Default::default()
+        }))
+        .await
+        .context("Create template failed")?;
+    wait_for_ready(events, id).await?;
+    run_and_collect(processes, id, &["/bin/echo", "template-warm"]).await?;
+    Ok(())
+}
+
+/// Restore a clone from the template snapshot and drive the same back half
+/// as a boot cycle. `ready` is the restore RPC completion: the RPC resumes
+/// the VM synchronously, so its return is the usability claim.
+async fn one_restore_cycle(
+    client: &mut SandboxServiceClient<Channel>,
+    processes: &mut SandboxProcessServiceClient<Channel>,
+    snapshots: &mut SandboxSnapshotServiceClient<Channel>,
+    id: &str,
+    snapshot_id: &str,
+) -> Result<Sample> {
+    let started = Instant::now();
+    snapshots
+        .restore(with_machine(RestoreRequest {
+            id: id.to_owned(),
+            snapshot_id: snapshot_id.to_owned(),
+            network_override: true,
+            ..Default::default()
+        }))
+        .await
+        .with_context(|| format!("Restore {id} failed"))?;
+    let restore_rpc = started.elapsed();
+
+    finish_cycle(
+        client,
+        processes,
+        id,
+        started,
+        restore_rpc,
+        restore_rpc,
+        false,
+    )
+    .await
+}
+
+fn log_sample(label: &str, iteration: usize, sample: &Sample) {
+    info!(
+        iteration,
+        group = label,
+        create_ms = sample.create_rpc.as_millis(),
+        ready_ms = sample.ready.as_millis(),
+        first_exec_ms = sample.first_exec.as_millis(),
+        second_exec_ms = sample.second_exec.as_millis(),
+        guest_uptime_s = sample.guest_uptime,
+        remove_ms = sample.remove.as_millis(),
+        "cold start"
+    );
+}
+
+/// Log the interesting lines of a guest boot dmesg: the timeline from
+/// kernel entry to init handoff, plus anything that took visibly long.
+fn log_boot_timeline(id: &str, dmesg: &str) {
+    for line in dmesg.lines() {
+        let interesting = ["Linux version", "Freeing unused kernel", "Run /"]
+            .iter()
+            .any(|m| line.contains(m));
+        if interesting {
+            info!(%id, "dmesg: {line}");
+        }
+    }
+    // The largest single gap between consecutive timestamped lines — where
+    // the boot actually stalled.
+    let stamps: Vec<(f64, &str)> = dmesg
+        .lines()
+        .filter_map(|l| {
+            let ts = l.split(']').next()?.trim_start_matches('[').trim();
+            Some((ts.parse::<f64>().ok()?, l))
+        })
+        .collect();
+    if let Some((gap, before, line)) = stamps
+        .windows(2)
+        .map(|w| (w[1].0 - w[0].0, w[0].1, w[1].1))
+        .max_by(|a, b| a.0.total_cmp(&b.0))
+    {
+        info!(%id, gap_s = gap, "dmesg: largest gap between: {before} → {line}");
+    }
+}
+
+async fn one_cycle(
+    client: &mut SandboxServiceClient<Channel>,
+    processes: &mut SandboxProcessServiceClient<Channel>,
+    events: &mut Streaming<arcbox_protocol::sandbox_v1::WatchEventsResponse>,
+    id: &str,
+    mode: NetworkMode,
+    params: &Params,
+    capture_dmesg: bool,
+) -> Result<Sample> {
+    let started = Instant::now();
+    let created = client
+        .create(with_machine(CreateSandboxRequest {
+            id: id.to_owned(),
+            limits: Some(ResourceLimits {
+                vcpus: params.vcpus,
+                memory_mib: params.memory_mib,
+            }),
+            network: Some(NetworkSpec { mode: mode.into() }),
+            ..Default::default()
+        }))
+        .await
+        .with_context(|| format!("Create {id} failed"))?
+        .into_inner();
+    let create_rpc = started.elapsed();
+    if created.state() != SandboxState::Starting {
+        bail!("{id}: unexpected create state {:?}", created.state());
+    }
+
+    wait_for_ready(events, id).await?;
+    let ready = started.elapsed();
+
+    finish_cycle(
+        client,
+        processes,
+        id,
+        started,
+        create_rpc,
+        ready,
+        capture_dmesg,
+    )
+    .await
+}
+
+/// The shared back half of a cycle: first exec (sampling guest uptime),
+/// warm exec, optional dmesg capture, remove.
+async fn finish_cycle(
+    client: &mut SandboxServiceClient<Channel>,
+    processes: &mut SandboxProcessServiceClient<Channel>,
+    id: &str,
+    started: Instant,
+    create_rpc: Duration,
+    ready: Duration,
+    capture_dmesg: bool,
+) -> Result<Sample> {
+    let stdout = run_and_collect(processes, id, &["/bin/cat", "/proc/uptime"]).await?;
+    let first_exec = started.elapsed();
+    let guest_uptime = stdout
+        .split_whitespace()
+        .next()
+        .and_then(|t| t.parse::<f64>().ok());
+    if guest_uptime.is_none() {
+        bail!("{id}: unexpected /proc/uptime output: {stdout:?}");
+    }
+
+    let second_started = Instant::now();
+    let stdout = run_and_collect(processes, id, &["/bin/echo", "warm-ok"]).await?;
+    let second_exec = second_started.elapsed();
+    if !stdout.contains("warm-ok") {
+        bail!("{id}: warm command output missing marker: {stdout:?}");
+    }
+
+    if capture_dmesg {
+        // One boot timeline per group: where the in-guest time goes.
+        match run_and_collect(processes, id, &["/bin/dmesg"]).await {
+            Ok(dmesg) => log_boot_timeline(id, &dmesg),
+            Err(error) => warn!(%id, "dmesg capture failed: {error:#}"),
+        }
+    }
+
+    let remove_started = Instant::now();
+    client
+        .remove(with_machine(RemoveSandboxRequest {
+            id: id.to_owned(),
+            force: true,
+        }))
+        .await
+        .with_context(|| format!("Remove {id} failed"))?;
+
+    Ok(Sample {
+        create_rpc,
+        ready,
+        first_exec,
+        second_exec,
+        guest_uptime,
+        remove: remove_started.elapsed(),
+    })
+}
+
+/// Starts one command and drains its attach stream until exit, asserting a
+/// zero exit code.
+async fn run_and_collect(
+    client: &mut SandboxProcessServiceClient<Channel>,
+    id: &str,
+    cmd: &[&str],
+) -> Result<String> {
+    let execution = client
+        .start_execution(with_machine(StartExecutionRequest {
+            sandbox_id: id.to_owned(),
+            cmd: cmd.iter().map(|s| (*s).to_owned()).collect(),
+            stdin: false,
+            ..Default::default()
+        }))
+        .await
+        .context("StartExecution failed")?
+        .into_inner();
+
+    let mut stream = client
+        .attach_execution(with_machine(AttachExecutionRequest {
+            sandbox_id: id.to_owned(),
+            execution_id: execution.id.clone(),
+            stdout_offset: 0,
+            stderr_offset: 0,
+        }))
+        .await
+        .context("AttachExecution failed")?
+        .into_inner();
+
+    let mut stdout = String::new();
+    while let Some(event) = stream.message().await.context("attach stream error")? {
+        match event.event {
+            Some(execution_event::Event::Output(output)) => {
+                if output.channel() != StdioChannel::Stderr {
+                    stdout.push_str(&String::from_utf8_lossy(&output.data));
+                }
+            }
+            Some(execution_event::Event::Exited(done)) => {
+                let state = done.execution.context("exit event without execution")?;
+                return match state.exit_status.as_ref().and_then(|s| s.status) {
+                    Some(exit_status::Status::Code(0)) => Ok(stdout),
+                    other => bail!("{id}: command {cmd:?} exit status {other:?}"),
+                };
+            }
+            _ => {}
+        }
+    }
+    bail!("{id}: attach stream ended without an exit event")
+}
+
+/// Consumes the shared event stream until `id` reports READY.
+///
+/// Frames for other sandboxes are skipped rather than buffered: the bench
+/// is strictly serial, so the only live sandbox is the one being timed.
+async fn wait_for_ready(
+    events: &mut Streaming<arcbox_protocol::sandbox_v1::WatchEventsResponse>,
+    id: &str,
+) -> Result<()> {
+    let deadline = Instant::now() + SANDBOX_READY_TIMEOUT;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            bail!("{id} did not reach READY within {SANDBOX_READY_TIMEOUT:?}");
+        }
+        let frame = tokio::time::timeout(remaining, events.message())
+            .await
+            .with_context(|| format!("{id}: READY timed out"))?
+            .context("Events stream failed")?
+            .context("Events stream ended before READY")?;
+        let Some(watch_events_response::Payload::Event(event)) = frame.payload else {
+            continue; // keepalive
+        };
+        if event.sandbox_id != id {
+            continue;
+        }
+        match event.kind() {
+            SandboxEventKind::Ready => return Ok(()),
+            SandboxEventKind::Failed => {
+                let reason = event
+                    .attributes
+                    .get("error")
+                    .map_or("unknown", String::as_str);
+                bail!("{id} failed while starting: {reason}");
+            }
+            _ => {}
+        }
+    }
+}
+
+fn report(label: &str, samples: &[Sample], metrics: &mut RunMetrics) {
+    let ready: Vec<f64> = samples.iter().map(|s| s.ready.as_secs_f64()).collect();
+    let exec: Vec<f64> = samples.iter().map(|s| s.first_exec.as_secs_f64()).collect();
+    let warm_exec: Vec<f64> = samples
+        .iter()
+        .map(|s| s.second_exec.as_secs_f64())
+        .collect();
+    let uptime: Vec<f64> = samples.iter().filter_map(|s| s.guest_uptime).collect();
+    let create: Vec<f64> = samples.iter().map(|s| s.create_rpc.as_secs_f64()).collect();
+    let remove: Vec<f64> = samples.iter().map(|s| s.remove.as_secs_f64()).collect();
+
+    // The first iteration of a group carries one-time cost (default
+    // template build, pool warm-up) and is reported apart from the steady
+    // state rather than folded into a median that hides it.
+    let (first_ready, rest_ready) = ready.split_first().expect("at least one iteration");
+    let (first_exec, rest_exec) = exec.split_first().expect("at least one iteration");
+    info!(
+        group = label,
+        first_ready_ms = (first_ready * 1000.0).round(),
+        ready_min_ms = ms(min(rest_ready)),
+        ready_p50_ms = ms(percentile(rest_ready, 0.50)),
+        ready_p90_ms = ms(percentile(rest_ready, 0.90)),
+        ready_max_ms = ms(max(rest_ready)),
+        first_exec_ms = (first_exec * 1000.0).round(),
+        exec_p50_ms = ms(percentile(rest_exec, 0.50)),
+        exec_p90_ms = ms(percentile(rest_exec, 0.90)),
+        warm_exec_p50_ms = ms(percentile(&warm_exec, 0.50)),
+        guest_uptime_p50_s = percentile(&uptime, 0.50),
+        create_rpc_p50_ms = ms(percentile(&create, 0.50)),
+        remove_p50_ms = ms(percentile(&remove, 0.50)),
+        "cold start summary"
+    );
+
+    metrics.record(
+        &format!("coldstart_{label}_warm_exec_p50"),
+        percentile(&warm_exec, 0.50).unwrap_or_default(),
+    );
+    for (metric, first, rest) in [
+        ("ready", first_ready, rest_ready),
+        ("exec", first_exec, rest_exec),
+    ] {
+        metrics.record(&format!("coldstart_{label}_{metric}_first"), *first);
+        metrics.record(
+            &format!("coldstart_{label}_{metric}_p50"),
+            percentile(rest, 0.50).unwrap_or(*first),
+        );
+        metrics.record(
+            &format!("coldstart_{label}_{metric}_p90"),
+            percentile(rest, 0.90).unwrap_or(*first),
+        );
+    }
+}
+
+fn ms(value: Option<f64>) -> f64 {
+    value.map_or(f64::NAN, |v| (v * 1000.0).round())
+}
+
+fn min(values: &[f64]) -> Option<f64> {
+    values.iter().copied().reduce(f64::min)
+}
+
+fn max(values: &[f64]) -> Option<f64> {
+    values.iter().copied().reduce(f64::max)
+}
+
+/// Nearest-rank percentile over an unsorted slice.
+fn percentile(values: &[f64], q: f64) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let rank = (q * sorted.len() as f64).ceil().max(1.0) as usize;
+    sorted.get(rank - 1).copied()
+}
+
+fn with_machine<T>(msg: T) -> tonic::Request<T> {
+    let mut request = tonic::Request::new(msg);
+    request.metadata_mut().insert(
+        "x-machine",
+        tonic::metadata::MetadataValue::from_static("default"),
+    );
+    request
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -42,7 +42,7 @@ mod agent {
     use std::io::{Read, Write};
     use std::os::unix::io::RawFd;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex, OnceLock, mpsc};
+    use std::sync::{Arc, Condvar, Mutex, OnceLock, mpsc};
     use std::thread;
 
     use serde::Deserialize;
@@ -606,6 +606,13 @@ mod agent {
         REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
     }
 
+    /// Wakes the reaper out of its no-children park when a spawn registers a
+    /// child (paired with the [`reap_registry`] mutex).
+    fn reap_wakeup() -> &'static Condvar {
+        static WAKEUP: OnceLock<Condvar> = OnceLock::new();
+        WAKEUP.get_or_init(Condvar::new)
+    }
+
     /// Narrow a `std::process::Child::id()` (u32) to a `pid_t`. Linux pids are
     /// bounded well below `i32::MAX`, so this never wraps.
     #[allow(clippy::cast_possible_wrap, reason = "pids fit in pid_t")]
@@ -659,9 +666,21 @@ mod agent {
                 // SAFETY: waitpid with a valid status pointer; -1 waits on any child.
                 let pid = unsafe { libc::waitpid(-1, &raw mut status, 0) };
                 if pid <= 0 {
-                    // ECHILD (no children yet) or EINTR — back off briefly so we
-                    // don't spin while the guest is idle.
-                    thread::sleep(std::time::Duration::from_millis(50));
+                    // ECHILD (no children) or EINTR. Park until a spawn
+                    // registers a child instead of polling: the old 50 ms
+                    // backoff put a flat ~50 ms floor under every short
+                    // execution whose child spawned and exited inside one
+                    // sleep. ECHILD means zero children of any kind — an
+                    // orphan can only be reparented to us while we still have
+                    // children, and then waitpid blocks rather than failing —
+                    // so a registry insert is the only way a child appears.
+                    // The timeout is a belt-and-braces bound, not a poll.
+                    let guard = reap_registry().lock().unwrap();
+                    let _ = reap_wakeup()
+                        .wait_timeout_while(guard, std::time::Duration::from_millis(500), |r| {
+                            r.is_empty()
+                        })
+                        .unwrap();
                     continue;
                 }
                 let Some(outcome) = wait_status_to_outcome(status) else {
@@ -736,6 +755,7 @@ mod agent {
             match cmd.spawn() {
                 Ok(c) => {
                     registry.insert(as_pid(c.id()), exit_tx);
+                    reap_wakeup().notify_all();
                     c
                 }
                 Err(e) => {
@@ -992,6 +1012,7 @@ mod agent {
             Ok(ForkResult::Parent { child }) => {
                 let child_pid = child.as_raw();
                 registry.insert(child_pid, exit_tx);
+                reap_wakeup().notify_all();
                 drop(registry); // release before the (long-lived) session loop
 
                 if start.timeout_seconds > 0 {

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -321,7 +321,46 @@ pub(super) fn chroot_root(fc_binary: &str, chroot_base_dir: &str, id: &str) -> P
         .join("root")
 }
 
-/// Copy kernel into the jailer chroot and set ownership.
+/// Stage a read-only file into a jailer chroot: hard-link when possible,
+/// copy otherwise.
+///
+/// A hard link shares the inode with the source, so it is only safe for
+/// files FC never writes — the kernel image, a snapshot vmstate, and a
+/// snapshot mem file (mapped MAP_PRIVATE on load). Do NOT use it for the
+/// rootfs copy fallback: FC writes guest blocks into that file. Linking is
+/// also reserved for the root jailer (uid/gid 0), because chown on a link
+/// would mutate the shared source inode; a non-root jailer gets a private
+/// copy with its own ownership.
+pub(super) async fn link_or_copy_for_jailer(
+    src: &Path,
+    dst: &Path,
+    uid: u32,
+    gid: u32,
+) -> Result<()> {
+    // Remove a stale entry first: hard_link fails on an existing dst, and a
+    // leftover from a previous run must not survive by accident.
+    if let Err(e) = tokio::fs::remove_file(dst).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(VmmError::Io(e));
+    }
+    if uid == 0 && gid == 0 {
+        match tokio::fs::hard_link(src, dst).await {
+            Ok(()) => return Ok(()),
+            // Cross-device (EXDEV) or filesystem quirk — fall through to copy.
+            Err(e) => {
+                debug!(src = %src.display(), dst = %dst.display(), error = %e,
+                    "hard link failed; falling back to copy");
+            }
+        }
+    }
+    tokio::fs::copy(src, dst).await.map_err(VmmError::Io)?;
+    chown(dst, Some(Uid::from_raw(uid)), Some(Gid::from_raw(gid)))
+        .map_err(|e| VmmError::Process(format!("chown {}: {e}", dst.display())))?;
+    Ok(())
+}
+
+/// Stage the kernel into the jailer chroot (link or copy).
 ///
 /// Returns the chroot-relative kernel path (e.g. `"/vmlinux"`).
 pub(super) async fn stage_kernel_for_jailer(
@@ -334,15 +373,7 @@ pub(super) async fn stage_kernel_for_jailer(
         .await
         .map_err(VmmError::Io)?;
     let kernel_dst = chroot_root.join("vmlinux");
-    tokio::fs::copy(kernel_src, &kernel_dst)
-        .await
-        .map_err(VmmError::Io)?;
-    chown(
-        &kernel_dst,
-        Some(Uid::from_raw(uid)),
-        Some(Gid::from_raw(gid)),
-    )
-    .map_err(|e| VmmError::Process(format!("chown kernel: {e}")))?;
+    link_or_copy_for_jailer(Path::new(kernel_src), &kernel_dst, uid, gid).await?;
     Ok("/vmlinux".to_string())
 }
 

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -1,5 +1,5 @@
 use super::boot::{
-    chroot_root, stage_kernel_for_jailer, stage_rootfs_copy_for_jailer,
+    chroot_root, link_or_copy_for_jailer, stage_kernel_for_jailer, stage_rootfs_copy_for_jailer,
     stage_rootfs_device_for_jailer,
 };
 use super::persistence::{ProvisionIntent, SandboxProvisionOutcome, SandboxTransition};
@@ -254,6 +254,11 @@ impl SandboxManager {
         // `../` id would traverse out of the snapshots directory.
         super::validate_id("snapshot id", &spec.snapshot_id)?;
 
+        // Phase clocks for the completion log: restore latency is a product
+        // metric (CORE-75) and the breakdown is what makes a regression
+        // attributable.
+        let restore_started = std::time::Instant::now();
+
         if caller_supplied_id
             && let Some(outcome) = self.records.replay_provision(&new_id, restore_key)?
         {
@@ -413,8 +418,10 @@ impl SandboxManager {
                 .await);
         }
 
+        let t_spawned = std::time::Instant::now();
+
         // In jailer mode the restored FC process also runs inside a chroot and
-        // cannot access the catalog's host-absolute paths.  Copy the snapshot
+        // cannot access the catalog's host-absolute paths.  Stage the snapshot
         // files into the new sandbox's chroot and use chroot-relative paths.
         let setup_result: Result<(String, Option<String>)> = async {
             let jc = jailer;
@@ -502,21 +509,18 @@ impl SandboxManager {
                 }
             }
 
-            // Copy vmstate into chroot.
+            // Stage vmstate + mem into the chroot. Both are read-only to FC
+            // (mem is mapped MAP_PRIVATE on load), so the root jailer
+            // hard-links them instead of copying — the mem file is the
+            // sandbox's full memory size (CORE-75).
             let dst_vmstate = snap_in_chroot.join("vmstate");
-            tokio::fs::copy(&snap_meta.vmstate_path, &dst_vmstate)
-                .await
-                .map_err(VmmError::Io)?;
-            nix::unistd::chown(&dst_vmstate, Some(uid), Some(gid))
-                .map_err(|e| VmmError::Process(format!("chown vmstate: {e}")))?;
+            link_or_copy_for_jailer(&snap_meta.vmstate_path, &dst_vmstate, jc.uid, jc.gid).await?;
 
             let effective_mem = if let Some(ref mf) = snap_meta.mem_path
                 && mf.exists()
             {
                 let dst_mem = snap_in_chroot.join("mem");
-                tokio::fs::copy(mf, &dst_mem).await.map_err(VmmError::Io)?;
-                nix::unistd::chown(&dst_mem, Some(uid), Some(gid))
-                    .map_err(|e| VmmError::Process(format!("chown mem: {e}")))?;
+                link_or_copy_for_jailer(mf, &dst_mem, jc.uid, jc.gid).await?;
                 Some(format!("/snapshots/{}/mem", spec.snapshot_id))
             } else {
                 None
@@ -544,6 +548,8 @@ impl SandboxManager {
                     .await);
             }
         };
+
+        let t_staged = std::time::Instant::now();
 
         // Build the restore parameters.
         let mut load_params = fc_sdk::types::SnapshotLoadParams {
@@ -582,6 +588,8 @@ impl SandboxManager {
             }
         };
 
+        let t_loaded = std::time::Instant::now();
+
         // Synchronise the guest clock to the host after restore.  The sandbox
         // clock is frozen at snapshot creation time; correct it before any
         // workload runs.  A failure here is non-fatal — the sandbox is still
@@ -590,16 +598,18 @@ impl SandboxManager {
         // Use a short timeout so clock sync never dominates restore latency.
         // sync_clock itself has a 5s read timeout, but connect_to_agent can
         // retry for up to AGENT_READY_TIMEOUT (30s).  Cap the whole operation.
-        match tokio::time::timeout(
-            std::time::Duration::from_secs(10),
-            vsock::sync_clock(&actual_vsock_path),
-        )
-        .await
-        {
-            Ok(Err(e)) => warn!(sandbox_id = %new_id, "clock sync after restore failed: {e}"),
-            Err(_) => warn!(sandbox_id = %new_id, "clock sync after restore timed out"),
-            Ok(Ok(())) => {}
-        }
+        let clock_sync = async {
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                vsock::sync_clock(&actual_vsock_path),
+            )
+            .await
+            {
+                Ok(Err(e)) => warn!(sandbox_id = %new_id, "clock sync after restore failed: {e}"),
+                Err(_) => warn!(sandbox_id = %new_id, "clock sync after restore timed out"),
+                Ok(Ok(())) => {}
+            }
+        };
 
         // Re-address the guest to the fresh allocation. The restored kernel
         // still carries the origin's `ip=` boot configuration, so without
@@ -608,32 +618,42 @@ impl SandboxManager {
         // clock, a fresh-network restore without a working network is the
         // silent breakage `network_override` exists to prevent — fail the
         // restore rather than hand back a half-networked sandbox.
-        if let Some(ref net) = net_alloc {
+        let net_reconfig = async {
+            let Some(ref net) = net_alloc else {
+                return Ok(());
+            };
             let cmd = crate::boot_proto::NetReconfigCommand {
                 ip: net.ip_address,
                 netmask: net.netmask(),
                 gateway: net.gateway,
             };
-            let reconfig = tokio::time::timeout(
+            tokio::time::timeout(
                 std::time::Duration::from_secs(10),
                 vsock::reconfigure_network(&actual_vsock_path, &cmd),
             )
             .await
             .map_err(|_| VmmError::Vsock("net reconfig after restore timed out".into()))
-            .and_then(|r| r);
-            if let Err(error) = reconfig {
-                return Err(self
-                    .rollback_restore(
-                        &new_id,
-                        reservation,
-                        error,
-                        Some(process),
-                        net_alloc,
-                        pending_cow,
-                    )
-                    .await);
-            }
+            .and_then(|r| r)
+        };
+
+        // The two guest configs are independent operations on separate vsock
+        // connections; run them concurrently — serially they were half the
+        // restore latency (CORE-75).
+        let ((), reconfig) = tokio::join!(clock_sync, net_reconfig);
+        if let Err(error) = reconfig {
+            return Err(self
+                .rollback_restore(
+                    &new_id,
+                    reservation,
+                    error,
+                    Some(process),
+                    net_alloc,
+                    pending_cow,
+                )
+                .await);
         }
+
+        let t_guest_cfg = std::time::Instant::now();
 
         // Persist cleanup metadata before handing runtime resources to the
         // instance. A failed durable write aborts and unwinds every resource.
@@ -736,9 +756,15 @@ impl SandboxManager {
             });
         }
 
+        let ms = |d: Duration| u64::try_from(d.as_millis()).unwrap_or(u64::MAX);
         info!(
             sandbox_id = %new_id,
             snapshot_id = %spec.snapshot_id,
+            spawn_ms = ms(t_spawned.duration_since(restore_started)),
+            stage_ms = ms(t_staged.duration_since(t_spawned)),
+            load_ms = ms(t_loaded.duration_since(t_staged)),
+            guest_cfg_ms = ms(t_guest_cfg.duration_since(t_loaded)),
+            total_ms = ms(restore_started.elapsed()),
             "sandbox restored from checkpoint"
         );
         if let Some(error) = ready_commit.durability_error {


### PR DESCRIPTION
Closes CORE-74. Part of CORE-75 (project **Sandbox Cold Start** — target: E2B-class start, restore RPC ≤150 ms).

## What

1. **`test(e2e)`: `sandbox_coldstart` probe** — the project's regression yardstick. Per group (networked / no-network / restore): Create/Restore RPC latency, create→READY via an Events stream subscribed before the first Create (a 500 ms Inspect poll would *be* the measurement at this scale), create→first-exec (`cat /proc/uptime` splits host vs in-guest time), warm exec, one dmesg boot timeline per group. Percentiles land in `metrics.json`. Test-only crate — nothing ships in production binaries.
2. **`perf(vm)`: restore fast path** — kernel/vmstate/mem are hard-linked into the jailer chroot instead of copied (FC only reads them; mem is mapped MAP_PRIVATE; copy fallback on link failure / non-root jailer), the post-restore clock-sync and eth0-reconfig vsock RPCs run concurrently, and the restore completion log carries a per-phase breakdown (`spawn/stage/load/guest_cfg`).
3. **`perf(vm-agent)`: event-driven reaper** — the no-children path polled every 50 ms, putting a flat ~50 ms floor under every short execution, product-wide. Now parks on a condvar paired with the reap-registry mutex; both spawn paths notify after registering. ECHILD means zero children of any kind (an orphan can only be reparented while children exist, which blocks `waitpid` instead of failing), so a registry insert is the only event that can end the wait; the 500 ms timeout is belt-and-braces, not a poll.

## Measured (M5 Max / macOS 26.4 / VZ, nested FC, 1 vCPU / 512 MiB, 10 serial iterations, this branch on 0.8.0 assets)

| Metric | Before | After |
|---|---|---|
| Restore RPC p50 | 263 ms | **269 ms**¹ |
| Restore → first exec p50 | 328 ms | **320 ms** |
| Warm exec p50 (every sandbox, product-wide) | 50 ms | **14–21 ms** |

¹ Restore phase breakdown (steady state): `spawn=62 stage=52 load=3 guest_cfg=114`. Two findings that reshape CORE-75: `LoadSnapshot`+resume is **3 ms** (lazy mmap) and Btrfs `copy_file_range` already reflinked the mem file, so the copies were never the dominant cost (the hard links are kept — they remove the dependence on reflink behavior); the real remainder is `guest_cfg` ≈ 114 ms where the two post-resume RPCs barely overlap even when joined — the restored guest appears to spend ~110 ms of single-vCPU settle time after resume (details and next steps on CORE-75).

## Validation

- `cargo test -p arcbox-vm` (128 tests) green; clippy clean incl. `--target aarch64-unknown-linux-musl` (vm-agent is Linux-only — host clippy does not see it)
- Full sandbox smoke green (`cargo test -p arcbox-e2e --test sandbox -- --ignored`): checkpoint, restore (both network modes), exec, file I/O, CORE-53 JSON POST
- Probe: `SKIP_BUILD=1 cargo test -p arcbox-e2e --test sandbox_coldstart -- --ignored --nocapture` (needs `cargo xtask dev boot-assets` + release daemon + musl guest binaries)