### PR TITLE
perf(sandbox): gate READY on agent vsock readiness and back off the connect poll

### DIFF
--- a/docs/sandbox-api.md
+++ b/docs/sandbox-api.md
@@ -104,6 +104,9 @@ STARTING ──► READY ──► RUNNING ──► READY   (execution exited; 
 States are the `SandboxState` enum (`SANDBOX_STATE_*`); events carry the
 `SandboxEventKind` enum. All timestamps are `google.protobuf.Timestamp`.
 
+- `READY` means the in-VM agent is accepting executions: on a cold boot
+  the transition (and its event) fires only after the guest has booted
+  and the agent answers over vsock, not when the VM process starts.
 - A sandbox is **not destroyed** when its execution exits — it returns to
   `READY` and accepts further `StartExecution` calls.
 - Destruction happens via `Stop`/`Remove`, `ttl_seconds` (hard maximum

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -4,6 +4,11 @@ use super::*;
 
 type BootOutput = (Arc<fc_sdk::Vm>, PathBuf);
 
+/// How long the agent-readiness gate waits for vm-agent to answer over vsock
+/// before the boot is declared failed. Covers guest kernel boot plus agent
+/// startup; `sync_clock`'s internal connect retries share this budget.
+const AGENT_GATE_TIMEOUT: Duration = Duration::from_secs(30);
+
 struct BootFailure {
     error: VmmError,
     process: Option<fc_sdk::FirecrackerProcess>,
@@ -42,8 +47,6 @@ pub(super) async fn boot_sandbox(
     .await
     {
         Ok((vm, vsock_uds_path)) => {
-            let ready_at = Utc::now();
-
             let current = instances.read().unwrap().get(&id).cloned();
             let is_current_generation = current
                 .as_ref()
@@ -52,6 +55,45 @@ pub(super) async fn boot_sandbox(
                 info!(sandbox_id = %id, "stale sandbox boot completed");
                 return;
             }
+
+            // READY promises "accepting executions", but InstanceStart returns
+            // while the guest kernel is still booting and vm-agent is not yet
+            // listening. Gate the transition on a completed agent round trip:
+            // sync_clock doubles as the readiness probe and sets the guest
+            // clock on cold boot the same way the restore path already does.
+            let agent_ready =
+                match tokio::time::timeout(AGENT_GATE_TIMEOUT, vsock::sync_clock(&vsock_uds_path))
+                    .await
+                {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(error)) => {
+                        Err(VmmError::Vsock(format!("agent readiness gate: {error}")))
+                    }
+                    Err(_) => Err(VmmError::Vsock(format!(
+                        "agent readiness gate: vm-agent did not answer within {}s",
+                        AGENT_GATE_TIMEOUT.as_secs()
+                    ))),
+                };
+            if let Err(gate_error) = agent_ready {
+                let message = gate_error.to_string();
+                fail_started_boot(
+                    &id,
+                    generation,
+                    &message,
+                    &vm_dir,
+                    &instances,
+                    &network,
+                    &config,
+                    &cow_manager,
+                    &records,
+                    &events_tx,
+                )
+                .await;
+                error!(sandbox_id = %id, error = %gate_error, "sandbox agent readiness gate failed");
+                return;
+            }
+
+            let ready_at = Utc::now();
 
             // do_boot persisted every cleanup resource before completing the
             // handoff, so only the lifecycle phase remains to make Ready.
@@ -66,58 +108,19 @@ pub(super) async fn boot_sandbox(
                     });
             if let Err(record_error) = durable_ready {
                 let message = format!("failed to persist ready state: {record_error}");
-                let value = instances.read().unwrap().get(&id).cloned();
-                let cleanup_lock = value
-                    .as_ref()
-                    .map(|arc| arc.lock().unwrap().cleanup_lock.clone());
-                let _cleanup_guard = match cleanup_lock.as_ref() {
-                    Some(lock) => Some(lock.lock().await),
-                    None => None,
-                };
-                let mut updated_current = false;
-                let mut failure_record_error = None;
-                let mut failure_record_visible = false;
-                if let Some(ref arc) = value {
-                    let mut inst = arc.lock().unwrap();
-                    if can_mark_boot_failed(&inst, generation) {
-                        (failure_record_visible, failure_record_error) =
-                            persist_boot_failure(&records, &id, generation, &message);
-                        inst.state = SandboxState::Failed;
-                        inst.error = Some(message.clone());
-                        updated_current = true;
-                    }
-                }
-                let cleanup_complete = if updated_current {
-                    match super::cleanup::release_runtime_resources(
-                        &id,
-                        value.as_ref().unwrap(),
-                        &network,
-                        &config,
-                        &cow_manager,
-                    )
-                    .await
-                    {
-                        Ok(()) => true,
-                        Err(error) => {
-                            error!(sandbox_id = %id, error = %error, "boot failure cleanup incomplete");
-                            false
-                        }
-                    }
-                } else {
-                    false
-                };
-                if failure_record_visible && cleanup_complete {
-                    if let Err(error) = super::reconcile::clear_state_record(&vm_dir) {
-                        error!(sandbox_id = %id, error = %error, "boot failure journal cleanup is not durable");
-                    }
-                }
-                if updated_current {
-                    let _ = events_tx
-                        .send(SandboxEvent::new(&id, action::FAILED).with_attr("error", &message));
-                }
-                if let Some(error) = failure_record_error {
-                    error!(sandbox_id = %id, error, "failed to persist sandbox boot failure");
-                }
+                fail_started_boot(
+                    &id,
+                    generation,
+                    &message,
+                    &vm_dir,
+                    &instances,
+                    &network,
+                    &config,
+                    &cow_manager,
+                    &records,
+                    &events_tx,
+                )
+                .await;
                 error!(sandbox_id = %id, error = %record_error, "sandbox ready state was not durable");
                 return;
             }
@@ -270,6 +273,80 @@ fn persist_boot_failure(
             None => (true, None),
         },
         Err(error) => (false, Some(error.to_string())),
+    }
+}
+
+/// Fail a boot whose VM process already started and whose cleanup resources
+/// were all transferred to the instance: persist the failure, flip the
+/// instance to `Failed`, release runtime resources, clear the boot journal,
+/// and broadcast the FAILED event. Shared by the agent-readiness gate and the
+/// durable-Ready persistence check; each caller logs its own context line.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "failure handling spans the boot task's captured manager state"
+)]
+async fn fail_started_boot(
+    id: &SandboxId,
+    generation: Uuid,
+    message: &str,
+    vm_dir: &Path,
+    instances: &super::InstanceMap,
+    network: &Arc<NetworkManager>,
+    config: &Arc<VmmConfig>,
+    cow_manager: &Arc<CowManager>,
+    records: &SandboxRecordStore,
+    events_tx: &broadcast::Sender<SandboxEvent>,
+) {
+    let value = instances.read().unwrap().get(id).cloned();
+    let cleanup_lock = value
+        .as_ref()
+        .map(|arc| arc.lock().unwrap().cleanup_lock.clone());
+    let _cleanup_guard = match cleanup_lock.as_ref() {
+        Some(lock) => Some(lock.lock().await),
+        None => None,
+    };
+    let mut updated_current = false;
+    let mut failure_record_error = None;
+    let mut failure_record_visible = false;
+    if let Some(ref arc) = value {
+        let mut inst = arc.lock().unwrap();
+        if can_mark_boot_failed(&inst, generation) {
+            (failure_record_visible, failure_record_error) =
+                persist_boot_failure(records, id, generation, message);
+            inst.state = SandboxState::Failed;
+            inst.error = Some(message.to_owned());
+            updated_current = true;
+        }
+    }
+    let cleanup_complete = if updated_current {
+        match super::cleanup::release_runtime_resources(
+            id,
+            value.as_ref().unwrap(),
+            network,
+            config,
+            cow_manager,
+        )
+        .await
+        {
+            Ok(()) => true,
+            Err(error) => {
+                error!(sandbox_id = %id, error = %error, "boot failure cleanup incomplete");
+                false
+            }
+        }
+    } else {
+        false
+    };
+    if failure_record_visible && cleanup_complete {
+        if let Err(error) = super::reconcile::clear_state_record(vm_dir) {
+            error!(sandbox_id = %id, error = %error, "boot failure journal cleanup is not durable");
+        }
+    }
+    if updated_current {
+        let _ = events_tx.send(SandboxEvent::new(id, action::FAILED).with_attr("error", message));
+    }
+    if let Some(error) = failure_record_error {
+        error!(sandbox_id = %id, error, "failed to persist sandbox boot failure");
     }
 }
 

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -6,8 +6,11 @@ type BootOutput = (Arc<fc_sdk::Vm>, PathBuf);
 
 /// How long the agent-readiness gate waits for vm-agent to answer over vsock
 /// before the boot is declared failed. Covers guest kernel boot plus agent
