### PR TITLE
feat(sandbox): network-identity-invariant snapshots

### DIFF
--- a/docs/sandbox-api.md
+++ b/docs/sandbox-api.md
@@ -297,6 +297,13 @@ the bundle ships 1.16.1). With it, a clone restores and runs while the
 origin keeps its NIC. Restore without `network_override` reuses the
 recorded NIC, so the origin must be stopped first.
 
+Snapshots are network-agnostic: every sandbox guest boots the identical
+fixed link-local identity, and the pool IP reported as `ip_address` is a
+host-side property of the TAP (per-TAP 1:1 NAT in the System VM). An
+invariant-addressed restore therefore performs zero guest-side network
+work; snapshots taken before this scheme keep the guest reconfig path.
+`ip_address`, DNS records, and expose always carry the external pool IP.
+
 ## Error model
 
 Agent-reported failures carry HTTP-style codes over the internal wire and

--- a/guest/arcbox-agent/Cargo.toml
+++ b/guest/arcbox-agent/Cargo.toml
@@ -62,6 +62,7 @@ http = "1"
 hyper-util = { version = "0.1.20", features = ["tokio"] }
 
 [dev-dependencies]
+arcbox-vm.workspace = true
 tempfile = "3"
 
 [features]

--- a/guest/arcbox-agent/src/agent/linux/port_forward.rs
+++ b/guest/arcbox-agent/src/agent/linux/port_forward.rs
@@ -13,6 +13,13 @@
 //! request or when the host finalizes the sandbox's durable cleanup ticket.
 //! `FORWARD` traffic is already accepted by the blanket sandbox subnet rules
 //! installed at boot (`init.rs::setup_sandbox_forwarding`).
+//!
+//! Invariant-addressed sandboxes (CORE-81) do not own their pool IP — the
+//! guest sits on the fixed link-local identity and the pool IP is a host-side
+//! TAP property. Their DNAT targets the fixed guest IP directly, paired with
+//! a mangle `MARK` rule on the same match so the rewritten destination routes
+//! out the right TAP via the sandbox's fwmark table. Legacy sandboxes keep
+//! the pool-IP target.
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -20,15 +27,18 @@ use std::net::Ipv4Addr;
 use std::process::Output;
 
 use anyhow::{Context, Result, bail};
+use arcbox_vm::SandboxNetworkIdentity;
+use arcbox_vm::network::invariant;
 use tokio::process::Command;
 
 /// First port of the reserved guest relay range.
 const PORT_RANGE_START: u16 = 40000;
 /// Last port of the reserved guest relay range (inclusive).
 const PORT_RANGE_END: u16 = 49999;
-/// iptables `--comment` tag stamped on every sandbox DNAT rule, so rules left
-/// behind by a crashed/restarted agent can be identified and flushed (they are
-/// otherwise untracked kernel state that would misroute after IP reuse).
+/// iptables `--comment` tag stamped on every sandbox forwarding rule, so
+/// rules left behind by a crashed/restarted agent can be identified and
+/// flushed (they are otherwise untracked kernel state that would misroute
+/// after IP reuse).
 const RULE_COMMENT_PREFIX: &str = "arcbox-sbx:";
 const LEGACY_RULE_COMMENT: &str = "arcbox-sbx";
 
@@ -48,16 +58,30 @@ impl Protocol {
     }
 }
 
-/// One installed DNAT mapping.
+/// One installed forwarding mapping.
 struct ForwardRule {
     guest_port: u16,
     sandbox_ip: Ipv4Addr,
     cleanup_token: String,
-    /// The exact iptables rule spec, so removal deletes precisely this rule.
+    /// The exact nat DNAT rule spec, so removal deletes precisely this rule.
     rule_args: Vec<String>,
+    /// Companion mangle `MARK` rule spec (invariant-addressed sandboxes only).
+    mangle_args: Option<Vec<String>>,
 }
 
