### PR TITLE
perf(sandbox): make boot readiness an event via guest vsock dial-out

### DIFF
--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -9,6 +9,10 @@
 //!    the process.
 //! 5. Sends a final `MSG_EXIT` frame when the process terminates.
 //!
+//! Once the exec (52) and file I/O (53) listeners are both bound, the agent
+//! dials out to host port 51 (`READY_PORT`) and writes one byte — the
+//! host's cold-boot readiness event.
+//!
 //! ## Frame format
 //!
 //! ```text
@@ -71,6 +75,8 @@ mod agent {
         FILE_ACK, FILE_DATA, FILE_DONE, FILE_ERR, FILE_PORT, FILE_READ_REQ, FILE_WRITE_REQ,
         MAX_FILE_SIZE,
     };
+    // Readiness dial-out port — shared with the host-side boot gate.
+    use arcbox_vm::vsock::READY_PORT;
 
     const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
 
@@ -1305,6 +1311,10 @@ mod agent {
         let exec_fd = create_vsock_listener(AGENT_PORT);
         let file_fd = create_vsock_listener(FILE_PORT);
 
+        // Both listeners are bound and mounts/DNS are done: tell the host.
+        // The dial-out is the cold-boot readiness event the host gates on.
+        signal_ready();
+
         // Shared counters for bounding active connection threads.
         let file_active: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
         let exec_active: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
@@ -1322,6 +1332,55 @@ mod agent {
         loop {
             let conn_fd = accept_connection(exec_fd);
             spawn_bounded(&exec_active, "exec", conn_fd, handle_connection);
+        }
+    }
+
+    /// Dial the host's readiness listener: connect `AF_VSOCK` to the host
+    /// (CID 2) on `READY_PORT`, write one byte, close. Firecracker forwards
+    /// the connect to the Unix socket the host pre-bound before starting
+    /// this VM — the accept there is the boot readiness event.
+    ///
+    /// Best-effort by design: under an OLD host without the listener,
+    /// Firecracker resets the connect (`ECONNRESET`-class error), and the
+    /// agent must keep serving — readiness detection then falls back to
+    /// that host's own connect polling.
+    fn signal_ready() {
+        // SAFETY: plain socket(2) call; result checked below.
+        let fd = unsafe { libc::socket(libc::AF_VSOCK, libc::SOCK_STREAM, 0) };
+        if fd < 0 {
+            eprintln!(
+                "vm-agent: ready dial-out: socket: {}",
+                std::io::Error::last_os_error()
+            );
+            return;
+        }
+        // SAFETY: fd is a freshly opened, owned socket fd.
+        let mut stream = unsafe { VsockStream::from_raw_fd(fd) };
+
+        let addr = libc::sockaddr_vm {
+            svm_family: libc::AF_VSOCK as libc::sa_family_t,
+            svm_reserved1: 0,
+            svm_port: READY_PORT,
+            svm_cid: libc::VMADDR_CID_HOST,
+            ..unsafe { std::mem::zeroed() }
+        };
+        // SAFETY: addr is a fully initialized sockaddr_vm; fd is a live socket.
+        let ret = unsafe {
+            libc::connect(
+                fd,
+                (&raw const addr).cast::<libc::sockaddr>(),
+                std::mem::size_of::<libc::sockaddr_vm>() as libc::socklen_t,
+            )
+        };
+        if ret != 0 {
+            eprintln!(
+                "vm-agent: ready dial-out failed (old host without a listener?): {}",
+                std::io::Error::last_os_error()
+            );
+            return;
+        }
+        if let Err(e) = stream.write_all(&[0u8]) {
+            eprintln!("vm-agent: ready dial-out write: {e}");
         }
     }
 

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -2,15 +2,17 @@ use super::persistence::{SandboxRecordStore, SandboxTransition};
 use super::types::action;
 use super::*;
 
-type BootOutput = (Arc<fc_sdk::Vm>, PathBuf);
+type BootOutput = (Arc<fc_sdk::Vm>, PathBuf, vsock::ReadyListener);
 
-/// How long the agent-readiness gate waits for vm-agent to answer over vsock
-/// before the boot is declared failed. Covers guest kernel boot plus agent
-/// startup. Deliberately wider than `sync_clock`'s internal connect deadline
-/// (`AGENT_READY_TIMEOUT`, 30 s) so that when the agent never appears the
-/// inner error — which names the socket and the elapsed budget — wins the
-/// race against this outer timeout's generic message.
+/// How long the readiness gate waits for vm-agent's dial-out (the guest
+/// connect to [`vsock::READY_PORT`]) before the boot is declared failed.
+/// Covers guest kernel boot plus agent startup.
 const AGENT_GATE_TIMEOUT: Duration = Duration::from_secs(35);
+
+/// Cap on the non-gating cold-boot clock sync: `sync_clock`'s internal
+/// connect loop can retry for up to 30 s, pointlessly long for an agent
+/// that has already dialed out. Mirrors the restore path's cap.
+const CLOCK_SYNC_TIMEOUT: Duration = Duration::from_secs(10);
 
 struct BootFailure {
     error: VmmError,
@@ -49,7 +51,7 @@ pub(super) async fn boot_sandbox(
     )
     .await
     {
-        Ok((vm, vsock_uds_path)) => {
+        Ok((vm, vsock_uds_path, ready_listener)) => {
             let current = instances.read().unwrap().get(&id).cloned();
             let is_current_generation = current
                 .as_ref()
@@ -61,33 +63,27 @@ pub(super) async fn boot_sandbox(
 
             // READY promises "accepting executions", but InstanceStart returns
             // while the guest kernel is still booting and vm-agent is not yet
-            // listening. Gate the transition on a completed agent round trip:
-            // sync_clock doubles as the readiness probe and sets the guest
-            // clock on cold boot the same way the restore path already does.
-            // Liveness is the gate, not the clock side effect: an agent that
-            // answered-but-failed (`ClockSync::AgentError`) proves the RPC
-            // path works, and tearing down a usable VM over a clock error
-            // would be strictly worse than a skewed clock.
-            let agent_ready = match tokio::time::timeout(
-                AGENT_GATE_TIMEOUT,
-                vsock::sync_clock(&vsock_uds_path),
-            )
-            .await
+            // listening. The gate is an event, not a poll: once its exec and
+            // file listeners are up, vm-agent dials host port READY_PORT, and
+            // the accept on the listener do_boot pre-bound IS the signal.
+            //
+            // Compat: an OLD vm-agent (no dial-out) under this host would sit
+            // out the full gate timeout — but the template freshness keys
+            // (the vm-agent binary among them) rebuild the default template
+            // and re-inject it into docker templates automatically, so a
+            // guest always carries the agent from the same build as its host.
+            let agent_ready = match tokio::time::timeout(AGENT_GATE_TIMEOUT, ready_listener.wait())
+                .await
             {
-                Ok(Ok(vsock::ClockSync::Synced)) => Ok(()),
-                Ok(Ok(vsock::ClockSync::AgentError(code))) => {
-                    warn!(
-                        sandbox_id = %id, code,
-                        "agent alive but clock sync failed; continuing with a possibly skewed clock"
-                    );
-                    Ok(())
-                }
+                Ok(Ok(())) => Ok(()),
                 Ok(Err(error)) => Err(VmmError::Vsock(format!("agent readiness gate: {error}"))),
                 Err(_) => Err(VmmError::Vsock(format!(
-                    "agent readiness gate: vm-agent did not answer within {}s",
+                    "agent readiness gate: vm-agent did not dial the ready port within {}s",
                     AGENT_GATE_TIMEOUT.as_secs()
                 ))),
             };
+            // The socket file is per-boot; the gate has consumed its one event.
+            drop(ready_listener);
             if let Err(gate_error) = agent_ready {
                 let message = gate_error.to_string();
                 fail_started_boot(
@@ -105,6 +101,28 @@ pub(super) async fn boot_sandbox(
                 .await;
                 error!(sandbox_id = %id, error = %gate_error, "sandbox agent readiness gate failed");
                 return;
+            }
+
+            // The guest clock still needs setting on cold boot (no RTC — the
+            // guest wakes at the kernel default epoch), but it no longer
+            // gates readiness: warn and continue on any failure, mirroring
+            // the restore path's non-fatal treatment. Retires when guest-side
+            // ptp_kvm self-sync lands.
+            match tokio::time::timeout(CLOCK_SYNC_TIMEOUT, vsock::sync_clock(&vsock_uds_path)).await
+            {
+                Ok(Ok(vsock::ClockSync::Synced)) => {}
+                Ok(Ok(vsock::ClockSync::AgentError(code))) => {
+                    warn!(
+                        sandbox_id = %id, code,
+                        "agent could not set the clock; continuing with a possibly skewed clock"
+                    );
+                }
+                Ok(Err(error)) => {
+                    warn!(sandbox_id = %id, %error, "cold-boot clock sync failed; continuing");
+                }
+                Err(_) => {
+                    warn!(sandbox_id = %id, "cold-boot clock sync timed out; continuing");
+                }
             }
 
             let ready_at = Utc::now();
@@ -898,6 +916,40 @@ async fn do_boot(
         });
     }
 
+    // Bind the readiness listener BEFORE InstanceStart: vm-agent dials host
+    // port READY_PORT as soon as it is serving, and Firecracker forwards
+    // that guest-initiated connect to `{uds_path}_{READY_PORT}` only if
+    // someone is already listening there — otherwise the guest is reset and
+    // the one readiness event is lost.
+    let ready_listener = match vsock::ReadyListener::bind(&vsock_host_path) {
+        Ok(listener) => listener,
+        Err(error) => {
+            return Err(BootFailure {
+                error,
+                process: None,
+                cow_handle: None,
+            });
+        }
+    };
+    // In jailer mode Firecracker connect(2)s to the socket as the jailed
+    // uid/gid, and connecting requires write permission on the socket file.
+    if let Some(ref jc) = fc_cfg.jailer
+        && let Err(e) = chown(
+            ready_listener.path(),
+            Some(Uid::from_raw(jc.uid)),
+            Some(Gid::from_raw(jc.gid)),
+        )
+    {
+        return Err(BootFailure {
+            error: VmmError::Process(format!(
+                "chown ready socket {}: {e}",
+                ready_listener.path().display()
+            )),
+            process: None,
+            cow_handle: None,
+        });
+    }
+
     // Configure and boot the VM.
     let vcpu_count =
         NonZeroU64::new(spec.vcpus.max(1) as u64).expect("max(1) guarantees a non-zero vCPU count");
@@ -982,7 +1034,7 @@ async fn do_boot(
             });
         }
     };
-    Ok((vm, vsock_host_path))
+    Ok((vm, vsock_host_path, ready_listener))
 }
 
 fn complete_resource_handoff(signal: &mut Option<tokio::sync::oneshot::Sender<()>>) {

--- a/virt/arcbox-vm/src/vsock.rs
+++ b/virt/arcbox-vm/src/vsock.rs
@@ -10,6 +10,10 @@
 //! 3. Read until `'\n'` — the response is `"OK {host_ephemeral_port}\n"`.
 //! 4. The socket is now a bidirectional pipe to the guest's vsock port.
 //!
+//! In the other direction, a guest-initiated connect to host port `P` is
+//! forwarded by Firecracker to a host Unix socket at `{uds_path}_{P}`; the
+//! boot readiness gate pre-listens there (see [`ReadyListener`]).
+//!
 //! ## Frame format
 //!
 //! Every message (in both directions) is:
@@ -31,16 +35,24 @@
 //! | 0x12 | Agent→Host  | `[i32 LE code][i32 LE signal]` (signal 0 = normal exit; old agents send only the 4-byte code). Net-reconfig replies append six `u32 LE` micros — see [`ReconfigTimings`]. Readers key on payload length. |
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::UnixStream;
+use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 
 use crate::error::{Result, VmmError};
+
+/// Host-side port the guest agent dials once it is fully serving.
+///
+/// Firecracker hybrid vsock forwards a guest-initiated connect to host port
+/// `P` onto the host Unix socket at `{uds_path}_{P}`, so a pre-bound
+/// [`ReadyListener`]'s `accept()` IS the "vm-agent is up" event — no
+/// connect polling involved.
+pub const READY_PORT: u32 = 51;
 
 /// Guest-side vsock port the agent listens on (exec channel).
 pub const AGENT_PORT: u32 = 52;
@@ -245,6 +257,78 @@ async fn try_vsock_handshake(uds_path: &Path, port: u32) -> Result<UnixStream> {
         )));
     }
     Ok(stream)