-/// startup; `sync_clock`'s internal connect retries share this budget.
-const AGENT_GATE_TIMEOUT: Duration = Duration::from_secs(30);
+/// startup. Deliberately wider than `sync_clock`'s internal connect deadline
+/// (`AGENT_READY_TIMEOUT`, 30 s) so that when the agent never appears the
+/// inner error — which names the socket and the elapsed budget — wins the
+/// race against this outer timeout's generic message.
+const AGENT_GATE_TIMEOUT: Duration = Duration::from_secs(35);
 
 struct BootFailure {
     error: VmmError,
@@ -61,19 +64,30 @@ pub(super) async fn boot_sandbox(
             // listening. Gate the transition on a completed agent round trip:
             // sync_clock doubles as the readiness probe and sets the guest
             // clock on cold boot the same way the restore path already does.
-            let agent_ready =
-                match tokio::time::timeout(AGENT_GATE_TIMEOUT, vsock::sync_clock(&vsock_uds_path))
-                    .await
-                {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(error)) => {
-                        Err(VmmError::Vsock(format!("agent readiness gate: {error}")))
-                    }
-                    Err(_) => Err(VmmError::Vsock(format!(
-                        "agent readiness gate: vm-agent did not answer within {}s",
-                        AGENT_GATE_TIMEOUT.as_secs()
-                    ))),
-                };
+            // Liveness is the gate, not the clock side effect: an agent that
+            // answered-but-failed (`ClockSync::AgentError`) proves the RPC
+            // path works, and tearing down a usable VM over a clock error
+            // would be strictly worse than a skewed clock.
+            let agent_ready = match tokio::time::timeout(
+                AGENT_GATE_TIMEOUT,
+                vsock::sync_clock(&vsock_uds_path),
+            )
+            .await
+            {
+                Ok(Ok(vsock::ClockSync::Synced)) => Ok(()),
+                Ok(Ok(vsock::ClockSync::AgentError(code))) => {
+                    warn!(
+                        sandbox_id = %id, code,
+                        "agent alive but clock sync failed; continuing with a possibly skewed clock"
+                    );
+                    Ok(())
+                }
+                Ok(Err(error)) => Err(VmmError::Vsock(format!("agent readiness gate: {error}"))),
+                Err(_) => Err(VmmError::Vsock(format!(
+                    "agent readiness gate: vm-agent did not answer within {}s",
+                    AGENT_GATE_TIMEOUT.as_secs()
+                ))),
+            };
             if let Err(gate_error) = agent_ready {
                 let message = gate_error.to_string();
                 fail_started_boot(

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -607,7 +607,10 @@ impl SandboxManager {
             {
                 Ok(Err(e)) => warn!(sandbox_id = %new_id, "clock sync after restore failed: {e}"),
                 Err(_) => warn!(sandbox_id = %new_id, "clock sync after restore timed out"),
-                Ok(Ok(())) => {}
+                Ok(Ok(vsock::ClockSync::AgentError(code))) => {
+                    warn!(sandbox_id = %new_id, code, "agent could not set the clock after restore");
+                }
+                Ok(Ok(vsock::ClockSync::Synced)) => {}
             }
         };
 

--- a/virt/arcbox-vm/src/vsock.rs
+++ b/virt/arcbox-vm/src/vsock.rs
@@ -50,7 +50,8 @@ const MSG_START: u8 = 0x01;
 const MSG_STDIN: u8 = 0x02;
 const MSG_RESIZE: u8 = 0x03;
 const MSG_EOF: u8 = 0x04;
-/// Synchronise the guest clock to the host after snapshot restore.
+/// Synchronise the guest clock to the host (after snapshot restore, and as
+/// the cold-boot agent-readiness gate).
 /// Payload: `[i64 LE unix_seconds][u32 LE nanos]` (12 bytes).
 pub(crate) const MSG_CLOCK_SYNC: u8 = 0x05;
 /// Re-address the guest network after a fresh-network snapshot restore.
@@ -157,8 +158,16 @@ pub struct StartCommand {
 
 /// How long to wait for the guest agent to start accepting vsock connections.
 const AGENT_READY_TIMEOUT: Duration = Duration::from_secs(30);
-/// Interval between vsock connection attempts while the guest is still booting.
-const AGENT_READY_POLL_INTERVAL: Duration = Duration::from_millis(200);
+/// First retry delay of the vsock connect backoff; doubles per attempt.
+const AGENT_READY_INITIAL_BACKOFF: Duration = Duration::from_millis(2);
+/// Ceiling for the vsock connect retry backoff.
+const AGENT_READY_MAX_BACKOFF: Duration = Duration::from_millis(200);
+
+/// Next delay of the exponential connect backoff: double, capped at
+/// [`AGENT_READY_MAX_BACKOFF`].
+fn next_backoff(current: Duration) -> Duration {
+    current.saturating_mul(2).min(AGENT_READY_MAX_BACKOFF)
+}
 
 /// Open a host-initiated vsock connection to the guest agent (port 52).
 ///
@@ -177,6 +186,7 @@ async fn connect_to_agent(uds_path: &Path) -> Result<UnixStream> {
 /// port-forward modules which operate on different vsock ports.
 pub(crate) async fn connect_to_port(uds_path: &Path, port: u32) -> Result<UnixStream> {
     let deadline = tokio::time::Instant::now() + AGENT_READY_TIMEOUT;
+    let mut backoff = AGENT_READY_INITIAL_BACKOFF;
     loop {
         match try_vsock_handshake(uds_path, port).await {
             Ok(stream) => return Ok(stream),
@@ -190,7 +200,8 @@ pub(crate) async fn connect_to_port(uds_path: &Path, port: u32) -> Result<UnixSt
                 AGENT_READY_TIMEOUT.as_secs(),
             )));
         }
-        tokio::time::sleep(AGENT_READY_POLL_INTERVAL).await;
+        tokio::time::sleep(backoff).await;
+        backoff = next_backoff(backoff);
     }
 }
 
@@ -417,9 +428,10 @@ pub async fn exec(
 /// Synchronise the guest clock to the current host time.
 ///
 /// Sends [`MSG_CLOCK_SYNC`] to the exec channel (vsock port 52) and waits for
-/// `MSG_EXIT(0)`.  Should be called immediately after `restore_sandbox()`
-/// completes so the guest does not run with a stale timestamp from snapshot
-/// creation time.
+/// `MSG_EXIT(0)`.  Called immediately after `restore_sandbox()` completes so
+/// the guest does not run with a stale timestamp from snapshot creation time,
+/// and by the cold-boot path as the agent-readiness gate: a completed round
+/// trip proves vm-agent is accepting executions.
 pub async fn sync_clock(uds_path: &Path) -> Result<()> {
     let mut stream = connect_to_agent(uds_path).await?;
 
@@ -541,6 +553,17 @@ mod tests {
         buf.extend_from_slice(&(payload.len() as u32).to_le_bytes());
         buf.extend_from_slice(payload);
         buf
+    }
+
+    #[test]
+    fn connect_backoff_doubles_up_to_the_cap() {
+        let mut delays = Vec::new();
+        let mut backoff = AGENT_READY_INITIAL_BACKOFF;
+        for _ in 0..10 {
+            delays.push(backoff.as_millis());
+            backoff = next_backoff(backoff);
+        }
+        assert_eq!(delays, [2, 4, 8, 16, 32, 64, 128, 200, 200, 200]);
     }
 
     #[tokio::test]

--- a/virt/arcbox-vm/src/vsock.rs
+++ b/virt/arcbox-vm/src/vsock.rs
@@ -425,14 +425,30 @@ pub async fn exec(
 // sync_clock() — synchronise guest clock after snapshot restore
 // =============================================================================
 
+/// Outcome of a completed clock-sync round trip.
+///
+/// Both variants prove liveness — the agent accepted the connection, parsed
+/// the frame, and replied — which is what the boot readiness gate needs.
+/// Only [`ClockSync::Synced`] means the guest wall clock was actually set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClockSync {
+    /// The agent set the clock.
+    Synced,
+    /// The agent answered but could not set the clock (e.g. `clock_settime`
+    /// failed); it carries the agent-reported exit code.
+    AgentError(i32),
+}
+
 /// Synchronise the guest clock to the current host time.
 ///
 /// Sends [`MSG_CLOCK_SYNC`] to the exec channel (vsock port 52) and waits for
-/// `MSG_EXIT(0)`.  Called immediately after `restore_sandbox()` completes so
+/// `MSG_EXIT`.  Called immediately after `restore_sandbox()` completes so
 /// the guest does not run with a stale timestamp from snapshot creation time,
-/// and by the cold-boot path as the agent-readiness gate: a completed round
-/// trip proves vm-agent is accepting executions.
-pub async fn sync_clock(uds_path: &Path) -> Result<()> {
+/// and by the cold-boot path as the agent-readiness gate. `Err` means the
+/// round trip itself failed (connect, transport, malformed reply); an agent
+/// that answered-but-failed is `Ok(ClockSync::AgentError)` so callers can
+/// separate liveness from the clock side effect.
+pub async fn sync_clock(uds_path: &Path) -> Result<ClockSync> {
     let mut stream = connect_to_agent(uds_path).await?;
 
     let now = std::time::SystemTime::now()
@@ -454,7 +470,7 @@ async fn sync_clock_on_stream<S: tokio::io::AsyncReadExt + tokio::io::AsyncWrite
     stream: &mut S,
     secs: i64,
     nanos: u32,
-) -> Result<()> {
+) -> Result<ClockSync> {
     let mut payload = [0u8; 12];
     payload[..8].copy_from_slice(&secs.to_le_bytes());
     payload[8..].copy_from_slice(&nanos.to_le_bytes());
@@ -481,11 +497,9 @@ async fn sync_clock_on_stream<S: tokio::io::AsyncReadExt + tokio::io::AsyncWrite
     }
     let code = i32::from_le_bytes(payload[..4].try_into().unwrap());
     if code != 0 {
-        return Err(VmmError::Vsock(format!(
-            "clock sync: agent returned exit code {code}"
-        )));
+        return Ok(ClockSync::AgentError(code));
     }
-    Ok(())
+    Ok(ClockSync::Synced)
 }
 
 /// Re-address the guest network after a fresh-network snapshot restore.
@@ -717,11 +731,12 @@ mod tests {
         });
 
         let result = sync_clock_on_stream(&mut host, 1_700_000_000, 123_456_789).await;
-        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), ClockSync::Synced);
         agent_handle.await.unwrap();
     }
 