-/// Manages the reserved-range DNAT mappings for all sandboxes.
+impl ForwardRule {
+    /// The `(table, spec)` halves this mapping installed, in install order.
+    fn halves(&self) -> Vec<(&'static str, Vec<String>)> {
+        let mut halves = Vec::with_capacity(2);
+        if let Some(ref mangle) = self.mangle_args {
+            halves.push(("mangle", mangle.clone()));
+        }
+        halves.push(("nat", self.rule_args.clone()));
+        halves
+    }
+}
+
+/// Manages the reserved-range forwarding mappings for all sandboxes.
 #[derive(Default)]
 pub struct PortForwardManager {
     /// `(sandbox_id, sandbox_port, protocol)` → installed rule.
@@ -67,67 +91,105 @@ pub struct PortForwardManager {
 }
 
 impl PortForwardManager {
-    /// Install (or return the existing) DNAT mapping for a sandbox port.
+    /// Install (or return the existing) forwarding mapping for a sandbox port.
     ///
     /// Returns the reserved-range guest port carrying the relay.
     pub async fn forward(
         &mut self,
         sandbox_id: &str,
-        sandbox_ip: Ipv4Addr,
-        cleanup_token: &str,
+        identity: &SandboxNetworkIdentity,
         sandbox_port: u16,
         protocol: Protocol,
     ) -> Result<u16> {
         let key = (sandbox_id.to_owned(), sandbox_port, protocol);
         if let Some(rule) = self.rules.get(&key) {
-            let guest_port = rule.guest_port;
-            let rule_args = rule.rule_args.clone();
-            if rule.sandbox_ip == sandbox_ip && rule.cleanup_token == cleanup_token {
-                if rule_is_installed(&rule_args).await? {
-                    return Ok(guest_port);
+            let same_ip = rule.sandbox_ip == identity.ip;
+            let same_generation = rule.cleanup_token == identity.cleanup_token;
+            if same_ip && same_generation {
+                let guest_port = rule.guest_port;
+                let halves = rule.halves();
+                let mut repaired = false;
+                for (table, spec) in halves {
+                    if rule_is_installed(&prepend_table(table, "-C", &spec)).await? {
+                        continue;
+                    }
+                    run_iptables(&prepend_table(table, "-I", &spec))
+                        .await
+                        .context("repairing missing forwarding rule")?;
+                    repaired = true;
                 }
-                run_iptables(&prepend(&["-t", "nat", "-I", "PREROUTING"], &rule_args))
-                    .await
-                    .context("repairing missing DNAT rule")?;
-                tracing::info!(
-                    sandbox_id,
-                    guest_port,
-                    sandbox_port,
-                    %sandbox_ip,
-                    "sandbox port forward repaired"
-                );
+                if repaired {
+                    tracing::info!(
+                        sandbox_id,
+                        guest_port,
+                        sandbox_port,
+                        sandbox_ip = %identity.ip,
+                        "sandbox port forward repaired"
+                    );
+                }
                 return Ok(guest_port);
             }
             self.remove_keys(vec![key.clone()]).await?;
         }
 
         let guest_port = self.allocate_port()?;
+        // Invariant guests own only the fixed guest IP: DNAT to it, and mark
+        // the packet on the same match so the rewritten destination routes
+        // out this sandbox's TAP (fwmark table). Legacy guests own the pool
+        // IP, which the main table routes directly.
+        let (target_ip, mangle_args) = if identity.net_invariant {
+            (
+                invariant::GUEST_IP,
+                Some(mark_rule_args(
+                    guest_port,
+                    identity.ip,
+                    &identity.cleanup_token,
+                    protocol,
+                )),
+            )
+        } else {
+            (identity.ip, None)
+        };
         let rule_args = dnat_rule_args(
             guest_port,
-            sandbox_ip,
-            cleanup_token,
+            target_ip,
+            &identity.cleanup_token,
             sandbox_port,
             protocol,
         );
 
-        run_iptables(&prepend(&["-t", "nat", "-I", "PREROUTING"], &rule_args))
+        if let Some(ref mangle) = mangle_args {
+            run_iptables(&prepend_table("mangle", "-I", mangle))
+                .await
+                .context("installing fwmark rule")?;
+        }
+        if let Err(error) = run_iptables(&prepend_table("nat", "-I", &rule_args))
             .await
-            .context("installing DNAT rule")?;
+            .context("installing DNAT rule")
+        {
+            // Roll the mangle half back so a failed install leaves no orphan.
+            if let Some(ref mangle) = mangle_args {
+                let _ = run_iptables(&prepend_table("mangle", "-D", mangle)).await;
+            }
+            return Err(error);
+        }
 
         tracing::info!(
             sandbox_id,
             guest_port,
             sandbox_port,
-            %sandbox_ip,
+            sandbox_ip = %identity.ip,
+            invariant = identity.net_invariant,
             "sandbox port forward installed"
         );
         self.rules.insert(
             key,
             ForwardRule {
                 guest_port,
-                sandbox_ip,
-                cleanup_token: cleanup_token.to_owned(),
+                sandbox_ip: identity.ip,
+                cleanup_token: identity.cleanup_token.clone(),
                 rule_args,
+                mangle_args,
             },
         );
         Ok(guest_port)
@@ -171,6 +233,9 @@ impl PortForwardManager {
         .await
     }
 
+    /// Both closures receive a full iptables argv (`-t <table> -C/-D
+    /// PREROUTING <spec>`); the indirection keeps the removal bookkeeping
+    /// testable without a kernel.
     async fn remove_keys_with<C, CFut, D, DFut>(
         &mut self,
         keys: Vec<(String, u16, Protocol)>,
@@ -188,17 +253,25 @@ impl PortForwardManager {
             let Some(rule) = self.rules.get(&key) else {
                 continue;
             };
-            let rule_args = rule.rule_args.clone();
-            let del_args = prepend(&["-t", "nat", "-D", "PREROUTING"], &rule.rule_args);
+            let halves = rule.halves();
             let guest_port = rule.guest_port;
 
-            // Delete the kernel rule BEFORE dropping the record. A failed
+            // Delete the kernel rules BEFORE dropping the record. A failed
             // record remains owned by this manager so a retry can remove it.
-            let result = match check(rule_args).await.context("checking DNAT rule") {
-                Ok(false) => Ok(()),
-                Ok(true) => delete(del_args).await.context("removing DNAT rule"),
-                Err(error) => Err(error),
-            };
+            let result = async {
+                for (table, spec) in halves {
+                    if check(prepend_table(table, "-C", &spec))
+                        .await
+                        .context("checking forwarding rule")?
+                    {
+                        delete(prepend_table(table, "-D", &spec))
+                            .await
+                            .context("removing forwarding rule")?;
+                    }
+                }
+                Ok::<(), anyhow::Error>(())
+            }
+            .await;
             match result {
                 Ok(()) => {
                     self.rules.remove(&key);
@@ -249,7 +322,7 @@ impl PortForwardManager {
 /// The protocol/port/destination spec shared by install and delete.
 fn dnat_rule_args(
     guest_port: u16,
-    sandbox_ip: Ipv4Addr,
+    target_ip: Ipv4Addr,
     cleanup_token: &str,
     sandbox_port: u16,
     protocol: Protocol,
@@ -266,13 +339,45 @@ fn dnat_rule_args(
         "-j".into(),
         "DNAT".into(),
         "--to-destination".into(),
-        format!("{sandbox_ip}:{sandbox_port}"),
+        format!("{target_ip}:{sandbox_port}"),
+    ]
+}
+
+/// The mangle-side companion of an invariant DNAT: the same match, marking
+/// the packet with the sandbox's fwmark so the rewritten (fixed-guest)
+/// destination routes out this sandbox's TAP.
+fn mark_rule_args(
+    guest_port: u16,
+    pool_ip: Ipv4Addr,
+    cleanup_token: &str,
+    protocol: Protocol,
+) -> Vec<String> {
+    vec![
+        "-p".into(),
+        protocol.iptables_name().into(),
+        "--dport".into(),
+        guest_port.to_string(),
+        "-m".into(),
+        "comment".into(),
+        "--comment".into(),
+        format!("{RULE_COMMENT_PREFIX}{cleanup_token}"),
+        "-j".into(),
+        "MARK".into(),
+        "--set-mark".into(),
+        format!("{:#x}", invariant::fwmark(pool_ip)),
     ]
 }
 
 /// If `line` belongs to the exact quarantined generation, return the argv
-/// that deletes it.
+/// that deletes it from `table`'s PREROUTING chain.
+///
+/// Tokenized rules are matched by their unique generation comment alone —
+/// their DNAT target differs by addressing mode (pool IP for legacy,
+/// the fixed guest IP for invariant sandboxes) and the mangle MARK half has
+/// no target at all. Pre-token rules carry only the bare legacy comment, so
+/// they are additionally gated on the pool-IP target.
 fn orphan_delete_args(
+    table: &'static str,
     line: &str,
     sandbox_ip: Ipv4Addr,
     cleanup_token: &str,
@@ -283,24 +388,20 @@ fn orphan_delete_args(
         .map(unquote_iptables_field)
         .collect();
     let comment = format!("{RULE_COMMENT_PREFIX}{cleanup_token}");
+    let exact = fields
+        .windows(2)
+        .any(|pair| pair[0] == "--comment" && pair[1] == comment);
+    let legacy = fields
+        .windows(2)
+        .any(|pair| pair[0] == "--comment" && pair[1] == LEGACY_RULE_COMMENT);
     let destination_prefix = format!("{sandbox_ip}:");
-    let tagged = fields.windows(2).any(|pair| {
-        pair[0] == "--comment" && (pair[1] == comment || pair[1] == LEGACY_RULE_COMMENT)
-    });
     let targets_ip = fields
         .windows(2)
         .any(|pair| pair[0] == "--to-destination" && pair[1].starts_with(&destination_prefix));
-    if !tagged || !targets_ip {
+    if !(exact || (legacy && targets_ip)) {
         return None;
     }
-    let mut args = vec![
-        "-t".to_owned(),
-        "nat".to_owned(),
-        "-D".to_owned(),
-        "PREROUTING".to_owned(),
-    ];
-    args.extend(fields);
-    Some(args)
+    Some(prepend_table(table, "-D", &fields))
 }
 
 fn unquote_iptables_field(field: &str) -> String {
@@ -323,39 +424,24 @@ fn legacy_orphan_delete_args(line: &str) -> Option<Vec<String>> {
     if !legacy {
         return None;
     }
-    let mut args = vec![
-        "-t".to_owned(),
-        "nat".to_owned(),
-        "-D".to_owned(),
-        "PREROUTING".to_owned(),
-    ];
-    args.extend(fields);
-    Some(args)
+    Some(prepend_table("nat", "-D", &fields))
 }
 
-/// Delete kernel DNAT state for one exact quarantined generation after the
-/// host has removed its listeners. This also covers agent restart, where the
-/// process-local rule registry is empty.
+/// Delete kernel forwarding state for one exact quarantined generation after
+/// the host has removed its listeners. This also covers agent restart, where
+/// the process-local rule registry is empty. Sweeps both the nat DNAT rules
+/// and the mangle MARK companions of invariant sandboxes.
 pub async fn remove_orphan_rules_for(sandbox_ip: Ipv4Addr, cleanup_token: &str) -> Result<()> {
-    let output = Command::new("/sbin/iptables")
-        .args(["-t", "nat", "-S", "PREROUTING"])
-        .output()
-        .await
-        .context("listing sandbox DNAT rules")?;
-    if !output.status.success() {
-        bail!(
-            "iptables -t nat -S PREROUTING failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    let listing = String::from_utf8_lossy(&output.stdout);
     let mut removed = 0usize;
     let mut failures = Vec::new();
-    for line in listing.lines() {
-        if let Some(args) = orphan_delete_args(line, sandbox_ip, cleanup_token) {
-            match run_iptables(&args).await {
-                Ok(()) => removed += 1,
-                Err(error) => failures.push(error.to_string()),
+    for table in ["nat", "mangle"] {
+        let listing = list_prerouting(table).await?;
+        for line in listing.lines() {
+            if let Some(args) = orphan_delete_args(table, line, sandbox_ip, cleanup_token) {
+                match run_iptables(&args).await {
+                    Ok(()) => removed += 1,
+                    Err(error) => failures.push(error.to_string()),
+                }
             }
         }
     }
@@ -363,12 +449,12 @@ pub async fn remove_orphan_rules_for(sandbox_ip: Ipv4Addr, cleanup_token: &str) 
         tracing::info!(
             removed,
             %sandbox_ip,
-            "removed quarantined sandbox DNAT rules"
+            "removed quarantined sandbox forwarding rules"
         );
     }
     if !failures.is_empty() {
         bail!(
-            "failed to remove {} quarantined DNAT rule(s): {}",
+            "failed to remove {} quarantined forwarding rule(s): {}",
             failures.len(),
             failures.join("; ")
         );
@@ -378,19 +464,9 @@ pub async fn remove_orphan_rules_for(sandbox_ip: Ipv4Addr, cleanup_token: &str) 
 
 /// Remove only pre-token sandbox rules during the startup handshake. Tokenized
 /// generations remain quarantined until their individual tickets finalize.
+/// Pre-token rules predate the mangle companions, so only nat is swept.
 pub async fn remove_legacy_orphan_rules() -> Result<()> {
-    let output = Command::new("/sbin/iptables")
-        .args(["-t", "nat", "-S", "PREROUTING"])
-        .output()
-        .await
-        .context("listing legacy sandbox DNAT rules")?;
-    if !output.status.success() {
-        bail!(
-            "iptables -t nat -S PREROUTING failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    let listing = String::from_utf8_lossy(&output.stdout);
+    let listing = list_prerouting("nat").await?;
     let mut failures = Vec::new();
     for args in listing.lines().filter_map(legacy_orphan_delete_args) {
         if let Err(error) = run_iptables(&args).await {
@@ -407,8 +483,24 @@ pub async fn remove_legacy_orphan_rules() -> Result<()> {
     Ok(())
 }
 
-fn prepend(head: &[&str], tail: &[String]) -> Vec<String> {
-    head.iter()
+async fn list_prerouting(table: &str) -> Result<String> {
+    let output = Command::new("/sbin/iptables")
+        .args(["-t", table, "-S", "PREROUTING"])
+        .output()
+        .await
+        .context("listing sandbox forwarding rules")?;
+    if !output.status.success() {
+        bail!(
+            "iptables -t {table} -S PREROUTING failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn prepend_table(table: &str, verb: &str, tail: &[String]) -> Vec<String> {
+    ["-t", table, verb, "PREROUTING"]
+        .iter()
         .map(|s| (*s).to_owned())
         .chain(tail.iter().cloned())
         .collect()
@@ -430,15 +522,14 @@ async fn run_iptables(args: &[String]) -> Result<()> {
     Ok(())
 }
 
-async fn rule_is_installed(rule_args: &[String]) -> Result<bool> {
-    let args = prepend(&["-t", "nat", "-C", "PREROUTING"], rule_args);
+async fn rule_is_installed(check_args: &[String]) -> Result<bool> {
     let output = Command::new("/sbin/iptables")
         .args(["-w", "2"])
-        .args(&args)
+        .args(check_args)
         .output()
         .await
         .context("failed to run iptables")?;
-    classify_rule_check(output, &args)
+    classify_rule_check(output, check_args)
 }
 
 fn classify_rule_check(output: Output, args: &[String]) -> Result<bool> {
@@ -490,37 +581,123 @@ mod tests {
     }
 
     #[test]
+    fn mark_spec_shares_the_dnat_match_and_carries_the_fwmark() {
+        let pool: Ipv4Addr = "172.20.0.2".parse().unwrap();
+        let args = mark_rule_args(40000, pool, "generation", Protocol::Tcp);
+        assert_eq!(
+            args,
+            [
+                "-p",
+                "tcp",
+                "--dport",
+                "40000",
+                "-m",
+                "comment",
+                "--comment",
+                "arcbox-sbx:generation",
+                "-j",
+                "MARK",
+                "--set-mark",
+                "0xac140002"
+            ]
+        );
+        // Same match prefix as the DNAT half — the two rules must classify
+        // the identical packets.
+        let dnat = dnat_rule_args(
+            40000,
+            invariant::GUEST_IP,
+            "generation",
+            8080,
+            Protocol::Tcp,
+        );
+        assert_eq!(args[..8], dnat[..8]);
+    }
+
+    #[test]
     fn orphan_delete_targets_only_tagged_prerouting_rules() {
         // A tagged arcbox rule (as `iptables -S` prints it, with the implicit
         // `-m tcp`) is converted from -A to a -D argv.
         let line = "-A PREROUTING -p tcp -m tcp --dport 40000 -m comment \
                     --comment \"arcbox-sbx:generation\" -j DNAT \
                     --to-destination 172.20.0.2:8080";
-        let args = orphan_delete_args(line, "172.20.0.2".parse().unwrap(), "generation")
+        let args = orphan_delete_args("nat", line, "172.20.0.2".parse().unwrap(), "generation")
             .expect("tagged rule should match");
         assert_eq!(args[..4], ["-t", "nat", "-D", "PREROUTING"]);
         assert_eq!(args.last().unwrap(), "172.20.0.2:8080");
         assert!(args.iter().any(|a| a == "arcbox-sbx:generation"));
         assert!(!args.iter().any(|a| a.contains('"')));
-        assert!(orphan_delete_args(line, "172.20.0.2".parse().unwrap(), "old").is_none());
-        assert!(orphan_delete_args(line, "172.20.0.3".parse().unwrap(), "generation").is_none());
+        assert!(orphan_delete_args("nat", line, "172.20.0.2".parse().unwrap(), "old").is_none());
+        // The exact generation token is unique, so it alone identifies the
+        // rule — a mismatched pool IP no longer shields a tokenized rule.
+        assert!(
+            orphan_delete_args("nat", line, "172.20.0.3".parse().unwrap(), "generation").is_some()
+        );
 
         // A foreign rule (e.g. Docker's) is left untouched.
         let docker = "-A PREROUTING -p tcp -m tcp --dport 8080 -j DNAT \
                       --to-destination 172.17.0.2:80";
-        assert!(orphan_delete_args(docker, "172.20.0.2".parse().unwrap(), "generation").is_none());
+        assert!(
+            orphan_delete_args("nat", docker, "172.20.0.2".parse().unwrap(), "generation")
+                .is_none()
+        );
 
         // A non-PREROUTING line is ignored.
         assert!(
-            orphan_delete_args("-N DOCKER", "172.20.0.2".parse().unwrap(), "generation").is_none()
+            orphan_delete_args(
+                "nat",
+                "-N DOCKER",
+                "172.20.0.2".parse().unwrap(),
+                "generation"
+            )
+            .is_none()
         );
 
         let legacy = "-A PREROUTING -p tcp --dport 40000 -m comment \
                       --comment \"arcbox-sbx\" -j DNAT \
                       --to-destination 172.20.0.2:8080";
-        assert!(orphan_delete_args(legacy, "172.20.0.2".parse().unwrap(), "generation").is_some());
+        assert!(
+            orphan_delete_args("nat", legacy, "172.20.0.2".parse().unwrap(), "generation")
+                .is_some()
+        );
+        // Pre-token rules stay gated on the pool-IP target.
+        assert!(
+            orphan_delete_args("nat", legacy, "172.20.0.3".parse().unwrap(), "generation")
+                .is_none()
+        );
         assert!(legacy_orphan_delete_args(legacy).is_some());
         assert!(legacy_orphan_delete_args(line).is_none());
+    }
+
+    #[test]
+    fn orphan_delete_matches_invariant_dnat_and_mark_rules() {
+        // Invariant DNAT targets the fixed guest IP; the token must still
+        // claim it for this generation's cleanup.
+        let dnat = "-A PREROUTING -p tcp -m tcp --dport 40000 -m comment \
+                    --comment \"arcbox-sbx:generation\" -j DNAT \
+                    --to-destination 169.254.100.2:8080";
+        assert!(
+            orphan_delete_args("nat", dnat, "172.20.0.2".parse().unwrap(), "generation").is_some()
+        );
+
+        // The mangle MARK companion has no --to-destination at all.
+        let mark = "-A PREROUTING -p tcp -m tcp --dport 40000 -m comment \
+                    --comment \"arcbox-sbx:generation\" -j MARK --set-xmark 0xac140002/0xffffffff";
+        let args = orphan_delete_args("mangle", mark, "172.20.0.2".parse().unwrap(), "generation")
+            .expect("tokenized mangle rule should match");
+        assert_eq!(args[..4], ["-t", "mangle", "-D", "PREROUTING"]);
+        assert!(
+            orphan_delete_args("mangle", mark, "172.20.0.2".parse().unwrap(), "other").is_none()
+        );
+    }
+
+    fn test_rule(port: u16, token: &str, mangle: bool) -> ForwardRule {
+        ForwardRule {
+            guest_port: PORT_RANGE_START + port,
+            sandbox_ip: "172.20.0.2".parse().unwrap(),
+            cleanup_token: token.into(),
+            rule_args: vec![port.to_string()],
+            mangle_args: mangle.then(|| vec![format!("mark-{port}")]),
+        }
     }
 
     #[test]
@@ -536,6 +713,7 @@ mod tests {
                 sandbox_ip: "172.20.0.2".parse().unwrap(),
                 cleanup_token: "generation".into(),
                 rule_args: vec![],
+                mangle_args: None,
             },
         );
         let second = mgr.allocate_port().unwrap();
@@ -546,18 +724,14 @@ mod tests {
     async fn bulk_remove_keeps_failed_rules_and_removes_the_rest() {
         let mut mgr = PortForwardManager::default();
         for (id, port) in [("target", 80), ("target", 81), ("other", 82)] {
+            let token = if id == "target" {
+                "generation"
+            } else {
+                "other-generation"
+            };
             mgr.rules.insert(
                 (id.into(), port, Protocol::Tcp),
-                ForwardRule {
-                    guest_port: PORT_RANGE_START + port,
-                    sandbox_ip: "172.20.0.2".parse().unwrap(),
-                    cleanup_token: if id == "target" {
-                        "generation".into()
-                    } else {
-                        "other-generation".into()
-                    },
-                    rule_args: vec![port.to_string()],
-                },
+                test_rule(port, token, false),
             );
         }
 
@@ -605,16 +779,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bulk_remove_deletes_both_halves_of_an_invariant_mapping() {
+        let mut mgr = PortForwardManager::default();
+        mgr.rules.insert(
+            ("target".into(), 80, Protocol::Tcp),
+            test_rule(80, "generation", true),
+        );
+        let deleted = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = std::sync::Arc::clone(&deleted);
+        mgr.remove_keys_with(
+            vec![("target".into(), 80, Protocol::Tcp)],
+            |_| async { Ok(true) },
+            move |args| {
+                let sink = std::sync::Arc::clone(&sink);
+                async move {
+                    sink.lock().unwrap().push(args);
+                    Ok(())
+                }
+            },
+        )
+        .await
+        .unwrap();
+        let deleted = deleted.lock().unwrap();
+        assert_eq!(deleted.len(), 2, "both the mangle and nat halves");
+        assert_eq!(deleted[0][..4], ["-t", "mangle", "-D", "PREROUTING"]);
+        assert_eq!(deleted[1][..4], ["-t", "nat", "-D", "PREROUTING"]);
+        assert!(mgr.rules.is_empty());
+    }
+
+    #[tokio::test]
     async fn bulk_remove_drops_records_for_rules_already_absent() {
         let mut mgr = PortForwardManager::default();
         mgr.rules.insert(
             ("target".into(), 80, Protocol::Tcp),
-            ForwardRule {
-                guest_port: PORT_RANGE_START,
-                sandbox_ip: "172.20.0.2".parse().unwrap(),
-                cleanup_token: "generation".into(),
-                rule_args: vec!["rule".into()],
-            },
+            test_rule(80, "generation", false),
         );
         let keys = vec![("target".into(), 80, Protocol::Tcp)];
         mgr.remove_keys_with(

--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -581,7 +581,7 @@ where
     svc.wait_startup_cleanup_complete().await;
     let _operation = svc.lock_operation(&req.id).await;
 
-    let (ip, cleanup_token) = match svc.sandbox_network_identity(&req.id) {
+    let identity = match svc.sandbox_network_identity(&req.id) {
         Ok(identity) => identity,
         Err(e) => {
             let err = ErrorResponse::new(e.status_code(), e.to_string());
@@ -593,7 +593,7 @@ where
     match port_forwards()
         .lock()
         .await
-        .forward(&req.id, ip, &cleanup_token, sandbox_port, protocol)
+        .forward(&req.id, &identity, sandbox_port, protocol)
         .await
     {
         Ok(guest_port) => {
@@ -649,7 +649,7 @@ where
         };
     svc.wait_startup_cleanup_complete().await;
     let _operation = svc.lock_operation(&req.id).await;
-    let (_, cleanup_token) = match svc.sandbox_network_identity(&req.id) {
+    let identity = match svc.sandbox_network_identity(&req.id) {
         Ok(identity) => identity,
         Err(error) => {
             let response = ErrorResponse::new(error.status_code(), error.to_string());
@@ -661,7 +661,7 @@ where
     match port_forwards()
         .lock()
         .await
-        .remove(&req.id, &cleanup_token, sandbox_port, protocol)
+        .remove(&req.id, &identity.cleanup_token, sandbox_port, protocol)
         .await
     {
         Ok(()) => {

--- a/guest/arcbox-agent/src/init.rs
+++ b/guest/arcbox-agent/src/init.rs
@@ -684,9 +684,23 @@ exit 0
     /// The subnet is read from the VMM config (default `172.20.0.0/16`).
     /// Uses `-I` (insert at chain top) so rules take effect even when
     /// Docker sets the default FORWARD policy to DROP.
+    ///
+    /// Invariant-addressed sandboxes (CORE-81) traverse FORWARD with the
+    /// fixed guest IP on the sandbox side — DNAT to it happens in PREROUTING
+    /// (before the filter) and SNAT off it in POSTROUTING (after) — so that
+    /// address needs its own accept pair; the subnet rules keep covering
+    /// legacy sandboxes.
+    ///
+    /// The mangle pair makes the deliberate sandbox-to-sandbox isolation
+    /// explicit: traffic from any sandbox TAP toward the pool is dropped
+    /// before it can be marked or DNAT'd (the per-TAP invariant NAT would
+    /// otherwise misattribute it), except toward the pool gateway, which
+    /// legacy guests use for DNS. These run at System VM boot, so per-sandbox
+    /// rules appended later always sit below them.
     fn setup_sandbox_forwarding() {
         let config = crate::config::load();
         let subnet = &config.network.cidr;
+        let guest_ip = format!("{}/32", arcbox_vm::network::invariant::GUEST_IP);
 
         run_iptables(
             &["-I", "FORWARD", "-d", subnet, "-j", "ACCEPT"],
@@ -695,6 +709,47 @@ exit 0
         run_iptables(
             &["-I", "FORWARD", "-s", subnet, "-j", "ACCEPT"],
             "FORWARD accept from sandbox subnet",
+        );
+        run_iptables(
+            &["-I", "FORWARD", "-d", &guest_ip, "-j", "ACCEPT"],
+            "FORWARD accept to invariant sandbox address",
+        );
+        run_iptables(
+            &["-I", "FORWARD", "-s", &guest_ip, "-j", "ACCEPT"],
+            "FORWARD accept from invariant sandbox address",
+        );
+
+        // Insert DROP first so the gateway ACCEPT lands above it.
+        let gateway = format!("{}/32", config.network.gateway);
+        run_iptables(
+            &[
+                "-t",
+                "mangle",
+                "-I",
+                "PREROUTING",
+                "-i",
+                "vmtap+",
+                "-d",
+                subnet,
+                "-j",
+                "DROP",
+            ],
+            "isolate sandbox-to-sandbox pool traffic",
+        );
+        run_iptables(
+            &[
+                "-t",
+                "mangle",
+                "-I",
+                "PREROUTING",
+                "-i",
+                "vmtap+",
+                "-d",
+                &gateway,
+                "-j",
+                "ACCEPT",
+            ],
+            "allow sandbox traffic to the pool gateway",
         );
 
         tracing::info!(subnet, "sandbox forwarding rules installed");

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -317,11 +317,12 @@ impl SandboxService {
         })
     }
 
-    /// Return the active generation's address and cleanup token.
+    /// Return the active generation's network identity (external pool IP,
+    /// cleanup token, and addressing mode).
     pub(crate) fn sandbox_network_identity(
         &self,
         sandbox_id: &str,
-    ) -> Result<(std::net::Ipv4Addr, String), SandboxError> {
+    ) -> Result<arcbox_vm::SandboxNetworkIdentity, SandboxError> {
         self.manager
             .sandbox_network_identity(sandbox_id)
             .map_err(SandboxError::from)

--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -433,8 +433,10 @@ async fn drive_sandboxes(
         bail!("fresh-network clone run output missing marker: {stdout:?}");
     }
 
-    // The vsock channel working proves nothing about the new TAP. Assert the
-    // guest actually re-addressed eth0 to the fresh allocation…
+    // The vsock channel working proves nothing about the new TAP. Under
+    // invariant addressing (CORE-81) every guest carries the fixed
+    // link-local identity and the pool IP lives host-side, so assert the
+    // guest kept the invariant address and never sees a pool IP…
     wait_ready(&mut sandboxes, "smoke3").await?;
     let addr = run_and_collect(
         &mut processes,
@@ -442,24 +444,20 @@ async fn drive_sandboxes(
         &["/bin/sh", "-c", "ip addr show eth0"],
     )
     .await?;
-    if !addr.contains(&cloned.ip_address) {
-        bail!(
-            "clone eth0 does not carry its allocated IP {} (got: {addr:?})",
-            cloned.ip_address
-        );
+    // Mirrors GUEST_IP in virt/arcbox-vm/src/network/invariant.rs.
+    if !addr.contains("169.254.100.2/") {
+        bail!("clone eth0 does not carry the invariant guest IP (got: {addr:?})");
     }
-    if addr.contains(&format!("{}/", created.ip_address)) {
-        bail!(
-            "clone eth0 still carries the origin's IP {} (got: {addr:?})",
-            created.ip_address
-        );
+    if addr.contains(&format!("{}/", created.ip_address))
+        || addr.contains(&format!("{}/", cloned.ip_address))
+    {
+        bail!("clone eth0 carries a pool IP; those must stay host-side (got: {addr:?})");
     }
 
     // …and that traffic flows through the new TAP: ping the gateway, which
     // is the local address of the clone's own TAP (sandboxes are isolated
     // point-to-point links, so peers are deliberately unreachable). Deriving
-    // the gateway from `ip route` also proves the reconfig re-installed the
-    // default route.
+    // the gateway from `ip route` also proves the restored default route.
     wait_ready(&mut sandboxes, "smoke3").await?;
     let ping = run_and_collect(
         &mut processes,

--- a/virt/arcbox-vm/src/lib.rs
+++ b/virt/arcbox-vm/src/lib.rs
@@ -51,8 +51,8 @@ pub use error::{Result, VmmError};
 pub use network::{NetworkAllocation, NetworkManager};
 pub use sandbox::{
     CheckpointInfo, CheckpointSummary, RestoreSandboxSpec, SandboxEvent, SandboxId, SandboxInfo,
-    SandboxManager, SandboxMountSpec, SandboxNetworkInfo, SandboxNetworkSpec, SandboxSpec,
-    SandboxState, SandboxSummary,
+    SandboxManager, SandboxMountSpec, SandboxNetworkIdentity, SandboxNetworkInfo,
+    SandboxNetworkSpec, SandboxSpec, SandboxState, SandboxSummary,
 };
 pub use sandbox::{
     ExecutionChannel, ExecutionOutput, ExecutionSnapshot, ExecutionSpec, StdinState,

--- a/virt/arcbox-vm/src/manager.rs
+++ b/virt/arcbox-vm/src/manager.rs
@@ -455,6 +455,9 @@ impl VmmManager {
             parent_id: None,
             kernel_path: None,
             rootfs_path: None,
+            // General VMs boot whatever network the caller configured; only
+            // sandbox checkpoints carry the invariant identity.
+            net_invariant: false,
         })?;
 
         if was_running {

--- a/virt/arcbox-vm/src/network.rs
+++ b/virt/arcbox-vm/src/network.rs
@@ -11,7 +11,37 @@ use uuid::Uuid;
 
 use crate::error::{Result, VmmError};
 
+#[cfg_attr(
+    not(target_os = "linux"),
+    allow(
+        dead_code,
+        reason = "TAP translation executes only on Linux; other platforms keep the pure rule builders for unit tests"
+    )
+)]
+pub mod invariant;
 mod quarantine;
+#[cfg_attr(
+    not(target_os = "linux"),
+    allow(
+        dead_code,
+        reason = "the netlink send is Linux-gated; other platforms keep the encoders for unit tests"
+    )
+)]
+mod rtnetlink;
+
+/// Host-side addressing scheme applied when a sandbox TAP is materialized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TapMode {
+    /// Fixed guest identity + per-TAP 1:1 NAT (CORE-81): the TAP's local
+    /// address is [`invariant::GUEST_GATEWAY`] and the pool IP is translated
+    /// host-side. Every fresh boot and every invariant-snapshot restore.
+    Invariant,
+    /// The pre-invariant shape: the TAP's local address is the pool gateway
+    /// and the guest owns the pool IP directly. Only restores of legacy
+    /// snapshots (no `net_invariant` marker), whose guests are re-addressed
+    /// over the reconfig RPC.
+    LegacySnapshot,
+}
 
 /// Default prefix length for backwards-compatible deserialization of records
 /// that predate the `prefix_len` field.
@@ -162,9 +192,13 @@ impl NetworkManager {
     /// On Linux this creates a persistent TAP device with a point-to-point IP
     /// configuration (gateway ↔ sandbox IP). The call is best-effort on
     /// non-Linux platforms (tests / macOS CI).
+    ///
+    /// General (non-sandbox) VMs boot the pool identity directly, so this
+    /// keeps the legacy TAP shape; the sandbox lifecycle activates invariant
+    /// TAPs via [`Self::activate`].
     pub fn allocate(&self, vm_id: &str) -> Result<NetworkAllocation> {
         let allocation = self.reserve(vm_id)?;
-        if let Err(error) = self.activate(&allocation) {
+        if let Err(error) = self.activate(&allocation, TapMode::LegacySnapshot) {
             self.release(&allocation);
             return Err(error);
         }
@@ -197,18 +231,40 @@ impl NetworkManager {
     }
 
     /// Materializes a previously reserved network allocation.
+    ///
+    /// In [`TapMode::Invariant`] the TAP's local address is the fixed
+    /// [`invariant::GUEST_GATEWAY`] and the per-TAP 1:1 NAT (pool IP ↔ fixed
+    /// guest IP) is installed alongside; in [`TapMode::LegacySnapshot`] the
+    /// TAP carries the pool gateway and no translation, matching guests that
+    /// own the pool IP directly.
     #[allow(
         clippy::unnecessary_wraps,
         reason = "Linux TAP activation is fallible; macOS test builds compile the no-op branch"
     )]
-    pub(crate) fn activate(&self, allocation: &NetworkAllocation) -> Result<()> {
+    pub(crate) fn activate(&self, allocation: &NetworkAllocation, mode: TapMode) -> Result<()> {
         info!(
             tap = %allocation.tap_name,
             ip = %allocation.ip_address,
+            ?mode,
             "activating sandbox network"
         );
         #[cfg(target_os = "linux")]
-        self.create_tap(&allocation.tap_name, allocation.ip_address)?;
+        {
+            let local = match mode {
+                TapMode::Invariant => invariant::GUEST_GATEWAY,
+                TapMode::LegacySnapshot => self.gateway,
+            };
+            self.create_tap(&allocation.tap_name, local, allocation.ip_address)?;
+            if mode == TapMode::Invariant
+                && let Err(error) = invariant::install(&allocation.tap_name, allocation.ip_address)
+            {
+                // Unwind the partial translation and the TAP so a failed
+                // activation leaves no half-translated interface behind.
+                let _ = invariant::remove(&allocation.tap_name, allocation.ip_address);
+                destroy_tap(&allocation.tap_name);
+                return Err(error);
+            }
+        }
         Ok(())
     }
 
@@ -230,6 +286,10 @@ impl NetworkManager {
         reason = "Linux TAP cleanup is fallible; macOS test builds compile the no-op branch"
     )]
     pub(crate) fn release_checked(&self, alloc: &NetworkAllocation) -> Result<()> {
+        // Translation rules do not die with the device; remove them first
+        // (tolerant of absence, so legacy TAPs are a no-op).
+        #[cfg(target_os = "linux")]
+        invariant::remove(&alloc.tap_name, alloc.ip_address)?;
         #[cfg(target_os = "linux")]
         destroy_tap_checked(&alloc.tap_name)?;
 
@@ -266,7 +326,7 @@ impl NetworkManager {
     }
 
     #[cfg(target_os = "linux")]
-    fn create_tap(&self, tap_name: &str, ip: Ipv4Addr) -> Result<()> {
+    fn create_tap(&self, tap_name: &str, local: Ipv4Addr, ip: Ipv4Addr) -> Result<()> {
         use std::os::fd::FromRawFd;
         use std::os::unix::io::AsRawFd;
 
@@ -341,9 +401,10 @@ impl NetworkManager {
             )));
         }
 
-        // 3. Configure point-to-point IP on TAP host end (gateway IP) so the
-        //    sandbox can use it as its default gateway. Each TAP is an isolated
-        //    link — sandboxes cannot see each other at L2.
+        // 3. Configure point-to-point IP on TAP host end (the gateway the
+        //    guest routes through) so the sandbox can use it as its default
+        //    gateway. Each TAP is an isolated link — sandboxes cannot see
+        //    each other at L2.
         //
         // Wrap in a closure so a failure in any set_ifaddr triggers TAP cleanup.
         if let Err(e) = (|| -> Result<()> {
@@ -352,7 +413,7 @@ impl NetworkManager {
                 &sock,
                 &ifr,
                 libc::SIOCSIFADDR,
-                self.gateway,
+                local,
                 tap_name,
                 "SIOCSIFADDR",
             )?;

--- a/virt/arcbox-vm/src/network/invariant.rs
+++ b/virt/arcbox-vm/src/network/invariant.rs
@@ -1,0 +1,346 @@
+//! Network-identity-invariant sandbox addressing (CORE-81).
+//!
+//! Every sandbox guest sees the identical network configuration — eth0 on
+//! [`GUEST_IP`] with gateway [`GUEST_GATEWAY`] — baked into the kernel `ip=`
+//! boot parameter. Snapshots therefore carry no per-sandbox network identity
+//! and a `network_override` restore needs zero guest-side work: no reconfig
+//! RPC, no resolv.conf rewrite (the nameserver is the fixed gateway
+//! everywhere). This mirrors E2B's architecture and is a design prerequisite
+//! for the pre-warm pool (CORE-78).
+//!
+//! The sandbox's external identity — the pool IP the rest of the system
+//! (DNS registry, expose DNAT, `CreateSandboxResponse.ip_address`) keeps
+//! using — is applied host-side, per TAP, inside the System VM:
+//!
+//! - Traffic addressed to the pool IP is DNAT'd to [`GUEST_IP`]
+//!   (`nat PREROUTING` for forwarded, `nat OUTPUT` for locally originated
+//!   packets), and traffic from the TAP toward local services is SNAT'd to
+//!   the pool IP in `nat INPUT` so DNS and relays keep seeing the pool
+//!   identity.
+//! - Sandbox-originated forwarded traffic is SNAT'd to the pool IP in
+//!   `nat POSTROUTING`, selected by a per-sandbox packet mark because
+//!   POSTROUTING cannot match the input interface.
+//! - Because the guest address is identical on every TAP, the post-DNAT
+//!   routing decision cannot use the main table. Each to-sandbox packet is
+//!   marked from its **pre-NAT** destination (`mangle` runs before `nat` in
+//!   the same hook), and a per-sandbox fwmark fib rule routes the rewritten
+//!   destination through a per-sandbox table holding `GUEST_IP dev <tap>`.
+//!
+//! Mechanism choice is grounded in what the System VM actually ships
+//! (2026-08, boot-assets rootfs + arcbox kernel config): static
+//! iptables-legacy and busybox only — no nftables userland, no `tc`, and the
+//! kernel enables neither `NET_ACT_NAT` nor `NETMAP` nor conntrack marks
+//! (`CONNMARK`). What it does enable — `IP_NF_NAT`, `IP_NF_MANGLE`,
+//! `NETFILTER_XT_MARK`, `IP_MULTIPLE_TABLES` — is exactly the rule set below.
+//!
+//! The TAP itself keeps today's point-to-point shape with one change: its
+//! local address is the fixed [`GUEST_GATEWAY`] instead of the pool gateway.
+//! The peer (`SIOCSIFDSTADDR`) stays the pool IP, which keeps a unique
+//! main-table host route per sandbox — that route's only jobs are to let the
+//! initial route lookup of locally-originated traffic succeed (the rewrite +
+//! fwmark reroute happens in the OUTPUT hooks) and to select the fixed
+//! gateway as source address; no packet egresses with the pool destination
+//! because every to-sandbox flow is DNAT'd first. ARP toward the guest
+//! resolves [`GUEST_IP`] (the table route's on-link next hop), which the
+//! guest answers regardless of which snapshot it was restored from.
+//!
+//! Rules are installed at TAP activation and removed with the TAP. Removal
+//! is tolerant of absence so the same teardown serves legacy TAPs, partial
+//! activations, and crash-recovery replays; rule specs derive entirely from
+//! the allocation, so cleanup needs no extra state.
+
+use std::net::Ipv4Addr;
+
+#[cfg(target_os = "linux")]
+use super::rtnetlink;
+#[cfg(target_os = "linux")]
+use crate::error::Result;
+
+/// Fixed guest-side eth0 address every sandbox boots with.
+///
+/// Link-local space cannot collide with the 172.20.0.0/16 pool or user
+/// traffic, and each TAP is an isolated point-to-point link, so identical
+/// guest addresses never conflict with each other.
+pub const GUEST_IP: Ipv4Addr = Ipv4Addr::new(169, 254, 100, 2);
+
+/// Fixed gateway (the System VM side of every sandbox TAP). Also the guest's
+/// DNS nameserver, which is what makes the snapshot's resolv.conf valid on
+/// any restore.
+pub const GUEST_GATEWAY: Ipv4Addr = Ipv4Addr::new(169, 254, 100, 1);
+
+/// Netmask of the guest link: 169.254.100.0/30 holds exactly the gateway and
+/// the guest.
+pub const GUEST_NETMASK: Ipv4Addr = Ipv4Addr::new(255, 255, 255, 252);
+
+/// Comment tag on every translation rule, marking them as arcbox-owned for
+/// forensics (`iptables -S`). Deletion goes by exact rule spec, not the tag.
+const RULE_COMMENT: &str = "arcbox-nat";
+
+/// Priority of the per-sandbox fwmark fib rules (before `main`, 32766).
+const FIB_RULE_PRIORITY: u32 = 8000;
+
+/// Per-sandbox packet mark and policy-routing table id: the pool IP itself.
+///
+/// Unique per active sandbox and derivable from the allocation alone, so
+/// teardown and crash-recovery replays need no extra state. Caveat: kube-proxy
+/// matches marks with masks 0x4000/0x8000; those bits sit in the third pool
+/// octet, so the first 16 382 addresses of a /16 pool are conflict-free.
+pub fn fwmark(pool_ip: Ipv4Addr) -> u32 {
+    u32::from(pool_ip)
+}
+
+/// One iptables rule of the per-TAP translation set.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct XtRule {
+    pub table: &'static str,
+    pub chain: &'static str,
+    pub spec: Vec<String>,
+}
+
+/// The complete per-TAP translation rule set, in install order.
+pub(crate) fn translation_rules(tap: &str, pool_ip: Ipv4Addr) -> Vec<XtRule> {
+    let mark = format!("{:#x}", fwmark(pool_ip));
+    let pool = format!("{pool_ip}/32");
+    let comment = |spec: &mut Vec<String>| {
+        spec.extend(["-m", "comment", "--comment", RULE_COMMENT].map(String::from));
+    };
+    let mut rules = Vec::new();
+    let mut rule = |table, chain, head: &[&str], tail: &[&str]| {
+        let mut spec: Vec<String> = head.iter().map(|s| (*s).to_owned()).collect();
+        comment(&mut spec);
+        spec.extend(tail.iter().map(|s| (*s).to_owned()));
+        rules.push(XtRule { table, chain, spec });
+    };
+
+    // Mark sandbox-originated packets so POSTROUTING (which cannot match the
+    // input interface) can select the right source identity.
+    rule(
+        "mangle",
+        "PREROUTING",
+        &["-i", tap],
+        &["-j", "MARK", "--set-mark", &mark],
+    );
+    // Mark to-sandbox packets from their pre-NAT destination; the fwmark fib
+    // rule then routes the DNAT'd destination out this TAP.
+    rule(
+        "mangle",
+        "PREROUTING",
+        &["-d", &pool],
+        &["-j", "MARK", "--set-mark", &mark],
+    );
+    rule(
+        "mangle",
+        "OUTPUT",
+        &["-d", &pool],
+        &["-j", "MARK", "--set-mark", &mark],
+    );
+    // External identity → fixed guest identity, both directions.
+    let guest_ip = GUEST_IP.to_string();
+    rule(
+        "nat",
+        "PREROUTING",
+        &["-d", &pool],
+        &["-j", "DNAT", "--to-destination", &guest_ip],
+    );
+    rule(
+        "nat",
+        "OUTPUT",
+        &["-d", &pool],
+        &["-j", "DNAT", "--to-destination", &guest_ip],
+    );
+    // Local services (DNS, relays) see the pool identity, and their replies
+    // are addressed to it — which is what makes them routable back out the
+    // right TAP (dst-based mark + fwmark table).
+    rule(
+        "nat",
+        "INPUT",
+        &["-i", tap],
+        &["-j", "SNAT", "--to-source", &pool_ip.to_string()],
+    );
+    // Forwarded sandbox-originated traffic. The source match is the
+    // definitive sandbox-origin signature at POSTROUTING (only pre-SNAT
+    // sandbox packets carry the fixed guest source); the mark picks which
+    // sandbox, keeping to-sandbox packets (marked with the same value but
+    // carrying a client source) out of this rewrite.
+    rule(
+        "nat",
+        "POSTROUTING",
+        &[
+            "-s",
+            &format!("{GUEST_IP}/32"),
+            "-m",
+            "mark",
+            "--mark",
+            &mark,
+        ],
+        &["-j", "SNAT", "--to-source", &pool_ip.to_string()],
+    );
+    rules
+}
+
+/// Install the per-TAP translation: sysctls, iptables rules, fwmark fib rule,
+/// and the per-sandbox table route. The TAP must already exist.
+#[cfg(target_os = "linux")]
+pub(crate) fn install(tap: &str, pool_ip: Ipv4Addr) -> Result<()> {
+    // rp_filter: the reverse lookup for the fixed guest source only resolves
+    // through the fwmark table, which strict mode consults solely when
+    // src_valid_mark is set. Write both so the invariant link stays up
+    // whatever the global rp_filter policy is.
+    write_tap_sysctl(tap, "rp_filter", "0")?;
+    write_tap_sysctl(tap, "src_valid_mark", "1")?;
+
+    for rule in translation_rules(tap, pool_ip) {
+        run_iptables(&rule, "-A", false)?;
+    }
+
+    let mark = fwmark(pool_ip);
+    // EEXIST tolerated: an identical rule surviving a crash is exactly what
+    // this add would create (specs derive from the allocation alone).
+    rtnetlink::execute(
+        &rtnetlink::new_fwmark_rule(mark, mark, FIB_RULE_PRIORITY),
+        &[libc::EEXIST],
+    )?;
+    rtnetlink::execute(
+        &rtnetlink::replace_link_route(GUEST_IP, tap_ifindex(tap)?, mark),
+        &[],
+    )?;
+    Ok(())
+}
+
+/// Remove the per-TAP translation, tolerating absence.
+///
+/// Also runs for legacy TAPs (which never had these rules) and for partially
+/// activated ones, so every miss is a no-op, not an error. The table route
+/// and sysctls die with the TAP device and need no explicit removal.
+#[cfg(target_os = "linux")]
+pub(crate) fn remove(tap: &str, pool_ip: Ipv4Addr) -> Result<()> {
+    let mut failures = Vec::new();
+    for rule in translation_rules(tap, pool_ip) {
+        if let Err(error) = run_iptables(&rule, "-D", true) {
+            failures.push(error.to_string());
+        }
+    }
+    let mark = fwmark(pool_ip);
+    if let Err(error) = rtnetlink::execute(
+        &rtnetlink::del_fwmark_rule(mark, mark, FIB_RULE_PRIORITY),
+        &[libc::ENOENT],
+    ) {
+        failures.push(error.to_string());
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(crate::error::VmmError::Network(format!(
+            "sandbox NAT teardown incomplete for {tap}: {}",
+            failures.join("; ")
+        )))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn write_tap_sysctl(tap: &str, key: &str, value: &str) -> Result<()> {
+    let path = format!("/proc/sys/net/ipv4/conf/{tap}/{key}");
+    std::fs::write(&path, value)
+        .map_err(|e| crate::error::VmmError::Network(format!("write {path}: {e}")))
+}
+
+#[cfg(target_os = "linux")]
+fn tap_ifindex(tap: &str) -> Result<u32> {
+    let name = std::ffi::CString::new(tap)
+        .map_err(|_| crate::error::VmmError::Network(format!("TAP name {tap:?} contains NUL")))?;
+    // SAFETY: name is a valid NUL-terminated string.
+    let index = unsafe { libc::if_nametoindex(name.as_ptr()) };
+    if index == 0 {
+        return Err(crate::error::VmmError::Network(format!(
+            "if_nametoindex {tap}: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(index)
+}
+
+/// Run one iptables verb on a rule. `tolerate_missing` treats exit status 1 —
+/// iptables-legacy's "no matching rule" — as success so teardown is
+/// idempotent; other failures (usage errors, the xtables lock timing out)
+/// still propagate.
+#[cfg(target_os = "linux")]
+fn run_iptables(rule: &XtRule, verb: &str, tolerate_missing: bool) -> Result<()> {
+    let output = std::process::Command::new("/sbin/iptables")
+        .args(["-w", "2", "-t", rule.table, verb, rule.chain])
+        .args(&rule.spec)
+        .output()
+        .map_err(|e| crate::error::VmmError::Network(format!("run iptables: {e}")))?;
+    if output.status.success() || (tolerate_missing && output.status.code() == Some(1)) {
+        return Ok(());
+    }
+    Err(crate::error::VmmError::Network(format!(
+        "iptables -t {} {verb} {} {}: {}",
+        rule.table,
+        rule.chain,
+        rule.spec.join(" "),
+        String::from_utf8_lossy(&output.stderr).trim()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constants_form_one_point_to_point_link() {
+        // /30: gateway and guest are the only hosts, in the same subnet.
+        let mask = u32::from(GUEST_NETMASK);
+        assert_eq!(mask.count_ones(), 30);
+        assert_eq!(
+            u32::from(GUEST_IP) & mask,
+            u32::from(GUEST_GATEWAY) & mask,
+            "guest and gateway must share the invariant subnet"
+        );
+        assert!(GUEST_IP.is_link_local());
+    }
+
+    #[test]
+    fn fwmark_is_unique_per_pool_ip() {
+        let a = fwmark("172.20.0.2".parse().unwrap());
+        let b = fwmark("172.20.0.3".parse().unwrap());
+        assert_ne!(a, b);
+        assert_ne!(a, 0, "a zero mark would match unmarked packets");
+    }
+
+    /// The rule specs are the NAT contract; pin them exactly so drift is loud.
+    #[test]
+    fn translation_rules_pin_the_nat_contract() {
+        let pool: Ipv4Addr = "172.20.0.2".parse().unwrap();
+        let rules = translation_rules("vmtap0-2", pool);
+        let rendered: Vec<String> = rules
+            .iter()
+            .map(|r| format!("-t {} {} {}", r.table, r.chain, r.spec.join(" ")))
+            .collect();
+        assert_eq!(
+            rendered,
+            [
+                "-t mangle PREROUTING -i vmtap0-2 -m comment --comment arcbox-nat -j MARK --set-mark 0xac140002",
+                "-t mangle PREROUTING -d 172.20.0.2/32 -m comment --comment arcbox-nat -j MARK --set-mark 0xac140002",
+                "-t mangle OUTPUT -d 172.20.0.2/32 -m comment --comment arcbox-nat -j MARK --set-mark 0xac140002",
+                "-t nat PREROUTING -d 172.20.0.2/32 -m comment --comment arcbox-nat -j DNAT --to-destination 169.254.100.2",
+                "-t nat OUTPUT -d 172.20.0.2/32 -m comment --comment arcbox-nat -j DNAT --to-destination 169.254.100.2",
+                "-t nat INPUT -i vmtap0-2 -m comment --comment arcbox-nat -j SNAT --to-source 172.20.0.2",
+                "-t nat POSTROUTING -s 169.254.100.2/32 -m mark --mark 0xac140002 -m comment --comment arcbox-nat -j SNAT --to-source 172.20.0.2",
+            ]
+        );
+    }
+
+    #[test]
+    fn snat_selection_never_rewrites_client_sources() {
+        // The POSTROUTING SNAT must be gated on the fixed guest source, not
+        // the mark alone: to-sandbox packets carry the same mark but a client
+        // source, and rewriting those would hide real client IPs from guests.
+        let rules = translation_rules("vmtap0-2", "172.20.0.2".parse().unwrap());
+        let postrouting = rules
+            .iter()
+            .find(|r| r.chain == "POSTROUTING")
+            .expect("POSTROUTING SNAT rule");
+        assert_eq!(postrouting.spec[0], "-s");
+        assert_eq!(postrouting.spec[1], format!("{GUEST_IP}/32"));
+    }
+}

--- a/virt/arcbox-vm/src/network/quarantine.rs
+++ b/virt/arcbox-vm/src/network/quarantine.rs
@@ -45,6 +45,10 @@ impl NetworkManager {
                 .insert(u32::from(alloc.ip_address));
         }
 
+        // Translation rules do not die with the device; remove them first
+        // (tolerant of absence, so legacy TAPs are a no-op).
+        #[cfg(target_os = "linux")]
+        super::invariant::remove(&alloc.tap_name, alloc.ip_address)?;
         #[cfg(target_os = "linux")]
         destroy_tap_checked(&alloc.tap_name)?;
         debug!(

--- a/virt/arcbox-vm/src/network/rtnetlink.rs
+++ b/virt/arcbox-vm/src/network/rtnetlink.rs
@@ -1,0 +1,305 @@
+//! Minimal rtnetlink encoding for the invariant-addressing plumbing.
+//!
+//! The System VM rootfs ships busybox `ip`, whose support for fwmark policy
+//! rules and >255 routing-table ids is build-dependent, so the two netlink
+//! operations the invariant scheme needs — a fwmark fib rule and a
+//! per-sandbox table route — are encoded and sent directly. rtnetlink is a
+//! stable kernel ABI; the encoders are pure and unit-tested, only the socket
+//! send is Linux-gated.
+
+use std::net::Ipv4Addr;
+
+// Message types.
+const NLMSG_ERROR: u16 = 2;
+const RTM_NEWROUTE: u16 = 24;
+const RTM_NEWRULE: u16 = 32;
+const RTM_DELRULE: u16 = 33;
+
+// nlmsghdr flags.
+const NLM_F_REQUEST: u16 = 0x1;
+const NLM_F_ACK: u16 = 0x4;
+const NLM_F_REPLACE: u16 = 0x100;
+const NLM_F_EXCL: u16 = 0x200;
+const NLM_F_CREATE: u16 = 0x400;
+
+// rtmsg / fib_rule_hdr field values.
+const AF_INET: u8 = 2;
+const RT_TABLE_UNSPEC: u8 = 0;
+const RTPROT_BOOT: u8 = 3;
+const RT_SCOPE_LINK: u8 = 253;
+const RTN_UNICAST: u8 = 1;
+const FR_ACT_TO_TBL: u8 = 1;
+
+// Route attributes.
+const RTA_DST: u16 = 1;
+const RTA_OIF: u16 = 4;
+const RTA_TABLE: u16 = 15;
+
+// Fib-rule attributes.
+const FRA_PRIORITY: u16 = 6;
+const FRA_FWMARK: u16 = 10;
+const FRA_TABLE: u16 = 15;
+
+const NLMSG_HDR_LEN: usize = 16;
+
+/// Incrementally builds one netlink request message.
+struct MessageBuilder {
+    buf: Vec<u8>,
+}
+
+impl MessageBuilder {
+    /// Start a message with the given type, flags, and 12-byte payload header
+    /// (`rtmsg` and `fib_rule_hdr` share that size).
+    fn new(msg_type: u16, flags: u16, header: [u8; 12]) -> Self {
+        let mut buf = Vec::with_capacity(64);
+        buf.extend_from_slice(&0u32.to_ne_bytes()); // len — patched in finish()
+        buf.extend_from_slice(&msg_type.to_ne_bytes());
+        buf.extend_from_slice(&(NLM_F_REQUEST | NLM_F_ACK | flags).to_ne_bytes());
+        buf.extend_from_slice(&1u32.to_ne_bytes()); // seq
+        buf.extend_from_slice(&0u32.to_ne_bytes()); // pid (kernel fills)
+        buf.extend_from_slice(&header);
+        Self { buf }
+    }
+
+    fn attr(&mut self, attr_type: u16, payload: &[u8]) {
+        let len = 4 + payload.len();
+        self.buf
+            .extend_from_slice(&u16::try_from(len).expect("attr fits u16").to_ne_bytes());
+        self.buf.extend_from_slice(&attr_type.to_ne_bytes());
+        self.buf.extend_from_slice(payload);
+        // Pad to 4-byte alignment.
+        self.buf.resize(self.buf.len().next_multiple_of(4), 0);
+    }
+
+    fn attr_u32(&mut self, attr_type: u16, value: u32) {
+        self.attr(attr_type, &value.to_ne_bytes());
+    }
+
+    fn finish(mut self) -> Vec<u8> {
+        let len = u32::try_from(self.buf.len()).expect("message fits u32");
+        self.buf[..4].copy_from_slice(&len.to_ne_bytes());
+        self.buf
+    }
+}
+
+fn fib_rule_header(table: u8, action: u8) -> [u8; 12] {
+    let mut header = [0u8; 12];
+    header[0] = AF_INET;
+    header[4] = table;
+    header[7] = action;
+    header
+}
+
+fn fwmark_rule(msg_type: u16, flags: u16, mark: u32, table: u32, priority: u32) -> Vec<u8> {
+    let mut msg = MessageBuilder::new(
+        msg_type,
+        flags,
+        fib_rule_header(RT_TABLE_UNSPEC, FR_ACT_TO_TBL),
+    );
+    msg.attr_u32(FRA_PRIORITY, priority);
+    msg.attr_u32(FRA_FWMARK, mark);
+    msg.attr_u32(FRA_TABLE, table);
+    msg.finish()
+}
+
+/// `ip rule add fwmark <mark> lookup <table> pref <priority>`.
+///
+/// `NLM_F_EXCL` makes a repeated add fail with `EEXIST` instead of stacking a
+/// duplicate rule; callers tolerate that errno for idempotency.
+pub(super) fn new_fwmark_rule(mark: u32, table: u32, priority: u32) -> Vec<u8> {
+    fwmark_rule(
+        RTM_NEWRULE,
+        NLM_F_CREATE | NLM_F_EXCL,
+        mark,
+        table,
+        priority,
+    )
+}
+
+/// `ip rule del fwmark <mark> lookup <table> pref <priority>`.
+pub(super) fn del_fwmark_rule(mark: u32, table: u32, priority: u32) -> Vec<u8> {
+    fwmark_rule(RTM_DELRULE, 0, mark, table, priority)
+}
+
+/// `ip route replace <dst>/32 dev <oif> table <table>` (onlink device route).
+pub(super) fn replace_link_route(dst: Ipv4Addr, oif: u32, table: u32) -> Vec<u8> {
+    let mut header = [0u8; 12];
+    header[0] = AF_INET;
+    header[1] = 32; // dst_len
+    header[4] = RT_TABLE_UNSPEC;
+    header[5] = RTPROT_BOOT;
+    header[6] = RT_SCOPE_LINK;
+    header[7] = RTN_UNICAST;
+    let mut msg = MessageBuilder::new(RTM_NEWROUTE, NLM_F_CREATE | NLM_F_REPLACE, header);
+    msg.attr_u32(RTA_TABLE, table);
+    msg.attr(RTA_DST, &dst.octets());
+    msg.attr_u32(RTA_OIF, oif);
+    msg.finish()
+}
+
+/// Send one request and wait for its ACK, tolerating the listed errnos.
+#[cfg(target_os = "linux")]
+pub(super) fn execute(message: &[u8], tolerated_errnos: &[i32]) -> crate::error::Result<()> {
+    use crate::error::VmmError;
+
+    // SAFETY: plain socket(2) call; result checked below.
+    let fd = unsafe {
+        libc::socket(
+            libc::AF_NETLINK,
+            libc::SOCK_RAW | libc::SOCK_CLOEXEC,
+            libc::NETLINK_ROUTE,
+        )
+    };
+    if fd < 0 {
+        return Err(VmmError::Network(format!(
+            "netlink socket: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    // SAFETY: fd is a freshly opened, owned socket.
+    let fd = unsafe { <std::os::fd::OwnedFd as std::os::fd::FromRawFd>::from_raw_fd(fd) };
+    let raw = std::os::fd::AsRawFd::as_raw_fd(&fd);
+
+    // SAFETY: message is a valid buffer; fd is a connected-less netlink socket
+    // (destination defaults to the kernel, pid 0).
+    let sent = unsafe { libc::send(raw, message.as_ptr().cast(), message.len(), 0) };
+    if sent != message.len().cast_signed() {
+        return Err(VmmError::Network(format!(
+            "netlink send: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+
+    let mut reply = [0u8; 4096];
+    // SAFETY: reply is a valid mutable buffer owned by this frame.
+    let received = unsafe { libc::recv(raw, reply.as_mut_ptr().cast(), reply.len(), 0) };
+    if received < 0 {
+        return Err(VmmError::Network(format!(
+            "netlink recv: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    match ack_errno(&reply[..received as usize]) {
+        Ok(0) => Ok(()),
+        Ok(errno) if tolerated_errnos.contains(&errno) => Ok(()),
+        Ok(errno) => Err(VmmError::Network(format!(
+            "netlink request failed: {}",
+            std::io::Error::from_raw_os_error(errno)
+        ))),
+        Err(reason) => Err(VmmError::Network(format!("netlink reply: {reason}"))),
+    }
+}
+
+/// Extract the errno from an `NLMSG_ERROR` ack (0 = success).
+fn ack_errno(reply: &[u8]) -> std::result::Result<i32, String> {
+    if reply.len() < NLMSG_HDR_LEN + 4 {
+        return Err(format!("truncated reply ({} bytes)", reply.len()));
+    }
+    let msg_type = u16::from_ne_bytes(reply[4..6].try_into().expect("length checked"));
+    if msg_type != NLMSG_ERROR {
+        return Err(format!("unexpected reply type {msg_type}"));
+    }
+    let negative_errno = i32::from_ne_bytes(
+        reply[NLMSG_HDR_LEN..NLMSG_HDR_LEN + 4]
+            .try_into()
+            .expect("length checked"),
+    );
+    Ok(-negative_errno)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse attributes out of a built message for shape assertions.
+    fn attrs(message: &[u8]) -> Vec<(u16, Vec<u8>)> {
+        let total = u32::from_ne_bytes(message[..4].try_into().unwrap()) as usize;
+        assert_eq!(total, message.len(), "nlmsghdr len must cover the message");
+        let mut offset = NLMSG_HDR_LEN + 12;
+        let mut parsed = vec![];
+        while offset < total {
+            let len = u16::from_ne_bytes(message[offset..offset + 2].try_into().unwrap()) as usize;
+            let ty = u16::from_ne_bytes(message[offset + 2..offset + 4].try_into().unwrap());
+            parsed.push((ty, message[offset + 4..offset + len].to_vec()));
+            offset += len.next_multiple_of(4);
+        }
+        parsed
+    }
+
+    fn msg_type_and_flags(message: &[u8]) -> (u16, u16) {
+        (
+            u16::from_ne_bytes(message[4..6].try_into().unwrap()),
+            u16::from_ne_bytes(message[6..8].try_into().unwrap()),
+        )
+    }
+
+    #[test]
+    fn fwmark_rule_carries_mark_table_and_priority() {
+        let msg = new_fwmark_rule(0xAC14_0002, 0xAC14_0002, 8000);
+        let (ty, flags) = msg_type_and_flags(&msg);
+        assert_eq!(ty, RTM_NEWRULE);
+        assert_eq!(
+            flags,
+            NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
+            "adds must be EXCL so retries surface EEXIST instead of stacking rules"
+        );
+        // fib_rule_hdr: family AF_INET, action FR_ACT_TO_TBL.
+        assert_eq!(msg[NLMSG_HDR_LEN], AF_INET);
+        assert_eq!(msg[NLMSG_HDR_LEN + 7], FR_ACT_TO_TBL);
+        assert_eq!(
+            attrs(&msg),
+            vec![
+                (FRA_PRIORITY, 8000u32.to_ne_bytes().to_vec()),
+                (FRA_FWMARK, 0xAC14_0002u32.to_ne_bytes().to_vec()),
+                (FRA_TABLE, 0xAC14_0002u32.to_ne_bytes().to_vec()),
+            ]
+        );
+    }
+
+    #[test]
+    fn rule_delete_mirrors_the_add() {
+        let add = new_fwmark_rule(7, 7, 8000);
+        let del = del_fwmark_rule(7, 7, 8000);
+        assert_eq!(msg_type_and_flags(&del).0, RTM_DELRULE);
+        assert_eq!(attrs(&add), attrs(&del), "delete must match the added rule");
+    }
+
+    #[test]
+    fn link_route_targets_the_device_in_the_sandbox_table() {
+        let msg = replace_link_route(Ipv4Addr::new(169, 254, 100, 2), 42, 0xAC14_0002);
+        let (ty, flags) = msg_type_and_flags(&msg);
+        assert_eq!(ty, RTM_NEWROUTE);
+        assert_eq!(
+            flags,
+            NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE
+        );
+        // rtmsg: family, /32 dst, link scope, unicast.
+        assert_eq!(msg[NLMSG_HDR_LEN], AF_INET);
+        assert_eq!(msg[NLMSG_HDR_LEN + 1], 32);
+        assert_eq!(msg[NLMSG_HDR_LEN + 6], RT_SCOPE_LINK);
+        assert_eq!(msg[NLMSG_HDR_LEN + 7], RTN_UNICAST);
+        assert_eq!(
+            attrs(&msg),
+            vec![
+                (RTA_TABLE, 0xAC14_0002u32.to_ne_bytes().to_vec()),
+                (RTA_DST, vec![169, 254, 100, 2]),
+                (RTA_OIF, 42u32.to_ne_bytes().to_vec()),
+            ]
+        );
+    }
+
+    #[test]
+    fn ack_errno_decodes_success_and_failure() {
+        // 20-byte NLMSG_ERROR: header + i32 negative errno.
+        let mut ok = vec![0u8; 20];
+        ok[..4].copy_from_slice(&20u32.to_ne_bytes());
+        ok[4..6].copy_from_slice(&NLMSG_ERROR.to_ne_bytes());
+        assert_eq!(ack_errno(&ok), Ok(0));
+
+        let mut eexist = ok.clone();
+        eexist[NLMSG_HDR_LEN..NLMSG_HDR_LEN + 4].copy_from_slice(&(-17i32).to_ne_bytes());
+        assert_eq!(ack_errno(&eexist), Ok(17));
+
+        assert!(ack_errno(&[0u8; 4]).is_err());
+    }
+}

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -263,8 +263,11 @@ impl SandboxManager {
         self.network.finalize_startup_cleanup(token)
     }
 
-    /// Return the active generation's IP and opaque cleanup token.
-    pub fn sandbox_network_identity(&self, id: &str) -> Result<(std::net::Ipv4Addr, String)> {
+    /// Return the active generation's network identity: the external pool IP
+    /// (what DNS, expose, and the API report), its opaque cleanup token, and
+    /// whether the guest runs the invariant addressing — which decides how
+    /// expose DNAT must target the sandbox (CORE-81).
+    pub fn sandbox_network_identity(&self, id: &str) -> Result<SandboxNetworkIdentity> {
         self.ensure_startup_cleanup_complete()?;
         let instance = self.get_instance(&id.to_owned())?;
         let instance = instance.lock().unwrap();
@@ -276,8 +279,26 @@ impl SandboxManager {
                 expected: "sandbox with an active network allocation".into(),
                 actual: instance.state.to_string(),
             })?;
-        Ok((allocation.ip_address, allocation.cleanup_token.clone()))
+        Ok(SandboxNetworkIdentity {
+            ip: allocation.ip_address,
+            cleanup_token: allocation.cleanup_token.clone(),
+            net_invariant: instance.net_invariant,
+        })
     }
+}
+
+/// A sandbox's network identity as seen by forwarding and DNS consumers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxNetworkIdentity {
+    /// External pool IP — the address the rest of the system keeps using.
+    pub ip: std::net::Ipv4Addr,
+    /// Opaque generation token carried through host cleanup finalization.
+    pub cleanup_token: String,
+    /// Whether the guest runs the fixed invariant addressing (CORE-81).
+    /// When set, DNAT toward the sandbox must target
+    /// [`crate::network::invariant::GUEST_IP`] with a companion fwmark rule;
+    /// legacy guests own the pool IP directly.
+    pub net_invariant: bool,
 }
 
 /// Validate a caller-supplied sandbox or snapshot id.

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -1057,14 +1057,18 @@ async fn do_boot(
     // Append static IP configuration to boot args so the kernel configures
     // eth0 before init runs.  The guest-side vm-agent parses this back via
     // `KernelIpParam::from_str` to derive the DNS nameserver.
-    let boot_args = if let Some(net) = net_alloc {
+    //
+    // Every sandbox boots the identical fixed identity (CORE-81): the pool
+    // IP stays a host-side property of the TAP, so snapshots taken from this
+    // guest are network-agnostic and restore with zero guest-side work.
+    let boot_args = if net_alloc.is_some() {
         if spec.boot_args.contains("ip=") {
             spec.boot_args.clone()
         } else {
             let ip_param = KernelIpParam {
-                client: net.ip_address,
-                gateway: net.gateway,
-                netmask: net.netmask(),
+                client: crate::network::invariant::GUEST_IP,
+                gateway: crate::network::invariant::GUEST_GATEWAY,
+                netmask: crate::network::invariant::GUEST_NETMASK,
             };
             format!("{} {ip_param}", spec.boot_args)
         }

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -371,7 +371,16 @@ impl SandboxManager {
             );
             super::reconcile::write_state_record(&vm_dir, &cleanup_record)?;
             if let Some(network) = &net_alloc {
-                self.network.activate(network)?;
+                // The restored guest keeps the addressing its snapshot baked:
+                // invariant snapshots pair with an invariant TAP (host-side
+                // NAT, no guest work); legacy snapshots keep the legacy TAP
+                // shape and are re-addressed over the reconfig RPC below.
+                let mode = if snap_meta.net_invariant {
+                    crate::network::TapMode::Invariant
+                } else {
+                    crate::network::TapMode::LegacySnapshot
+                };
+                self.network.activate(network, mode)?;
             }
             Ok(())
         })();

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -42,10 +42,11 @@ impl SandboxManager {
         labels: HashMap<String, String>,
     ) -> Result<CheckpointInfo> {
         // Verify state and capture the kernel/rootfs paths for jailer
-        // re-staging, plus the id the sandbox's chroot is actually keyed by
+        // re-staging, the id the sandbox's chroot is actually keyed by
         // — a sandbox restored from a pre-warmed pool slot lives in the
-        // slot's chroot, and FC resolves snapshot paths inside it.
-        let (kernel_path, rootfs_path, chroot_owner) = {
+        // slot's chroot, and FC resolves snapshot paths inside it — plus
+        // the guest's network addressing mode.
+        let (kernel_path, rootfs_path, chroot_owner, net_invariant) = {
             let instance = self.get_instance(sandbox_id)?;
             let inst = instance.lock().unwrap();
             if inst.state != SandboxState::Ready {
@@ -62,6 +63,7 @@ impl SandboxManager {
                 inst.pool_slot_id
                     .clone()
                     .unwrap_or_else(|| sandbox_id.clone()),
+                inst.net_invariant,
             )
         };
 
@@ -147,6 +149,7 @@ impl SandboxManager {
             parent_id: None,
             kernel_path: Some(kernel_path),
             rootfs_path: Some(rootfs_path),
+            net_invariant,
         })?;
 
         let snap_dir_path = meta
@@ -672,6 +675,14 @@ impl SandboxManager {
             let Some(ref net) = net_alloc else {
                 return Ok(());
             };
+            // Invariant-addressed snapshot: the guest already holds the fixed
+            // link-local identity and its resolv.conf already points at the
+            // fixed gateway; the fresh TAP carries the new pool IP host-side.
+            // Zero guest-side work (CORE-81). Legacy snapshots (flag absent /
+            // false) keep the reconfig RPC below.
+            if snap_meta.net_invariant {
+                return Ok(());
+            }
             let cmd = crate::boot_proto::NetReconfigCommand {
                 ip: net.ip_address,
                 netmask: net.netmask(),
@@ -769,6 +780,7 @@ impl SandboxManager {
             inst.vm = Some(vm);
             inst.vsock_uds_path = Some(actual_vsock_path);
             inst.cow_handle = pending_cow.take();
+            inst.net_invariant = snap_meta.net_invariant;
             inst.state = SandboxState::Ready;
             inst.ready_at = Some(Utc::now());
         }

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -123,7 +123,8 @@ impl SandboxManager {
             );
             super::reconcile::write_state_record(&vm_dir, &cleanup_record)?;
             if let Some(net) = &net_alloc {
-                self.network.activate(net)?;
+                self.network
+                    .activate(net, crate::network::TapMode::Invariant)?;
             }
 
             let outcome = SandboxProvisionOutcome {
@@ -188,6 +189,11 @@ impl SandboxManager {
         // Populate the reserved instance. Keep a Weak to identify this exact
         // generation when its TTL timer fires (see expire_sandbox).
         creating_instance.network.clone_from(&net_alloc);
+        // The boot bakes the invariant `ip=` identity unless the caller
+        // supplied an explicit ip= (see do_boot); record which one this guest
+        // runs so checkpoints carry the right restore contract.
+        creating_instance.net_invariant =
+            creating_instance.network.is_some() && !spec.boot_args.contains("ip=");
         let ttl_armed_for = Arc::downgrade(&arc);
 
         // Retain the boot task so force/TTL removal can cancel and join it

--- a/virt/arcbox-vm/src/sandbox/types.rs
+++ b/virt/arcbox-vm/src/sandbox/types.rs
@@ -160,6 +160,11 @@ pub struct SandboxInstance {
     /// names are keyed by. `None` for resources created under the
     /// sandbox's own id.
     pub(super) pool_slot_id: Option<String>,
+    /// Whether this guest runs the fixed invariant network identity
+    /// (CORE-81). Set by the create path when the boot bakes the invariant
+    /// `ip=` parameter, and inherited from [`crate::snapshot::SnapshotMeta`]
+    /// on restore so chained checkpoints record the guest's actual addressing.
+    pub(super) net_invariant: bool,
 }
 
 impl SandboxInstance {
@@ -209,6 +214,7 @@ impl SandboxInstance {
             error: None,
             cow_handle: None,
             pool_slot_id: None,
+            net_invariant: false,
         }
     }
 

--- a/virt/arcbox-vm/src/snapshot.rs
+++ b/virt/arcbox-vm/src/snapshot.rs
@@ -41,6 +41,13 @@ pub struct SnapshotMeta {
     /// Host-absolute rootfs path (required for jailer-mode restore staging).
     #[serde(default)]
     pub rootfs_path: Option<String>,
+    /// Whether the origin guest ran the fixed invariant network identity
+    /// (CORE-81): eth0 on the constant link-local address with the constant
+    /// gateway, external identity applied host-side per TAP. A restore of such
+    /// a snapshot needs zero guest-side network work. `serde(default)` so
+    /// legacy snapshots read back `false` and keep the reconfig-RPC path.
+    #[serde(default)]
+    pub net_invariant: bool,
 }
 
 /// Info returned to callers / gRPC layer.
@@ -145,6 +152,8 @@ pub struct SnapshotDraft {
     /// Host-absolute rootfs path (required for restore to rebuild the
     /// dm-snapshot origin).
     pub rootfs_path: Option<String>,
+    /// Whether the origin guest ran the invariant network identity (CORE-81).
+    pub net_invariant: bool,
 }
 
 /// A snapshot being written, not yet part of the catalog.
@@ -198,6 +207,7 @@ impl PendingSnapshot<'_> {
             parent_id: draft.parent_id,
             kernel_path: draft.kernel_path,
             rootfs_path: draft.rootfs_path,
+            net_invariant: draft.net_invariant,
         };
 
         sync_private_file(&staging.join(VMSTATE_FILE))?;
@@ -486,6 +496,7 @@ mod tests {
             parent_id: None,
             kernel_path: None,
             rootfs_path: None,
+            net_invariant: false,
         }
     }
 
@@ -578,6 +589,24 @@ mod tests {
         let listed = catalog.list("vm-1").unwrap();
         assert_eq!(listed.len(), 1, "pre-labels snapshot must still load");
         assert!(listed[0].labels.is_empty());
+        // Field absent on disk → legacy addressing → the reconfig-RPC restore
+        // path must stay selected.
+        assert!(!catalog.get("vm-1", "old-snap").unwrap().net_invariant);
+    }
+
+    #[test]
+    fn net_invariant_survives_the_catalog_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
+        let meta = publish(
+            &catalog,
+            "vm-1",
+            SnapshotDraft {
+                net_invariant: true,
+                ..draft()
+            },
+        );
+        assert!(catalog.get("vm-1", &meta.id).unwrap().net_invariant);
     }
 
     #[test]

--- a/virt/arcbox-vm/tests/integration.rs
+++ b/virt/arcbox-vm/tests/integration.rs
@@ -28,6 +28,7 @@ fn snapshot_catalog_persists_across_instances() {
                 parent_id: None,
                 kernel_path: None,
                 rootfs_path: None,
+                net_invariant: false,
             })
             .unwrap()
             .id


### PR DESCRIPTION
Stacked on #561 (← #560 ← #559 ← #558 ← master); merge in order. Part of CORE-81, project **Sandbox Cold Start**.

## What (4 commits)

Every sandbox guest now boots the identical link-local identity (`ip=169.254.100.2::169.254.100.1:255.255.255.252::eth0:off`); the pool IP the rest of the system sees is applied host-side, per TAP. Snapshots become network-agnostic: a `network_override` restore of an invariant snapshot needs **zero guest-side work** — the eth0-reconfig vsock RPC and its resolv rewrite are skipped entirely (the reconfig wiring stays for legacy snapshots, gated by a `net_invariant` flag in snapshot metadata, `serde(default)` so old metas read false; chained checkpoints record the guest's actual addressing).

Mechanism (chosen after surveying what the System VM actually ships — iptables-legacy 1.8.13 + busybox, no nftables, no NETMAP/CONNMARK in the kernel): per-TAP mark-from-pre-NAT-destination in mangle + DNAT to the fixed guest IP; SNAT back to the pool IP in nat INPUT (so DNS/relays keep seeing pool IPs) and POSTROUTING (mark-scoped, so real client IPs are never rewritten); post-DNAT routing via per-sandbox fwmark fib rule + table (mark = table = pool-ip u32) programmed over hand-rolled rtnetlink (busybox `ip` fwmark support is build-dependent). Expose DNAT targets the guest IP with a mangle MARK companion; boot rules gain an explicit vmtap→pool isolation drop pair, making the "sandboxes are deliberately isolated" claim enforced rather than incidental. vm-agent is untouched — it derives DNS from `ip=`, so resolv.conf is invariant automatically.

Also updates the sandbox smoke's fresh-net assertions to the new contract (guest carries the invariant IP; pool IPs never appear in-guest).

## Hardware-validated (full 5-layer stack, probe + smoke)

Pool-hit restores with the net RPC deleted: **best-case total 83–88 ms** (`spawn 17–22 + stage 0 + load 4 + guest_cfg ≈58` — guest_cfg is now the clock RPC alone); probe p50 128 ms with back-to-back-restore variance attributable to pool refill I/O racing the next resume (worst-case pattern; noted for CORE-78 follow-up). Full sandbox smoke green: both restore modes, expose, file I/O, docker template.

## Review notes / risks for reviewers

- rp_filter interplay handled via `src_valid_mark`; mangle LOCAL_OUT reroute-on-mark and LOCAL_IN SNAT are standard kernel semantics but called out for scrutiny.
- A sandbox reaching its own pool IP now drops (previously looped in-guest); sandbox↔sandbox via pool IPs is explicitly dead — both aligned with the isolation contract but observable changes.
- kube-proxy mark bits collide only beyond ~16k concurrent sandboxes (documented at the fwmark helper).

## Validation

151 arcbox-vm tests green (new: exact NAT rule argv pinning, rtnetlink encodings, snapshot serde compat, expose both-halves removal, sweep matching); clippy clean host + musl (zero new warnings on arcbox-agent's changed lines); fmt clean.