+}
+
+/// Derive the host Unix-socket path Firecracker forwards guest-initiated
+/// [`READY_PORT`] connections to: `{uds_path}_{READY_PORT}`.
+///
+/// The suffix convention is Firecracker's hybrid-vsock contract ("a guest
+/// connection to port 52 will get forwarded to `./v.sock_52`", FC
+/// docs/vsock.md). FC resolves the path against its own filesystem view,
+/// which matches the host view here: in jailer mode both are the same file
+/// under the chroot root, in direct mode the same absolute path.
+fn ready_socket_path(uds_path: &Path) -> PathBuf {
+    let mut path = uds_path.as_os_str().to_owned();
+    path.push(format!("_{READY_PORT}"));
+    PathBuf::from(path)
+}
+
+/// Pre-bound listener for the guest agent's readiness dial-out.
+///
+/// Must be bound BEFORE Firecracker `InstanceStart`: FC forwards the guest's
+/// connect only to an already-listening socket and resets the guest
+/// otherwise, losing the event. The socket file is per-boot; dropping the
+/// listener removes it.
+pub(crate) struct ReadyListener {
+    listener: UnixListener,
+    path: PathBuf,
+}
+
+impl ReadyListener {
+    /// Bind the readiness socket for `uds_path`, replacing any stale socket
+    /// file left behind by a previous boot of the same VM directory.
+    pub(crate) fn bind(uds_path: &Path) -> Result<Self> {
+        let path = ready_socket_path(uds_path);
+        if let Err(e) = std::fs::remove_file(&path)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(VmmError::Vsock(format!(
+                "remove stale ready socket {}: {e}",
+                path.display()
+            )));
+        }
+        let listener = UnixListener::bind(&path)
+            .map_err(|e| VmmError::Vsock(format!("bind ready socket {}: {e}", path.display())))?;
+        Ok(Self { listener, path })
+    }
+
+    /// The bound socket path (so jailer boots can grant FC connect access).
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Wait for the guest's dial-out: `accept()` one connection and read
+    /// (and discard) its single byte. Completion is the readiness event.
+    pub(crate) async fn wait(&self) -> Result<()> {
+        let (mut stream, _) = self
+            .listener
+            .accept()
+            .await
+            .map_err(|e| VmmError::Vsock(format!("accept on ready socket: {e}")))?;
+        let mut byte = [0u8; 1];
+        stream
+            .read(&mut byte)
+            .await
+            .map_err(|e| VmmError::Vsock(format!("read ready byte: {e}")))?;
+        Ok(())
+    }
+}
+
+impl Drop for ReadyListener {
+    fn drop(&mut self) {
+        // The socket file is meaningful only to the boot that bound it.
+        let _ = std::fs::remove_file(&self.path);
+    }
 }
 
 /// Write a single frame to any `AsyncWrite`.