-    /// Agent returns a non-zero exit code.
+    /// Agent answers with a non-zero exit code: liveness proven, clock not
+    /// set — `Ok(AgentError)`, not `Err`, so the boot gate can pass on it.
     #[tokio::test]
     async fn test_sync_clock_agent_error() {
         let (mut agent, mut host) = tokio::io::duplex(256);
@@ -734,9 +749,7 @@ mod tests {
         });
 
         let result = sync_clock_on_stream(&mut host, 1_700_000_000, 0).await;
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("exit code -1"), "unexpected error: {msg}");
+        assert_eq!(result.unwrap(), ClockSync::AgentError(-1));
         agent_handle.await.unwrap();
     }
 


### PR DESCRIPTION
Stacked on #555 (merge that first, then retarget/rebase onto master). Closes CORE-76 (project **Sandbox Cold Start**).

## What

1. **READY becomes honest.** The READY lifecycle event fired when FC `InstanceStart` returned (~100 ms), ~2.5 s before the microVM's agent could accept an execution — the proto comment ("sandbox accepting executions") was a lie. `boot_sandbox` now gates the durable Ready transition, the state flip, and the event on a completed `sync_clock` round trip to the in-microVM agent (30 s cap), which doubles as boot-path clock setting, symmetric with restore. Gate failure follows the existing durable-ready failure machinery (extracted into a shared `fail_started_boot`, not duplicated). `ready_at` is captured after the gate.
2. **Exponential connect backoff.** `connect_to_port`'s flat 200 ms poll (worth ~100 ms average on every cold start) becomes 2 ms doubling to a 200 ms cap, same 30 s deadline; the backoff sequence is a pure function with a unit test.
3. `docs/sandbox-api.md` state-machine wording updated; no proto changes (the existing comment now describes reality).

## Expected metric shift (intended)

create→READY on cold boot rises from ~100 ms to match actual usability (~1.1–1.4 s after #556's `quiet`); the `sandbox_coldstart` probe's `ready` and `first_exec` series should converge. Restore path untouched.

## Validation

- fmt/clippy clean (host + `aarch64-unknown-linux-musl` bins), `cargo test -p arcbox-vm`: 129 lib + 1 integration green, new backoff unit test
- Hardware-validated combined with #556 (cherry-pick onto r2): probe green — cold create→READY p50 1219 ms networked / 1056 ms no-network, converged with first-exec (1270/1111 ms; the READY→usable gap shrank from ~2.5 s to ~50 ms) — and the full sandbox smoke passes