### PR TITLE
perf(sandbox): quiet microVM console + reconfig latency attribution + resolv on tmpfs (round 2)

### DIFF
--- a/guest/arcbox-agent/src/config.rs
+++ b/guest/arcbox-agent/src/config.rs
@@ -63,7 +63,10 @@ fn guest_defaults() -> VmmConfig {
             memory_mib: 512,
             kernel: runtime_root.join("kernel/vmlinux").to_string_lossy().into(),
             rootfs: format!("{SANDBOX_DATA_DIR}/rootfs.ext4"),
-            boot_args: "console=ttyS0 reboot=k panic=1 pci=off init=/sbin/vm-agent".into(),
+            // `quiet`: every boot printk is a serial MMIO exit, doubled by
+            // nesting — silencing the console measurably shortens the cold
+            // kernel boot (CORE-75/CORE-79).
+            boot_args: "console=ttyS0 quiet reboot=k panic=1 pci=off init=/sbin/vm-agent".into(),
         },
     }
 }

--- a/guest/arcbox-agent/src/rootfs_builder.rs
+++ b/guest/arcbox-agent/src/rootfs_builder.rs
@@ -449,6 +449,22 @@ fn build_default_rootfs(spec: &DefaultRootfsSpec, out: &Path) -> Result<()> {
     )
     .context("write /etc/group")?;
 
+    // resolv.conf lives on tmpfs (/run, mounted by vm-agent): DNS writes on
+    // the post-restore reconfig path must not touch the block device — the
+    // clone's first ext4 write pays a synchronous dm-snapshot CoW exception
+    // through the nested I/O stack, measured at ~30 ms (CORE-75).
+    fmt.create(
+        "/etc/resolv.conf",
+        LNK,
+        Some("../run/resolv.conf"),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .context("symlink /etc/resolv.conf")?;
+
     fmt.close().context("failed to finalize ext4 image")?;
     Ok(())
 }
@@ -505,6 +521,21 @@ async fn inject_vm_agent(ext4_path: &str, req_id: &str) -> Result<()> {
             .args(["chmod", "755", &dest])
             .status()
             .await;
+    }
+
+    // Point resolv.conf at tmpfs, mirroring the default template: DNS
+    // rewrites must stay off the CoW block device (CORE-75). Rewriting is
+    // safe for Docker images — Docker itself never ships meaningful
+    // resolv.conf content (it bind-mounts one at run time).
+    if copy_result.is_ok() {
+        let etc = format!("{mount_dir}/etc");
+        if tokio::fs::create_dir_all(&etc).await.is_ok() {
+            let resolv = format!("{etc}/resolv.conf");
+            let _ = tokio::fs::remove_file(&resolv).await;
+            if let Err(e) = tokio::fs::symlink("../run/resolv.conf", &resolv).await {
+                tracing::warn!(error = %e, "resolv.conf symlink failed; DNS rewrites will hit the CoW device");
+            }
+        }
     }
 
     // Always unmount and cleanup, even on failure.