@@ -620,6 +704,37 @@ mod tests {
         buf.extend_from_slice(&(payload.len() as u32).to_le_bytes());
         buf.extend_from_slice(payload);
         buf
+    }
+
+    #[test]
+    fn ready_socket_path_appends_the_port_suffix() {
+        // Pins the Firecracker hybrid-vsock naming contract AND the port
+        // value: the guest dials 51, so the host must listen at `..._51`.
+        assert_eq!(
+            ready_socket_path(Path::new("/vm/dir/firecracker.vsock")),
+            Path::new("/vm/dir/firecracker.vsock_51")
+        );
+    }
+
+    #[tokio::test]
+    async fn ready_listener_accepts_the_dial_out_and_cleans_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let uds = dir.path().join("fc.vsock");
+        // A stale socket file from a previous boot must not fail the bind.
+        std::fs::write(ready_socket_path(&uds), b"stale").unwrap();
+
+        let listener = ReadyListener::bind(&uds).unwrap();
+        let dial_path = listener.path().to_owned();
+        let dial = tokio::spawn(async move {
+            let mut stream = UnixStream::connect(&dial_path).await.unwrap();
+            stream.write_all(&[0u8]).await.unwrap();
+        });
+        listener.wait().await.unwrap();
+        dial.await.unwrap();
+
+        let path = listener.path().to_owned();
+        drop(listener);
+        assert!(!path.exists(), "drop must remove the per-boot socket file");
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #559 (← #558 ← master); merge those first, then retarget/rebase. Part of CORE-80, project **Sandbox Cold Start** (the ptp_kvm clock-deletion half of CORE-80 is deliberately not in this PR).

