### PR TITLE
perf(sandbox): pre-warm restore slots behind an LRU snapshot pool

### DIFF
--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -513,7 +513,7 @@ where
                 send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
             }
         },
-        MessageType::SandboxDeleteSnapshotRequest => match svc.delete_snapshot(payload) {
+        MessageType::SandboxDeleteSnapshotRequest => match svc.delete_snapshot(payload).await {
             Ok(()) => {
                 write_message(
                     stream,

--- a/guest/arcbox-agent/src/config.rs
+++ b/guest/arcbox-agent/src/config.rs
@@ -48,6 +48,7 @@ fn guest_defaults() -> VmmConfig {
             http_api_max_payload_size: None,
             mmds_size_limit: None,
             socket_timeout_secs: None,
+            pool_size: 1,
         },
         network: NetworkConfig {
             cidr: "172.20.0.0/16".into(),

--- a/guest/arcbox-agent/src/sandbox/snapshots.rs
+++ b/guest/arcbox-agent/src/sandbox/snapshots.rs
@@ -110,11 +110,12 @@ impl SandboxService {
     }
 
     /// Delete a snapshot.
-    pub fn delete_snapshot(&self, payload: &[u8]) -> Result<(), SandboxError> {
+    pub async fn delete_snapshot(&self, payload: &[u8]) -> Result<(), SandboxError> {
         let req = sandbox_v1::DeleteSnapshotRequest::decode_from_slice(payload)
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
         self.manager
             .delete_checkpoint(&req.snapshot_id)
+            .await
             .map_err(SandboxError::from)
     }
 }

--- a/guest/arcbox-agent/tests/sandbox_service_manager.rs
+++ b/guest/arcbox-agent/tests/sandbox_service_manager.rs
@@ -35,6 +35,9 @@ fn test_config() -> VmmConfig {
             http_api_max_payload_size: None,
             mmds_size_limit: None,
             socket_timeout_secs: Some(15),
+            // Direct mode cannot restore (and so never pools); keep the
+            // test run free of background pre-warm spawns regardless.
+            pool_size: 0,
         },
         network: NetworkConfig {
             cidr: "172.31.0.0/16".to_string(),

--- a/virt/arcbox-vm/src/config.rs
+++ b/virt/arcbox-vm/src/config.rs
@@ -314,6 +314,19 @@ pub struct FirecrackerConfig {
     /// `None` uses the five-second default.
     #[serde(default)]
     pub socket_timeout_secs: Option<u64>,
+    /// Spare pre-warmed restore slots kept per snapshot id (CORE-78).
+    ///
+    /// A slot pre-executes the fixed host-side restore setup — jailer
+    /// chroot, Firecracker spawn, kernel/vmstate/mem staging, dm-snapshot
+    /// — so a restore only claims it and issues LoadSnapshot. Only
+    /// snapshots that have been restored at least once are pooled, for at
+    /// most two distinct snapshot ids (LRU-evicted). `0` disables pooling.
+    #[serde(default = "default_pool_size")]
+    pub pool_size: usize,
+}
+
+fn default_pool_size() -> usize {
+    1
 }
 
 /// Network IP-pool settings for sandbox TAP interfaces.
@@ -359,6 +372,7 @@ impl Default for VmmConfig {
                 http_api_max_payload_size: None,
                 mmds_size_limit: None,
                 socket_timeout_secs: None,
+                pool_size: default_pool_size(),
             },
             network: NetworkConfig {
                 cidr: "172.20.0.0/16".into(),
@@ -549,6 +563,16 @@ mod tests {
         assert!(cfg.defaults.boot_args.contains("console=ttyS0"));
         assert!(!cfg.network.cidr.is_empty());
         assert!(!cfg.firecracker.binary.is_empty());
+    }
+
+    #[test]
+    fn pool_size_defaults_to_one_spare_slot() {
+        assert_eq!(VmmConfig::default().firecracker.pool_size, 1);
+        // A config written before the knob existed still loads with the default.
+        let cfg: FirecrackerConfig =
+            toml::from_str("binary = \"/usr/bin/firecracker\"\ndata_dir = \"/var/lib/vmm\"\n")
+                .unwrap();
+        assert_eq!(cfg.pool_size, 1);
     }
 
     #[test]

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -37,6 +37,7 @@ mod cleanup;
 mod execution;
 mod lifecycle;
 mod persistence;
+mod pool;
 mod reconcile;
 mod types;
 mod workload;
@@ -65,6 +66,8 @@ pub struct SandboxManager {
     config: Arc<VmmConfig>,
     events_tx: broadcast::Sender<SandboxEvent>,
     cow_manager: Arc<CowManager>,
+    /// Pre-warmed restore slots (CORE-78); see `pool.rs`.
+    pool: Arc<pool::SlotPool>,
     /// Addressable executions (CORE-55); see `execution.rs`.
     executions: Arc<execution::ExecutionRegistry>,
     /// Publishes the startup reconciliation result. Lifecycle and read APIs
@@ -166,6 +169,7 @@ impl SandboxManager {
             config,
             events_tx,
             cow_manager,
+            pool: Arc::new(pool::SlotPool::default()),
             executions,
             reconcile_done,
         })

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -553,6 +553,106 @@ pub(super) async fn stage_rootfs_device_for_jailer(
     Ok("/rootfs.ext4".to_string())
 }
 
+/// A failed restore-staging step, carrying whichever CoW resources were
+/// acquired before the failure so the caller can roll them back.
+pub(super) struct StageError {
+    pub error: VmmError,
+    pub cow_handle: Option<CowHandle>,
+}
+
+/// Stage a snapshot's rootfs into a jailer chroot: dm-snapshot + mknod
+/// when device-mapper is available, full copy otherwise.
+///
+/// `owner_id` keys the dm/CoW resource names (the sandbox id, or a pool
+/// slot id for pre-warmed slots). `journal` persists the caller's crash
+/// record whenever CoW resources appear or disappear, so reconciliation
+/// can always identify them. Returns the CoW handle when the dm path was
+/// taken; the staged rootfs is `/rootfs.ext4` inside the chroot either way.
+pub(super) async fn stage_rootfs_cow_or_copy(
+    cow_manager: &CowManager,
+    chroot: &Path,
+    owner_id: &str,
+    rootfs: &str,
+    uid: u32,
+    gid: u32,
+    journal: &(dyn Fn(Option<&CowHandle>) -> Result<()> + Sync),
+) -> std::result::Result<Option<CowHandle>, StageError> {
+    let fail = |error: VmmError, cow_handle: Option<CowHandle>| StageError { error, cow_handle };
+    match cow_manager.setup(owner_id, rootfs).await {
+        Ok(handle) => {
+            if let Err(error) = journal(Some(&handle)) {
+                return Err(fail(error, Some(handle)));
+            }
+            match stage_rootfs_device_for_jailer(chroot, &handle.dm_device, uid, gid).await {
+                Ok(_) => Ok(Some(handle)),
+                Err(e) => {
+                    debug!(
+                        owner_id,
+                        error = %e,
+                        "mknod failed, falling back to rootfs copy"
+                    );
+                    if let Err(error) = cow_manager.teardown_checked(&handle).await {
+                        return Err(fail(error, Some(handle)));
+                    }
+                    journal(None).map_err(|error| fail(error, None))?;
+                    stage_rootfs_copy_for_jailer(chroot, rootfs, uid, gid)
+                        .await
+                        .map_err(|error| fail(error, None))?;
+                    Ok(None)
+                }
+            }
+        }
+        Err(e) if matches!(e, VmmError::Unavailable(_)) => Err(fail(e, None)),
+        Err(e) => {
+            debug!(
+                owner_id,
+                error = %e,
+                "dm-snapshot unavailable, copying rootfs into chroot"
+            );
+            stage_rootfs_copy_for_jailer(chroot, rootfs, uid, gid)
+                .await
+                .map_err(|error| fail(error, None))?;
+            Ok(None)
+        }
+    }
+}
+
+/// Stage a snapshot's vmstate/mem into `{chroot}/snapshots/{snapshot_id}`
+/// via [`link_or_copy_for_jailer`] and return their chroot-relative paths
+/// `(vmstate, mem)` for `SnapshotLoadParams`.
+pub(super) async fn stage_snapshot_files(
+    chroot: &Path,
+    snapshot: &crate::snapshot::SnapshotMeta,
+    uid: u32,
+    gid: u32,
+) -> Result<(String, Option<String>)> {
+    let snap_in_chroot = chroot.join("snapshots").join(&snapshot.id);
+    std::fs::create_dir_all(&snap_in_chroot).map_err(VmmError::Io)?;
+    chown(
+        &snap_in_chroot,
+        Some(Uid::from_raw(uid)),
+        Some(Gid::from_raw(gid)),
+    )
+    .map_err(|e| VmmError::Process(format!("chown snap dir: {e}")))?;
+
+    link_or_copy_for_jailer(
+        &snapshot.vmstate_path,
+        &snap_in_chroot.join("vmstate"),
+        uid,
+        gid,
+    )
+    .await?;
+    let mem = if let Some(ref mf) = snapshot.mem_path
+        && mf.exists()
+    {
+        link_or_copy_for_jailer(mf, &snap_in_chroot.join("mem"), uid, gid).await?;
+        Some(format!("/snapshots/{}/mem", snapshot.id))
+    } else {
+        None
+    };
+    Ok((format!("/snapshots/{}/vmstate", snapshot.id), mem))
+}
+
 /// Create a stable `{vm_dir}/rootfs.link` symlink pointing at the dm-snapshot
 /// device.  Returns the symlink path as a string for Firecracker to use as the
 /// rootfs.  The vmstate records this path verbatim, so on restore we can

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -41,8 +41,11 @@ impl SandboxManager {
         name: String,
         labels: HashMap<String, String>,
     ) -> Result<CheckpointInfo> {
-        // Verify state and capture the kernel/rootfs paths for jailer re-staging.
-        let (kernel_path, rootfs_path) = {
+        // Verify state and capture the kernel/rootfs paths for jailer
+        // re-staging, plus the id the sandbox's chroot is actually keyed by
+        // — a sandbox restored from a pre-warmed pool slot lives in the
+        // slot's chroot, and FC resolves snapshot paths inside it.
+        let (kernel_path, rootfs_path, chroot_owner) = {
             let instance = self.get_instance(sandbox_id)?;
             let inst = instance.lock().unwrap();
             if inst.state != SandboxState::Ready {
@@ -53,7 +56,13 @@ impl SandboxManager {
                 });
             }
             // Only needed for jailer mode; safe to capture regardless.
-            (inst.spec.kernel.clone(), inst.spec.rootfs.clone())
+            (
+                inst.spec.kernel.clone(),
+                inst.spec.rootfs.clone(),
+                inst.pool_slot_id
+                    .clone()
+                    .unwrap_or_else(|| sandbox_id.clone()),
+            )
         };
 
         let vm = self.get_vm_handle(sandbox_id)?;
@@ -81,7 +90,7 @@ impl SandboxManager {
             let (fc_vmstate_path, fc_mem_path, chroot_snap_dir_opt) =
                 if let Some(ref jc) = self.config.firecracker.jailer {
                     let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-                    let cr = chroot_root(&self.config.firecracker.binary, base, sandbox_id);
+                    let cr = chroot_root(&self.config.firecracker.binary, base, &chroot_owner);
                     let chroot_snap = cr.join("snapshots").join(&snapshot_id);
                     std::fs::create_dir_all(&chroot_snap).map_err(VmmError::Io)?;
                     // Firecracker runs as jc.uid/jc.gid; chown the directory so

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -3,6 +3,7 @@ use super::boot::{
     stage_snapshot_files,
 };
 use super::persistence::{ProvisionIntent, SandboxProvisionOutcome, SandboxTransition};
+use super::pool::PreparedSlot;
 use super::types::action;
 use super::*;
 
@@ -377,120 +378,216 @@ impl SandboxManager {
         // On success, the CoW handle is moved onto the SandboxInstance.
         let mut pending_cow: Option<CowHandle> = None;
 
-        // Determine the actual host-side vsock UDS path FC will bind to on restore
-        // and ensure the socket path is clear before spawning.
-        //
-        // Each jailer restore owns a distinct chroot and vsock path.
-        let spawned: Result<(fc_sdk::FirecrackerProcess, PathBuf)> = async {
-            let base = jailer.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-            let cr = chroot_root(&fc_cfg.binary, base, &new_id);
-            // Ensure the `run/` directory exists inside the new chroot so FC can
-            // create the vsock socket there on restore.
-            let run_dir = cr.join("run");
-            std::fs::create_dir_all(&run_dir).map_err(VmmError::Io)?;
-            let vsock_path = cr.join("run/firecracker.vsock");
-            let _ = std::fs::remove_file(&vsock_path);
-
-            let proc = spawn_jailer(jailer, fc_cfg, &new_id).await?;
-            Ok((proc, vsock_path))
-        }
-        .await;
-        let (process, actual_vsock_path) = match spawned {
-            Ok(spawned) => spawned,
-            Err(error) => {
-                return Err(self
-                    .rollback_restore(&new_id, reservation, error, None, net_alloc, None)
-                    .await);
-            }
-        };
-
-        #[allow(
-            clippy::cast_possible_wrap,
-            reason = "Firecracker pid fits platform pid_t"
-        )]
-        let pid = process.pid().map(|pid| pid as i32);
-        let journal = |cow: Option<&CowHandle>| {
-            super::reconcile::write_state_record(
-                &vm_dir,
-                &super::reconcile::SandboxStateRecord::new(
+        // CORE-78: a pre-warmed slot has already executed the spawn and
+        // staging blocks below; claiming one leaves LoadSnapshot + guest
+        // reconfiguration as the only restore work. From the claim on, the
+        // slot's resources are owned by this restore and unwind through
+        // rollback_restore like freshly created ones.
+        let claimed = self.claim_restore_slot(&spec.snapshot_id);
+        let pool_hit = claimed.is_some();
+        let (process, actual_vsock_path, effective_vmstate, effective_mem, t_spawned, t_staged) =
+            if let Some(slot) = claimed {
+                // Record the adopting sandbox's slot id first: failure cleanup
+                // and crash reconciliation key the chroot and dm/CoW teardown
+                // on it (see release_runtime_resources / sweep_orphans).
+                reservation.instance().lock().unwrap().pool_slot_id = Some(slot.slot_id.clone());
+                #[allow(
+                    clippy::cast_possible_wrap,
+                    reason = "Firecracker pid fits platform pid_t"
+                )]
+                let adopted_record = super::reconcile::SandboxStateRecord::new(
                     &new_id,
-                    pid,
+                    slot.process.pid().map(|pid| pid as i32),
                     net_alloc.as_ref(),
-                    cow,
+                    slot.cow_handle.as_ref(),
                     true,
                     None,
-                ),
-            )
-        };
-        if let Err(error) = journal(None) {
-            return Err(self
-                .rollback_restore(&new_id, reservation, error, Some(process), net_alloc, None)
-                .await);
-        }
-
-        let t_spawned = std::time::Instant::now();
-
-        // In jailer mode the restored FC process also runs inside a chroot and
-        // cannot access the catalog's host-absolute paths.  Stage the snapshot
-        // files into the new sandbox's chroot and use chroot-relative paths.
-        let setup_result: Result<(String, Option<String>)> = async {
-            let jc = jailer;
-            let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-            let cr = chroot_root(&fc_cfg.binary, base, &new_id);
-
-            // Stage kernel (always hard-linked or copied, ~16MB).
-            if let Some(k) = snap_meta.kernel_path.as_deref() {
-                stage_kernel_for_jailer(&cr, k, jc.uid, jc.gid).await?;
-            }
-
-            // Stage rootfs: dm-snapshot + mknod with full-copy fallback,
-            // mirroring the boot path so restored sandboxes get the same CoW
-            // semantics (block-level template sharing, sparse COW).
-            if let Some(r) = snap_meta.rootfs_path.as_deref() {
-                match stage_rootfs_cow_or_copy(
-                    &self.cow_manager,
-                    &cr,
-                    &new_id,
-                    r,
-                    jc.uid,
-                    jc.gid,
-                    &journal,
                 )
-                .await
+                .with_pool_slot(Some(&slot.slot_id));
+                let handover = super::reconcile::write_state_record(&vm_dir, &adopted_record);
+                // The slot's own journal is superseded: the record above (or the
+                // rollback below) covers its resources under the sandbox id. The
+                // crash window where both journals exist is safe — the startup
+                // sweep is idempotent over already-released resources.
+                if let Err(error) = super::reconcile::clear_state_record(&slot.vm_dir) {
+                    warn!(
+                        sandbox_id = %new_id,
+                        slot_id = %slot.slot_id,
+                        error = %error,
+                        "claimed slot journal not cleared; the startup sweep will reconcile it"
+                    );
+                } else if let Err(error) = tokio::fs::remove_dir_all(&slot.vm_dir).await
+                    && error.kind() != std::io::ErrorKind::NotFound
                 {
-                    Ok(cow) => pending_cow = cow,
-                    Err(StageError { error, cow_handle }) => {
-                        pending_cow = cow_handle;
-                        return Err(error);
-                    }
+                    warn!(
+                        sandbox_id = %new_id,
+                        slot_id = %slot.slot_id,
+                        error = %error,
+                        "claimed slot runtime dir not removed"
+                    );
                 }
-            }
+                let PreparedSlot {
+                    process: slot_process,
+                    cow_handle,
+                    vmstate_path,
+                    mem_path,
+                    vsock_path,
+                    ..
+                } = slot;
+                pending_cow = cow_handle;
+                if let Err(error) = handover {
+                    return Err(self
+                        .rollback_restore(
+                            &new_id,
+                            reservation,
+                            error,
+                            Some(slot_process),
+                            net_alloc,
+                            pending_cow,
+                        )
+                        .await);
+                }
+                // Both phases were pre-executed by the slot; the timestamps
+                // collapse so the completion log reports them honestly as ~0.
+                let t_claimed = std::time::Instant::now();
+                (
+                    slot_process,
+                    vsock_path,
+                    vmstate_path,
+                    mem_path,
+                    t_claimed,
+                    t_claimed,
+                )
+            } else {
+                // Determine the actual host-side vsock UDS path FC will bind to
+                // on restore and ensure the socket path is clear before spawning.
+                //
+                // Each jailer restore owns a distinct chroot and vsock path.
+                let spawned: Result<(fc_sdk::FirecrackerProcess, PathBuf)> = async {
+                    let base = jailer.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
+                    let cr = chroot_root(&fc_cfg.binary, base, &new_id);
+                    // Ensure the `run/` directory exists inside the new chroot so
+                    // FC can create the vsock socket there on restore.
+                    let run_dir = cr.join("run");
+                    std::fs::create_dir_all(&run_dir).map_err(VmmError::Io)?;
+                    let vsock_path = cr.join("run/firecracker.vsock");
+                    let _ = std::fs::remove_file(&vsock_path);
 
-            // Stage vmstate + mem into the chroot. Both are read-only to FC
-            // (mem is mapped MAP_PRIVATE on load), so the root jailer
-            // hard-links them instead of copying — the mem file is the
-            // sandbox's full memory size (CORE-75).
-            stage_snapshot_files(&cr, &snap_meta, jc.uid, jc.gid).await
-        }
-        .await;
+                    let proc = spawn_jailer(jailer, fc_cfg, &new_id).await?;
+                    Ok((proc, vsock_path))
+                }
+                .await;
+                let (spawned_process, vsock_path) = match spawned {
+                    Ok(spawned) => spawned,
+                    Err(error) => {
+                        return Err(self
+                            .rollback_restore(&new_id, reservation, error, None, net_alloc, None)
+                            .await);
+                    }
+                };
 
-        let (effective_vmstate, effective_mem) = match setup_result {
-            Ok(x) => x,
-            Err(error) => {
-                return Err(self
-                    .rollback_restore(
-                        &new_id,
-                        reservation,
-                        error,
-                        Some(process),
-                        net_alloc,
-                        pending_cow,
+                #[allow(
+                    clippy::cast_possible_wrap,
+                    reason = "Firecracker pid fits platform pid_t"
+                )]
+                let pid = spawned_process.pid().map(|pid| pid as i32);
+                let journal = |cow: Option<&CowHandle>| {
+                    super::reconcile::write_state_record(
+                        &vm_dir,
+                        &super::reconcile::SandboxStateRecord::new(
+                            &new_id,
+                            pid,
+                            net_alloc.as_ref(),
+                            cow,
+                            true,
+                            None,
+                        ),
                     )
-                    .await);
-            }
-        };
+                };
+                if let Err(error) = journal(None) {
+                    return Err(self
+                        .rollback_restore(
+                            &new_id,
+                            reservation,
+                            error,
+                            Some(spawned_process),
+                            net_alloc,
+                            None,
+                        )
+                        .await);
+                }
 
-        let t_staged = std::time::Instant::now();
+                let t_spawned = std::time::Instant::now();
+
+                // In jailer mode the restored FC process also runs inside a
+                // chroot and cannot access the catalog's host-absolute paths.
+                // Stage the snapshot files into the new sandbox's chroot and use
+                // chroot-relative paths.
+                let setup_result: Result<(String, Option<String>)> = async {
+                    let jc = jailer;
+                    let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
+                    let cr = chroot_root(&fc_cfg.binary, base, &new_id);
+
+                    // Stage kernel (always hard-linked or copied, ~16MB).
+                    if let Some(k) = snap_meta.kernel_path.as_deref() {
+                        stage_kernel_for_jailer(&cr, k, jc.uid, jc.gid).await?;
+                    }
+
+                    // Stage rootfs: dm-snapshot + mknod with full-copy fallback,
+                    // mirroring the boot path so restored sandboxes get the same
+                    // CoW semantics (block-level template sharing, sparse COW).
+                    if let Some(r) = snap_meta.rootfs_path.as_deref() {
+                        match stage_rootfs_cow_or_copy(
+                            &self.cow_manager,
+                            &cr,
+                            &new_id,
+                            r,
+                            jc.uid,
+                            jc.gid,
+                            &journal,
+                        )
+                        .await
+                        {
+                            Ok(cow) => pending_cow = cow,
+                            Err(StageError { error, cow_handle }) => {
+                                pending_cow = cow_handle;
+                                return Err(error);
+                            }
+                        }
+                    }
+
+                    // Stage vmstate + mem into the chroot. Both are read-only to
+                    // FC (mem is mapped MAP_PRIVATE on load), so the root jailer
+                    // hard-links them instead of copying — the mem file is the
+                    // sandbox's full memory size (CORE-75).
+                    stage_snapshot_files(&cr, &snap_meta, jc.uid, jc.gid).await
+                }
+                .await;
+
+                let (effective_vmstate, effective_mem) = match setup_result {
+                    Ok(staged) => staged,
+                    Err(error) => {
+                        return Err(self
+                            .rollback_restore(
+                                &new_id,
+                                reservation,
+                                error,
+                                Some(spawned_process),
+                                net_alloc,
+                                pending_cow,
+                            )
+                            .await);
+                    }
+                };
+                (
+                    spawned_process,
+                    vsock_path,
+                    effective_vmstate,
+                    effective_mem,
+                    t_spawned,
+                    std::time::Instant::now(),
+                )
+            };
 
         // Build the restore parameters.
         let mut load_params = fc_sdk::types::SnapshotLoadParams {
@@ -601,6 +698,7 @@ impl SandboxManager {
 
         // Persist cleanup metadata before handing runtime resources to the
         // instance. A failed durable write aborts and unwinds every resource.
+        let adopted_slot = reservation.instance().lock().unwrap().pool_slot_id.clone();
         #[allow(
             clippy::cast_possible_wrap,
             reason = "Firecracker pid fits platform pid_t"
@@ -612,7 +710,8 @@ impl SandboxManager {
             pending_cow.as_ref(),
             true,
             None,
-        );
+        )
+        .with_pool_slot(adopted_slot.as_deref());
         if let Err(error) = super::reconcile::write_state_record(&vm_dir, &state_record) {
             return Err(self
                 .rollback_restore(
@@ -700,10 +799,14 @@ impl SandboxManager {
             });
         }
 
+        // On a pool hit, spawn_ms covers records + network + the claim
+        // itself (the phases that still ran) and stage_ms is genuinely 0 —
+        // the log never fakes the pre-executed phases.
         let ms = |d: Duration| u64::try_from(d.as_millis()).unwrap_or(u64::MAX);
         info!(
             sandbox_id = %new_id,
             snapshot_id = %spec.snapshot_id,
+            pool_hit,
             spawn_ms = ms(t_spawned.duration_since(restore_started)),
             stage_ms = ms(t_staged.duration_since(t_spawned)),
             load_ms = ms(t_loaded.duration_since(t_staged)),
@@ -711,6 +814,10 @@ impl SandboxManager {
             total_ms = ms(restore_started.elapsed()),
             "sandbox restored from checkpoint"
         );
+
+        // Populate/refill the pool for this snapshot in the background:
+        // the successful restore is what makes it eligible for pooling.
+        self.spawn_pool_refill(&spec.snapshot_id);
         if let Some(error) = ready_commit.durability_error {
             return Err(VmmError::Unavailable(format!(
                 "sandbox {new_id} was restored, but ACK durability is unconfirmed: {error}"
@@ -742,8 +849,10 @@ impl SandboxManager {
             .collect())
     }
 
-    /// Delete a checkpoint by its ID.
-    pub fn delete_checkpoint(&self, snapshot_id: &str) -> Result<()> {
+    /// Delete a checkpoint by its ID, tearing down any pre-warmed restore
+    /// slots staged from it first.
+    pub async fn delete_checkpoint(&self, snapshot_id: &str) -> Result<()> {
+        self.drain_pool(Some(snapshot_id)).await;
         self.snapshots.delete_by_id(snapshot_id)
     }
 }

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -167,7 +167,10 @@ impl SandboxManager {
         cow_handle: Option<CowHandle>,
     ) -> VmmError {
         let arc = reservation.instance();
-        let vm_dir = arc.lock().unwrap().vm_dir.clone();
+        let (vm_dir, pool_slot_id) = {
+            let inst = arc.lock().unwrap();
+            (inst.vm_dir.clone(), inst.pool_slot_id.clone())
+        };
         #[allow(
             clippy::cast_possible_wrap,
             reason = "Firecracker pid fits platform pid_t"
@@ -182,7 +185,8 @@ impl SandboxManager {
             cow_handle.as_ref(),
             self.config.firecracker.jailer.is_some(),
             None,
-        );
+        )
+        .with_pool_slot(pool_slot_id.as_deref());
         let journal_error = super::reconcile::write_state_record(&vm_dir, &state_record).err();
         {
             let mut inst = arc.lock().unwrap();

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -1,6 +1,6 @@
 use super::boot::{
-    chroot_root, link_or_copy_for_jailer, stage_kernel_for_jailer, stage_rootfs_copy_for_jailer,
-    stage_rootfs_device_for_jailer,
+    StageError, chroot_root, stage_kernel_for_jailer, stage_rootfs_cow_or_copy,
+    stage_snapshot_files,
 };
 use super::persistence::{ProvisionIntent, SandboxProvisionOutcome, SandboxTransition};
 use super::types::action;
@@ -408,15 +408,21 @@ impl SandboxManager {
             clippy::cast_possible_wrap,
             reason = "Firecracker pid fits platform pid_t"
         )]
-        let spawned_record = super::reconcile::SandboxStateRecord::new(
-            &new_id,
-            process.pid().map(|pid| pid as i32),
-            net_alloc.as_ref(),
-            None,
-            self.config.firecracker.jailer.is_some(),
-            None,
-        );
-        if let Err(error) = super::reconcile::write_state_record(&vm_dir, &spawned_record) {
+        let pid = process.pid().map(|pid| pid as i32);
+        let journal = |cow: Option<&CowHandle>| {
+            super::reconcile::write_state_record(
+                &vm_dir,
+                &super::reconcile::SandboxStateRecord::new(
+                    &new_id,
+                    pid,
+                    net_alloc.as_ref(),
+                    cow,
+                    true,
+                    None,
+                ),
+            )
+        };
+        if let Err(error) = journal(None) {
             return Err(self
                 .rollback_restore(&new_id, reservation, error, Some(process), net_alloc, None)
                 .await);
@@ -431,84 +437,31 @@ impl SandboxManager {
             let jc = jailer;
             let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
             let cr = chroot_root(&fc_cfg.binary, base, &new_id);
-            let snap_in_chroot = cr.join("snapshots").join(&spec.snapshot_id);
-            std::fs::create_dir_all(&snap_in_chroot).map_err(VmmError::Io)?;
-            let uid = nix::unistd::Uid::from_raw(jc.uid);
-            let gid = nix::unistd::Gid::from_raw(jc.gid);
-            nix::unistd::chown(&snap_in_chroot, Some(uid), Some(gid))
-                .map_err(|e| VmmError::Process(format!("chown snap dir: {e}")))?;
 
-            // Stage kernel (always copied, ~16MB).
+            // Stage kernel (always hard-linked or copied, ~16MB).
             if let Some(k) = snap_meta.kernel_path.as_deref() {
                 stage_kernel_for_jailer(&cr, k, jc.uid, jc.gid).await?;
             }
 
-            // Stage rootfs: try dm-snapshot + mknod, fall back to full copy.
-            // Mirrors the boot path so restored sandboxes get the same CoW
-            // semantics (block-level sharing of the template, sparse COW).
+            // Stage rootfs: dm-snapshot + mknod with full-copy fallback,
+            // mirroring the boot path so restored sandboxes get the same CoW
+            // semantics (block-level template sharing, sparse COW).
             if let Some(r) = snap_meta.rootfs_path.as_deref() {
-                match self.cow_manager.setup(&new_id, r).await {
-                    Ok(handle) => {
-                        pending_cow = Some(handle);
-                        #[allow(
-                            clippy::cast_possible_wrap,
-                            reason = "Firecracker pid fits platform pid_t"
-                        )]
-                        let record = super::reconcile::SandboxStateRecord::new(
-                            &new_id,
-                            process.pid().map(|pid| pid as i32),
-                            net_alloc.as_ref(),
-                            pending_cow.as_ref(),
-                            true,
-                            None,
-                        );
-                        super::reconcile::write_state_record(&vm_dir, &record)?;
-                        match stage_rootfs_device_for_jailer(
-                            &cr,
-                            &pending_cow.as_ref().unwrap().dm_device,
-                            jc.uid,
-                            jc.gid,
-                        )
-                        .await
-                        {
-                            Ok(_) => {}
-                            Err(e) => {
-                                debug!(
-                                    sandbox_id = %new_id,
-                                    error = %e,
-                                    "mknod failed on restore, falling back to rootfs copy"
-                                );
-                                self.cow_manager
-                                    .teardown_checked(pending_cow.as_ref().unwrap())
-                                    .await?;
-                                pending_cow = None;
-                                #[allow(
-                                    clippy::cast_possible_wrap,
-                                    reason = "Firecracker pid fits platform pid_t"
-                                )]
-                                let record = super::reconcile::SandboxStateRecord::new(
-                                    &new_id,
-                                    process.pid().map(|pid| pid as i32),
-                                    net_alloc.as_ref(),
-                                    None,
-                                    true,
-                                    None,
-                                );
-                                super::reconcile::write_state_record(&vm_dir, &record)?;
-                                stage_rootfs_copy_for_jailer(&cr, r, jc.uid, jc.gid).await?;
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        if matches!(e, VmmError::Unavailable(_)) {
-                            return Err(e);
-                        }
-                        debug!(
-                            sandbox_id = %new_id,
-                            error = %e,
-                            "dm-snapshot unavailable on restore, copying rootfs"
-                        );
-                        stage_rootfs_copy_for_jailer(&cr, r, jc.uid, jc.gid).await?;
+                match stage_rootfs_cow_or_copy(
+                    &self.cow_manager,
+                    &cr,
+                    &new_id,
+                    r,
+                    jc.uid,
+                    jc.gid,
+                    &journal,
+                )
+                .await
+                {
+                    Ok(cow) => pending_cow = cow,
+                    Err(StageError { error, cow_handle }) => {
+                        pending_cow = cow_handle;
+                        return Err(error);
                     }
                 }
             }
@@ -517,23 +470,7 @@ impl SandboxManager {
             // (mem is mapped MAP_PRIVATE on load), so the root jailer
             // hard-links them instead of copying — the mem file is the
             // sandbox's full memory size (CORE-75).
-            let dst_vmstate = snap_in_chroot.join("vmstate");
-            link_or_copy_for_jailer(&snap_meta.vmstate_path, &dst_vmstate, jc.uid, jc.gid).await?;
-
-            let effective_mem = if let Some(ref mf) = snap_meta.mem_path
-                && mf.exists()
-            {
-                let dst_mem = snap_in_chroot.join("mem");
-                link_or_copy_for_jailer(mf, &dst_mem, jc.uid, jc.gid).await?;
-                Some(format!("/snapshots/{}/mem", spec.snapshot_id))
-            } else {
-                None
-            };
-
-            Ok((
-                format!("/snapshots/{}/vmstate", spec.snapshot_id),
-                effective_mem,
-            ))
+            stage_snapshot_files(&cr, &snap_meta, jc.uid, jc.gid).await
         }
         .await;
 

--- a/virt/arcbox-vm/src/sandbox/cleanup.rs
+++ b/virt/arcbox-vm/src/sandbox/cleanup.rs
@@ -326,10 +326,16 @@ pub(super) async fn release_runtime_resources(
         }
     }
 
-    // Clean up the jailer chroot directory if applicable.
+    // Clean up the jailer chroot directory if applicable. A sandbox that
+    // adopted a pre-warmed pool slot lives in the slot's chroot, so the
+    // removal is keyed by the owning id, not the sandbox id.
     if let Some(ref jc) = config.firecracker.jailer {
         let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-        let chroot_dir = chroot_root(&config.firecracker.binary, base, id);
+        let chroot_owner = {
+            let inst = arc.lock().unwrap();
+            inst.pool_slot_id.clone().unwrap_or_else(|| id.to_owned())
+        };
+        let chroot_dir = chroot_root(&config.firecracker.binary, base, &chroot_owner);
         // Remove {base}/{exec_name}/{id}/ (parent of "root/").
         if let Some(parent) = chroot_dir.parent()
             && let Err(e) = tokio::fs::remove_dir_all(parent).await
@@ -740,6 +746,60 @@ mod tests {
         assert!(!vm_dir.exists());
 
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn release_removes_the_chroot_of_an_adopted_pool_slot() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let chroot_base = data_dir.path().join("jailer");
+        let mut config = VmmConfig::default();
+        config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
+        config.firecracker.jailer = Some(crate::config::JailerConfig {
+            binary: "/usr/bin/jailer".into(),
+            uid: 0,
+            gid: 0,
+            chroot_base_dir: Some(chroot_base.to_string_lossy().into_owned()),
+            netns: None,
+            new_pid_ns: false,
+            cgroup_version: None,
+            parent_cgroup: None,
+            resource_limits: vec![],
+        });
+        let slot_chroot = chroot_root(
+            &config.firecracker.binary,
+            &chroot_base.to_string_lossy(),
+            "pool-slot",
+        );
+        let sandbox_chroot = chroot_root(
+            &config.firecracker.binary,
+            &chroot_base.to_string_lossy(),
+            "job",
+        );
+        std::fs::create_dir_all(&slot_chroot).unwrap();
+        std::fs::create_dir_all(&sandbox_chroot).unwrap();
+
+        let arc = instance("job");
+        arc.lock().unwrap().pool_slot_id = Some("pool-slot".into());
+        let config = Arc::new(config);
+        let network = Arc::new(
+            NetworkManager::new(
+                &config.network.cidr,
+                &config.network.gateway,
+                config.network.dns.clone(),
+            )
+            .unwrap(),
+        );
+        let cow_manager = Arc::new(CowManager::new(&config.firecracker.data_dir).unwrap());
+
+        release_runtime_resources("job", &arc, &network, &config, &cow_manager)
+            .await
+            .unwrap();
+
+        assert!(!slot_chroot.parent().unwrap().exists());
+        assert!(
+            sandbox_chroot.exists(),
+            "the sandbox-id chroot belongs to nobody here and must not be touched"
+        );
     }
 
     #[tokio::test]

--- a/virt/arcbox-vm/src/sandbox/pool.rs
+++ b/virt/arcbox-vm/src/sandbox/pool.rs
@@ -1,0 +1,513 @@
+//! Pre-warmed restore slots (CORE-78).
+//!
+//! The fixed host-side setup of a snapshot restore — jailer chroot,
+//! Firecracker spawn, kernel/vmstate/mem staging, dm-snapshot — costs
+//! ~114 ms of the restore RPC. A [`PreparedSlot`] pre-executes exactly
+//! that sequence, so a restore that claims one proceeds directly to
+//! LoadSnapshot + guest reconfiguration.
+//!
+//! Slots are keyed by snapshot id and journaled under `pool-<uuid>` ids in
+//! the same `sandboxes/` namespace as real sandboxes, so a crash leaves
+//! nothing behind that the startup orphan sweep cannot reclaim. TAP and IP
+//! allocation deliberately stay in the claim path: the network override at
+//! LoadSnapshot time binds a claimed slot to its TAP, which keeps slots
+//! network-agnostic (the seam CORE-81 builds on).
+
+use super::boot::{
+    StageError, chroot_root, kill_and_reap_fc_checked, stage_kernel_for_jailer,
+    stage_rootfs_cow_or_copy, stage_snapshot_files,
+};
+use super::reconcile::{self, POOL_SLOT_PREFIX, SandboxStateRecord};
+use super::*;
+use crate::config::JailerConfig;
+use crate::snapshot::SnapshotMeta;
+
+/// Most distinct snapshot ids pooled at once. The least recently restored
+/// id is evicted — its slots torn down — when a third id starts filling.
+const MAX_POOLED_SNAPSHOTS: usize = 2;
+
+/// A fully staged restore slot: jailer chroot prepared, Firecracker
+/// spawned (API socket up, nothing loaded yet), kernel + vmstate + mem
+/// staged, dm-snapshot of the rootfs created.
+pub(super) struct PreparedSlot {
+    /// Slot id (`pool-<uuid>`): the chroot, dm/CoW names, and crash
+    /// journal are keyed by it.
+    pub slot_id: String,
+    /// Firecracker process, chrooted into the slot's jail.
+    pub process: fc_sdk::FirecrackerProcess,
+    /// dm-snapshot of the snapshot's rootfs (`None` = copy fallback).
+    pub cow_handle: Option<CowHandle>,
+    /// Chroot-relative vmstate path for `SnapshotLoadParams`.
+    pub vmstate_path: String,
+    /// Chroot-relative mem path, when the snapshot has one.
+    pub mem_path: Option<String>,
+    /// Host-side vsock UDS path inside the slot's chroot.
+    pub vsock_path: PathBuf,
+    /// Slot runtime dir (`sandboxes/pool-<uuid>`) holding its crash journal.
+    pub vm_dir: PathBuf,
+}
+
+impl PreparedSlot {
+    /// Whether the pre-spawned Firecracker process is still alive.
+    pub fn process_alive(&self) -> bool {
+        self.process.pid().is_some_and(|pid| {
+            nix::sys::signal::kill(
+                #[allow(
+                    clippy::cast_possible_wrap,
+                    reason = "Firecracker pid fits platform pid_t"
+                )]
+                nix::unistd::Pid::from_raw(pid as i32),
+                None,
+            )
+            .is_ok()
+        })
+    }
+}
+
+/// Refill work computed under the pool lock: how many slot prepares to
+/// spawn and which evicted slots to tear down.
+pub(super) struct FillPlan<S> {
+    pub spawn: usize,
+    pub evicted: Vec<S>,
+}
+
+/// Slot storage and policy: keyed by snapshot id, capped to
+/// [`MAX_POOLED_SNAPSHOTS`] distinct ids (LRU), with in-flight refill
+/// accounting. Generic over the slot type so the policy is unit-testable
+/// without spawning Firecracker; the lock is never held across an await.
+pub(super) struct SlotPool<S = PreparedSlot> {
+    inner: Mutex<PoolInner<S>>,
+}
+
+struct PoolInner<S> {
+    /// Ready slots per snapshot id.
+    ready: HashMap<String, Vec<S>>,
+    /// In-flight prepare tasks per snapshot id.
+    filling: HashMap<String, usize>,
+    /// Pooled snapshot ids, least recently restored first. Membership is
+    /// the pooling permission: an offer for an id not listed here (evicted
+    /// or drained while its fill was in flight) is rejected.
+    lru: Vec<String>,
+}
+
+impl<S> Default for SlotPool<S> {
+    fn default() -> Self {
+        Self {
+            inner: Mutex::new(PoolInner {
+                ready: HashMap::new(),
+                filling: HashMap::new(),
+                lru: Vec::new(),
+            }),
+        }
+    }
+}
+
+impl<S> SlotPool<S> {
+    /// Pop a ready slot for `snapshot_id`, refreshing its recency.
+    pub fn claim(&self, snapshot_id: &str) -> Option<S> {
+        let mut inner = self.inner.lock().unwrap();
+        let slot = inner.ready.get_mut(snapshot_id)?.pop()?;
+        inner.touch(snapshot_id);
+        inner.prune(snapshot_id);
+        Some(slot)
+    }
+
+    /// Plan a refill of `snapshot_id` up to `target` spare slots,
+    /// refreshing its recency and evicting beyond the LRU cap. The caller
+    /// must run one prepare per `spawn` (finishing each with [`Self::offer`]
+    /// or [`Self::abandon_fill`]) and tear down every evicted slot.
+    pub fn begin_fill(&self, snapshot_id: &str, target: usize) -> FillPlan<S> {
+        if target == 0 {
+            return FillPlan {
+                spawn: 0,
+                evicted: Vec::new(),
+            };
+        }
+        let mut inner = self.inner.lock().unwrap();
+        inner.touch(snapshot_id);
+        let ready = inner.ready.get(snapshot_id).map_or(0, Vec::len);
+        let filling = inner.filling.get(snapshot_id).copied().unwrap_or(0);
+        let spawn = target.saturating_sub(ready + filling);
+        if spawn > 0 {
+            *inner.filling.entry(snapshot_id.to_owned()).or_default() += spawn;
+        }
+        let mut evicted = Vec::new();
+        while inner.lru.len() > MAX_POOLED_SNAPSHOTS {
+            let stale = inner.lru.remove(0);
+            evicted.extend(inner.ready.remove(&stale).unwrap_or_default());
+            // In-flight fills for the evicted id keep their accounting and
+            // get rejected at offer time (the id is no longer listed).
+        }
+        FillPlan { spawn, evicted }
+    }
+
+    /// Deliver a prepared slot. Returns it back for teardown when its
+    /// snapshot was evicted or drained while the fill was in flight.
+    pub fn offer(&self, snapshot_id: &str, slot: S) -> Option<S> {
+        let mut inner = self.inner.lock().unwrap();
+        inner.finish_fill(snapshot_id);
+        if inner.lru.iter().any(|id| id == snapshot_id) {
+            inner
+                .ready
+                .entry(snapshot_id.to_owned())
+                .or_default()
+                .push(slot);
+            None
+        } else {
+            Some(slot)
+        }
+    }
+
+    /// Account a failed fill for `snapshot_id`.
+    pub fn abandon_fill(&self, snapshot_id: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.finish_fill(snapshot_id);
+        inner.prune(snapshot_id);
+    }
+
+    /// Remove every ready slot for `snapshot_id` (or for all snapshots)
+    /// and stop pooling it until the next restore refills.
+    pub fn drain(&self, snapshot_id: Option<&str>) -> Vec<S> {
+        let mut inner = self.inner.lock().unwrap();
+        match snapshot_id {
+            Some(id) => {
+                inner.lru.retain(|entry| entry != id);
+                inner.ready.remove(id).unwrap_or_default()
+            }
+            None => {
+                inner.lru.clear();
+                inner.ready.drain().flat_map(|(_, slots)| slots).collect()
+            }
+        }
+    }
+}
+
+impl<S> PoolInner<S> {
+    /// Move `snapshot_id` to the most-recent end of the LRU list.
+    fn touch(&mut self, snapshot_id: &str) {
+        self.lru.retain(|id| id != snapshot_id);
+        self.lru.push(snapshot_id.to_owned());
+    }
+
+    /// Drop the LRU entry when nothing is pooled or filling for the id.
+    fn prune(&mut self, snapshot_id: &str) {
+        let ready = self.ready.get(snapshot_id).is_some_and(|s| !s.is_empty());
+        let filling = self.filling.get(snapshot_id).copied().unwrap_or(0) > 0;
+        if !ready && !filling {
+            self.ready.remove(snapshot_id);
+            self.lru.retain(|id| id != snapshot_id);
+        }
+    }
+
+    fn finish_fill(&mut self, snapshot_id: &str) {
+        if let Some(count) = self.filling.get_mut(snapshot_id) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                self.filling.remove(snapshot_id);
+            }
+        }
+    }
+}
+
+/// Pre-execute the restore setup sequence for `snapshot`: journal, spawn
+/// the jailed Firecracker, stage kernel + rootfs (dm-snapshot with copy
+/// fallback) + vmstate/mem hard links. A failure unwinds every partial
+/// resource before returning.
+pub(super) async fn prepare_slot(
+    config: &VmmConfig,
+    cow_manager: &CowManager,
+    snapshot: &SnapshotMeta,
+) -> Result<PreparedSlot> {
+    let fc_cfg = &config.firecracker;
+    let jc = fc_cfg
+        .jailer
+        .as_ref()
+        .ok_or_else(|| VmmError::Config("restore slot pooling requires jailer isolation".into()))?;
+    let slot_id = format!("{POOL_SLOT_PREFIX}{}", Uuid::new_v4());
+    let vm_dir = PathBuf::from(&fc_cfg.data_dir)
+        .join("sandboxes")
+        .join(&slot_id);
+
+    // Journal before the first external resource exists so a crash
+    // mid-prepare is swept like any orphaned sandbox.
+    reconcile::create_runtime_dir(&vm_dir)?;
+    reconcile::write_state_record(
+        &vm_dir,
+        &SandboxStateRecord::new(&slot_id, None, None, None, true, None),
+    )?;
+
+    match stage_slot(fc_cfg, jc, cow_manager, snapshot, &slot_id, &vm_dir).await {
+        Ok((process, cow_handle, vmstate_path, mem_path, vsock_path)) => Ok(PreparedSlot {
+            slot_id,
+            process,
+            cow_handle,
+            vmstate_path,
+            mem_path,
+            vsock_path,
+            vm_dir,
+        }),
+        Err(mut failure) => {
+            // Unwind whatever the failed stage acquired; on unwind failure
+            // the journal stays for the startup sweep to retry.
+            let fc_unwound = match failure.process.take() {
+                Some(mut process) => match kill_and_reap_fc_checked(&mut process).await {
+                    Ok(()) => true,
+                    Err(error) => {
+                        warn!(slot_id, error = %error, "failed slot prepare left its firecracker behind");
+                        false
+                    }
+                },
+                None => true,
+            };
+            let cow_unwound = match failure.cow_handle.take() {
+                Some(handle) => match cow_manager.teardown_checked(&handle).await {
+                    Ok(()) => true,
+                    Err(error) => {
+                        warn!(slot_id, error = %error, "failed slot prepare left CoW resources behind");
+                        false
+                    }
+                },
+                None => true,
+            };
+            if fc_unwound && cow_unwound {
+                let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
+                let chroot = chroot_root(&fc_cfg.binary, base, &slot_id);
+                if let Some(parent) = chroot.parent() {
+                    let _ = tokio::fs::remove_dir_all(parent).await;
+                }
+                if let Err(error) = reconcile::clear_state_record(&vm_dir) {
+                    warn!(slot_id, error = %error, "failed slot prepare kept its journal");
+                } else {
+                    let _ = tokio::fs::remove_dir_all(&vm_dir).await;
+                }
+            }
+            Err(failure.error)
+        }
+    }
+}
+
+struct SlotFailure {
+    error: VmmError,
+    process: Option<fc_sdk::FirecrackerProcess>,
+    cow_handle: Option<CowHandle>,
+}
+
+impl From<VmmError> for SlotFailure {
+    fn from(error: VmmError) -> Self {
+        Self {
+            error,
+            process: None,
+            cow_handle: None,
+        }
+    }
+}
+
+type StagedSlot = (
+    fc_sdk::FirecrackerProcess,
+    Option<CowHandle>,
+    String,
+    Option<String>,
+    PathBuf,
+);
+
+async fn stage_slot(
+    fc_cfg: &crate::config::FirecrackerConfig,
+    jc: &JailerConfig,
+    cow_manager: &CowManager,
+    snapshot: &SnapshotMeta,
+    slot_id: &str,
+    vm_dir: &Path,
+) -> std::result::Result<StagedSlot, SlotFailure> {
+    let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
+    let cr = chroot_root(&fc_cfg.binary, base, slot_id);
+    std::fs::create_dir_all(cr.join("run")).map_err(VmmError::Io)?;
+    let vsock_path = cr.join("run/firecracker.vsock");
+
+    let process = spawn_jailer(jc, fc_cfg, slot_id).await?;
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "Firecracker pid fits platform pid_t"
+    )]
+    let pid = process.pid().map(|pid| pid as i32);
+    let journal = |cow: Option<&CowHandle>| {
+        reconcile::write_state_record(
+            vm_dir,
+            &SandboxStateRecord::new(slot_id, pid, None, cow, true, None),
+        )
+    };
+    let carry = |error: VmmError, process, cow_handle| SlotFailure {
+        error,
+        process,
+        cow_handle,
+    };
+    if let Err(error) = journal(None) {
+        return Err(carry(error, Some(process), None));
+    }
+
+    if let Some(kernel) = snapshot.kernel_path.as_deref() {
+        if let Err(error) = stage_kernel_for_jailer(&cr, kernel, jc.uid, jc.gid).await {
+            return Err(carry(error, Some(process), None));
+        }
+    }
+
+    let mut cow_handle = None;
+    if let Some(rootfs) = snapshot.rootfs_path.as_deref() {
+        match stage_rootfs_cow_or_copy(cow_manager, &cr, slot_id, rootfs, jc.uid, jc.gid, &journal)
+            .await
+        {
+            Ok(handle) => cow_handle = handle,
+            Err(StageError {
+                error,
+                cow_handle: leaked,
+            }) => return Err(carry(error, Some(process), leaked)),
+        }
+    }
+
+    match stage_snapshot_files(&cr, snapshot, jc.uid, jc.gid).await {
+        Ok((vmstate_path, mem_path)) => {
+            Ok((process, cow_handle, vmstate_path, mem_path, vsock_path))
+        }
+        Err(error) => Err(carry(error, Some(process), cow_handle)),
+    }
+}
+
+/// Tear down a slot completely: process, CoW resources, chroot, journal.
+///
+/// On error the slot's crash journal is left in place so the startup
+/// sweep retries; callers log and move on.
+pub(super) async fn destroy_slot(
+    config: &VmmConfig,
+    cow_manager: &CowManager,
+    mut slot: PreparedSlot,
+) -> Result<()> {
+    // FC must be dead before the dm teardown (`dmsetup remove` returns
+    // EBUSY while the block device is open).
+    kill_and_reap_fc_checked(&mut slot.process).await?;
+    if let Some(handle) = slot.cow_handle.take() {
+        cow_manager.teardown_checked(&handle).await?;
+    }
+    if let Some(ref jc) = config.firecracker.jailer {
+        let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
+        let chroot = chroot_root(&config.firecracker.binary, base, &slot.slot_id);
+        if let Some(parent) = chroot.parent()
+            && let Err(error) = tokio::fs::remove_dir_all(parent).await
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(VmmError::Io(error));
+        }
+    }
+    reconcile::clear_state_record(&slot.vm_dir)?;
+    match tokio::fs::remove_dir_all(&slot.vm_dir).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(VmmError::Io(error)),
+    }
+}
+
+impl SandboxManager {
+    /// Claim a live pre-warmed slot for `snapshot_id`. Slots whose
+    /// Firecracker died in the meantime are discarded and torn down in
+    /// the background.
+    pub(super) fn claim_restore_slot(&self, snapshot_id: &str) -> Option<PreparedSlot> {
+        loop {
+            let slot = self.pool.claim(snapshot_id)?;
+            if slot.process_alive() {
+                return Some(slot);
+            }
+            warn!(
+                snapshot_id,
+                slot_id = %slot.slot_id,
+                "discarding pre-warmed slot whose firecracker died"
+            );
+            self.spawn_slot_teardown(slot);
+        }
+    }
+
+    fn spawn_slot_teardown(&self, slot: PreparedSlot) {
+        let config = Arc::clone(&self.config);
+        let cow_manager = Arc::clone(&self.cow_manager);
+        tokio::spawn(async move {
+            let slot_id = slot.slot_id.clone();
+            if let Err(error) = destroy_slot(&config, &cow_manager, slot).await {
+                warn!(
+                    slot_id,
+                    error = %error,
+                    "pool slot teardown incomplete; the startup sweep will retry"
+                );
+            }
+        });
+    }
+
+    /// Refill the pool for `snapshot_id` up to `firecracker.pool_size`
+    /// spare slots, in the background. Fired after each successful
+    /// restore — which is exactly what makes a snapshot "restored at
+    /// least once" and eligible for pooling — so a failing restore never
+    /// spawns warm processes in a loop.
+    pub(super) fn spawn_pool_refill(&self, snapshot_id: &str) {
+        let plan = self
+            .pool
+            .begin_fill(snapshot_id, self.config.firecracker.pool_size);
+        for slot in plan.evicted {
+            self.spawn_slot_teardown(slot);
+        }
+        for _ in 0..plan.spawn {
+            let pool = Arc::clone(&self.pool);
+            let config = Arc::clone(&self.config);
+            let cow_manager = Arc::clone(&self.cow_manager);
+            let snapshots = Arc::clone(&self.snapshots);
+            let snapshot_id = snapshot_id.to_owned();
+            tokio::spawn(async move {
+                // Re-resolve the snapshot: it may have been deleted since.
+                let staged = match snapshots.find_by_id(&snapshot_id) {
+                    Ok(meta) => prepare_slot(&config, &cow_manager, &meta).await,
+                    Err(error) => Err(error),
+                };
+                match staged {
+                    Ok(slot) => match pool.offer(&snapshot_id, slot) {
+                        None => debug!(snapshot_id, "restore slot pre-warmed"),
+                        Some(rejected) => {
+                            // Evicted or drained while the fill was in flight.
+                            let slot_id = rejected.slot_id.clone();
+                            if let Err(error) = destroy_slot(&config, &cow_manager, rejected).await
+                            {
+                                warn!(
+                                    slot_id,
+                                    error = %error,
+                                    "pool slot teardown incomplete; the startup sweep will retry"
+                                );
+                            }
+                        }
+                    },
+                    Err(error) => {
+                        pool.abandon_fill(&snapshot_id);
+                        warn!(snapshot_id, error = %error, "restore slot pre-warm failed");
+                    }
+                }
+            });
+        }
+    }
+
+    /// Tear down pooled slots: all of them, or those staged from one
+    /// snapshot. Teardown failures are logged and left to the startup
+    /// sweep — the slots' crash journals keep them reclaimable.
+    pub(super) async fn drain_pool(&self, snapshot_id: Option<&str>) {
+        for slot in self.pool.drain(snapshot_id) {
+            let slot_id = slot.slot_id.clone();
+            if let Err(error) = destroy_slot(&self.config, &self.cow_manager, slot).await {
+                warn!(
+                    slot_id,
+                    error = %error,
+                    "pool slot teardown incomplete; the startup sweep will retry"
+                );
+            }
+        }
+    }
+
+    /// Release manager-held background resources: tears down every
+    /// pre-warmed restore slot. Live sandboxes are untouched. On a crash
+    /// (no shutdown) the startup orphan sweep reclaims slots via their
+    /// `pool-<uuid>` crash journals instead.
+    pub async fn shutdown(&self) {
+        self.drain_pool(None).await;
+    }
+}

--- a/virt/arcbox-vm/src/sandbox/pool.rs
+++ b/virt/arcbox-vm/src/sandbox/pool.rs
@@ -511,3 +511,124 @@ impl SandboxManager {
         self.drain_pool(None).await;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Policy tests run against `SlotPool<u32>` — the slot type is opaque
+    // to the policy, so no Firecracker process is needed.
+
+    /// Refill `snapshot` to `target` and deliver every planned slot as
+    /// consecutive values starting at `base`.
+    fn fill_and_offer(pool: &SlotPool<u32>, snapshot: &str, target: usize, base: u32) {
+        let plan = pool.begin_fill(snapshot, target);
+        assert!(plan.evicted.is_empty(), "unexpected eviction while filling");
+        for offset in 0..plan.spawn {
+            assert!(
+                pool.offer(snapshot, base + u32::try_from(offset).unwrap())
+                    .is_none()
+            );
+        }
+    }
+
+    #[test]
+    fn claims_are_keyed_by_snapshot_id() {
+        let pool = SlotPool::<u32>::default();
+        fill_and_offer(&pool, "a", 1, 10);
+
+        assert_eq!(pool.claim("other"), None);
+        assert_eq!(pool.claim("a"), Some(10));
+        assert_eq!(pool.claim("a"), None);
+    }
+
+    #[test]
+    fn refill_accounts_for_ready_and_in_flight_slots() {
+        let pool = SlotPool::<u32>::default();
+        let plan = pool.begin_fill("a", 2);
+        assert_eq!(plan.spawn, 2);
+
+        // Nothing delivered yet: a concurrent refill must not over-spawn.
+        assert_eq!(pool.begin_fill("a", 2).spawn, 0);
+        assert!(pool.offer("a", 10).is_none());
+        assert!(pool.offer("a", 11).is_none());
+        assert_eq!(pool.begin_fill("a", 2).spawn, 0);
+
+        // A claim frees one spare; the next refill replaces exactly it.
+        assert_eq!(pool.claim("a"), Some(11));
+        assert_eq!(pool.begin_fill("a", 2).spawn, 1);
+
+        // A failed fill releases its accounting for the next refill.
+        pool.abandon_fill("a");
+        assert_eq!(pool.begin_fill("a", 2).spawn, 1);
+    }
+
+    #[test]
+    fn pool_size_zero_disables_pooling() {
+        let pool = SlotPool::<u32>::default();
+        let plan = pool.begin_fill("a", 0);
+        assert_eq!(plan.spawn, 0);
+        assert!(plan.evicted.is_empty());
+        assert_eq!(pool.claim("a"), None);
+    }
+
+    #[test]
+    fn a_third_snapshot_evicts_the_least_recently_restored() {
+        let pool = SlotPool::<u32>::default();
+        fill_and_offer(&pool, "a", 1, 10);
+        fill_and_offer(&pool, "b", 1, 20);
+
+        let plan = pool.begin_fill("c", 1);
+        assert_eq!(plan.spawn, 1);
+        assert_eq!(plan.evicted, vec![10], "a's slot must be handed back");
+        assert_eq!(pool.claim("a"), None);
+        assert_eq!(pool.claim("b"), Some(20));
+    }
+
+    #[test]
+    fn claiming_refreshes_recency() {
+        let pool = SlotPool::<u32>::default();
+        fill_and_offer(&pool, "a", 2, 10);
+        fill_and_offer(&pool, "b", 1, 20);
+
+        // Restoring from `a` again makes `b` the eviction candidate.
+        assert_eq!(pool.claim("a"), Some(11));
+        let plan = pool.begin_fill("c", 1);
+        assert_eq!(plan.evicted, vec![20]);
+        assert_eq!(pool.claim("b"), None);
+        assert_eq!(pool.claim("a"), Some(10));
+    }
+
+    #[test]
+    fn late_offers_for_an_evicted_snapshot_are_rejected() {
+        let pool = SlotPool::<u32>::default();
+        let plan = pool.begin_fill("a", 1);
+        assert_eq!(plan.spawn, 1);
+        fill_and_offer(&pool, "b", 1, 20);
+        fill_and_offer(&pool, "c", 1, 30); // evicts "a" while its fill is in flight
+
+        assert_eq!(pool.offer("a", 10), Some(10), "must come back for teardown");
+        assert_eq!(pool.claim("a"), None);
+    }
+
+    #[test]
+    fn drain_scopes_to_one_snapshot_or_all() {
+        let pool = SlotPool::<u32>::default();
+        fill_and_offer(&pool, "a", 2, 10);
+        fill_and_offer(&pool, "b", 1, 20);
+
+        let mut drained = pool.drain(Some("a"));
+        drained.sort_unstable();
+        assert_eq!(drained, vec![10, 11]);
+        assert_eq!(pool.claim("a"), None);
+
+        // A fill in flight across the drain is rejected on delivery.
+        let plan = pool.begin_fill("a", 1);
+        assert_eq!(plan.spawn, 1);
+        assert!(pool.drain(Some("a")).is_empty());
+        assert_eq!(pool.offer("a", 12), Some(12));
+
+        assert_eq!(pool.drain(None), vec![20]);
+        assert_eq!(pool.claim("b"), None);
+    }
+}

--- a/virt/arcbox-vm/src/sandbox/reconcile.rs
+++ b/virt/arcbox-vm/src/sandbox/reconcile.rs
@@ -28,6 +28,12 @@ use crate::snapshot_cow::{CowHandle, CowManager};
 const STATE_FILE: &str = "state.json";
 const AGENT_RESTART_ERROR: &str = "sandbox runtime was cleaned after agent restart";
 
+/// Id prefix of pre-warmed restore slots (CORE-78). A slot's chroot,
+/// dm/CoW names, and runtime dir are keyed by `pool-<uuid>`, so the
+/// startup sweep recognizes and reclaims orphaned slots like any other
+/// journaled sandbox.
+pub(super) const POOL_SLOT_PREFIX: &str = "pool-";
+
 /// Plain serializable mirror of [`CowHandle`].
 ///
 /// `CowHandle` itself is deliberately `!Clone`/`!Serialize` (it owns a
@@ -90,6 +96,10 @@ pub(super) struct SandboxStateRecord {
     /// For restored sandboxes: the recreated origin directory to remove.
     #[serde(default)]
     pub restore_origin_dir: Option<PathBuf>,
+    /// For sandboxes that adopted a pre-warmed pool slot (CORE-78): the
+    /// slot id the jailer chroot and dm/CoW names are keyed by.
+    #[serde(default)]
+    pub pool_slot_id: Option<String>,
 }
 
 impl SandboxStateRecord {
@@ -109,7 +119,22 @@ impl SandboxStateRecord {
             cow: cow.map(CowRecord::from_handle),
             jailer,
             restore_origin_dir: restore_origin_dir.map(Path::to_path_buf),
+            pool_slot_id: None,
         }
+    }
+
+    /// Key the record's chroot and dm/CoW resources by an adopted pool
+    /// slot id instead of the sandbox id.
+    pub fn with_pool_slot(mut self, slot_id: Option<&str>) -> Self {
+        self.pool_slot_id = slot_id.map(str::to_owned);
+        self
+    }
+
+    /// Id the per-sandbox host resources (chroot, dm/CoW names) are
+    /// actually named after: the adopted pool slot id when present, the
+    /// sandbox id otherwise.
+    pub fn resource_owner(&self) -> &str {
+        self.pool_slot_id.as_deref().unwrap_or(&self.id)
     }
 }
 
@@ -219,10 +244,10 @@ pub(super) async fn sweep_orphans(
 
     let mut swept = HashSet::new();
     let mut runtime_dirs = Vec::new();
-    for (dir, record) in records {
+    for (dir, mut record) in records {
         info!(sandbox_id = %record.id, "reconciling orphaned sandbox");
 
-        if let Some(cow) = record.cow {
+        if let Some(cow) = record.cow.take() {
             cow_manager.teardown_checked(&cow.into_handle()).await?;
         }
 
@@ -234,7 +259,8 @@ pub(super) async fn sweep_orphans(
             && let Some(ref jc) = config.firecracker.jailer
         {
             let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-            let chroot = super::boot::chroot_root(&config.firecracker.binary, base, &record.id);
+            let chroot =
+                super::boot::chroot_root(&config.firecracker.binary, base, record.resource_owner());
             if let Some(parent) = chroot.parent() {
                 remove_dir_if_present(parent).await?;
             }
@@ -392,11 +418,21 @@ fn validate_state_record(
             )));
         }
     }
+    if let Some(slot_id) = &record.pool_slot_id {
+        super::validate_id("pool slot id", slot_id)?;
+        if !slot_id.starts_with(POOL_SLOT_PREFIX) {
+            return Err(crate::error::VmmError::Config(format!(
+                "sandbox {} cleanup record has non-pool slot id {slot_id}",
+                record.id
+            )));
+        }
+    }
     if let Some(cow) = &record.cow {
-        let expected_name = format!("arcbox-snap-{}", record.id);
+        let owner = record.resource_owner();
+        let expected_name = format!("arcbox-snap-{owner}");
         let expected_file = Path::new(&config.firecracker.data_dir)
             .join("cow")
-            .join(format!("arcbox-cow-{}.img", record.id));
+            .join(format!("arcbox-cow-{owner}.img"));
         if cow.dm_name != expected_name
             || cow.dm_device != format!("/dev/mapper/{expected_name}")
             || cow.cow_file != expected_file
@@ -451,7 +487,7 @@ fn discover_firecracker_pids(
         .join("firecracker.sock");
     let jailer_root = config.firecracker.jailer.as_ref().map(|jailer| {
         let base = jailer.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-        super::boot::chroot_root(&config.firecracker.binary, base, &record.id)
+        super::boot::chroot_root(&config.firecracker.binary, base, record.resource_owner())
     });
 
     for entry in std::fs::read_dir("/proc")? {
@@ -600,14 +636,73 @@ mod tests {
             }),
             jailer: true,
             restore_origin_dir: None,
+            pool_slot_id: Some("pool-1".into()),
         };
         let bytes = serde_json::to_vec(&record).unwrap();
         let parsed: SandboxStateRecord = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(parsed.id, "sb-1");
         assert_eq!(parsed.pid, Some(42));
         assert!(parsed.jailer);
+        assert_eq!(parsed.pool_slot_id.as_deref(), Some("pool-1"));
+        assert_eq!(parsed.resource_owner(), "pool-1");
         let handle = parsed.cow.unwrap().into_handle();
         assert_eq!(handle.dm_name, "arcbox-snap-sb-1");
+    }
+
+    #[test]
+    fn cleanup_record_validation_keys_cow_resources_by_the_pool_slot() {
+        let config = VmmConfig::default();
+        let sandboxes_dir = Path::new("/var/lib/firecracker-vmm/sandboxes");
+        let directory = sandboxes_dir.join("sb-1");
+        let cow_for = |owner: &str| CowRecord {
+            dm_name: format!("arcbox-snap-{owner}"),
+            dm_device: format!("/dev/mapper/arcbox-snap-{owner}"),
+            cow_loop: "/dev/loop7".into(),
+            cow_file: Path::new(&config.firecracker.data_dir)
+                .join("cow")
+                .join(format!("arcbox-cow-{owner}.img")),
+            template_path: "/var/lib/arcbox/sandbox/rootfs.ext4".into(),
+        };
+        let record = |slot: Option<&str>, cow_owner: &str| SandboxStateRecord {
+            id: "sb-1".into(),
+            pid: None,
+            network: None,
+            cow: Some(cow_for(cow_owner)),
+            jailer: true,
+            restore_origin_dir: None,
+            pool_slot_id: slot.map(str::to_owned),
+        };
+
+        // Slot-keyed resources validate against the slot id, not the sandbox id.
+        validate_state_record(
+            &config,
+            sandboxes_dir,
+            &directory,
+            &record(Some("pool-abc"), "pool-abc"),
+        )
+        .unwrap();
+        // A claimed record whose CoW is named after the sandbox id is corrupt.
+        assert!(
+            validate_state_record(
+                &config,
+                sandboxes_dir,
+                &directory,
+                &record(Some("pool-abc"), "sb-1"),
+            )
+            .is_err()
+        );
+        // A slot id outside the pool namespace is rejected.
+        assert!(
+            validate_state_record(
+                &config,
+                sandboxes_dir,
+                &directory,
+                &record(Some("other-abc"), "other-abc"),
+            )
+            .is_err()
+        );
+        // Without a slot the sandbox id keys the resources, as before.
+        validate_state_record(&config, sandboxes_dir, &directory, &record(None, "sb-1")).unwrap();
     }
 
     #[test]

--- a/virt/arcbox-vm/src/sandbox/types.rs
+++ b/virt/arcbox-vm/src/sandbox/types.rs
@@ -155,6 +155,11 @@ pub struct SandboxInstance {
     pub error: Option<String>,
     /// dm-snapshot CoW handle (present when snapshot-based rootfs is active).
     pub cow_handle: Option<CowHandle>,
+    /// When this sandbox adopted a pre-warmed restore slot's resources
+    /// (CORE-78), the slot id (`pool-<uuid>`) its jailer chroot and dm/CoW
+    /// names are keyed by. `None` for resources created under the
+    /// sandbox's own id.
+    pub(super) pool_slot_id: Option<String>,
 }
 
 impl SandboxInstance {
@@ -203,6 +208,7 @@ impl SandboxInstance {
             last_exit_status: None,
             error: None,
             cow_handle: None,
+            pool_slot_id: None,
         }
     }
 

--- a/virt/arcbox-vm/tests/e2e.rs
+++ b/virt/arcbox-vm/tests/e2e.rs
@@ -58,6 +58,9 @@ fn try_config(data_dir: &str) -> Option<VmmConfig> {
             http_api_max_payload_size: None,
             mmds_size_limit: None,
             socket_timeout_secs: Some(15),
+            // Direct mode cannot restore (and so never pools); keep the
+            // e2e run free of background pre-warm spawns regardless.
+            pool_size: 0,
         },
         network: NetworkConfig {
             cidr: "172.99.0.0/24".into(),


### PR DESCRIPTION
Stacked on #560 (← #559 ← #558 ← master); merge in order. Part of CORE-78, project **Sandbox Cold Start**.

## What (5 commits)

A pre-warmed slot pool for the restore path: after a snapshot's first successful restore, a background fill prepares `firecracker.pool_size` (default 1, 0 = off) spare slots — jailed FC spawned (API socket up, nothing loaded), kernel + vmstate/mem hard-links staged, dm-snapshot created. `restore_sandbox` claims a matching slot and goes straight to `LoadSnapshot`+resume; misses take today's path. LRU cap of 2 distinct snapshot ids.

Design notes: slots journal as `sandboxes/pool-<uuid>/state.json` so the existing `sweep_orphans` reclaims them with no special-casing; a claimed slot's resources are re-keyed onto the sandbox record before the slot journal clears (crash window is idempotent under the sweep); `SandboxStateRecord.pool_slot_id` keys chroot/CoW naming everywhere, including `checkpoint_sandbox` — FC resolves snapshot paths inside the *slot's* chroot for adopted sandboxes (real bug caught in audit, own commit). Dead-FC probe at claim discards wedged slots. Refill fires only after a *successful* restore so a failing snapshot cannot respawn warm processes in a loop. TAP/network stays in the claim path — the seam for CORE-81's network-agnostic slots is marked.

## Hardware-validated (stack #558+#559+#560+this, probe restore group, 8 iterations)

| Metric | Before | After (pool hit) |
|---|---|---|
| Restore RPC p50 | 215 ms | **104 ms** |
| Restore → first exec p50 | 287 ms | **178 ms** |

Phase log on a hit: `spawn_ms=12-24 stage_ms=0 load_ms=3 guest_cfg_ms=~80 pool_hit=true` (spawn_ms now carries records+network+claim — honest, not faked to 0). First restore (miss + fill) unchanged at ~395 ms. Full sandbox smoke green (incl. checkpoint of a pool-restored sandbox).

## Validation

142 arcbox-vm tests green (new pool-policy suite: keying, LRU eviction, refill accounting, claim/rejection races); clippy clean host + musl + workspace `-D warnings`; fmt clean.