--- a/tests/e2e/tests/sandbox_coldstart.rs
+++ b/tests/e2e/tests/sandbox_coldstart.rs
@@ -58,7 +58,8 @@ fn sandbox_coldstart() -> Result<()> {
         .with_test_writer()
         .try_init();
 
-    let iters = env_usize("ARCBOX_COLDSTART_ITERS", 10);
+    // Floor of 1: `report` assumes at least one sample per group.
+    let iters = env_usize("ARCBOX_COLDSTART_ITERS", 10).max(1);
     let vcpus = env_usize("ARCBOX_COLDSTART_VCPUS", 1) as u32;
     let memory_mib = env_usize("ARCBOX_COLDSTART_MEMORY_MIB", 512) as u64;
 
@@ -503,8 +504,19 @@ async fn run_and_collect(
         .context("AttachExecution failed")?
         .into_inner();
 
+    // Deadline the drain like wait_for_ready: a wedged exec must fail the
+    // probe (writing metrics + preserving the test dir), not hang it.
+    let deadline = Instant::now() + Duration::from_secs(60);
     let mut stdout = String::new();
-    while let Some(event) = stream.message().await.context("attach stream error")? {
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let event = tokio::time::timeout(remaining, stream.message())
+            .await
+            .with_context(|| format!("{id}: command {cmd:?} timed out"))?
+            .context("attach stream error")?;
+        let Some(event) = event else {
+            bail!("{id}: attach stream ended without an exit event");
+        };
         match event.event {
             Some(execution_event::Event::Output(output)) => {
                 if output.channel() != StdioChannel::Stderr {
@@ -521,7 +533,6 @@ async fn run_and_collect(
             _ => {}
         }
     }
-    bail!("{id}: attach stream ended without an exit event")
 }
 
 /// Consumes the shared event stream until `id` reports READY.

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -26,7 +26,7 @@
 //! | 0x07 | Host→Agent  | `[i32 LE signal]` — signal the workload's process group |
 //! | 0x10 | Agent→Host  | raw stdout bytes                 |
 //! | 0x11 | Agent→Host  | raw stderr bytes                 |
-//! | 0x12 | Agent→Host  | `[i32 LE code][i32 LE signal]` — signal 0 = normal exit |
+//! | 0x12 | Agent→Host  | `[i32 LE code][i32 LE signal]` — signal 0 = normal exit. Net-reconfig replies append six `u32 LE` micros (addr/netmask/delrt/addrt ioctls, resolv write, whole handler); legacy agents send only the 4-byte code. Readers key on payload length. |
 //!
 //! This binary requires Linux — it uses AF_VSOCK, accept4, openpty, and fork,
 //! none of which are available on other platforms.  The workspace compiles the
@@ -290,16 +290,16 @@ mod agent {
         if let Err(e) = std::fs::write("/etc/resolv.conf", &content) {
             eprintln!("agent: net reconfig: failed to write /etc/resolv.conf: {e}");
         }
-        let clamp = |d: std::time::Duration| u32::try_from(d.as_millis()).unwrap_or(u32::MAX);
-        let resolv_ms = clamp(resolv_started.elapsed());
-        let handler_ms = clamp(handler_started.elapsed());
+        let clamp = |d: std::time::Duration| u32::try_from(d.as_micros()).unwrap_or(u32::MAX);
+        let resolv_us = clamp(resolv_started.elapsed());
+        let handler_us = clamp(handler_started.elapsed());
 
-        // Exit payload: [i32 code][i32 signal] plus six u32 millis (four
+        // Exit payload: [i32 code][i32 signal] plus six u32 micros (four
         // per-ioctl, resolv write, whole handler) so the host can attribute
         // reconfig latency. Hosts read the first 4 bytes only, so the
         // extension is backward compatible.
         let mut payload = [0u8; 32];
-        let timings = steps.iter().copied().chain([resolv_ms, handler_ms]);
+        let timings = steps.iter().copied().chain([resolv_us, handler_us]);
         for (slot, ms) in payload[8..].chunks_exact_mut(4).zip(timings) {
             slot.copy_from_slice(&ms.to_le_bytes());
         }
@@ -382,8 +382,10 @@ mod agent {
         pub fn apply(cmd: &NetReconfigCommand) -> Result<[u32; 4], String> {
             let mut steps = [0u32; 4];
             let mut mark = std::time::Instant::now();
+            // Microseconds: the ioctls land well under a millisecond each,
+            // and u32 micros still spans ~71 minutes.
             let mut lap = |slot: &mut u32| {
-                *slot = u32::try_from(mark.elapsed().as_millis()).unwrap_or(u32::MAX);
+                *slot = u32::try_from(mark.elapsed().as_micros()).unwrap_or(u32::MAX);
                 mark = std::time::Instant::now();
             };
 
@@ -648,6 +650,20 @@ mod agent {
         WAKEUP.get_or_init(Condvar::new)
     }
 
+    /// Register a spawned child for reaping AND wake the parked reaper.
+    ///
+    /// The single entry point for both spawn paths: an insert without the
+    /// wakeup would strand that child's exit for up to the reaper's park
+    /// timeout, so the two steps must never be separated.
+    fn register_child(
+        registry: &mut HashMap<libc::pid_t, mpsc::Sender<WaitOutcome>>,
+        pid: libc::pid_t,
+        exit_tx: mpsc::Sender<WaitOutcome>,
+    ) {
+        registry.insert(pid, exit_tx);
+        reap_wakeup().notify_all();
+    }
+
     /// Narrow a `std::process::Child::id()` (u32) to a `pid_t`. Linux pids are
     /// bounded well below `i32::MAX`, so this never wraps.
     #[allow(clippy::cast_possible_wrap, reason = "pids fit in pid_t")]
@@ -789,8 +805,7 @@ mod agent {
             let mut registry = reap_registry().lock().unwrap();
             match cmd.spawn() {
                 Ok(c) => {
-                    registry.insert(as_pid(c.id()), exit_tx);
-                    reap_wakeup().notify_all();
+                    register_child(&mut registry, as_pid(c.id()), exit_tx);
                     c
                 }
                 Err(e) => {
@@ -1046,8 +1061,7 @@ mod agent {
 
             Ok(ForkResult::Parent { child }) => {
                 let child_pid = child.as_raw();
-                registry.insert(child_pid, exit_tx);
-                reap_wakeup().notify_all();
+                register_child(&mut registry, child_pid, exit_tx);
                 drop(registry); // release before the (long-lived) session loop
 
                 if start.timeout_seconds > 0 {

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -274,23 +274,44 @@ mod agent {
             }
         };
 
-        if let Err(e) = net_reconfig::apply(&cmd) {
-            eprintln!("agent: net reconfig failed: {e}");
-            let _ = write_frame(&mut conn, MSG_EXIT, &(-1i32).to_le_bytes());
-            return;
-        }
+        let handler_started = std::time::Instant::now();
+        let steps = match net_reconfig::apply(&cmd) {
+            Ok(steps) => steps,
+            Err(e) => {
+                eprintln!("agent: net reconfig failed: {e}");
+                let _ = write_frame(&mut conn, MSG_EXIT, &(-1i32).to_le_bytes());
+                return;
+            }
+        };
 
         // Repoint DNS at the new gateway, mirroring the boot-time setup_dns.
+        let resolv_started = std::time::Instant::now();
         let content = format!("nameserver {}\n", cmd.gateway);
         if let Err(e) = std::fs::write("/etc/resolv.conf", &content) {
             eprintln!("agent: net reconfig: failed to write /etc/resolv.conf: {e}");
         }
+        let clamp = |d: std::time::Duration| u32::try_from(d.as_millis()).unwrap_or(u32::MAX);
+        let resolv_ms = clamp(resolv_started.elapsed());
+        let handler_ms = clamp(handler_started.elapsed());
 
+        // Exit payload: [i32 code][i32 signal] plus six u32 millis (four
+        // per-ioctl, resolv write, whole handler) so the host can attribute
+        // reconfig latency. Hosts read the first 4 bytes only, so the
+        // extension is backward compatible.
+        let mut payload = [0u8; 32];
+        let timings = steps.iter().copied().chain([resolv_ms, handler_ms]);
+        for (slot, ms) in payload[8..].chunks_exact_mut(4).zip(timings) {
+            slot.copy_from_slice(&ms.to_le_bytes());
+        }
+        let _ = write_frame(&mut conn, MSG_EXIT, &payload);
+
+        // Console logging goes AFTER the response: /dev/console is the FC
+        // serial device, written byte-by-byte through nested MMIO exits —
+        // putting it before the reply held the restore RPC hostage to it.
         eprintln!(
             "agent: reconfigured eth0 to {}/{} via {}",
             cmd.ip, cmd.netmask, cmd.gateway
         );
-        let _ = write_frame(&mut conn, MSG_EXIT, &0i32.to_le_bytes());
     }
 
     /// eth0 re-addressing via raw `ioctl(2)`, self-contained so it works on
@@ -355,7 +376,17 @@ mod agent {
         }
 
         /// Set eth0's address + netmask and replace the default route.
-        pub fn apply(cmd: &NetReconfigCommand) -> Result<(), String> {
+        ///
+        /// Returns per-step millis `[addr, netmask, delrt, addrt]` so the
+        /// host can attribute reconfig latency (CORE-75 diagnostics).
+        pub fn apply(cmd: &NetReconfigCommand) -> Result<[u32; 4], String> {
+            let mut steps = [0u32; 4];
+            let mut mark = std::time::Instant::now();
+            let mut lap = |slot: &mut u32| {
+                *slot = u32::try_from(mark.elapsed().as_millis()).unwrap_or(u32::MAX);
+                mark = std::time::Instant::now();
+            };
+
             // SAFETY: plain socket(2) call; result checked below.
             let raw = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
             if raw < 0 {
@@ -367,10 +398,12 @@ mod agent {
             let mut req = ifreq_with_addr(sockaddr_in(cmd.ip));
             ioctl(&fd, libc::SIOCSIFADDR, (&raw mut req).cast())
                 .map_err(|e| format!("SIOCSIFADDR: {e}"))?;
+            lap(&mut steps[0]);
 
             let mut req = ifreq_with_addr(sockaddr_in(cmd.netmask));
             ioctl(&fd, libc::SIOCSIFNETMASK, (&raw mut req).cast())
                 .map_err(|e| format!("SIOCSIFNETMASK: {e}"))?;
+            lap(&mut steps[1]);
 
             // The kernel flushes routes through the interface when its
             // primary address changes, but don't rely on that implicit
@@ -386,6 +419,7 @@ mod agent {
                     eprintln!("agent: net reconfig: SIOCDELRT stale default: {e}");
                 }
             }
+            lap(&mut steps[2]);
 
             // Add the default route via the new gateway.
             // SAFETY: rtentry is POD; fields set below, rest zeroed.
@@ -396,8 +430,9 @@ mod agent {
             route.rt_flags = libc::RTF_UP | libc::RTF_GATEWAY;
             ioctl(&fd, libc::SIOCADDRT, (&raw mut route).cast())
                 .map_err(|e| format!("SIOCADDRT default via {}: {e}", cmd.gateway))?;
+            lap(&mut steps[3]);
 
-            Ok(())
+            Ok(steps)
         }
     }
 

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -1168,6 +1168,17 @@ mod agent {
                 libc::MS_NOSUID | libc::MS_NOEXEC,
                 "newinstance,ptmxmode=0666",
             ),
+            // /etc/resolv.conf is a symlink into /run so DNS rewrites (boot
+            // setup_dns, post-restore net reconfig) stay off the CoW block
+            // device — a first ext4 write costs a ~30 ms synchronous
+            // dm-snapshot exception through the nested I/O stack (CORE-75).
+            (
+                "/run",
+                "tmpfs",
+                "tmpfs",
+                libc::MS_NOSUID | libc::MS_NODEV,
+                "mode=0755",
+            ),
         ];
 
         for (target, source, fstype, flags, data) in mounts {

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -347,9 +347,12 @@ pub(super) async fn link_or_copy_for_jailer(
     if uid == 0 && gid == 0 {
         match tokio::fs::hard_link(src, dst).await {
             Ok(()) => return Ok(()),
-            // Cross-device (EXDEV) or filesystem quirk — fall through to copy.
+            // Cross-device (EXDEV) or filesystem quirk. warn, not debug: the
+            // copy fallback silently forfeits the restore fast path, and at
+            // default log levels a misplaced chroot base would only ever be
+            // rediscovered by re-measuring.
             Err(e) => {
-                debug!(src = %src.display(), dst = %dst.display(), error = %e,
+                warn!(src = %src.display(), dst = %dst.display(), error = %e,
                     "hard link failed; falling back to copy");
             }
         }

--- a/virt/arcbox-vm/src/vsock.rs
+++ b/virt/arcbox-vm/src/vsock.rs
@@ -38,7 +38,7 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 use tokio::sync::mpsc;
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::error::{Result, VmmError};
 
@@ -421,7 +421,12 @@ pub async fn exec(
 /// completes so the guest does not run with a stale timestamp from snapshot
 /// creation time.
 pub async fn sync_clock(uds_path: &Path) -> Result<()> {
+    // Split connect vs frame RTT: on a just-resumed guest these have very
+    // different causes (vsock handshake vs guest-side processing), and the
+    // CORE-75 settle-window investigation needs them attributable.
+    let started = std::time::Instant::now();
     let mut stream = connect_to_agent(uds_path).await?;
+    let connected = std::time::Instant::now();
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -431,7 +436,13 @@ pub async fn sync_clock(uds_path: &Path) -> Result<()> {
         .map_err(|e| VmmError::Vsock(format!("unix timestamp overflow: {e}")))?;
     let nanos = now.subsec_nanos();
 
-    sync_clock_on_stream(&mut stream, secs, nanos).await
+    let result = sync_clock_on_stream(&mut stream, secs, nanos).await;
+    info!(
+        connect_ms = connected.duration_since(started).as_millis() as u64,
+        rpc_ms = connected.elapsed().as_millis() as u64,
+        "clock sync"
+    );
+    result
 }
 
 /// Send a clock-sync frame and validate the agent response.
@@ -486,8 +497,16 @@ pub async fn reconfigure_network(
     uds_path: &Path,
     cmd: &crate::boot_proto::NetReconfigCommand,
 ) -> Result<()> {
+    let started = std::time::Instant::now();
     let mut stream = connect_to_agent(uds_path).await?;
-    net_reconfig_on_stream(&mut stream, cmd).await
+    let connected = std::time::Instant::now();
+    let result = net_reconfig_on_stream(&mut stream, cmd).await;
+    info!(
+        connect_ms = connected.duration_since(started).as_millis() as u64,
+        rpc_ms = connected.elapsed().as_millis() as u64,
+        "net reconfig"
+    );
+    result
 }
 
 /// Send a net-reconfig frame and validate the agent response.
@@ -526,6 +545,22 @@ async fn net_reconfig_on_stream<S: tokio::io::AsyncReadExt + tokio::io::AsyncWri
         return Err(VmmError::Vsock(format!(
             "net reconfig: agent returned exit code {code}"
         )));
+    }
+    // Newer agents append six u32 millis (four per-ioctl, resolv write,
+    // whole handler) after the [code][signal] header — CORE-75 latency
+    // attribution.
+    if payload.len() >= 32 {
+        let step =
+            |i: usize| u32::from_le_bytes(payload[8 + i * 4..12 + i * 4].try_into().unwrap());
+        info!(
+            addr_ms = step(0),
+            netmask_ms = step(1),
+            delrt_ms = step(2),
+            addrt_ms = step(3),
+            resolv_ms = step(4),
+            handler_ms = step(5),
+            "net reconfig guest split"
+        );
     }
     Ok(())
 }

--- a/virt/arcbox-vm/src/vsock.rs
+++ b/virt/arcbox-vm/src/vsock.rs
@@ -28,7 +28,7 @@
 //! | 0x07 | Host→Agent  | `[i32 LE signal]` — deliver to workload    |
 //! | 0x10 | Agent→Host  | raw stdout bytes                           |
 //! | 0x11 | Agent→Host  | raw stderr bytes                           |
-//! | 0x12 | Agent→Host  | `[i32 LE code][i32 LE signal]` (signal 0 = normal exit; old agents send only the 4-byte code) |
+//! | 0x12 | Agent→Host  | `[i32 LE code][i32 LE signal]` (signal 0 = normal exit; old agents send only the 4-byte code). Net-reconfig replies append six `u32 LE` micros — see [`ReconfigTimings`]. Readers key on payload length. |
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -546,23 +546,41 @@ async fn net_reconfig_on_stream<S: tokio::io::AsyncReadExt + tokio::io::AsyncWri
             "net reconfig: agent returned exit code {code}"
         )));
     }
-    // Newer agents append six u32 millis (four per-ioctl, resolv write,
-    // whole handler) after the [code][signal] header — CORE-75 latency
-    // attribution.
-    if payload.len() >= 32 {
-        let step =
-            |i: usize| u32::from_le_bytes(payload[8 + i * 4..12 + i * 4].try_into().unwrap());
+    if let Some(t) = ReconfigTimings::parse(&payload) {
         info!(
-            addr_ms = step(0),
-            netmask_ms = step(1),
-            delrt_ms = step(2),
-            addrt_ms = step(3),
-            resolv_ms = step(4),
-            handler_ms = step(5),
+            addr_us = t.steps[0],
+            netmask_us = t.steps[1],
+            delrt_us = t.steps[2],
+            addrt_us = t.steps[3],
+            resolv_us = t.resolv,
+            handler_us = t.handler,
             "net reconfig guest split"
         );
     }
     Ok(())
+}
+
+/// Guest-side timing breakdown a net-reconfig `MSG_EXIT` reply may carry:
+/// six `u32 LE` microsecond values (four per-ioctl, resolv.conf write, whole
+/// handler) appended after the `[code][signal]` header — CORE-75 latency
+/// attribution. Absent from legacy agents; readers key on payload length.
+#[derive(Debug, PartialEq, Eq)]
+struct ReconfigTimings {
+    steps: [u32; 4],
+    resolv: u32,
+    handler: u32,
+}
+
+impl ReconfigTimings {
+    fn parse(payload: &[u8]) -> Option<Self> {
+        let extra = payload.get(8..32)?;
+        let at = |i: usize| u32::from_le_bytes(extra[i * 4..i * 4 + 4].try_into().unwrap());
+        Some(Self {
+            steps: [at(0), at(1), at(2), at(3)],
+            resolv: at(4),
+            handler: at(5),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -841,6 +859,43 @@ mod tests {
             msg.contains("agent returned exit code -1"),
             "unexpected error: {msg}"
         );
+        agent_handle.await.unwrap();
+    }
+
+    /// The extended 32-byte reply parses in the exact layout the agent
+    /// writes: `[code][signal]` then six u32 LE micros. A reply with an
+    /// extended payload must also still pass the success path end to end.
+    #[tokio::test]
+    async fn test_net_reconfig_timing_payload() {
+        // Layout mirror of vm-agent's handle_net_reconfig response builder.
+        let mut payload = [0u8; 32];
+        for (slot, us) in payload[8..]
+            .chunks_exact_mut(4)
+            .zip([1_u32, 2, 3, 4, 30_000, 40_000])
+        {
+            slot.copy_from_slice(&us.to_le_bytes());
+        }
+
+        assert_eq!(
+            ReconfigTimings::parse(&payload),
+            Some(ReconfigTimings {
+                steps: [1, 2, 3, 4],
+                resolv: 30_000,
+                handler: 40_000,
+            })
+        );
+        // Legacy shapes carry no timings.
+        assert_eq!(ReconfigTimings::parse(&0i32.to_le_bytes()), None);
+        assert_eq!(ReconfigTimings::parse(&[0u8; 8]), None);
+
+        let (mut agent, mut host) = tokio::io::duplex(1024);
+        let agent_handle = tokio::spawn(async move {
+            let _ = read_frame(&mut agent).await.unwrap();
+            write_frame(&mut agent, MSG_EXIT, &payload).await.unwrap();
+        });
+        net_reconfig_on_stream(&mut host, &reconfig_cmd())
+            .await
+            .expect("extended payload must still count as success");
         agent_handle.await.unwrap();
     }
 }

--- a/xtask/src/commands/e2e.rs
+++ b/xtask/src/commands/e2e.rs
@@ -160,7 +160,8 @@ fn prebuild(root: &std::path::Path, test: &str) -> Result<bool> {
         }
         // Must match tests/e2e/src/sandbox.rs::build_binaries exactly
         // (packages AND profiles), or SKIP_BUILD runs stale binaries.
-        "sandbox" => {
+        // sandbox_coldstart reuses that same build_binaries().
+        "sandbox" | "sandbox_coldstart" => {
             xshell::cmd!(
                 shell,
                 "cargo build --release -p arcbox-cli -p arcbox-daemon"


### PR DESCRIPTION
Supersedes #556 (auto-closed by the #555 base-branch deletion, unreopenable after rebase — all its review threads were addressed in 02aaccce and are reflected here). Part of CORE-75, project **Sandbox Cold Start**. Now based directly on master.

## What (4 commits)

1. **`quiet` on the microVM cmdline** — boot printks over FC serial are nested-doubled MMIO exits. Measured: cold create→first-exec p50 **2.71 s → 1.37 s** (networked) / 2.65 → 1.10 s (no-network).
2. **End-to-end reconfig latency attribution** — host logs connect-vs-frame RTT for the post-restore RPCs; net-reconfig replies carry six u32 **micros** (per-ioctl ×4, resolv write, whole handler), parsed by `ReconfigTimings` with a layout-pinning unit test; three MSG_EXIT payload shapes documented in both frame tables. Guest replies before its serial eprintln.
3. **resolv.conf on tmpfs** — the attribution showed the `/etc/resolv.conf` write costs 27–35 ms (clone's first write pays a synchronous dm-snapshot CoW exception through the nested ext4→virtio-blk→dm→loop→Btrfs stack). Both template builders bake it as a symlink to `/run/resolv.conf`; vm-agent mounts `/run` tmpfs; auto-rollout via template freshness keys. Measured: reconfig handler 37–52 → **12–19 ms**, **restore RPC p50 243 → 215 ms**, restore→first-exec p50 **287 ms**.
4. **Review fixes from #555/#556 threads** — probe iters floor + deadlined attach drain, `xtask` prebuild arm for `sandbox_coldstart`, vm-agent `register_child` (insert+wake fused), hard-link fallback logs at warn.

## Validation

fmt/clippy clean (host + musl bins); `cargo test -p arcbox-vm -p arcbox-agent` green (incl. new layout test); probe green ×4 runs; full sandbox smoke green ×2 (covers docker-template conversion).