## What

Replaces the readiness gate's detection-by-polling with a real event, using Firecracker hybrid-vsock guest-initiated connections (convention verified against FC docs/vsock.md: a guest connect to port P arrives at the host Unix socket `{uds_path}_P`):

- Host: `ReadyListener` binds `{vsock_uds}_51` before `InstanceStart` (stale file removed; chown'd to the jailer uid/gid — FC needs write permission to connect; Drop deletes the per-boot socket on every path including boot failures).
- Guest: vm-agent, after both its listeners are bound, dials CID 2 port 51, writes one byte, closes. Failures are logged and tolerated (an old host without the listener must not break a new agent).
- Gate: `accept()` + one byte under `AGENT_GATE_TIMEOUT`; timeout/error takes the same `fail_started_boot` path. Clock sync stays on the boot path but strictly best-effort (10 s cap, warn on failure), pending ptp_kvm.

## Hardware-validated (full stack: #558 + #559 + this)

Cold create→READY p50 **1219 → 1118 ms** (networked) / 1056 → 1065 ms (no-network), still converged with first-exec (1167/1121 ms) — the event fires the moment the agent is accepting, ~100 ms earlier than a completed clock round trip. Restore path untouched (229 ms p50). Full sandbox smoke green.

## Validation

132 arcbox-vm unit tests + 1 integration green (new: ready-socket path pinning, ReadyListener accept/cleanup over a real UDS); clippy clean host + musl bins; fmt clean.