### PR TITLE
feat(sandbox): implement pause/resume + daemon-side auto-resume (CORE-21)

### DIFF
--- a/app/arcbox-api/src/connect/control.rs
+++ b/app/arcbox-api/src/connect/control.rs
@@ -19,6 +19,7 @@ use crate::ApiError;
 
 use super::sandbox_cleanup;
 use super::sandbox_locks::SandboxOperationLocks;
+use super::sandbox_resume;
 use super::{ConnectRuntimeExt as _, ContextExt as _, protocol_key, wire_protocol, with_keepalive};
 
 /// Sandbox lifecycle service implementation.
@@ -138,27 +139,58 @@ impl pb::SandboxService for SandboxServiceImpl {
         Response::ok(Empty::default())
     }
 
-    /// Contract-only stub (CORE-58 phase 1): pause/auto-pause lands with
-    /// CORE-21.
+    /// Pause: checkpoint in the guest, release the VM, then complete the
+    /// host half of the network release — the guest quarantines the TAP+IP
+    /// exactly like Stop and hands back the same durable cleanup ticket
+    /// (which also drops the sandbox's host DNS entry).
     async fn pause(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::PauseSandboxRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::PauseSandboxRequest>,
     ) -> ServiceResult<Empty> {
-        Err(ConnectError::unimplemented(
-            "sandbox pause is not implemented yet (CORE-21)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let sandbox_id = req.id.clone();
+        let _operation = self.operations.lock(&machine, &sandbox_id).await;
+        let runtime = self.runtime.ready()?;
+        let mut agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
+        // Same reason as create/stop/remove: a failed lifecycle mutation must
+        // reach the daemon log on its own, not only the caller (CORE-82).
+        let response = agent
+            .sandbox_pause(req)
+            .await
+            .inspect_err(|error| {
+                tracing::warn!(machine = %machine, sandbox_id = %sandbox_id, %error, "sandbox pause failed");
+            })
+            .map_err(ApiError::from)?;
+        if let Some(ticket) = response.ticket.as_option() {
+            sandbox_cleanup::complete(runtime, &mut agent, ticket)
+                .await
+                .map_err(ApiError::from)?;
+        }
+
+        Response::ok(Empty::default())
     }
 
-    /// Contract-only stub (CORE-58 phase 1): resume lands with CORE-21.
+    /// Explicit resume; data-plane RPCs resume transparently through the
+    /// same routine (`sandbox_resume`), differing only in the event reason.
     async fn resume(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::ResumeSandboxRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::ResumeSandboxRequest>,
     ) -> ServiceResult<Empty> {
-        Err(ConnectError::unimplemented(
-            "sandbox resume is not implemented yet (CORE-21)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let runtime = self.runtime.ready()?;
+        sandbox_resume::resume(
+            runtime,
+            &self.operations,
+            &machine,
+            &req.id,
+            sandbox_resume::REASON_RESUME,
+        )
+        .await?;
+        Response::ok(Empty::default())
     }
 
     /// Contract-only stub (CORE-58 phase 1): the TTL wire-up lands with

--- a/app/arcbox-api/src/connect/filesystem.rs
+++ b/app/arcbox-api/src/connect/filesystem.rs
@@ -1,5 +1,7 @@
 //! Sandbox filesystem service — data plane.
 
+use std::sync::Arc;
+
 use arcbox_connect::sandbox_v1 as pb;
 use arcbox_connect::sandbox_v1::{FileChunk, write_file_request};
 use buffa_types::google::protobuf::Empty;
@@ -15,21 +17,29 @@ use arcbox_core::WriteFileChunk;
 use super::SharedRuntime;
 use crate::ApiError;
 
+use super::sandbox_locks::SandboxOperationLocks;
+use super::sandbox_resume;
 use super::{ConnectRuntimeExt as _, ContextExt as _, with_keepalive};
 
 /// Filesystem service implementation.
 ///
 /// Carries file bytes for one sandbox, so it belongs with the data plane
-/// rather than the control-plane front door.
+/// rather than the control-plane front door — and, like the rest of the
+/// data plane, it transparently resumes a paused sandbox (CORE-21) unless
+/// the caller set `x-arcbox-no-auto-resume`.
 pub struct SandboxFilesystemServiceImpl {
     runtime: SharedRuntime,
+    operations: Arc<SandboxOperationLocks>,
 }
 
 impl SandboxFilesystemServiceImpl {
     /// Creates a new filesystem service with a deferred runtime.
     #[must_use]
-    pub fn new(runtime: SharedRuntime) -> Self {
-        Self { runtime }
+    pub(super) fn new(runtime: SharedRuntime, operations: Arc<SandboxOperationLocks>) -> Self {
+        Self {
+            runtime,
+            operations,
+        }
     }
 }
 
@@ -46,17 +56,40 @@ impl pb::SandboxFilesystemService for SandboxFilesystemServiceImpl {
         request: ServiceRequest<'_, pb::ReadFileRequest>,
     ) -> ServiceResult<ServiceStream<FileChunk>> {
         let machine = ctx.sandbox_machine_id()?;
-        let agent = self
-            .runtime
-            .ready()?
-            .get_agent(&machine)
-            .map_err(ApiError::from)?;
-        let rx = agent
-            .sandbox_read_file(request.to_owned_message())
+        let req = request.to_owned_message();
+        let runtime = self.runtime.ready()?;
+
+        // Optimistic first attempt. The guest's verdict arrives as the first
+        // stream frame, so peek it: a SANDBOX_PAUSED answer becomes one
+        // resume + one fresh read instead of an in-stream error.
+        let agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
+        let mut rx = agent
+            .sandbox_read_file(req.clone())
             .await
             .map_err(ApiError::from)?;
-        let stream =
-            ReceiverStream::new(rx).map(|r| r.map_err(|e| ConnectError::from(ApiError::from(e))));
+        let first = match rx.recv().await {
+            Some(Err(error)) if sandbox_resume::is_sandbox_paused(&error) => {
+                if sandbox_resume::auto_resume_opted_out(&ctx) {
+                    return Err(ConnectError::from(ApiError::from(error)));
+                }
+                sandbox_resume::resume(
+                    runtime,
+                    &self.operations,
+                    &machine,
+                    &req.id,
+                    sandbox_resume::REASON_AUTO_RESUME,
+                )
+                .await?;
+                let agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
+                rx = agent.sandbox_read_file(req).await.map_err(ApiError::from)?;
+                rx.recv().await
+            }
+            other => other,
+        };
+
+        let stream = tokio_stream::iter(first)
+            .chain(ReceiverStream::new(rx))
+            .map(|r| r.map_err(|e| ConnectError::from(ApiError::from(e))));
         // Keepalives are empty non-final chunks, as documented in the proto.
         let stream = with_keepalive(stream, FileChunk::default);
         Response::ok(Box::pin(stream))
@@ -68,11 +101,7 @@ impl pb::SandboxFilesystemService for SandboxFilesystemServiceImpl {
         mut requests: InboundStream<pb::WriteFileRequest>,
     ) -> ServiceResult<Empty> {
         let machine = ctx.sandbox_machine_id()?;
-        let agent = self
-            .runtime
-            .ready()?
-            .get_agent(&machine)
-            .map_err(ApiError::from)?;
+        let runtime = self.runtime.ready()?;
 
         // The first message in the stream must carry the Open payload.
         let first = requests.next().await.ok_or_else(|| {
@@ -86,6 +115,18 @@ impl pb::SandboxFilesystemService for SandboxFilesystemServiceImpl {
                 ));
             }
         };
+
+        // A paused sandbox must be handled before any chunk is consumed —
+        // the input stream cannot be replayed for a retry.
+        sandbox_resume::ensure_resumed_for_write(
+            runtime,
+            &self.operations,
+            &ctx,
+            &machine,
+            &open.id,
+        )
+        .await?;
+        let agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
 
         // Bridge Connect chunks into the agent write stream. A clean end (the
         // client's `done` chunk) closes the channel, which triggers the

--- a/app/arcbox-api/src/connect/mod.rs
+++ b/app/arcbox-api/src/connect/mod.rs
@@ -33,6 +33,7 @@ mod migration;
 mod process;
 mod sandbox_cleanup;
 mod sandbox_locks;
+mod sandbox_resume;
 mod snapshot;
 mod stats;
 mod system;
@@ -215,8 +216,14 @@ pub fn router(runtime: SharedRuntime) -> connectrpc::Router {
             clone(),
             Arc::clone(&sandbox_operations),
         )))
-        .add_service(Arc::new(SandboxProcessServiceImpl::new(clone())))
-        .add_service(Arc::new(SandboxFilesystemServiceImpl::new(clone())))
+        .add_service(Arc::new(SandboxProcessServiceImpl::new(
+            clone(),
+            Arc::clone(&sandbox_operations),
+        )))
+        .add_service(Arc::new(SandboxFilesystemServiceImpl::new(
+            clone(),
+            Arc::clone(&sandbox_operations),
+        )))
         .add_service(Arc::new(SandboxSnapshotServiceImpl::new(
             clone(),
             Arc::clone(&sandbox_operations),

--- a/app/arcbox-api/src/connect/process.rs
+++ b/app/arcbox-api/src/connect/process.rs
@@ -1,5 +1,7 @@
 //! Sandbox process (execution) service — data plane.
 
+use std::sync::Arc;
+
 use arcbox_connect::sandbox_v1 as pb;
 use arcbox_connect::sandbox_v1::{ExecutionEvent, KeepAlive, execution_event};
 use buffa_types::google::protobuf::Empty;
@@ -13,6 +15,8 @@ use tokio_stream::wrappers::ReceiverStream;
 use super::SharedRuntime;
 use crate::ApiError;
 
+use super::sandbox_locks::SandboxOperationLocks;
+use super::sandbox_resume;
 use super::{ConnectRuntimeExt as _, ContextExt as _, with_keepalive};
 
 /// Execution service implementation.
@@ -21,15 +25,25 @@ use super::{ConnectRuntimeExt as _, ContextExt as _, with_keepalive};
 /// stdio, so this is the half a cloud deployment serves from whatever is
 /// co-located with the sandbox rather than from the control-plane front
 /// door.
+///
+/// Data-plane calls transparently resume a paused sandbox (CORE-21): a
+/// guest answer of SANDBOX_PAUSED triggers one shared resume and one retry,
+/// unless the caller opted out via `x-arcbox-no-auto-resume`. Calls that
+/// address execution *history* (attach, wait, stdin status, signal, resize)
+/// are served from the guest's registry without waking the sandbox.
 pub struct SandboxProcessServiceImpl {
     runtime: SharedRuntime,
+    operations: Arc<SandboxOperationLocks>,
 }
 
 impl SandboxProcessServiceImpl {
     /// Creates a new execution service with a deferred runtime.
     #[must_use]
-    pub fn new(runtime: SharedRuntime) -> Self {
-        Self { runtime }
+    pub(super) fn new(runtime: SharedRuntime, operations: Arc<SandboxOperationLocks>) -> Self {
+        Self {
+            runtime,
+            operations,
+        }
     }
 }
 
@@ -46,15 +60,23 @@ impl pb::SandboxProcessService for SandboxProcessServiceImpl {
         request: ServiceRequest<'_, pb::StartExecutionRequest>,
     ) -> ServiceResult<pb::Execution> {
         let machine = ctx.sandbox_machine_id()?;
-        let mut agent = self
-            .runtime
-            .ready()?
-            .get_agent(&machine)
-            .map_err(ApiError::from)?;
-        let execution = agent
-            .sandbox_exec_start(request.to_owned_message())
-            .await
-            .map_err(ApiError::from)?;
+        let req = request.to_owned_message();
+        let runtime = self.runtime.ready()?;
+        let execution = sandbox_resume::with_auto_resume(
+            runtime,
+            &self.operations,
+            &ctx,
+            &machine,
+            &req.sandbox_id,
+            || {
+                let req = req.clone();
+                async {
+                    let mut agent = runtime.get_agent(&machine)?;
+                    agent.sandbox_exec_start(req).await
+                }
+            },
+        )
+        .await?;
         Response::ok(execution)
     }
 
@@ -88,15 +110,23 @@ impl pb::SandboxProcessService for SandboxProcessServiceImpl {
         request: ServiceRequest<'_, pb::WriteStdinRequest>,
     ) -> ServiceResult<pb::StdinStatus> {
         let machine = ctx.sandbox_machine_id()?;
-        let mut agent = self
-            .runtime
-            .ready()?
-            .get_agent(&machine)
-            .map_err(ApiError::from)?;
-        let status = agent
-            .sandbox_stdin_write(request.to_owned_message())
-            .await
-            .map_err(ApiError::from)?;
+        let req = request.to_owned_message();
+        let runtime = self.runtime.ready()?;
+        let status = sandbox_resume::with_auto_resume(
+            runtime,
+            &self.operations,
+            &ctx,
+            &machine,
+            &req.sandbox_id,
+            || {
+                let req = req.clone();
+                async {
+                    let mut agent = runtime.get_agent(&machine)?;
+                    agent.sandbox_stdin_write(req).await
+                }
+            },
+        )
+        .await?;
         Response::ok(status)
     }
 
@@ -113,17 +143,23 @@ impl pb::SandboxProcessService for SandboxProcessServiceImpl {
             // truncated body), so it must fail the RPC rather than be read
             // as a clean finish — only `None` means the client is done.
             let req = item?.to_owned_message();
-            let mut agent = self
-                .runtime
-                .ready()?
-                .get_agent(&machine)
-                .map_err(ApiError::from)?;
-            last = Some(
-                agent
-                    .sandbox_stdin_write(req)
-                    .await
-                    .map_err(ApiError::from)?,
-            );
+            let runtime = self.runtime.ready()?;
+            let status = sandbox_resume::with_auto_resume(
+                runtime,
+                &self.operations,
+                &ctx,
+                &machine,
+                &req.sandbox_id,
+                || {
+                    let req = req.clone();
+                    async {
+                        let mut agent = runtime.get_agent(&machine)?;
+                        agent.sandbox_stdin_write(req).await
+                    }
+                },
+            )
+            .await?;
+            last = Some(status);
         }
         let last = last
             .ok_or_else(|| ConnectError::invalid_argument("stream_stdin: empty request stream"))?;

--- a/app/arcbox-api/src/connect/sandbox_resume.rs
+++ b/app/arcbox-api/src/connect/sandbox_resume.rs
@@ -1,0 +1,212 @@
+//! Daemon-side transparent resume for paused sandboxes (CORE-21).
+//!
+//! Data-plane RPCs (executions, files) targeting a PAUSED sandbox resume it
+//! before proceeding, so clients see a latency blip instead of an error.
+//! The guest signals "paused" with the dedicated wire code 423
+//! (`SandboxError::SandboxPaused`); callers opt out with the reserved
+//! `x-arcbox-no-auto-resume` request header and receive the honest
+//! `FAILED_PRECONDITION` carrying the `SANDBOX_PAUSED` `ErrorInfo` detail.
+//! `Inspect`/`List` never resume.
+//!
+//! Concurrent auto-resumes share one resume by construction: the per-sandbox
+//! operation lock serializes them and the guest's Resume is idempotent, so
+//! every follower no-ops against the already-resumed sandbox.
+
+use std::sync::Arc;
+
+use arcbox_connect::v1::SandboxResumeCommand;
+use arcbox_core::{CoreError, Runtime};
+use connectrpc::{ConnectError, RequestContext};
+
+use super::sandbox_cleanup;
+use super::sandbox_locks::SandboxOperationLocks;
+use crate::ApiError;
+
+/// Reserved request header opting out of transparent resume.
+pub(super) const NO_AUTO_RESUME_HEADER: &str = "x-arcbox-no-auto-resume";
+
+/// Wire code the guest agent answers for a paused sandbox
+/// (`SandboxError::SandboxPaused`; see `guest/arcbox-agent/src/error.rs`).
+pub(super) const SANDBOX_PAUSED_WIRE_CODE: i32 = 423;
+
+/// Resume reasons, surfaced verbatim as the RESUMED event's "reason"
+/// attribute. The value vocabulary is defined on `SandboxResumeCommand`
+/// (`agent.proto`).
+pub(super) const REASON_RESUME: &str = "resume";
+pub(super) const REASON_AUTO_RESUME: &str = "auto_resume";
+
+/// True when this agent error means "the sandbox is paused".
+pub(super) fn is_sandbox_paused(error: &CoreError) -> bool {
+    matches!(
+        error,
+        CoreError::Agent {
+            code: SANDBOX_PAUSED_WIRE_CODE,
+            ..
+        }
+    )
+}
+
+/// True when the caller opted out of transparent resume.
+///
+/// The documented form is `x-arcbox-no-auto-resume: 1`; any value except an
+/// explicit off ("", "0", "false") opts out, so a client that sets the
+/// header at all gets the honest state machine.
+pub(super) fn auto_resume_opted_out(ctx: &RequestContext) -> bool {
+    ctx.header(NO_AUTO_RESUME_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| !matches!(value, "" | "0" | "false"))
+}
+
+/// Resume `sandbox_id` on `machine` and re-register its host DNS entry.
+///
+/// Shared by the explicit `SandboxService.Resume` handler and the
+/// data-plane auto-resume; only `reason` differs. Mirrors Create's DNS
+/// discipline: the fresh IP is registered only after confirming it still
+/// names the live sandbox under the host-state lock.
+pub(super) async fn resume(
+    runtime: &Arc<Runtime>,
+    operations: &SandboxOperationLocks,
+    machine: &str,
+    sandbox_id: &str,
+    reason: &str,
+) -> Result<(), ConnectError> {
+    let _operation = operations.lock(machine, sandbox_id).await;
+    let mut agent = runtime
+        .get_agent(machine)
+        .map_err(|e| ConnectError::from(ApiError::from(e)))?;
+    let resumed = agent
+        .sandbox_resume(SandboxResumeCommand {
+            id: sandbox_id.to_owned(),
+            reason: reason.to_owned(),
+            ..Default::default()
+        })
+        .await
+        // Same reason as create/stop/remove/pause: a failed lifecycle
+        // mutation must reach the daemon log on its own (CORE-82). It matters
+        // more here — an auto-resume has no caller expecting a Resume RPC, so
+        // the failure would otherwise surface only as the data-plane error.
+        .inspect_err(|error| {
+            tracing::warn!(machine, sandbox_id, reason, %error, "sandbox resume failed");
+        })
+        .map_err(|e| ConnectError::from(ApiError::from(e)))?;
+
+    let _host_state = runtime.lock_sandbox_host_state().await;
+    if let Ok(ip) = resumed.ip_address.parse()
+        && sandbox_cleanup::live_sandbox_matches(runtime, machine, sandbox_id, ip).await
+    {
+        runtime.register_sandbox_dns(sandbox_id, ip).await;
+    }
+    Ok(())
+}
+
+/// Run a data-plane call, transparently resuming a paused sandbox once.
+///
+/// The call is optimistic: nothing is added to the hot path until the guest
+/// answers SANDBOX_PAUSED, and then exactly one resume + one retry happen.
+pub(super) async fn with_auto_resume<T, F, Fut>(
+    runtime: &Arc<Runtime>,
+    operations: &SandboxOperationLocks,
+    ctx: &RequestContext,
+    machine: &str,
+    sandbox_id: &str,
+    call: F,
+) -> Result<T, ConnectError>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, CoreError>>,
+{
+    match call().await {
+        Ok(value) => Ok(value),
+        Err(error) if is_sandbox_paused(&error) => {
+            if auto_resume_opted_out(ctx) {
+                return Err(ConnectError::from(ApiError::from(error)));
+            }
+            resume(runtime, operations, machine, sandbox_id, REASON_AUTO_RESUME).await?;
+            call()
+                .await
+                .map_err(|e| ConnectError::from(ApiError::from(e)))
+        }
+        Err(error) => Err(ConnectError::from(ApiError::from(error))),
+    }
+}
+
+/// Pre-flight for client-streaming writes.
+///
+/// `WriteFile` consumes its input stream before the guest's verdict comes
+/// back, so a paused sandbox cannot be handled by retrying the call — the
+/// bytes are gone. Instead the sandbox's state is checked up front and a
+/// paused one is resumed (or refused, honoring the opt-out header) before
+/// any chunk is bridged.
+pub(super) async fn ensure_resumed_for_write(
+    runtime: &Arc<Runtime>,
+    operations: &SandboxOperationLocks,
+    ctx: &RequestContext,
+    machine: &str,
+    sandbox_id: &str,
+) -> Result<(), ConnectError> {
+    use arcbox_connect::sandbox_v1::{InspectSandboxRequest, SandboxState};
+
+    let mut agent = runtime
+        .get_agent(machine)
+        .map_err(|e| ConnectError::from(ApiError::from(e)))?;
+    let info = agent
+        .sandbox_inspect(InspectSandboxRequest {
+            id: sandbox_id.to_owned(),
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| ConnectError::from(ApiError::from(e)))?;
+    // Pausing counts too: the guest serializes on its per-sandbox operation
+    // lock, so the resume below simply waits for the pause to finish.
+    if matches!(
+        info.state.as_known(),
+        Some(SandboxState::Paused | SandboxState::Pausing)
+    ) {
+        if auto_resume_opted_out(ctx) {
+            return Err(ConnectError::from(ApiError::from(CoreError::Agent {
+                code: SANDBOX_PAUSED_WIRE_CODE,
+                message: format!("sandbox '{sandbox_id}' is paused"),
+            })));
+        }
+        resume(runtime, operations, machine, sandbox_id, REASON_AUTO_RESUME).await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx_with_header(value: Option<&str>) -> RequestContext {
+        let mut headers = http::HeaderMap::new();
+        if let Some(value) = value {
+            headers.insert(NO_AUTO_RESUME_HEADER, value.parse().unwrap());
+        }
+        RequestContext::new(headers)
+    }
+
+    #[test]
+    fn only_the_paused_wire_code_triggers_auto_resume() {
+        assert!(is_sandbox_paused(&CoreError::Agent {
+            code: 423,
+            message: "sandbox 'box' is paused".into(),
+        }));
+        for code in [400, 404, 409, 412, 416, 500, 503] {
+            assert!(!is_sandbox_paused(&CoreError::Agent {
+                code,
+                message: "other".into(),
+            }));
+        }
+        assert!(!is_sandbox_paused(&CoreError::Machine("dead vsock".into())));
+    }
+
+    #[test]
+    fn opt_out_header_is_presence_with_explicit_off_values() {
+        assert!(!auto_resume_opted_out(&ctx_with_header(None)));
+        assert!(!auto_resume_opted_out(&ctx_with_header(Some(""))));
+        assert!(!auto_resume_opted_out(&ctx_with_header(Some("0"))));
+        assert!(!auto_resume_opted_out(&ctx_with_header(Some("false"))));
+        assert!(auto_resume_opted_out(&ctx_with_header(Some("1"))));
+        assert!(auto_resume_opted_out(&ctx_with_header(Some("true"))));
+    }
+}

--- a/app/arcbox-api/src/error.rs
+++ b/app/arcbox-api/src/error.rs
@@ -60,6 +60,15 @@ impl From<ApiError> for connectrpc::ConnectError {
                 412 => ErrorCode::FailedPrecondition,
                 // Stdin offset gap: the client resyncs via GetStdinStatus.
                 416 => ErrorCode::OutOfRange,
+                // Paused sandbox surfaced without a transparent resume
+                // (control-plane call, or the caller opted out): a
+                // FAILED_PRECONDITION carrying the machine-readable
+                // SANDBOX_PAUSED detail (CORE-21).
+                423 => {
+                    let mut error = Self::new(ErrorCode::FailedPrecondition, message);
+                    error.details.push(sandbox_paused_detail());
+                    return error;
+                }
                 503 => ErrorCode::Unavailable,
                 _ => ErrorCode::Internal,
             },
@@ -67,6 +76,20 @@ impl From<ApiError> for connectrpc::ConnectError {
         };
         Self::new(code, message)
     }
+}
+
+/// The `SANDBOX_PAUSED` `ErrorInfo` Connect error detail (`errors.proto`).
+fn sandbox_paused_detail() -> connectrpc::ErrorDetail {
+    use arcbox_connect::sandbox_v1 as pb;
+
+    let info = pb::ErrorInfo {
+        code: pb::ErrorCode::SandboxPaused.into(),
+        suggestion: "resume the sandbox (`abctl sandbox resume <id>`), or retry \
+                     the data-plane call without `x-arcbox-no-auto-resume`"
+            .into(),
+        ..Default::default()
+    };
+    connectrpc::ErrorDetail::from_message("arcbox.sandbox.v1.ErrorInfo", &info)
 }
 
 impl ApiError {

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -17,10 +17,10 @@ use arcbox_connect::sandbox_v1::{
     AttachExecutionRequest, CheckpointRequest, CheckpointResponse, CreateSandboxRequest,
     CreateSandboxResponse, DeleteSnapshotRequest, Execution, ExecutionEvent, FileChunk,
     GetStdinStatusRequest, InspectSandboxRequest, ListSandboxesRequest, ListSandboxesResponse,
-    ListSnapshotsRequest, ListSnapshotsResponse, ReadFileRequest, RemoveSandboxRequest,
-    ResizeExecutionTtyRequest, RestoreRequest, RestoreResponse, SandboxEvent, SandboxEventsRequest,
-    SandboxInfo, SignalExecutionRequest, StartExecutionRequest, StdinStatus, StopSandboxRequest,
-    WaitExecutionRequest, WriteFileOpen, WriteStdinRequest, execution_event,
+    ListSnapshotsRequest, ListSnapshotsResponse, PauseSandboxRequest, ReadFileRequest,
+    RemoveSandboxRequest, ResizeExecutionTtyRequest, RestoreRequest, RestoreResponse, SandboxEvent,
+    SandboxEventsRequest, SandboxInfo, SignalExecutionRequest, StartExecutionRequest, StdinStatus,
+    StopSandboxRequest, WaitExecutionRequest, WriteFileOpen, WriteStdinRequest, execution_event,
 };
 use arcbox_connect::v1::{
     AgentPingRequest as PingRequest, AgentPingResponse as PingResponse, ContainerFsPathsRequest,
@@ -33,8 +33,9 @@ use arcbox_connect::v1::{
     MmapReadFileResponse, ReadinessEvent, RuntimeEnsureRequest, RuntimeEnsureResponse,
     RuntimeStatusRequest, RuntimeStatusResponse, SandboxCleanupResponse, SandboxCleanupTicket,
     SandboxPortForwardRemoveRequest, SandboxPortForwardRequest, SandboxPortForwardResponse,
-    SystemInfo, TerminalSize, WatchMemoryPressureRequest, WatchReadinessRequest,
-    WatchSandboxCleanupRequest, WatchStatsRequest,
+    SandboxResumeCommand, SandboxResumeResponse, SystemInfo, TerminalSize,
+    WatchMemoryPressureRequest, WatchReadinessRequest, WatchSandboxCleanupRequest,
+    WatchStatsRequest,
 };
 use arcbox_constants::ports::AGENT_PORT;
 use arcbox_constants::wire::MessageType;
@@ -1094,6 +1095,49 @@ impl AgentClient {
             MessageType::SandboxStopRequest,
             &payload,
             MessageType::SandboxStopResponse,
+        )
+        .await
+    }
+
+    /// Pauses a sandbox in the guest VM (checkpoint + release; CORE-21).
+    ///
+    /// Answers with the same durable network-cleanup ticket a Stop does —
+    /// pause quarantines the sandbox's TAP + IP for host-side cleanup.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_pause(
+        &mut self,
+        req: PauseSandboxRequest,
+    ) -> Result<SandboxCleanupResponse> {
+        let payload = req.encode_to_vec();
+        self.unary_rpc(
+            MessageType::SandboxPauseRequest,
+            &payload,
+            MessageType::SandboxPauseResponse,
+        )
+        .await
+    }
+
+    /// Resumes a paused sandbox in place (CORE-21).
+    ///
+    /// `req.reason` distinguishes an explicit Resume from the daemon's
+    /// transparent auto-resume; the guest surfaces it on the RESUMED event.
+    /// The response carries the fresh IP for host DNS re-registration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_resume(
+        &mut self,
+        req: SandboxResumeCommand,
+    ) -> Result<SandboxResumeResponse> {
+        let payload = req.encode_to_vec();
+        self.unary_rpc(
+            MessageType::SandboxResumeRequest,
+            &payload,
+            MessageType::SandboxResumeResponse,
         )
         .await
     }

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -131,6 +131,18 @@ pub enum MessageType {
     SandboxListSnapshotsRequest = 0x0042,
     SandboxDeleteSnapshotRequest = 0x0043,
 
+    // Sandbox pause/resume request types (0x0044 - 0x0045), CORE-21.
+    /// Pause a sandbox: checkpoint, then release its VM while keeping the
+    /// record and disk under the same id (payload:
+    /// `arcbox.sandbox.v1.PauseSandboxRequest`). Answered with
+    /// [`Self::SandboxPauseResponse`].
+    SandboxPauseRequest = 0x0044,
+    /// Resume a paused sandbox in place (payload:
+    /// `arcbox.v1.SandboxResumeCommand`, which carries the resume reason
+    /// the RESUMED event surfaces). Answered with
+    /// [`Self::SandboxResumeResponse`].
+    SandboxResumeRequest = 0x0045,
+
     // Sandbox execution request types (0x0060 - 0x0066), from the
     // execution redesign (CORE-55/56).
     /// Start an addressable execution (payload:
@@ -228,6 +240,13 @@ pub enum MessageType {
     SandboxCleanupFinalizeResponse = 0x1028,
     /// One durable cleanup ticket answering [`Self::WatchSandboxCleanupRequest`].
     SandboxCleanupEvent = 0x1029,
+    /// Answers [`Self::SandboxPauseRequest`] (payload:
+    /// `arcbox.v1.SandboxCleanupResponse` — pause quarantines the network
+    /// like Stop, so it hands back the same durable cleanup ticket).
+    SandboxPauseResponse = 0x1044,
+    /// Answers [`Self::SandboxResumeRequest`] (payload:
+    /// `arcbox.v1.SandboxResumeResponse` with the fresh IP).
+    SandboxResumeResponse = 0x1045,
 
     // Sandbox workload response types (streaming).
     // 0x1035 (SandboxRunOutput) and 0x1036 (SandboxExecOutput) were
@@ -321,6 +340,8 @@ impl MessageType {
             0x0041 => Some(Self::SandboxRestoreRequest),
             0x0042 => Some(Self::SandboxListSnapshotsRequest),
             0x0043 => Some(Self::SandboxDeleteSnapshotRequest),
+            0x0044 => Some(Self::SandboxPauseRequest),
+            0x0045 => Some(Self::SandboxResumeRequest),
             // Sandbox execution requests (execution redesign, CORE-55/56).
             0x0060 => Some(Self::SandboxExecStartRequest),
             0x0061 => Some(Self::SandboxExecAttachRequest),
@@ -366,6 +387,8 @@ impl MessageType {
             0x1027 => Some(Self::SandboxCleanupPrepareResponse),
             0x1028 => Some(Self::SandboxCleanupFinalizeResponse),
             0x1029 => Some(Self::SandboxCleanupEvent),
+            0x1044 => Some(Self::SandboxPauseResponse),
+            0x1045 => Some(Self::SandboxResumeResponse),
             // Sandbox workload responses (streaming).
             0x1037 => Some(Self::SandboxEvent),
             0x1038 => Some(Self::SandboxFileData),
@@ -412,6 +435,8 @@ impl MessageType {
                 | Self::SandboxRestoreRequest
                 | Self::SandboxListSnapshotsRequest
                 | Self::SandboxDeleteSnapshotRequest
+                | Self::SandboxPauseRequest
+                | Self::SandboxResumeRequest
                 | Self::SandboxExecStartRequest
                 | Self::SandboxExecAttachRequest
                 | Self::SandboxStdinWriteRequest
@@ -550,6 +575,10 @@ mod tests {
             (0x0041, MessageType::SandboxRestoreRequest),
             (0x0042, MessageType::SandboxListSnapshotsRequest),
             (0x0043, MessageType::SandboxDeleteSnapshotRequest),
+            (0x0044, MessageType::SandboxPauseRequest),
+            (0x0045, MessageType::SandboxResumeRequest),
+            (0x1044, MessageType::SandboxPauseResponse),
+            (0x1045, MessageType::SandboxResumeResponse),
             (0x1040, MessageType::SandboxCheckpointResponse),
             (0x1041, MessageType::SandboxRestoreResponse),
             (0x1042, MessageType::SandboxListSnapshotsResponse),
@@ -582,6 +611,8 @@ mod tests {
         assert!(MessageType::SandboxFileReadRequest.is_sandbox_request());
         assert!(MessageType::SandboxFileWriteRequest.is_sandbox_request());
         assert!(MessageType::SandboxCheckpointRequest.is_sandbox_request());
+        assert!(MessageType::SandboxPauseRequest.is_sandbox_request());
+        assert!(MessageType::SandboxResumeRequest.is_sandbox_request());
         assert!(!MessageType::PingRequest.is_sandbox_request());
         assert!(!MessageType::SandboxCreateResponse.is_sandbox_request());
     }

--- a/docs/sandbox-api.md
+++ b/docs/sandbox-api.md
@@ -81,13 +81,17 @@ surface is on the wire ahead of its implementation; these RPCs answer
 
 - `TemplateService` (`template.proto`) — the template catalog (CORE-21;
   Build additionally gated on CORE-5/CORE-16).
-- `SandboxService.Pause/Resume` (CORE-21), `SetLifecycle` (CORE-60 /
-  CORE-21), `GetCapabilities` (CORE-13).
+- `SetLifecycle` (CORE-60 / CORE-21 — the idle knobs land with the idle
+  detector), `GetCapabilities` (CORE-13).
 - `SandboxProcessService.ListExecutions/WaitForPort` (CORE-58 phase 2).
 - The `SandboxFilesystemService` path verbs — `Stat`, `ListDir`,
   `MakeDir`, `Remove`, `Move`, `WatchDir` (CORE-62).
 - `errors.proto` — the `ErrorCode` registry; handlers attach `ErrorInfo`
-  as a Connect error detail in a follow-up phase (CORE-58).
+  as a Connect error detail in a follow-up phase (CORE-58; `SANDBOX_PAUSED`
+  already ships it).
+
+`SandboxService.Pause/Resume` and daemon-side transparent auto-resume are
+implemented (CORE-21) — see **Pause / Resume** below.
 
 ## Sandbox state machine
 
@@ -95,8 +99,8 @@ surface is on the wire ahead of its implementation; these RPCs answer
 STARTING ──► READY ──► RUNNING ──► READY   (execution exited; IDLE event)
                │          │
                ├──────────┴──► STOPPING ──► STOPPED
-               │          │
-               ├──────────┴──► PAUSING ──► PAUSED ──(Resume)──► STARTING  (same ID)
+               │
+               ├──► PAUSING ──► PAUSED ──(Resume)──► STARTING  (same ID)
                │          │
                └──────────┴──► FAILED   (error + failed_at set)
 ```
@@ -115,9 +119,13 @@ States are the `SandboxState` enum (`SANDBOX_STATE_*`); events carry the
   contract-only today).
 - `stopped` sandboxes have released their TAP/IP, CoW device, and chroot;
   only the inspectable record and logs remain until `Remove`.
-- `paused` sandboxes keep their record **and** an on-disk checkpoint
-  (`storage_bytes`) under the same ID; data-plane calls resume them
-  transparently, `Inspect`/`List` never do.
+- `paused` sandboxes keep their record, an on-disk checkpoint, **and their
+  disk overlay** (`storage_bytes`, `paused_at`) under the same ID;
+  data-plane calls resume them transparently, `Inspect`/`List` never do.
+- `PAUSING` branches from `READY` only: a `RUNNING` sandbox has a live
+  execution whose session cannot survive the VM being checkpointed and
+  killed, so `Pause` on it answers `FAILED_PRECONDITION` — finish or stop
+  the execution first.
 
 ## SandboxService
 
@@ -257,13 +265,45 @@ host listener :H → inbound relay → guest :G (reserved 40000-49999)
 mapping. Mappings are removed automatically on Stop/Remove/TTL. CLI:
 `abctl sandbox expose <id> <port>` / `unexpose`.
 
+### Pause / Resume (CORE-21)
+
+- `Pause{id}`: checkpoints the sandbox (memory + device state) and
+  releases its VM, TAP/IP, and chroot while **retaining the disk
+  overlay** — both memory and disk survive under the same ID. Requires
+  `READY`; `Pause` on a `PAUSED` sandbox is a no-op. The VM is not
+  resumed after the snapshot, so the checkpoint and disk can never
+  diverge. Port exposures are dropped with the released network.
+- `Resume{id}`: restores the checkpoint against the retained overlay in a
+  fresh microVM with a **fresh IP** (the `sandbox-id.arcbox.local` DNS
+  name follows it), then returns once `READY`. `Resume` on a
+  `READY`/`RUNNING` sandbox is a no-op; re-expose ports as needed. The
+  internal pause checkpoint is deleted on a successful resume.
+- **Transparent auto-resume**: data-plane RPCs (executions, files)
+  hitting a paused sandbox resume it first and then proceed — one shared
+  resume even under concurrent callers. Calls that address execution
+  *history* (attach, wait, stdin status, signal, resize) are served from
+  the retained records without waking the sandbox. Opt out per request
+  with the `x-arcbox-no-auto-resume: 1` header to receive the honest
+  `FAILED_PRECONDITION` carrying the `SANDBOX_PAUSED` `ErrorInfo` detail.
+- **Events**: `PAUSING` (attributes `reason: pause`, later
+  `idle_timeout`), `PAUSED`, and `RESUMED` (attributes `reason: resume`
+  or `auto_resume`) make every automated transition visible.
+- Paused sandboxes report `paused_at` and `storage_bytes` (checkpoint +
+  overlay footprint) in `Inspect`/`List`, survive daemon and VM restarts,
+  and still honor `ttl_seconds` — the hard cap destroys a paused sandbox
+  too. Idle-driven auto-pause (`idle_timeout_seconds` + `on_idle: PAUSE`)
+  is contract-only until the idle detector lands.
+
 ### Stop / Remove
 
 - `Stop{id, timeout_seconds}` (default 30 s): drains an active workload
   up to the budget, asks the guest to shut down, and force-kills only on
-  timeout. Releases network/CoW/chroot resources.
-- `Remove{id, force}`: destroys the sandbox and every remaining resource.
-  `force: true` removes even a `running` sandbox.
+  timeout. Releases network/CoW/chroot resources. A `paused` sandbox has
+  no VM to stop — `Stop` answers `FAILED_PRECONDITION`; use
+  `Resume`+`Stop` or `Remove`.
+- `Remove{id, force}`: destroys the sandbox and every remaining resource,
+  including a paused sandbox's checkpoint and disk overlay. `force: true`
+  removes even a `running` sandbox.
 
 ### Inspect / List / Events
 
@@ -315,6 +355,7 @@ map onto gRPC statuses:
 | unknown sandbox / snapshot | `NOT_FOUND` |
 | duplicate sandbox ID | `ALREADY_EXISTS` |
 | wrong state, missing nested virt, V1-unsupported field | `FAILED_PRECONDITION` |
+| paused sandbox, transparent resume not applied (opt-out header or control-plane call) | `FAILED_PRECONDITION` + `SANDBOX_PAUSED` `ErrorInfo` detail |
 | stdin write offset past the accepted count | `OUT_OF_RANGE` (resync via `GetStdinStatus`) |
 | sandbox service initialisation failure | `UNAVAILABLE` |
 | daemon still starting (runtime not ready) | `UNAVAILABLE` |

--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -248,6 +248,76 @@ where
                 }
             }
         }
+        MessageType::SandboxPauseRequest => {
+            use arcbox_connect::sandbox_v1::PauseSandboxRequest;
+            use arcbox_connect::v1::SandboxCleanupResponse;
+            let req = match PauseSandboxRequest::decode_from_slice(payload) {
+                Ok(req) => req,
+                Err(error) => {
+                    send_sandbox_error(stream, trace_id, 400, &error.to_string()).await?;
+                    return Ok(());
+                }
+            };
+            let sandbox_id = req.id.clone();
+            let _operation = svc.lock_operation(&req.id).await;
+            match svc.pause_request(req).await {
+                // Pause quarantines the network exactly like Stop, so it
+                // answers with the same durable cleanup ticket for the
+                // daemon's host-side forwarding cleanup.
+                Ok(()) => match svc.pending_cleanup_ticket(&sandbox_id).await {
+                    Ok(ticket) => {
+                        let response = SandboxCleanupResponse {
+                            ticket: ticket.into(),
+                            ..Default::default()
+                        };
+                        write_message(
+                            stream,
+                            MessageType::SandboxPauseResponse,
+                            trace_id,
+                            &response.encode_to_vec(),
+                        )
+                        .await?;
+                    }
+                    Err(error) => {
+                        send_sandbox_error(
+                            stream,
+                            trace_id,
+                            error.status_code(),
+                            &error.to_string(),
+                        )
+                        .await?;
+                    }
+                },
+                Err(e) => {
+                    send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+                }
+            }
+        }
+        MessageType::SandboxResumeRequest => {
+            use arcbox_connect::v1::SandboxResumeCommand;
+            let req = match SandboxResumeCommand::decode_from_slice(payload) {
+                Ok(req) => req,
+                Err(error) => {
+                    send_sandbox_error(stream, trace_id, 400, &error.to_string()).await?;
+                    return Ok(());
+                }
+            };
+            let _operation = svc.lock_operation(&req.id).await;
+            match svc.resume_request(req).await {
+                Ok(resp) => {
+                    write_message(
+                        stream,
+                        MessageType::SandboxResumeResponse,
+                        trace_id,
+                        &resp.encode_to_vec(),
+                    )
+                    .await?;
+                }
+                Err(e) => {
+                    send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+                }
+            }
+        }
         MessageType::SandboxCleanupPrepareRequest => {
             use arcbox_connect::v1::SandboxCleanupTicket;
 

--- a/guest/arcbox-agent/src/error.rs
+++ b/guest/arcbox-agent/src/error.rs
@@ -21,6 +21,10 @@ pub enum SandboxError {
     AlreadyExists(String),
     /// The sandbox is not in a state that allows the operation.
     WrongState(String),
+    /// The sandbox is paused. Carried as its own wire code (423) so the
+    /// daemon can recognise "paused" machine-readably and resume the
+    /// sandbox transparently on data-plane calls (CORE-21).
+    SandboxPaused(String),
     /// A stdin write's offset is past the accepted byte count; the client
     /// must resync via `GetStdinStatus` and resume from the reported offset.
     StdinGap(String),
@@ -40,6 +44,7 @@ impl fmt::Display for SandboxError {
             | Self::NotFound(msg)
             | Self::AlreadyExists(msg)
             | Self::WrongState(msg)
+            | Self::SandboxPaused(msg)
             | Self::StdinGap(msg)
             | Self::Unsupported(msg)
             | Self::Unavailable(msg)
@@ -53,7 +58,10 @@ impl SandboxError {
     ///
     /// The host maps these onto gRPC statuses: 400 → `INVALID_ARGUMENT`,
     /// 404 → `NOT_FOUND`, 409 → `ALREADY_EXISTS`, 412 → `FAILED_PRECONDITION`,
-    /// 416 → `OUT_OF_RANGE`, 503 → `UNAVAILABLE`, anything else → `INTERNAL`.
+    /// 416 → `OUT_OF_RANGE`, 423 → `FAILED_PRECONDITION` (after the daemon's
+    /// transparent auto-resume declined — 423 is the machine-readable
+    /// "paused" signal it keys on, CORE-21), 503 → `UNAVAILABLE`, anything
+    /// else → `INTERNAL`.
     pub const fn status_code(&self) -> i32 {
         match self {
             Self::Decode(_) | Self::InvalidArgument(_) => 400,
@@ -61,6 +69,7 @@ impl SandboxError {
             Self::AlreadyExists(_) => 409,
             Self::WrongState(_) | Self::Unsupported(_) => 412,
             Self::StdinGap(_) => 416,
+            Self::SandboxPaused(_) => 423,
             Self::Unavailable(_) => 503,
             Self::Internal(_) => 500,
         }
@@ -74,6 +83,7 @@ impl From<arcbox_vm::VmmError> for SandboxError {
             VmmError::NotFound(_) => Self::NotFound(e.to_string()),
             VmmError::AlreadyExists(_) => Self::AlreadyExists(e.to_string()),
             VmmError::WrongState { .. } => Self::WrongState(e.to_string()),
+            VmmError::Paused(_) => Self::SandboxPaused(e.to_string()),
             VmmError::StdinGap { .. } => Self::StdinGap(e.to_string()),
             VmmError::Unavailable(_) | VmmError::AckUnconfirmed { .. } => {
                 Self::Unavailable(e.to_string())
@@ -111,6 +121,13 @@ mod tests {
         });
         assert!(matches!(err, SandboxError::StdinGap(_)));
         assert_eq!(err.status_code(), 416);
+    }
+
+    #[test]
+    fn paused_maps_to_423_for_the_daemon_auto_resume() {
+        let err = SandboxError::from(arcbox_vm::VmmError::Paused("box".into()));
+        assert!(matches!(err, SandboxError::SandboxPaused(_)));
+        assert_eq!(err.status_code(), 423);
     }
 
     #[test]

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -266,6 +266,49 @@ impl SandboxService {
         Ok(())
     }
 
+    /// Pause a sandbox: checkpoint, then release its VM while keeping the
+    /// record and disk under the same id (CORE-21). The sandbox's DNS entry
+    /// is dropped with its released IP; Resume re-registers the fresh one.
+    pub(crate) async fn pause_request(
+        &self,
+        req: sandbox_v1::PauseSandboxRequest,
+    ) -> Result<(), SandboxError> {
+        self.manager
+            .pause_sandbox(&req.id)
+            .await
+            .map_err(SandboxError::from)?;
+        deregister_sandbox_dns(&req.id);
+        Ok(())
+    }
+
+    /// Resume a paused sandbox in place and re-register its fresh IP.
+    ///
+    /// The wire reason is constrained to the two values the contract
+    /// documents; anything else (including empty) reads as an explicit
+    /// resume rather than injecting arbitrary event attributes.
+    pub(crate) async fn resume_request(
+        &self,
+        req: arcbox_connect::v1::SandboxResumeCommand,
+    ) -> Result<arcbox_connect::v1::SandboxResumeResponse, SandboxError> {
+        let reason = if req.reason == arcbox_vm::pause_reason::AUTO_RESUME {
+            arcbox_vm::pause_reason::AUTO_RESUME
+        } else {
+            arcbox_vm::pause_reason::RESUME
+        };
+        let ip_address = self
+            .manager
+            .resume_sandbox(&req.id, reason)
+            .await
+            .map_err(SandboxError::from)?;
+        if !ip_address.is_empty() {
+            register_sandbox_dns(&req.id, &ip_address);
+        }
+        Ok(arcbox_connect::v1::SandboxResumeResponse {
+            ip_address,
+            ..Default::default()
+        })
+    }
+
     /// Remove a sandbox.
     pub async fn remove(&self, payload: &[u8]) -> Result<(), SandboxError> {
         let req = sandbox_v1::RemoveSandboxRequest::decode_from_slice(payload)
@@ -450,11 +493,15 @@ impl SandboxService {
 fn completed_create_is_stale(state: Result<SandboxState, VmmError>) -> bool {
     match state {
         Ok(SandboxState::Stopped | SandboxState::Failed) | Err(VmmError::NotFound(_)) => true,
+        // A paused sandbox is logically alive: the same-id create replay
+        // must keep answering until it is actually removed.
         Ok(
             SandboxState::Starting
             | SandboxState::Ready
             | SandboxState::Running
-            | SandboxState::Stopping,
+            | SandboxState::Stopping
+            | SandboxState::Pausing
+            | SandboxState::Paused,
         )
         | Err(_) => false,
     }

--- a/guest/arcbox-agent/src/sandbox/convert.rs
+++ b/guest/arcbox-agent/src/sandbox/convert.rs
@@ -97,6 +97,8 @@ pub(super) fn state_to_proto(state: SandboxState) -> sandbox_v1::SandboxState {
         SandboxState::Stopping => sandbox_v1::SandboxState::Stopping,
         SandboxState::Stopped => sandbox_v1::SandboxState::Stopped,
         SandboxState::Failed => sandbox_v1::SandboxState::Failed,
+        SandboxState::Pausing => sandbox_v1::SandboxState::Pausing,
+        SandboxState::Paused => sandbox_v1::SandboxState::Paused,
     }
 }
 
@@ -111,8 +113,6 @@ pub(super) fn state_filter(state: sandbox_v1::SandboxState) -> Option<&'static s
         sandbox_v1::SandboxState::Stopping => Some("stopping"),
         sandbox_v1::SandboxState::Stopped => Some("stopped"),
         sandbox_v1::SandboxState::Failed => Some("failed"),
-        // Pause states (CORE-21): the manager cannot produce them yet, so
-        // the filter matches nothing until pause lands guest-side.
         sandbox_v1::SandboxState::Pausing => Some("pausing"),
         sandbox_v1::SandboxState::Paused => Some("paused"),
     }
@@ -129,6 +129,9 @@ pub(super) fn event_kind(action: &str) -> sandbox_v1::SandboxEventKind {
         "stopped" => sandbox_v1::SandboxEventKind::Stopped,
         "failed" => sandbox_v1::SandboxEventKind::Failed,
         "removed" => sandbox_v1::SandboxEventKind::Removed,
+        "pausing" => sandbox_v1::SandboxEventKind::Pausing,
+        "paused" => sandbox_v1::SandboxEventKind::Paused,
+        "resumed" => sandbox_v1::SandboxEventKind::Resumed,
         _ => sandbox_v1::SandboxEventKind::Unspecified,
     }
 }
@@ -167,6 +170,8 @@ pub(super) fn info_to_proto(info: SandboxInfo) -> sandbox_v1::SandboxInfo {
         last_exited_at: info.last_exited_at.map(timestamp).into(),
         last_exit_status: info.last_exit_status.map(exit_status_to_proto).into(),
         error: info.error.unwrap_or_default(),
+        paused_at: info.paused_at.map(timestamp).into(),
+        storage_bytes: info.storage_bytes,
         ..Default::default()
     }
 }
@@ -178,6 +183,8 @@ pub(super) fn summary_to_proto(s: SandboxSummary) -> sandbox_v1::SandboxSummary 
         labels: s.labels.into_iter().collect(),
         ip_address: s.ip_address,
         created_at: timestamp(s.created_at).into(),
+        paused_at: s.paused_at.map(timestamp).into(),
+        storage_bytes: s.storage_bytes,
         ..Default::default()
     }
 }

--- a/rpc/arcbox-protocol/proto/agent.proto
+++ b/rpc/arcbox-protocol/proto/agent.proto
@@ -549,3 +549,25 @@ message SandboxCleanupResponse {
 // Opens the internal stream of pending sandbox cleanup tickets. The guest
 // first replays its durable snapshot, then streams new terminal generations.
 message WatchSandboxCleanupRequest {}
+
+// Ask the guest agent to resume a paused sandbox in place (CORE-21).
+//
+// Internal wire message rather than the public ResumeSandboxRequest: the
+// daemon decides *why* a resume runs (an explicit Resume call vs its own
+// transparent auto-resume on a data-plane RPC), and the guest surfaces that
+// verbatim as the RESUMED event's "reason" attribute — the visibility the
+// contract promises for automation.
+message SandboxResumeCommand {
+    // Sandbox ID.
+    string id = 1;
+    // "resume" (explicit) or "auto_resume" (daemon-side transparent resume).
+    // Empty is treated as "resume".
+    string reason = 2;
+}
+
+// Guest agent's answer to a resume: the fresh network identity.
+message SandboxResumeResponse {
+    // IP address of the resumed sandbox's new allocation (empty when the
+    // sandbox has no network). The daemon re-registers host DNS from it.
+    string ip_address = 1;
+}

--- a/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/sandbox.proto
+++ b/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/sandbox.proto
@@ -43,12 +43,14 @@ service SandboxService {
     rpc Remove(RemoveSandboxRequest) returns (google.protobuf.Empty);
 
     // Pause a sandbox: checkpoint it to disk under the same ID, then
-    // release its runtime resources (VM, network, CoW overlay). The
-    // record survives as PAUSED and Resume restores it in place — the
+    // release its runtime resources (VM, network) while retaining the
+    // checkpoint and the disk overlay — memory AND disk state survive.
+    // The record survives as PAUSED and Resume restores it in place — the
     // origin VM is gone by construction, which sidesteps the direct-mode
     // relocation constraint documented in `snapshot.proto` (CORE-21).
     // Returns once the sandbox reaches PAUSED; requires READY (no active
-    // execution). Trades RAM for disk: a paused sandbox keeps paying
+    // execution — see the state machine below for why RUNNING cannot
+    // pause). Trades RAM for disk: a paused sandbox keeps paying
     // `storage_bytes` until removed.
     rpc Pause(PauseSandboxRequest) returns (google.protobuf.Empty);
 
@@ -58,8 +60,12 @@ service SandboxService {
     // resume it transparently before proceeding, so clients see a
     // latency blip rather than an error. Callers that want the honest
     // state machine instead set the reserved `x-arcbox-no-auto-resume`
-    // request header (not yet honored) and receive SANDBOX_PAUSED
-    // (`errors.proto`). Inspect and List never resume.
+    // request header and receive SANDBOX_PAUSED (`errors.proto`).
+    // Inspect and List never resume.
+    //
+    // Resuming re-allocates networking: the sandbox comes back with a
+    // fresh IP (its DNS name follows), and port exposures dropped at
+    // pause time must be re-established with ExposePort.
     rpc Resume(ResumeSandboxRequest) returns (google.protobuf.Empty);
 
     // Replace a sandbox's lifecycle deadlines: the hard maximum lifetime
@@ -106,10 +112,16 @@ service SandboxService {
 //   STARTING ──► READY ──► RUNNING ──► READY  (execution exited, sandbox alive)
 //                  │          │
 //                  ├──────────┴──► STOPPING ──► STOPPED
-//                  │          │
-//                  ├──────────┴──► PAUSING ──► PAUSED ──(Resume)──► STARTING  (same ID)
+//                  │
+//                  ├──► PAUSING ──► PAUSED ──(Resume)──► STARTING  (same ID)
 //                  │          │
 //                  └──────────┴──► FAILED  (error reason set)
+//
+// PAUSING branches from READY only: pausing means checkpointing a quiescent
+// sandbox, and a RUNNING one has a live execution whose host-side session
+// cannot survive the VM being checkpointed and killed — finish or stop the
+// execution first (the idle detector pauses on the READY edge for the same
+// reason). Every other non-terminal state can also reach FAILED.
 enum SandboxState {
     SANDBOX_STATE_UNSPECIFIED = 0;
     // Firecracker process spawned; VM still booting.

--- a/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
@@ -487,10 +487,16 @@ pub struct UnexposePortRequest {
 ///    STARTING ──► READY ──► RUNNING ──► READY  (execution exited, sandbox alive)
 ///                   │          │
 ///                   ├──────────┴──► STOPPING ──► STOPPED
-///                   │          │
-///                   ├──────────┴──► PAUSING ──► PAUSED ──(Resume)──► STARTING  (same ID)
+///                   │
+///                   ├──► PAUSING ──► PAUSED ──(Resume)──► STARTING  (same ID)
 ///                   │          │
 ///                   └──────────┴──► FAILED  (error reason set)
+///
+/// PAUSING branches from READY only: pausing means checkpointing a quiescent
+/// sandbox, and a RUNNING one has a live execution whose host-side session
+/// cannot survive the VM being checkpointed and killed — finish or stop the
+/// execution first (the idle detector pauses on the READY edge for the same
+/// reason). Every other non-terminal state can also reach FAILED.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum SandboxState {

--- a/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.v1.rs
@@ -3560,6 +3560,31 @@ pub struct SandboxCleanupResponse {
 /// first replays its durable snapshot, then streams new terminal generations.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct WatchSandboxCleanupRequest {}
+/// Ask the guest agent to resume a paused sandbox in place (CORE-21).
+///
+/// Internal wire message rather than the public ResumeSandboxRequest: the
+/// daemon decides *why* a resume runs (an explicit Resume call vs its own
+/// transparent auto-resume on a data-plane RPC), and the guest surfaces that
+/// verbatim as the RESUMED event's "reason" attribute — the visibility the
+/// contract promises for automation.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SandboxResumeCommand {
+    /// Sandbox ID.
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    /// "resume" (explicit) or "auto_resume" (daemon-side transparent resume).
+    /// Empty is treated as "resume".
+    #[prost(string, tag = "2")]
+    pub reason: ::prost::alloc::string::String,
+}
+/// Guest agent's answer to a resume: the fresh network identity.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SandboxResumeResponse {
+    /// IP address of the resumed sandbox's new allocation (empty when the
+    /// sandbox has no network). The daemon re-registers host DNS from it.
+    #[prost(string, tag = "1")]
+    pub ip_address: ::prost::alloc::string::String,
+}
 /// Transport protocol of a forwarded sandbox port.
 ///
 /// Deliberately separate from `arcbox.sandbox.v1.PortProtocol`: the public

--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -417,6 +417,33 @@ async fn drive_sandboxes(
     );
     info!(%snapshot_id, "checkpoint taken");
 
+    // Datapath proof for the *resumed origin*: the pause/resume phase asserts
+    // only its addressing (its `run_and_collect` calls ride vsock, which never
+    // crosses the TAP), because probing the gateway there would bake a
+    // REACHABLE neighbour entry into the checkpoint above — and the clone,
+    // restoring onto a TAP with a different gateway MAC, would inherit it and
+    // blackhole until it aged out. After the checkpoint that hazard is gone
+    // (no further snapshot of `smoke1` is taken; the reuse-NIC restore below
+    // replays this same one), so ping here: it proves `restore_paused`'s
+    // freshly activated invariant TAP actually moves packets, which is a
+    // different code path from the clone's `network_overrides` restore.
+    wait_ready(&mut sandboxes, "smoke1").await?;
+    let resumed_ping = run_and_collect(
+        &mut processes,
+        "smoke1",
+        &[
+            "/bin/sh",
+            "-c",
+            "gw=$(ip route | sed -n 's/^default via \\([0-9.]*\\).*/\\1/p' | head -1); \
+             echo \"gateway=$gw\"; ping -c 1 -W 2 \"$gw\"",
+        ],
+    )
+    .await?;
+    if !resumed_ping.contains(" 0% packet loss") {
+        bail!("resumed sandbox could not reach its gateway over its new TAP: {resumed_ping:?}");
+    }
+    info!("resumed origin reaches its gateway over the post-resume TAP");
+
     // -- Fresh-network restore (origin still running) ----------------------
     // `network_override: true` gives the clone a new TAP via FC's
     // `network_overrides` snapshot-load field (Firecracker >= 1.12), so the
@@ -1020,9 +1047,10 @@ async fn pause_resume_scenario(
     // REACHABLE neighbour entry for it in the guest, and the checkpoint the
     // next phase takes of this very sandbox inherits that entry. The clone
     // restores onto a *different* TAP, whose gateway MAC differs, so the
-    // inherited entry blackholes the clone until it ages out. The clone
-    // phase owns the datapath proof (it pings from a guest whose neighbour
-    // cache was not freshly warmed); duplicating it here breaks it.
+    // inherited entry blackholes the clone until it ages out. The proof for
+    // this sandbox's own post-resume TAP lives in the caller, just after the
+    // checkpoint is taken — past the point where a warmed neighbour entry
+    // could still be captured.
     let info = inspect(sandboxes, "smoke1").await?;
     let resumed_ip = info
         .network

--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -22,11 +22,12 @@ use arcbox_grpc::sandbox_v1::sandbox_service_client::SandboxServiceClient;
 use arcbox_grpc::sandbox_v1::sandbox_snapshot_service_client::SandboxSnapshotServiceClient;
 use arcbox_protocol::sandbox_v1::{
     AttachExecutionRequest, CheckpointRequest, CreateSandboxRequest, Execution, ExecutionEvent,
-    FileChunk, GetStdinStatusRequest, InspectSandboxRequest, ListSandboxesRequest, ReadFileRequest,
-    RemoveSandboxRequest, ResourceLimits, RestoreRequest, SandboxState, Signal,
+    FileChunk, GetStdinStatusRequest, InspectSandboxRequest, ListSandboxesRequest,
+    PauseSandboxRequest, ReadFileRequest, RemoveSandboxRequest, ResourceLimits, RestoreRequest,
+    ResumeSandboxRequest, SandboxEventKind, SandboxEventsRequest, SandboxState, Signal,
     SignalExecutionRequest, StartExecutionRequest, StdioChannel, StopSandboxRequest,
-    WaitExecutionRequest, WriteFileOpen, WriteFileRequest, WriteStdinRequest, execution_event,
-    exit_status, write_file_request,
+    WaitExecutionRequest, WatchEventsResponse, WriteFileOpen, WriteFileRequest, WriteStdinRequest,
+    execution_event, exit_status, watch_events_response, write_file_request,
 };
 use tonic::transport::Channel;
 use tracing::{info, warn};
@@ -390,6 +391,14 @@ async fn drive_sandboxes(
     metrics.record("sandbox_file_io", file_started.elapsed().as_secs_f64());
     info!("file round-trip verified");
 
+    // -- Pause / transparent auto-resume / explicit Resume (CORE-21) -------
+    let pause_started = Instant::now();
+    let origin_ip = pause_resume_scenario(&mut sandboxes, &mut processes, &mut files).await?;
+    metrics.record(
+        "sandbox_pause_resume",
+        pause_started.elapsed().as_secs_f64(),
+    );
+
     // -- Checkpoint / Restore --------------------------------------------
     let checkpoint_started = Instant::now();
     let snapshot_id = snapshots
@@ -424,10 +433,11 @@ async fn drive_sandboxes(
         .context("Fresh-network restore failed")?
         .into_inner();
     info!(id = %cloned.id, ip = %cloned.ip_address, "sandbox restored with fresh network while origin runs");
-    if cloned.ip_address.is_empty() || cloned.ip_address == created.ip_address {
+    // The origin's IP changed across pause/resume; compare against its
+    // current allocation, which is also what the checkpoint recorded.
+    if cloned.ip_address.is_empty() || cloned.ip_address == origin_ip {
         bail!(
-            "fresh-network clone must get its own IP (origin {}, clone {:?})",
-            created.ip_address,
+            "fresh-network clone must get its own IP (origin {origin_ip}, clone {:?})",
             cloned.ip_address
         );
     }
@@ -451,7 +461,10 @@ async fn drive_sandboxes(
     if !addr.contains("169.254.100.2/") {
         bail!("clone eth0 does not carry the invariant guest IP (got: {addr:?})");
     }
+    // `origin_ip` is the origin's *post-resume* allocation, distinct from the
+    // one it was created with — both are pool IPs and neither may leak in.
     if addr.contains(&format!("{}/", created.ip_address))
+        || addr.contains(&format!("{origin_ip}/"))
         || addr.contains(&format!("{}/", cloned.ip_address))
     {
         bail!("clone eth0 carries a pool IP; those must stay host-side (got: {addr:?})");
@@ -864,6 +877,212 @@ async fn exec_signal_and_keepalive(
     }
     info!("stream-free signal delivered and reported as a signal death");
     Ok(())
+}
+
+/// CORE-21 acceptance: pause → paused honesty (state, paused_at,
+/// storage_bytes, opt-out header) → transparent auto-resume on a data-plane
+/// call → pause again → explicit Resume, with memory AND disk state proven
+/// to survive and every transition visible on the Events stream.
+///
+/// Returns the origin's post-resume IP for the later restore assertions.
+async fn pause_resume_scenario(
+    sandboxes: &mut SandboxServiceClient<Channel>,
+    processes: &mut SandboxProcessServiceClient<Channel>,
+    files: &mut SandboxFilesystemServiceClient<Channel>,
+) -> Result<String> {
+    // Disk marker on the ext4 rootfs — unlike /tmp (tmpfs, which rides the
+    // memory image) this proves the CoW overlay itself survives. The sync
+    // pushes it out of the page cache into the overlay.
+    let disk_marker: Vec<u8> = (0..64 * 1024).map(|i| (i % 199) as u8).collect();
+    write_file(files, "smoke1", "/pause-disk-marker.bin", &disk_marker).await?;
+    run_and_collect(processes, "smoke1", &["/bin/sh", "-c", "sync"]).await?;
+    wait_ready(sandboxes, "smoke1").await?;
+
+    // Subscribe before pausing so every transition is captured.
+    let mut events = sandboxes
+        .events(with_machine(SandboxEventsRequest {
+            sandbox_id: "smoke1".into(),
+            ..Default::default()
+        }))
+        .await
+        .context("Events subscribe failed")?
+        .into_inner();
+
+    // -- Pause ------------------------------------------------------------
+    sandboxes
+        .pause(with_machine(PauseSandboxRequest {
+            id: "smoke1".into(),
+        }))
+        .await
+        .context("Pause failed")?;
+    let info = inspect(sandboxes, "smoke1").await?;
+    if info.state() != SandboxState::Paused {
+        bail!("expected PAUSED after Pause, got {:?}", info.state());
+    }
+    if info.paused_at.is_none() {
+        bail!("paused sandbox must report paused_at");
+    }
+    if info.storage_bytes == 0 {
+        bail!("paused sandbox must report a nonzero storage_bytes");
+    }
+    next_event(&mut events, SandboxEventKind::Pausing, Some("pause")).await?;
+    next_event(&mut events, SandboxEventKind::Paused, None).await?;
+    info!(storage_bytes = info.storage_bytes, "sandbox paused");
+
+    // Pause is idempotent on a paused sandbox.
+    sandboxes
+        .pause(with_machine(PauseSandboxRequest {
+            id: "smoke1".into(),
+        }))
+        .await
+        .context("idempotent Pause failed")?;
+
+    // -- Opt-out header gets the honest FAILED_PRECONDITION ---------------
+    let mut opted_out = with_machine(StartExecutionRequest {
+        sandbox_id: "smoke1".into(),
+        cmd: vec!["/bin/true".into()],
+        stdin: false,
+        ..Default::default()
+    });
+    opted_out.metadata_mut().insert(
+        "x-arcbox-no-auto-resume",
+        tonic::metadata::MetadataValue::from_static("1"),
+    );
+    match processes.start_execution(opted_out).await {
+        Ok(_) => bail!("opted-out execution on a paused sandbox must fail"),
+        Err(status) if status.code() == tonic::Code::FailedPrecondition => {}
+        Err(status) => bail!("opted-out execution: expected FAILED_PRECONDITION, got {status}"),
+    }
+    let info = inspect(sandboxes, "smoke1").await?;
+    if info.state() != SandboxState::Paused {
+        bail!(
+            "the opted-out call must not wake the sandbox (state: {:?})",
+            info.state()
+        );
+    }
+
+    // -- Transparent auto-resume on a data-plane call ---------------------
+    let stdout = run_and_collect(
+        processes,
+        "smoke1",
+        &["/bin/sh", "-c", "wc -c < /pause-disk-marker.bin"],
+    )
+    .await?;
+    if stdout.trim() != disk_marker.len().to_string() {
+        bail!("disk marker size after auto-resume: {stdout:?}");
+    }
+    next_event(&mut events, SandboxEventKind::Resumed, Some("auto_resume")).await?;
+    wait_ready(sandboxes, "smoke1").await?;
+    let back = read_file(files, "smoke1", "/pause-disk-marker.bin").await?;
+    if back != disk_marker {
+        bail!("disk overlay state lost across pause/auto-resume");
+    }
+    let tmp = read_file(files, "smoke1", "/tmp/smoke.bin").await?;
+    if tmp.len() != 1024 * 1024 {
+        bail!(
+            "tmpfs (memory) state lost across pause/auto-resume ({} bytes)",
+            tmp.len()
+        );
+    }
+    info!("transparent auto-resume verified (disk + memory intact)");
+
+    // -- Pause again, resume explicitly -----------------------------------
+    sandboxes
+        .pause(with_machine(PauseSandboxRequest {
+            id: "smoke1".into(),
+        }))
+        .await
+        .context("second Pause failed")?;
+    next_event(&mut events, SandboxEventKind::Paused, None).await?;
+    sandboxes
+        .resume(with_machine(ResumeSandboxRequest {
+            id: "smoke1".into(),
+        }))
+        .await
+        .context("Resume failed")?;
+    next_event(&mut events, SandboxEventKind::Resumed, Some("resume")).await?;
+    // Resume is idempotent on a live sandbox.
+    sandboxes
+        .resume(with_machine(ResumeSandboxRequest {
+            id: "smoke1".into(),
+        }))
+        .await
+        .context("idempotent Resume failed")?;
+    wait_ready(sandboxes, "smoke1").await?;
+
+    // Resume allocates a fresh TAP + IP, but under invariant addressing
+    // (CORE-81) that is a purely host-side change: the guest keeps the fixed
+    // link-local identity and the pool IP lives on the TAP. The pool IP
+    // itself may legitimately be recycled — pause released it and this is
+    // the only sandbox — so what is asserted is the addressing shape.
+    //
+    // Deliberately NOT a gateway ping here: probing the gateway leaves a
+    // REACHABLE neighbour entry for it in the guest, and the checkpoint the
+    // next phase takes of this very sandbox inherits that entry. The clone
+    // restores onto a *different* TAP, whose gateway MAC differs, so the
+    // inherited entry blackholes the clone until it ages out. The clone
+    // phase owns the datapath proof (it pings from a guest whose neighbour
+    // cache was not freshly warmed); duplicating it here breaks it.
+    let info = inspect(sandboxes, "smoke1").await?;
+    let resumed_ip = info
+        .network
+        .as_ref()
+        .map(|n| n.ip_address.clone())
+        .unwrap_or_default();
+    if resumed_ip.is_empty() {
+        bail!("resumed sandbox must report an IP");
+    }
+    let addr =
+        run_and_collect(processes, "smoke1", &["/bin/sh", "-c", "ip addr show eth0"]).await?;
+    // Mirrors GUEST_IP in virt/arcbox-vm/src/network/invariant.rs.
+    if !addr.contains("169.254.100.2/") {
+        bail!("resumed eth0 does not carry the invariant guest IP (got: {addr:?})");
+    }
+    if addr.contains(&format!("{resumed_ip}/")) {
+        bail!("resumed eth0 carries a pool IP; those must stay host-side (got: {addr:?})");
+    }
+    // The default route must survive the checkpoint/restore round trip.
+    if !run_and_collect(processes, "smoke1", &["/bin/sh", "-c", "ip route"])
+        .await?
+        .contains("default via 169.254.100.1")
+    {
+        bail!("resumed sandbox lost its default route");
+    }
+    info!(ip = %resumed_ip, "explicit resume verified");
+    Ok(resumed_ip)
+}
+
+/// Scans the events stream (skipping keepalives and unrelated kinds) until
+/// `kind` arrives, asserting its "reason" attribute when specified.
+async fn next_event(
+    stream: &mut tonic::Streaming<WatchEventsResponse>,
+    kind: SandboxEventKind,
+    reason: Option<&str>,
+) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .with_context(|| format!("timed out waiting for {kind:?} event"))?;
+        let message = tokio::time::timeout(remaining, stream.message())
+            .await
+            .with_context(|| format!("timed out waiting for {kind:?} event"))?
+            .context("events stream error")?
+            .context("events stream ended")?;
+        let Some(watch_events_response::Payload::Event(event)) = message.payload else {
+            continue; // keepalive
+        };
+        if event.kind() != kind {
+            continue;
+        }
+        if let Some(reason) = reason {
+            let got = event.attributes.get("reason").map(String::as_str);
+            if got != Some(reason) {
+                bail!("{kind:?} event reason: expected {reason:?}, got {got:?}");
+            }
+        }
+        return Ok(());
+    }
 }
 
 async fn inspect(

--- a/virt/arcbox-vm/src/error.rs
+++ b/virt/arcbox-vm/src/error.rs
@@ -19,6 +19,12 @@ pub enum VmmError {
         actual: String,
     },
 
+    /// The sandbox is paused. Distinct from [`Self::WrongState`] so callers
+    /// (the daemon's transparent auto-resume, CORE-21) can recognise
+    /// "paused" machine-readably instead of parsing state strings.
+    #[error("sandbox '{0}' is paused")]
+    Paused(String),
+
     /// I/O error (file system, sockets, etc.).
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),

--- a/virt/arcbox-vm/src/lib.rs
+++ b/virt/arcbox-vm/src/lib.rs
@@ -51,6 +51,7 @@ pub use config::{
 };
 pub use error::{Result, VmmError};
 pub use network::{ExposeTarget, NetworkAllocation, NetworkManager};
+pub use sandbox::pause_reason;
 pub use sandbox::{
     CheckpointInfo, CheckpointSummary, RestoreSandboxSpec, SandboxEvent, SandboxId, SandboxInfo,
     SandboxManager, SandboxMountSpec, SandboxNetworkIdentity, SandboxNetworkInfo,

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -36,6 +36,7 @@ mod checkpoint;
 mod cleanup;
 mod execution;
 mod lifecycle;
+mod pause;
 mod persistence;
 mod pool;
 mod reconcile;
@@ -46,6 +47,7 @@ mod workload;
 pub use execution::{
     ExecutionChannel, ExecutionOutput, ExecutionSnapshot, ExecutionSpec, StdinState,
 };
+pub use pause::reason as pause_reason;
 pub use types::{
     CheckpointInfo, CheckpointSummary, RestoreSandboxSpec, SandboxEvent, SandboxId, SandboxInfo,
     SandboxInstance, SandboxMountSpec, SandboxNetworkInfo, SandboxNetworkSpec, SandboxSpec,
@@ -122,9 +124,14 @@ impl SandboxManager {
             let instances = Arc::clone(&instances);
             tokio::spawn(async move {
                 let result = async {
-                    let swept =
-                        reconcile::sweep_orphans(&config, &network, &cow_manager, &snapshots)
-                            .await?;
+                    let swept = reconcile::sweep_orphans(
+                        &config,
+                        &network,
+                        &cow_manager,
+                        &snapshots,
+                        &records,
+                    )
+                    .await?;
                     let inactive = reconcile::normalize_durable_records(
                         &records,
                         Path::new(&config.firecracker.data_dir),

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -12,7 +12,7 @@ use super::*;
 /// The jailer chroot is its own vfsmount (bind + pivot_root), so a plain
 /// `rename(2)` out of it fails with `EXDEV` regardless of the underlying
 /// filesystem; fall back to copy + remove in that case.
-async fn move_file(from: &Path, to: &Path) -> std::io::Result<()> {
+pub(super) async fn move_file(from: &Path, to: &Path) -> std::io::Result<()> {
     match tokio::fs::rename(from, to).await {
         Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
             tokio::fs::copy(from, to).await?;
@@ -54,19 +54,45 @@ pub(super) enum RestoreOrigin {
     WarmCreate,
 }
 
-/// Pause a `Ready` sandbox, capture a full snapshot into the catalog, and
-/// resume it.
+/// What a single [`checkpoint_impl`] call should capture, and how it should
+/// leave the guest.
+pub(super) struct CheckpointRequest {
+    /// Catalog name recorded on the committed snapshot.
+    pub(super) name: String,
+    /// Catalog labels recorded on the committed snapshot.
+    pub(super) labels: HashMap<String, String>,
+    /// State the instance must be in. The Checkpoint RPC and the warm-create
+    /// publisher require `Ready`; pause has already claimed the instance and
+    /// moved it to `Pausing` (CORE-21).
+    pub(super) expected_state: SandboxState,
+    /// Resume the guest once the snapshot files are written.
+    ///
+    /// False only for pause, whose whole point is that the guest must never
+    /// run past the memory image — any progress after it would diverge from
+    /// the retained disk overlay. The caller then owns the resume-on-error.
+    pub(super) resume_after: bool,
+}
+
+/// Pause a sandbox, capture a full snapshot into the catalog, and (unless
+/// the request opts out) resume it.
 ///
 /// Free-standing (rather than a method) so the boot task can publish warm
-/// snapshots (CORE-77) through the exact code path the Checkpoint RPC uses.
+/// snapshots (CORE-77) through the exact code path the Checkpoint RPC uses,
+/// and so pause (CORE-21) inherits the same chroot-owner and addressing-mode
+/// handling instead of re-deriving it.
 pub(super) async fn checkpoint_impl(
     instances: &super::InstanceMap,
     snapshots: &SnapshotCatalog,
     config: &VmmConfig,
     sandbox_id: &SandboxId,
-    name: String,
-    labels: HashMap<String, String>,
+    request: CheckpointRequest,
 ) -> Result<CheckpointInfo> {
+    let CheckpointRequest {
+        name,
+        labels,
+        expected_state,
+        resume_after,
+    } = request;
     // Verify state and capture the kernel/rootfs paths for jailer
     // re-staging, the id the sandbox's chroot is actually keyed by
     // — a sandbox restored from a pre-warmed pool slot lives in the
@@ -80,10 +106,10 @@ pub(super) async fn checkpoint_impl(
             .cloned()
             .ok_or_else(|| VmmError::NotFound(sandbox_id.clone()))?;
         let inst = instance.lock().unwrap();
-        if inst.state != SandboxState::Ready {
+        if inst.state != expected_state {
             return Err(VmmError::WrongState {
                 id: sandbox_id.clone(),
-                expected: "Ready".into(),
+                expected: expected_state.to_string(),
                 actual: inst.state.to_string(),
             });
         }
@@ -93,7 +119,7 @@ pub(super) async fn checkpoint_impl(
             .map(Arc::clone)
             .ok_or_else(|| VmmError::WrongState {
                 id: sandbox_id.clone(),
-                expected: "Ready (VM handle available)".into(),
+                expected: format!("{expected_state} (VM handle available)"),
                 actual: inst.state.to_string(),
             })?;
         // Only needed for jailer mode; safe to capture regardless.
@@ -120,9 +146,9 @@ pub(super) async fn checkpoint_impl(
 
     // Everything between pause and resume is fallible (chroot dir setup,
     // chown, the snapshot RPC). Run it in a block whose result is handled
-    // only AFTER an unconditional resume — a bare `?` here previously left
-    // the guest paused forever, wedging every later RPC. Returns the chroot
-    // snapshot dir (jailer mode) to move afterward.
+    // only AFTER the resume — a bare `?` here previously left the guest
+    // paused forever, wedging every later RPC. Returns the chroot snapshot
+    // dir (jailer mode) to move afterward.
     //
     // In jailer mode FC runs inside a chroot and can only write to paths
     // within it, so the snapshot is written to a chroot-local dir and moved
@@ -159,12 +185,18 @@ pub(super) async fn checkpoint_impl(
     }
     .await;
 
-    // Always resume, regardless of how the paused section fared.
-    let _ = vm.resume().await;
+    // Always resume, regardless of how the paused section fared — unless the
+    // caller owns the resume decision (pause).
+    if resume_after {
+        let _ = vm.resume().await;
+    }
 
     let chroot_snap_dir_opt = paused?;
 
-    // If jailer mode, move snapshot files from the chroot into staging.
+    // If jailer mode, move snapshot files from the chroot into staging. The
+    // guest is either resumed (and the files complete, FC having flushed
+    // them before returning) or deliberately left paused, so in both cases
+    // nothing is still writing to them.
     if let Some(chroot_snap) = chroot_snap_dir_opt {
         move_file(&chroot_snap.join("vmstate"), &staging_dir.join("vmstate"))
             .await
@@ -222,6 +254,14 @@ impl SandboxManager {
         labels: HashMap<String, String>,
     ) -> Result<CheckpointInfo> {
         self.check_reconcile()?;
+        // The pause machinery owns this name: Remove deletes every snapshot
+        // carrying it, so a user checkpoint must not squat on it (CORE-21).
+        if name == super::pause::PAUSE_SNAPSHOT_NAME {
+            return Err(VmmError::Config(format!(
+                "checkpoint name {:?} is reserved for sandbox pause",
+                super::pause::PAUSE_SNAPSHOT_NAME
+            )));
+        }
         // The warm-create cache (CORE-77) trusts its label as the lookup
         // key; a caller must not be able to plant one.
         super::warm::reject_reserved_labels(&labels)?;
@@ -230,8 +270,12 @@ impl SandboxManager {
             &self.snapshots,
             &self.config,
             sandbox_id,
-            name,
-            labels,
+            CheckpointRequest {
+                name,
+                labels,
+                expected_state: SandboxState::Ready,
+                resume_after: true,
+            },
         )
         .await
     }
@@ -291,6 +335,7 @@ impl SandboxManager {
             &self.config,
             &self.cow_manager,
             &self.records,
+            &self.snapshots,
         )
         .await
         .err();
@@ -386,6 +431,16 @@ impl SandboxManager {
         // Resolve read-only prerequisites before claiming durable ownership.
         // Once the intent exists, every failure goes through rollback.
         let snap_meta = self.snapshots.find_by_id(&request.snapshot_id)?;
+        // A pause checkpoint pairs with its sandbox's retained disk overlay;
+        // cloning it with a fresh overlay would silently discard that disk
+        // state. Resume is the only consumer (CORE-21).
+        if snap_meta.name.as_deref() == Some(super::pause::PAUSE_SNAPSHOT_NAME) {
+            return Err(VmmError::WrongState {
+                id: request.snapshot_id.clone(),
+                expected: "a user checkpoint".into(),
+                actual: "the internal pause checkpoint of a paused sandbox".into(),
+            });
+        }
         let jailer = self.config.firecracker.jailer.as_ref().ok_or_else(|| {
             VmmError::Config(
                 "checkpoint restore requires jailer isolation; direct mode embeds shared origin paths"
@@ -933,6 +988,7 @@ impl SandboxManager {
             let config2 = Arc::clone(&self.config);
             let cow2 = Arc::clone(&self.cow_manager);
             let records = Arc::clone(&self.records);
+            let snapshots = Arc::clone(&self.snapshots);
             let id2 = new_id.clone();
             let ttl = request.spec.ttl_seconds;
             let armed_for = ttl_armed_for;
@@ -948,6 +1004,7 @@ impl SandboxManager {
                     &config2,
                     &cow2,
                     &records,
+                    &snapshots,
                 )
                 .await;
             });
@@ -1001,6 +1058,9 @@ impl SandboxManager {
     }
 
     /// List checkpoints, optionally filtered by origin sandbox ID.
+    ///
+    /// Internal pause checkpoints are hidden: they are lifecycle state, not
+    /// user-owned snapshots, and deleting one would strand a paused sandbox.
     pub fn list_checkpoints(&self, sandbox_id: Option<&str>) -> Result<Vec<CheckpointSummary>> {
         let infos = match sandbox_id {
             Some(sid) => self.snapshots.list(sid)?,
@@ -1008,6 +1068,7 @@ impl SandboxManager {
         };
         Ok(infos
             .into_iter()
+            .filter(|s| s.name.as_deref() != Some(super::pause::PAUSE_SNAPSHOT_NAME))
             .map(|s| CheckpointSummary {
                 id: s.id,
                 sandbox_id: s.vm_id,
@@ -1025,7 +1086,18 @@ impl SandboxManager {
 
     /// Delete a checkpoint by its ID, tearing down any pre-warmed restore
     /// slots staged from it first.
+    ///
+    /// Internal pause checkpoints are refused — deleting one would strand
+    /// its paused sandbox; they die with the sandbox via `Remove`.
     pub async fn delete_checkpoint(&self, snapshot_id: &str) -> Result<()> {
+        let meta = self.snapshots.find_by_id(snapshot_id)?;
+        if meta.name.as_deref() == Some(super::pause::PAUSE_SNAPSHOT_NAME) {
+            return Err(VmmError::WrongState {
+                id: snapshot_id.to_owned(),
+                expected: "a user checkpoint".into(),
+                actual: "the internal pause checkpoint of a paused sandbox".into(),
+            });
+        }
         self.drain_pool(Some(snapshot_id)).await;
         self.snapshots.delete_by_id(snapshot_id)
     }

--- a/virt/arcbox-vm/src/sandbox/cleanup.rs
+++ b/virt/arcbox-vm/src/sandbox/cleanup.rs
@@ -31,6 +31,7 @@ pub(super) async fn remove_sandbox_impl(
     config: &Arc<VmmConfig>,
     cow_manager: &Arc<CowManager>,
     records: &Arc<SandboxRecordStore>,
+    snapshots: &Arc<crate::snapshot::SnapshotCatalog>,
 ) -> Result<()> {
     let cleanup_lock = expected.lock().unwrap().cleanup_lock.clone();
     let _cleanup_guard = cleanup_lock.lock().await;
@@ -39,6 +40,12 @@ pub(super) async fn remove_sandbox_impl(
 
     cancel_and_join_boot(id, expected, boot_task).await?;
     release_runtime_resources(id, expected, network, config, cow_manager).await?;
+
+    // Pause artifacts survive Stop-style release by design (CORE-21); Remove
+    // is where they die: the retained disk overlay and the internal pause
+    // checkpoint(s), including any leaked by an interrupted pause.
+    cow_manager.remove_preserved_cow(id).await?;
+    super::pause::delete_pause_snapshots(snapshots, id)?;
 
     // Remove the sandbox working directory (sockets, logs, state journal).
     let vm_dir = PathBuf::from(&config.firecracker.data_dir)
@@ -203,6 +210,7 @@ pub(super) async fn expire_sandbox(
     config: &Arc<VmmConfig>,
     cow_manager: &Arc<CowManager>,
     records: &Arc<SandboxRecordStore>,
+    snapshots: &Arc<crate::snapshot::SnapshotCatalog>,
 ) {
     let mut retry_delay = TTL_REMOVE_RETRY_INITIAL;
     loop {
@@ -220,6 +228,7 @@ pub(super) async fn expire_sandbox(
             config,
             cow_manager,
             records,
+            snapshots,
         )
         .await
         {
@@ -256,6 +265,83 @@ pub(super) async fn release_runtime_resources(
     network: &Arc<NetworkManager>,
     config: &Arc<VmmConfig>,
     cow_manager: &Arc<CowManager>,
+) -> Result<()> {
+    kill_sandbox_process(id, arc).await?;
+
+    // Teardown dm-snapshot CoW device (must happen after FC process exits
+    // because Firecracker holds the block device open).
+    {
+        let cow_handle = arc.lock().unwrap().cow_handle.take();
+        if let Some(handle) = cow_handle
+            && let Err(error) = cow_manager.teardown_checked(&handle).await
+        {
+            arc.lock().unwrap().cow_handle = Some(handle);
+            return Err(error);
+        }
+    }
+    cow_manager.cleanup_setup_orphan(id).await?;
+
+    // Release network resources (destroys TAP via ioctl).
+    {
+        let mut inst = arc.lock().unwrap();
+        if let Some(net) = inst.network.take() {
+            drop(inst);
+            if let Err(error) = network.quarantine_checked(id, &net) {
+                arc.lock().unwrap().network = Some(net);
+                return Err(error);
+            }
+        }
+    }
+
+    // Clean up the jailer chroot directory if applicable. A sandbox that
+    // adopted a pre-warmed pool slot lives in the slot's chroot, so the
+    // removal is keyed by the owning id, not the sandbox id.
+    remove_jailer_chroot(id, arc, config).await
+}
+
+/// Remove the jailer chroot a sandbox actually lives in.
+///
+/// Keyed by the adopted pool slot id when the sandbox claimed a pre-warmed
+/// slot (CORE-78), by the sandbox id otherwise. Shared with the pause path,
+/// which releases the same chroot while keeping the disk.
+pub(super) async fn remove_jailer_chroot(
+    id: &str,
+    arc: &Arc<Mutex<SandboxInstance>>,
+    config: &Arc<VmmConfig>,
+) -> Result<()> {
+    let Some(ref jc) = config.firecracker.jailer else {
+        return Ok(());
+    };
+    let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
+    let chroot_owner = chroot_owner(id, arc);
+    let chroot_dir = chroot_root(&config.firecracker.binary, base, &chroot_owner);
+    // Remove {base}/{exec_name}/{id}/ (parent of "root/").
+    if let Some(parent) = chroot_dir.parent()
+        && let Err(e) = tokio::fs::remove_dir_all(parent).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(VmmError::Io(e));
+    }
+    Ok(())
+}
+
+/// Id the sandbox's jailer chroot and dm/CoW resources are named after.
+pub(super) fn chroot_owner(id: &str, arc: &Arc<Mutex<SandboxInstance>>) -> String {
+    arc.lock()
+        .unwrap()
+        .pool_slot_id
+        .clone()
+        .unwrap_or_else(|| id.to_owned())
+}
+
+/// SIGKILL the sandbox's Firecracker process and reap it with a bounded wait.
+///
+/// Extracted so the pause path (which keeps the disk overlay) shares the exact
+/// kill/reap discipline with full release. A failed reap restores the handle
+/// so a retry can finish the job. Idempotent — the process is `take()`n.
+pub(super) async fn kill_sandbox_process(
+    id: &str,
+    arc: &Arc<Mutex<SandboxInstance>>,
 ) -> Result<()> {
     let mut fc_process = {
         let mut inst = arc.lock().unwrap();
@@ -300,50 +386,6 @@ pub(super) async fn release_runtime_resources(
             }
         }
     }
-
-    // Teardown dm-snapshot CoW device (must happen after FC process exits
-    // because Firecracker holds the block device open).
-    {
-        let cow_handle = arc.lock().unwrap().cow_handle.take();
-        if let Some(handle) = cow_handle
-            && let Err(error) = cow_manager.teardown_checked(&handle).await
-        {
-            arc.lock().unwrap().cow_handle = Some(handle);
-            return Err(error);
-        }
-    }
-    cow_manager.cleanup_setup_orphan(id).await?;
-
-    // Release network resources (destroys TAP via ioctl).
-    {
-        let mut inst = arc.lock().unwrap();
-        if let Some(net) = inst.network.take() {
-            drop(inst);
-            if let Err(error) = network.quarantine_checked(id, &net) {
-                arc.lock().unwrap().network = Some(net);
-                return Err(error);
-            }
-        }
-    }
-
-    // Clean up the jailer chroot directory if applicable. A sandbox that
-    // adopted a pre-warmed pool slot lives in the slot's chroot, so the
-    // removal is keyed by the owning id, not the sandbox id.
-    if let Some(ref jc) = config.firecracker.jailer {
-        let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-        let chroot_owner = {
-            let inst = arc.lock().unwrap();
-            inst.pool_slot_id.clone().unwrap_or_else(|| id.to_owned())
-        };
-        let chroot_dir = chroot_root(&config.firecracker.binary, base, &chroot_owner);
-        // Remove {base}/{exec_name}/{id}/ (parent of "root/").
-        if let Some(parent) = chroot_dir.parent()
-            && let Err(e) = tokio::fs::remove_dir_all(parent).await
-            && e.kind() != std::io::ErrorKind::NotFound
-        {
-            return Err(VmmError::Io(e));
-        }
-    }
     Ok(())
 }
 
@@ -364,6 +406,9 @@ pub(super) fn inst_to_info(inst: &SandboxInstance) -> SandboxInfo {
         last_exited_at: inst.last_exited_at,
         last_exit_status: inst.last_exit_status,
         error: inst.error.clone(),
+        paused_at: inst.paused_at,
+        // Filled by the manager for paused sandboxes (it owns the paths).
+        storage_bytes: 0,
     }
 }
 
@@ -463,6 +508,9 @@ mod tests {
                 .unwrap(),
             );
             let cow_manager = Arc::new(CowManager::new(&config.firecracker.data_dir).unwrap());
+            let snapshots = Arc::new(crate::snapshot::SnapshotCatalog::new(
+                &config.firecracker.data_dir,
+            ));
             let (events_tx, _) = broadcast::channel(1);
             let armed_for = Arc::downgrade(&expected);
 
@@ -478,6 +526,7 @@ mod tests {
                         &config,
                         &cow_manager,
                         &records,
+                        &snapshots,
                     )
                     .await;
                     Ok(())
@@ -492,6 +541,7 @@ mod tests {
                         &config,
                         &cow_manager,
                         &records,
+                        &snapshots,
                     )
                     .await
                 }
@@ -593,6 +643,9 @@ mod tests {
             .unwrap(),
         );
         let cow_manager = Arc::new(CowManager::new(&config.firecracker.data_dir).unwrap());
+        let snapshots = Arc::new(crate::snapshot::SnapshotCatalog::new(
+            &config.firecracker.data_dir,
+        ));
         let (events_tx, _) = broadcast::channel(1);
         let armed_for = Arc::downgrade(&expected);
 
@@ -608,6 +661,7 @@ mod tests {
                 &config,
                 &cow_manager,
                 &records,
+                &snapshots,
             ),
         )
         .await
@@ -839,6 +893,9 @@ mod tests {
         );
         let cow_manager = Arc::new(CowManager::new(&config.firecracker.data_dir).unwrap());
         let records = Arc::new(SandboxRecordStore::new(data_dir.path()).unwrap());
+        let snapshots = Arc::new(crate::snapshot::SnapshotCatalog::new(
+            &config.firecracker.data_dir,
+        ));
         let (events_tx, _) = broadcast::channel(1);
 
         assert!(matches!(
@@ -852,6 +909,7 @@ mod tests {
                 &config,
                 &cow_manager,
                 &records,
+                &snapshots,
             )
             .await,
             Err(VmmError::WrongState { .. })

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -349,6 +349,7 @@ impl SandboxManager {
             let config2 = Arc::clone(&self.config);
             let cow2 = Arc::clone(&self.cow_manager);
             let records = Arc::clone(&self.records);
+            let snapshots = Arc::clone(&self.snapshots);
             let id2 = id.clone();
             let ttl = spec.ttl_seconds;
             let armed_for = ttl_armed_for;
@@ -364,6 +365,7 @@ impl SandboxManager {
                     &config2,
                     &cow2,
                     &records,
+                    &snapshots,
                 )
                 .await;
             });
@@ -579,6 +581,7 @@ impl SandboxManager {
             &self.config,
             &self.cow_manager,
             &self.records,
+            &self.snapshots,
         )
         .await?;
         info!(sandbox_id = %id, "sandbox removed");
@@ -589,7 +592,11 @@ impl SandboxManager {
     pub fn inspect_sandbox(&self, id: &SandboxId) -> Result<SandboxInfo> {
         let instance = self.get_instance(id)?;
         let inst = instance.lock().unwrap();
-        Ok(inst_to_info(&inst))
+        let mut info = inst_to_info(&inst);
+        if inst.state == SandboxState::Paused {
+            info.storage_bytes = self.paused_storage_bytes(&inst);
+        }
+        Ok(info)
     }
 
     /// List sandboxes, optionally filtered by state string and/or labels.
@@ -632,6 +639,12 @@ impl SandboxManager {
                         .map(|n| n.ip_address.to_string())
                         .unwrap_or_default(),
                     created_at: inst.created_at,
+                    paused_at: inst.paused_at,
+                    storage_bytes: if inst.state == SandboxState::Paused {
+                        self.paused_storage_bytes(&inst)
+                    } else {
+                        0
+                    },
                 })
             })
             .collect())
@@ -653,11 +666,17 @@ impl SandboxManager {
     }
 
     /// Verify the sandbox is `Ready` and return its vsock UDS path.
+    ///
+    /// A paused sandbox answers [`VmmError::Paused`], not `WrongState`, so
+    /// the daemon can resume it transparently and retry (CORE-21).
     pub(super) fn require_ready_vsock(&self, id: &SandboxId) -> Result<PathBuf> {
         let instance = self.get_instance(id)?;
         let inst = instance.lock().unwrap();
         match inst.state {
             SandboxState::Ready => {}
+            SandboxState::Pausing | SandboxState::Paused => {
+                return Err(VmmError::Paused(id.clone()));
+            }
             s => {
                 return Err(VmmError::WrongState {
                     id: id.clone(),
@@ -674,11 +693,16 @@ impl SandboxManager {
     /// Verify the sandbox is alive (Ready or Running) and return its vsock
     /// UDS path. Unlike [`Self::require_ready_vsock`], an in-flight workload
     /// does not block the operation — file I/O works alongside Run/Exec.
+    /// Paused states map to [`VmmError::Paused`] for the daemon's
+    /// transparent resume, as above.
     pub(super) fn require_alive_vsock(&self, id: &SandboxId) -> Result<PathBuf> {
         let instance = self.get_instance(id)?;
         let inst = instance.lock().unwrap();
         match inst.state {
             SandboxState::Ready | SandboxState::Running => {}
+            SandboxState::Pausing | SandboxState::Paused => {
+                return Err(VmmError::Paused(id.clone()));
+            }
             s => {
                 return Err(VmmError::WrongState {
                     id: id.clone(),

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -1,0 +1,998 @@
+//! Pause / Resume — checkpoint a sandbox and release its VM while keeping
+//! the record, checkpoint, and disk overlay under the same id (CORE-21).
+//!
+//! Pause differs from Checkpoint+Stop in two load-bearing ways:
+//!
+//! - The VM is **not resumed** after the snapshot. Any guest progress after
+//!   the memory image is written would diverge from the retained disk, so
+//!   the snapshot is the sandbox's final state until Resume.
+//! - The disk survives. The dm-snapshot overlay is detached but its
+//!   persistent (`P`) COW file stays on disk (or, in copy-mode fallback,
+//!   the staged rootfs copy is moved out of the chroot), and Resume
+//!   re-assembles exactly the device the memory image expects. A plain
+//!   Restore instead builds a fresh overlay from the template, discarding
+//!   writes — which is why restoring *from* a pause checkpoint is refused.
+//!
+//! Resume mirrors the fresh-network restore path: a new TAP + IP is
+//! allocated (`RestoreSandboxSpec::network_override` semantics) and the
+//! sandbox returns to `Ready` under its original id. The old allocation was
+//! quarantined at pause time and its host forwarding state cleaned via the
+//! same durable ticket flow Stop uses. Whether the guest needs re-addressing
+//! at all depends on the snapshot's addressing mode — an invariant-addressed
+//! guest (CORE-81) already holds the fixed link-local identity and only the
+//! host-side TAP changes.
+//!
+//! A sandbox that adopted a pre-warmed restore slot (CORE-78) lives in the
+//! slot's chroot with slot-keyed dm/CoW names. Pause releases that chroot and
+//! renames the retained overlay onto the sandbox-id path, so from `Paused`
+//! onwards every resource is keyed by the sandbox id again and resume,
+//! reconciliation, and `Remove` all see one naming scheme.
+
+use super::boot::{
+    chroot_root, link_or_copy_for_jailer, stage_kernel_for_jailer, stage_rootfs_device_for_jailer,
+};
+use super::checkpoint::{CheckpointRequest, checkpoint_impl, move_file};
+use super::persistence::SandboxTransition;
+use super::types::action;
+use super::*;
+
+/// Reserved catalog name for internal pause checkpoints.
+///
+/// Everything with this name is lifecycle state owned by the pause
+/// machinery: hidden from ListSnapshots, refused by DeleteSnapshot and
+/// Restore, rejected as a user checkpoint name, and deleted by Remove.
+pub(super) const PAUSE_SNAPSHOT_NAME: &str = "arcbox-pause";
+
+/// Where a copy-mode rootfs is parked inside `vm_dir` while paused.
+const PAUSED_ROOTFS_FILE: &str = "paused-rootfs.ext4";
+
+/// Reason attribute values for pause/resume events.
+pub mod reason {
+    /// Client-driven `Pause`.
+    pub const PAUSE: &str = "pause";
+    /// Client-driven `Resume`.
+    pub const RESUME: &str = "resume";
+    /// Daemon-side transparent resume on a data-plane call.
+    pub const AUTO_RESUME: &str = "auto_resume";
+}
+
+/// Delete every internal pause checkpoint of `sandbox_id`.
+///
+/// Scans by the reserved name rather than the recorded snapshot id so a
+/// checkpoint leaked by an interrupted pause (committed to the catalog but
+/// never recorded durably) is cleaned up too.
+pub(super) fn delete_pause_snapshots(
+    snapshots: &crate::snapshot::SnapshotCatalog,
+    sandbox_id: &str,
+) -> Result<()> {
+    for info in snapshots.list(sandbox_id)? {
+        if info.name.as_deref() == Some(PAUSE_SNAPSHOT_NAME) {
+            snapshots.delete_by_id(&info.id)?;
+        }
+    }
+    Ok(())
+}
+
+/// Runtime resources a successful in-place restore hands back to the
+/// instance.
+struct ResumedRuntime {
+    process: fc_sdk::FirecrackerProcess,
+    vm: Arc<fc_sdk::Vm>,
+    vsock_uds_path: PathBuf,
+    network: Option<NetworkAllocation>,
+    cow_handle: Option<CowHandle>,
+    ip_address: String,
+}
+
+/// How a failed resume left the sandbox.
+struct ResumeFailure {
+    error: VmmError,
+    /// True when every re-created resource was released again and the
+    /// retained pause state (checkpoint + disk) is intact — the sandbox can
+    /// go back to `Paused` and a retry can succeed.
+    unwound: bool,
+}
+
+impl SandboxManager {
+    /// Pause a `Ready` sandbox: checkpoint it, then release its runtime
+    /// resources while keeping the record, checkpoint, and disk overlay
+    /// under the same id.
+    ///
+    /// Idempotent: pausing a `Paused` sandbox is a no-op. Any other state
+    /// answers `WrongState` — an active execution must finish (or be
+    /// stopped) first, matching the contract's "requires READY".
+    pub async fn pause_sandbox(&self, id: &SandboxId) -> Result<()> {
+        self.await_reconcile().await?;
+        let instance = self.get_instance(id)?;
+        let cleanup_lock = instance.lock().unwrap().cleanup_lock.clone();
+        let _cleanup_guard = cleanup_lock.lock().await;
+        super::ensure_current_instance(&self.instances, id, &instance)?;
+
+        let (generation, vm) = {
+            let inst = instance.lock().unwrap();
+            match inst.state {
+                SandboxState::Paused => return Ok(()),
+                SandboxState::Ready => {}
+                s => {
+                    return Err(VmmError::WrongState {
+                        id: id.clone(),
+                        expected: "Ready".into(),
+                        actual: s.to_string(),
+                    });
+                }
+            }
+            (inst.record_generation, inst.vm.as_ref().map(Arc::clone))
+        };
+        // Resume restores into a fresh jailer chroot; direct-mode vmstate
+        // pins origin paths, so a direct-mode pause could never resume.
+        // Fail fast before touching anything.
+        let jailer = self.config.firecracker.jailer.as_ref().ok_or_else(|| {
+            VmmError::Config(
+                "sandbox pause requires jailer isolation; direct mode cannot resume".into(),
+            )
+        })?;
+        let vm = vm.ok_or_else(|| VmmError::WrongState {
+            id: id.clone(),
+            expected: "a sandbox with a live VM handle".into(),
+            actual: "no VM handle".into(),
+        })?;
+
+        if let Some(generation) = generation {
+            let commit = self
+                .records
+                .transition(id, generation, SandboxTransition::Pausing)?;
+            if let Some(error) = commit.durability_error {
+                warn!(
+                    sandbox_id = %id,
+                    error,
+                    "pausing transition is visible but durability is unconfirmed"
+                );
+            }
+        }
+        instance.lock().unwrap().state = SandboxState::Pausing;
+        let _ = self
+            .events_tx
+            .send(SandboxEvent::new(id, action::PAUSING).with_attr("reason", reason::PAUSE));
+
+        // Checkpoint through the shared implementation — it owns the
+        // chroot-owner (pool slot) and addressing-mode bookkeeping — but with
+        // the resume suppressed: guest progress past the memory image would
+        // diverge from the retained disk overlay. On failure the VM is
+        // resumed here and the sandbox reverts to Ready, because a failed
+        // pause must leave a usable sandbox behind.
+        let snapshot_id = match checkpoint_impl(
+            &self.instances,
+            &self.snapshots,
+            &self.config,
+            id,
+            CheckpointRequest {
+                name: PAUSE_SNAPSHOT_NAME.to_owned(),
+                labels: HashMap::new(),
+                expected_state: SandboxState::Pausing,
+                resume_after: false,
+            },
+        )
+        .await
+        {
+            Ok(info) => info.snapshot_id,
+            Err(error) => {
+                let _ = vm.resume().await;
+                if let Some(generation) = generation
+                    && let Err(revert) =
+                        self.records
+                            .transition(id, generation, SandboxTransition::Ready)
+                {
+                    warn!(sandbox_id = %id, error = %revert, "pause revert transition failed");
+                }
+                instance.lock().unwrap().state = SandboxState::Ready;
+                let _ = self.events_tx.send(SandboxEvent::new(id, action::READY));
+                return Err(error);
+            }
+        };
+        // Deliberately no `vm.resume()` on success: guest progress after the
+        // snapshot would diverge from the retained disk overlay.
+
+        // Release the VM, TAP + IP (quarantined for host cleanup), and
+        // chroot; keep the disk. A failure here is a half-released sandbox
+        // whose VM state is already gone — degrade honestly to Failed.
+        if let Err(error) = self.release_for_pause(id, &instance, jailer).await {
+            if let Some(generation) = generation
+                && let Err(mark) = self.records.transition(
+                    id,
+                    generation,
+                    SandboxTransition::Failed(error.to_string()),
+                )
+            {
+                warn!(sandbox_id = %id, error = %mark, "pause failure transition failed");
+            }
+            {
+                let mut inst = instance.lock().unwrap();
+                inst.state = SandboxState::Failed;
+                inst.error = Some(error.to_string());
+            }
+            let _ = self
+                .events_tx
+                .send(SandboxEvent::new(id, action::FAILED).with_attr("error", &error.to_string()));
+            return Err(error);
+        }
+
+        let paused_commit = generation
+            .map(|generation| {
+                self.records.transition(
+                    id,
+                    generation,
+                    SandboxTransition::Paused {
+                        snapshot_id: snapshot_id.clone(),
+                    },
+                )
+            })
+            .transpose()?;
+        {
+            let mut inst = instance.lock().unwrap();
+            inst.state = SandboxState::Paused;
+            inst.paused_at = Some(Utc::now());
+            inst.pause_snapshot_id = Some(snapshot_id.clone());
+            inst.vm = None;
+            inst.vsock_uds_path = None;
+            if paused_commit
+                .as_ref()
+                .is_none_or(|commit| commit.durability_error.is_none())
+            {
+                // Every runtime resource is released and Paused is durable;
+                // what remains on disk is retained state, not orphans.
+                super::reconcile::clear_state_record(&inst.vm_dir)?;
+            }
+        }
+        let _ = self.events_tx.send(SandboxEvent::new(id, action::PAUSED));
+        info!(sandbox_id = %id, snapshot_id = %snapshot_id, "sandbox paused");
+        paused_commit
+            .map(|commit| commit.confirmed("sandbox pause"))
+            .transpose()?;
+        Ok(())
+    }
+
+    /// Resume a `Paused` sandbox in place: restore from its internal pause
+    /// checkpoint with a fresh network allocation, back to `Ready` under
+    /// the same id.
+    ///
+    /// Idempotent: `Ready`/`Running` return the current IP without touching
+    /// anything. `reason` is surfaced verbatim as the `RESUMED` event's
+    /// "reason" attribute (see [`reason`]).
+    ///
+    /// Returns the sandbox's (fresh) IP address, empty without networking.
+    pub async fn resume_sandbox(&self, id: &SandboxId, resume_reason: &str) -> Result<String> {
+        self.await_reconcile().await?;
+        let instance = self.get_instance(id)?;
+        let cleanup_lock = instance.lock().unwrap().cleanup_lock.clone();
+        let _cleanup_guard = cleanup_lock.lock().await;
+        super::ensure_current_instance(&self.instances, id, &instance)?;
+
+        let (generation, snapshot_id, vm_dir, networked) = {
+            let inst = instance.lock().unwrap();
+            match inst.state {
+                SandboxState::Ready | SandboxState::Running => {
+                    return Ok(inst
+                        .network
+                        .as_ref()
+                        .map(|n| n.ip_address.to_string())
+                        .unwrap_or_default());
+                }
+                SandboxState::Paused => {}
+                s => {
+                    return Err(VmmError::WrongState {
+                        id: id.clone(),
+                        expected: "Paused".into(),
+                        actual: s.to_string(),
+                    });
+                }
+            }
+            let snapshot_id = inst.pause_snapshot_id.clone().ok_or_else(|| {
+                VmmError::Snapshot(format!(
+                    "paused sandbox {id} has no pause checkpoint recorded"
+                ))
+            })?;
+            (
+                inst.record_generation,
+                snapshot_id,
+                inst.vm_dir.clone(),
+                inst.spec.network.mode != "none",
+            )
+        };
+        let jailer =
+            self.config.firecracker.jailer.as_ref().ok_or_else(|| {
+                VmmError::Config("sandbox resume requires jailer isolation".into())
+            })?;
+        let snap_meta = self.snapshots.find_by_id(&snapshot_id)?;
+
+        if let Some(generation) = generation {
+            let commit = self
+                .records
+                .transition(id, generation, SandboxTransition::Resuming)?;
+            if let Some(error) = commit.durability_error {
+                warn!(
+                    sandbox_id = %id,
+                    error,
+                    "resuming transition is visible but durability is unconfirmed"
+                );
+            }
+        }
+        instance.lock().unwrap().state = SandboxState::Starting;
+
+        let restore_started = std::time::Instant::now();
+        match self
+            .restore_paused(id, jailer, &snap_meta, &vm_dir, networked)
+            .await
+        {
+            Ok(resumed) => {
+                let ready_commit = generation
+                    .map(|generation| {
+                        self.records
+                            .transition(id, generation, SandboxTransition::Ready)
+                    })
+                    .transpose()?;
+                let ip_address = resumed.ip_address.clone();
+                {
+                    let mut inst = instance.lock().unwrap();
+                    inst.process = Some(resumed.process);
+                    inst.vm = Some(resumed.vm);
+                    inst.vsock_uds_path = Some(resumed.vsock_uds_path);
+                    inst.network = resumed.network;
+                    inst.cow_handle = resumed.cow_handle;
+                    // Re-establish the guest's addressing mode from the
+                    // checkpoint, exactly as Restore does: a paused sandbox
+                    // rebuilt by the restart sweep has no live instance to
+                    // inherit it from, and a later Checkpoint must record the
+                    // guest's actual addressing (CORE-81).
+                    inst.net_invariant = snap_meta.net_invariant;
+                    inst.state = SandboxState::Ready;
+                    inst.paused_at = None;
+                    inst.pause_snapshot_id = None;
+                }
+                // The checkpoint matched the disk *at pause time*; the
+                // sandbox will now diverge, so it must not be restorable
+                // again. Deletion also frees the memory-sized image.
+                if let Err(error) = self.snapshots.delete_by_id(&snapshot_id) {
+                    warn!(
+                        sandbox_id = %id,
+                        snapshot_id = %snapshot_id,
+                        error = %error,
+                        "resumed, but deleting the pause checkpoint failed"
+                    );
+                }
+                let _ = self.events_tx.send(
+                    SandboxEvent::new(id, action::RESUMED).with_attr("reason", resume_reason),
+                );
+                info!(
+                    sandbox_id = %id,
+                    reason = resume_reason,
+                    total_ms = u64::try_from(restore_started.elapsed().as_millis())
+                        .unwrap_or(u64::MAX),
+                    "sandbox resumed from pause checkpoint"
+                );
+                ready_commit
+                    .map(|commit| commit.confirmed("sandbox resume"))
+                    .transpose()?;
+                Ok(ip_address)
+            }
+            Err(failure) => {
+                if failure.unwound {
+                    // Retained state is intact: park back at Paused so a
+                    // retry (or Remove) still works.
+                    if let Some(generation) = generation
+                        && let Err(revert) = self.records.transition(
+                            id,
+                            generation,
+                            SandboxTransition::Paused {
+                                snapshot_id: snapshot_id.clone(),
+                            },
+                        )
+                    {
+                        warn!(sandbox_id = %id, error = %revert, "resume revert transition failed");
+                    }
+                    instance.lock().unwrap().state = SandboxState::Paused;
+                    let _ = self.events_tx.send(SandboxEvent::new(id, action::PAUSED));
+                } else {
+                    if let Some(generation) = generation
+                        && let Err(mark) = self.records.transition(
+                            id,
+                            generation,
+                            SandboxTransition::Failed(failure.error.to_string()),
+                        )
+                    {
+                        warn!(sandbox_id = %id, error = %mark, "resume failure transition failed");
+                    }
+                    {
+                        let mut inst = instance.lock().unwrap();
+                        inst.state = SandboxState::Failed;
+                        inst.error = Some(failure.error.to_string());
+                    }
+                    let _ = self.events_tx.send(
+                        SandboxEvent::new(id, action::FAILED)
+                            .with_attr("error", &failure.error.to_string()),
+                    );
+                }
+                Err(failure.error)
+            }
+        }
+    }
+
+    /// Free the VM, network, and chroot of a checkpointed sandbox while
+    /// keeping its disk.
+    ///
+    /// Ordering is load-bearing, mirroring full release: Firecracker must be
+    /// dead before the dm detach (EBUSY) and TAP destruction. The network
+    /// allocation is quarantined — the daemon completes host-side forwarding
+    /// cleanup through the same durable ticket flow Stop uses.
+    ///
+    /// A sandbox that adopted a pre-warmed slot (CORE-78) is released out of
+    /// the *slot's* chroot and its slot-keyed overlay is renamed onto the
+    /// sandbox-id path, so `Paused` is always reached with every retained
+    /// resource keyed by the sandbox id.
+    async fn release_for_pause(
+        &self,
+        id: &SandboxId,
+        arc: &Arc<Mutex<SandboxInstance>>,
+        jailer: &crate::config::JailerConfig,
+    ) -> Result<()> {
+        super::cleanup::kill_sandbox_process(id, arc).await?;
+        let owner = super::cleanup::chroot_owner(id, arc);
+
+        // Disk: detach the overlay but keep its COW file; the copy-mode
+        // fallback parks the staged rootfs (the sandbox's actual disk) in
+        // vm_dir before the chroot is removed.
+        let cow_handle = arc.lock().unwrap().cow_handle.take();
+        if let Some(handle) = cow_handle {
+            if let Err(error) = self.cow_manager.detach_keep_cow(&handle).await {
+                arc.lock().unwrap().cow_handle = Some(handle);
+                return Err(error);
+            }
+            // A slot-keyed overlay must become sandbox-keyed: resume's
+            // `reattach`, the restart sweep's keep-list, and `Remove` all
+            // look the file up by sandbox id.
+            let retained = self.preserved_cow_file(id);
+            let detached = self.preserved_cow_file(&owner);
+            if detached != retained && detached.exists() {
+                tokio::fs::rename(&detached, &retained)
+                    .await
+                    .map_err(VmmError::Io)?;
+            }
+        } else {
+            let base = jailer.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
+            let staged =
+                chroot_root(&self.config.firecracker.binary, base, &owner).join("rootfs.ext4");
+            if staged.exists() {
+                let vm_dir = arc.lock().unwrap().vm_dir.clone();
+                move_file(&staged, &vm_dir.join(PAUSED_ROOTFS_FILE))
+                    .await
+                    .map_err(VmmError::Io)?;
+            }
+        }
+
+        {
+            let mut inst = arc.lock().unwrap();
+            if let Some(net) = inst.network.take() {
+                drop(inst);
+                if let Err(error) = self.network.quarantine_checked(id, &net) {
+                    arc.lock().unwrap().network = Some(net);
+                    return Err(error);
+                }
+            }
+        }
+
+        super::cleanup::remove_jailer_chroot(id, arc, &self.config).await?;
+        // Nothing slot-keyed survives this point.
+        arc.lock().unwrap().pool_slot_id = None;
+        Ok(())
+    }
+
+    /// Re-create the runtime of a paused sandbox from its checkpoint.
+    ///
+    /// On failure every re-created resource is unwound (Firecracker killed,
+    /// overlay detached with its COW kept, copy-mode rootfs parked again,
+    /// fresh network quarantined, chroot and journal removed) so the caller
+    /// can park the sandbox back at `Paused`.
+    async fn restore_paused(
+        &self,
+        id: &SandboxId,
+        jailer: &crate::config::JailerConfig,
+        snap_meta: &crate::snapshot::SnapshotMeta,
+        vm_dir: &Path,
+        networked: bool,
+    ) -> std::result::Result<ResumedRuntime, ResumeFailure> {
+        let fc_cfg = &self.config.firecracker;
+        let base = jailer.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
+        let cr = chroot_root(&fc_cfg.binary, base, id);
+        let uid = jailer.uid;
+        let gid = jailer.gid;
+
+        // Incrementally-owned resources for the unwind.
+        let mut net_alloc: Option<NetworkAllocation> = None;
+        let mut process: Option<fc_sdk::FirecrackerProcess> = None;
+        let mut cow_handle: Option<CowHandle> = None;
+
+        let attempt: Result<ResumedRuntime> = async {
+            // Reserve network metadata, journal it, then materialize the
+            // TAP — the same order boot and restore use, so a crash never
+            // leaves an unowned interface.
+            if networked {
+                net_alloc = Some(self.network.reserve(id)?);
+            }
+            let ip_address = net_alloc
+                .as_ref()
+                .map(|n| n.ip_address.to_string())
+                .unwrap_or_default();
+            let journal =
+                |pid: Option<i32>, cow: Option<&CowHandle>, net: Option<&NetworkAllocation>| {
+                    let record =
+                        super::reconcile::SandboxStateRecord::new(id, pid, net, cow, true, None);
+                    super::reconcile::write_state_record(vm_dir, &record)
+                };
+            journal(None, None, net_alloc.as_ref())?;
+            if let Some(net) = &net_alloc {
+                // The resumed guest keeps the addressing its pause checkpoint
+                // baked, exactly as Restore does: an invariant guest pairs
+                // with an invariant TAP (host-side NAT, no guest work), a
+                // legacy one with the legacy TAP shape plus the reconfig RPC
+                // below (CORE-81).
+                let mode = if snap_meta.net_invariant {
+                    crate::network::TapMode::Invariant
+                } else {
+                    crate::network::TapMode::LegacySnapshot
+                };
+                self.network.activate(net, mode)?;
+            }
+
+            // Fresh chroot + Firecracker process.
+            let run_dir = cr.join("run");
+            std::fs::create_dir_all(&run_dir).map_err(VmmError::Io)?;
+            let vsock_path = cr.join("run/firecracker.vsock");
+            let _ = std::fs::remove_file(&vsock_path);
+            let spawned = spawn_jailer(jailer, fc_cfg, id).await?;
+            #[allow(
+                clippy::cast_possible_wrap,
+                reason = "Firecracker pid fits platform pid_t"
+            )]
+            let pid = spawned.pid().map(|pid| pid as i32);
+            process = Some(spawned);
+            journal(pid, None, net_alloc.as_ref())?;
+
+            // Stage kernel + the retained disk + snapshot files.
+            if let Some(kernel) = snap_meta.kernel_path.as_deref() {
+                stage_kernel_for_jailer(&cr, kernel, uid, gid).await?;
+            }
+            let preserved_cow = self.preserved_cow_file(id);
+            if preserved_cow.exists() {
+                let rootfs = snap_meta.rootfs_path.as_deref().ok_or_else(|| {
+                    VmmError::Snapshot(format!(
+                        "pause checkpoint for {id} records no rootfs template"
+                    ))
+                })?;
+                let handle = self.cow_manager.reattach(id, rootfs).await?;
+                journal(pid, Some(&handle), net_alloc.as_ref())?;
+                stage_rootfs_device_for_jailer(&cr, &handle.dm_device, uid, gid).await?;
+                cow_handle = Some(handle);
+            } else {
+                let parked = vm_dir.join(PAUSED_ROOTFS_FILE);
+                if !parked.exists() {
+                    return Err(VmmError::Snapshot(format!(
+                        "paused sandbox {id} has neither a preserved overlay nor a parked rootfs"
+                    )));
+                }
+                let staged = cr.join("rootfs.ext4");
+                move_file(&parked, &staged).await.map_err(VmmError::Io)?;
+                nix::unistd::chown(
+                    &staged,
+                    Some(nix::unistd::Uid::from_raw(uid)),
+                    Some(nix::unistd::Gid::from_raw(gid)),
+                )
+                .map_err(|e| VmmError::Process(format!("chown parked rootfs: {e}")))?;
+            }
+
+            let snap_in_chroot = cr.join("snapshots").join(&snap_meta.id);
+            std::fs::create_dir_all(&snap_in_chroot).map_err(VmmError::Io)?;
+            nix::unistd::chown(
+                &snap_in_chroot,
+                Some(nix::unistd::Uid::from_raw(uid)),
+                Some(nix::unistd::Gid::from_raw(gid)),
+            )
+            .map_err(|e| VmmError::Process(format!("chown snap dir: {e}")))?;
+            link_or_copy_for_jailer(
+                &snap_meta.vmstate_path,
+                &snap_in_chroot.join("vmstate"),
+                uid,
+                gid,
+            )
+            .await?;
+            let effective_mem = if let Some(ref mem) = snap_meta.mem_path
+                && mem.exists()
+            {
+                link_or_copy_for_jailer(mem, &snap_in_chroot.join("mem"), uid, gid).await?;
+                Some(format!("/snapshots/{}/mem", snap_meta.id))
+            } else {
+                None
+            };
+
+            // Load the snapshot; retarget eth0 onto the fresh TAP.
+            let mut load_params = fc_sdk::types::SnapshotLoadParams {
+                snapshot_path: format!("/snapshots/{}/vmstate", snap_meta.id),
+                mem_file_path: effective_mem,
+                mem_backend: None,
+                enable_diff_snapshots: None,
+                track_dirty_pages: None,
+                resume_vm: Some(true),
+                network_overrides: vec![],
+            };
+            if let Some(ref net) = net_alloc {
+                load_params.network_overrides = vec![fc_sdk::types::NetworkOverride {
+                    iface_id: "eth0".into(),
+                    host_dev_name: net.tap_name.clone(),
+                }];
+            }
+            let socket = process
+                .as_ref()
+                .expect("process set above")
+                .socket_path()
+                .to_owned();
+            let vm = Arc::new(
+                fc_sdk::restore(
+                    socket.to_str().ok_or_else(|| {
+                        VmmError::Config("non-UTF-8 firecracker socket path".into())
+                    })?,
+                    load_params,
+                )
+                .await
+                .map_err(VmmError::from)?,
+            );
+
+            // Clock sync is DETACHED, mirroring restore and cold boot
+            // (CORE-80): the guest wall clock froze at pause time, but
+            // vm-agent re-syncs itself from ptp_kvm on every accepted exec
+            // connection, so correct time no longer depends on this RPC.
+            // Awaiting it would put the post-resume vsock connect settle back
+            // on the resume critical path.
+            {
+                let id = id.clone();
+                let vsock_path = vsock_path.clone();
+                tokio::spawn(async move {
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(10),
+                        vsock::sync_clock(&vsock_path),
+                    )
+                    .await
+                    {
+                        Ok(Ok(vsock::ClockSync::Synced)) => {}
+                        Ok(Ok(vsock::ClockSync::AgentError(code))) => {
+                            warn!(sandbox_id = %id, code, "agent could not set the clock after resume");
+                        }
+                        Ok(Err(e)) => warn!(sandbox_id = %id, "clock sync after resume failed: {e}"),
+                        Err(_) => warn!(sandbox_id = %id, "clock sync after resume timed out"),
+                    }
+                });
+            }
+
+            // Re-address the guest only when its snapshot is legacy-addressed.
+            // An invariant guest (CORE-81) already holds the fixed link-local
+            // identity and its resolv.conf already points at the fixed
+            // gateway; the fresh TAP carries the new pool IP host-side, so
+            // resume awaits nothing here.
+            if let Some(ref net) = net_alloc
+                && !snap_meta.net_invariant
+            {
+                let cmd = crate::boot_proto::NetReconfigCommand {
+                    ip: net.ip_address,
+                    netmask: net.netmask(),
+                    gateway: net.gateway,
+                };
+                tokio::time::timeout(
+                    std::time::Duration::from_secs(10),
+                    vsock::reconfigure_network(&vsock_path, &cmd),
+                )
+                .await
+                .map_err(|_| VmmError::Vsock("net reconfig after resume timed out".into()))
+                .and_then(|r| r)?;
+            }
+
+            journal(pid, cow_handle.as_ref(), net_alloc.as_ref())?;
+            Ok(ResumedRuntime {
+                process: process.take().expect("process set above"),
+                vm,
+                vsock_uds_path: vsock_path,
+                network: net_alloc.take(),
+                cow_handle: cow_handle.take(),
+                ip_address,
+            })
+        }
+        .await;
+
+        match attempt {
+            Ok(resumed) => Ok(resumed),
+            Err(error) => {
+                let unwound = self
+                    .unwind_resume(id, vm_dir, jailer, process, cow_handle, net_alloc)
+                    .await;
+                Err(ResumeFailure { error, unwound })
+            }
+        }
+    }
+
+    /// Best-effort release of everything a failed resume re-created,
+    /// restoring the on-disk shape of a cleanly paused sandbox.
+    ///
+    /// Returns true when the sandbox can safely go back to `Paused`.
+    async fn unwind_resume(
+        &self,
+        id: &SandboxId,
+        vm_dir: &Path,
+        jailer: &crate::config::JailerConfig,
+        process: Option<fc_sdk::FirecrackerProcess>,
+        cow_handle: Option<CowHandle>,
+        net_alloc: Option<NetworkAllocation>,
+    ) -> bool {
+        let mut clean = true;
+
+        if let Some(mut proc) = process {
+            if let Some(pid) = proc.pid()
+                && pid > 0
+            {
+                #[allow(
+                    clippy::cast_possible_wrap,
+                    reason = "Firecracker pid fits platform pid_t"
+                )]
+                let _ = nix::sys::signal::kill(
+                    nix::unistd::Pid::from_raw(pid as i32),
+                    nix::sys::signal::Signal::SIGKILL,
+                );
+            }
+            if tokio::time::timeout(std::time::Duration::from_secs(5), proc.wait())
+                .await
+                .is_err()
+            {
+                warn!(sandbox_id = %id, "resume unwind: firecracker did not exit");
+                clean = false;
+            }
+        }
+
+        if let Some(handle) = cow_handle
+            && let Err(error) = self.cow_manager.detach_keep_cow(&handle).await
+        {
+            warn!(sandbox_id = %id, error = %error, "resume unwind: overlay detach failed");
+            clean = false;
+        }
+
+        // Copy-mode fallback: park the staged rootfs back in vm_dir so the
+        // retained disk state survives the chroot removal below.
+        let base = jailer.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
+        let cr = chroot_root(&self.config.firecracker.binary, base, id);
+        let staged = cr.join("rootfs.ext4");
+        if !self.preserved_cow_file(id).exists() && staged.exists() {
+            if let Err(error) = move_file(&staged, &vm_dir.join(PAUSED_ROOTFS_FILE)).await {
+                warn!(sandbox_id = %id, error = %error, "resume unwind: parking rootfs failed");
+                clean = false;
+            }
+        }
+
+        if let Some(net) = net_alloc
+            && let Err(error) = self.network.quarantine_checked(id, &net)
+        {
+            warn!(sandbox_id = %id, error = %error, "resume unwind: network quarantine failed");
+            clean = false;
+        }
+
+        if let Some(parent) = cr.parent()
+            && let Err(error) = tokio::fs::remove_dir_all(parent).await
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            warn!(sandbox_id = %id, error = %error, "resume unwind: chroot removal failed");
+            clean = false;
+        }
+
+        if clean && let Err(error) = super::reconcile::clear_state_record(vm_dir) {
+            warn!(sandbox_id = %id, error = %error, "resume unwind: journal removal failed");
+            clean = false;
+        }
+        clean
+    }
+
+    fn preserved_cow_file(&self, id: &str) -> PathBuf {
+        PathBuf::from(&self.config.firecracker.data_dir)
+            .join("cow")
+            .join(format!("arcbox-cow-{id}.img"))
+    }
+
+    /// On-disk footprint of a paused sandbox's retained state: checkpoint
+    /// (vmstate + mem) plus the disk overlay (allocated blocks of the
+    /// sparse COW file, or the parked rootfs copy).
+    pub(super) fn paused_storage_bytes(&self, inst: &SandboxInstance) -> u64 {
+        use std::os::unix::fs::MetadataExt as _;
+
+        let mut total = 0u64;
+        if let Some(snapshot_id) = inst.pause_snapshot_id.as_deref()
+            && let Ok(meta) = self.snapshots.find_by_id(snapshot_id)
+        {
+            for path in std::iter::once(&meta.vmstate_path).chain(meta.mem_path.iter()) {
+                if let Ok(metadata) = std::fs::metadata(path) {
+                    total = total.saturating_add(metadata.blocks().saturating_mul(512));
+                }
+            }
+        }
+        for path in [
+            self.preserved_cow_file(&inst.id),
+            inst.vm_dir.join(PAUSED_ROOTFS_FILE),
+        ] {
+            if let Ok(metadata) = std::fs::metadata(&path) {
+                total = total.saturating_add(metadata.blocks().saturating_mul(512));
+            }
+        }
+        total
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn manager(data_dir: &Path) -> SandboxManager {
+        let mut config = VmmConfig::default();
+        config.firecracker.data_dir = data_dir.to_string_lossy().into_owned();
+        let manager = SandboxManager::new(config).unwrap();
+        manager.await_reconcile().await.unwrap();
+        manager
+    }
+
+    fn insert_instance(
+        manager: &SandboxManager,
+        id: &str,
+        state: SandboxState,
+    ) -> Arc<Mutex<SandboxInstance>> {
+        let vm_dir = PathBuf::from(&manager.config.firecracker.data_dir)
+            .join("sandboxes")
+            .join(id);
+        let mut inst = SandboxInstance::new(
+            id.to_owned(),
+            SandboxSpec {
+                id: Some(id.to_owned()),
+                ..Default::default()
+            },
+            None,
+            vm_dir,
+        );
+        inst.state = state;
+        let arc = Arc::new(Mutex::new(inst));
+        manager
+            .instances
+            .write()
+            .unwrap()
+            .insert(id.to_owned(), Arc::clone(&arc));
+        arc
+    }
+
+    #[tokio::test]
+    async fn pause_is_idempotent_and_gates_on_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = manager(dir.path()).await;
+
+        assert!(matches!(
+            manager.pause_sandbox(&"missing".to_owned()).await,
+            Err(VmmError::NotFound(_))
+        ));
+
+        insert_instance(&manager, "paused", SandboxState::Paused);
+        manager.pause_sandbox(&"paused".to_owned()).await.unwrap();
+
+        insert_instance(&manager, "busy", SandboxState::Running);
+        assert!(matches!(
+            manager.pause_sandbox(&"busy".to_owned()).await,
+            Err(VmmError::WrongState { .. })
+        ));
+
+        // Ready but no jailer configured: pause must fail fast before
+        // touching anything — a direct-mode pause could never resume.
+        insert_instance(&manager, "ready", SandboxState::Ready);
+        let error = manager
+            .pause_sandbox(&"ready".to_owned())
+            .await
+            .unwrap_err();
+        assert!(matches!(error, VmmError::Config(_)), "{error}");
+        assert!(error.to_string().contains("jailer"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn resume_noops_on_live_states_and_rejects_others() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = manager(dir.path()).await;
+
+        insert_instance(&manager, "ready", SandboxState::Ready);
+        assert_eq!(
+            manager
+                .resume_sandbox(&"ready".to_owned(), reason::RESUME)
+                .await
+                .unwrap(),
+            ""
+        );
+        insert_instance(&manager, "running", SandboxState::Running);
+        manager
+            .resume_sandbox(&"running".to_owned(), reason::RESUME)
+            .await
+            .unwrap();
+
+        insert_instance(&manager, "stopped", SandboxState::Stopped);
+        assert!(matches!(
+            manager
+                .resume_sandbox(&"stopped".to_owned(), reason::RESUME)
+                .await,
+            Err(VmmError::WrongState { .. })
+        ));
+
+        // Paused with no recorded checkpoint is corrupt retained state.
+        insert_instance(&manager, "hollow", SandboxState::Paused);
+        assert!(matches!(
+            manager
+                .resume_sandbox(&"hollow".to_owned(), reason::RESUME)
+                .await,
+            Err(VmmError::Snapshot(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn data_plane_gates_report_paused_machine_readably() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = manager(dir.path()).await;
+        insert_instance(&manager, "asleep", SandboxState::Paused);
+
+        assert!(matches!(
+            manager.require_ready_vsock(&"asleep".to_owned()),
+            Err(VmmError::Paused(id)) if id == "asleep"
+        ));
+        assert!(matches!(
+            manager.require_alive_vsock(&"asleep".to_owned()),
+            Err(VmmError::Paused(id)) if id == "asleep"
+        ));
+    }
+
+    #[tokio::test]
+    async fn pause_snapshots_are_hidden_and_protected() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = manager(dir.path()).await;
+
+        // Seed a committed pause snapshot plus a user checkpoint.
+        let pending = manager.snapshots.begin("box").unwrap();
+        std::fs::write(pending.dir().join("vmstate"), b"state").unwrap();
+        let pause_meta = pending
+            .commit(SnapshotDraft {
+                name: Some(PAUSE_SNAPSHOT_NAME.to_owned()),
+                labels: HashMap::new(),
+                snapshot_type: crate::config::SnapshotType::Full,
+                parent_id: None,
+                kernel_path: None,
+                rootfs_path: None,
+                net_invariant: false,
+            })
+            .unwrap();
+        let pending = manager.snapshots.begin("box").unwrap();
+        std::fs::write(pending.dir().join("vmstate"), b"state").unwrap();
+        let user_meta = pending
+            .commit(SnapshotDraft {
+                name: Some("warm".to_owned()),
+                labels: HashMap::new(),
+                snapshot_type: crate::config::SnapshotType::Full,
+                parent_id: None,
+                kernel_path: None,
+                rootfs_path: None,
+                net_invariant: false,
+            })
+            .unwrap();
+
+        let listed = manager.list_checkpoints(Some("box")).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, user_meta.id);
+
+        assert!(matches!(
+            manager.delete_checkpoint(&pause_meta.id).await,
+            Err(VmmError::WrongState { .. })
+        ));
+
+        delete_pause_snapshots(&manager.snapshots, "box").unwrap();
+        assert!(manager.snapshots.find_by_id(&pause_meta.id).is_err());
+        assert!(manager.snapshots.find_by_id(&user_meta.id).is_ok());
+    }
+}

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -309,11 +309,25 @@ impl SandboxManager {
                 .records
                 .transition(id, generation, SandboxTransition::Resuming)?;
             if let Some(error) = commit.durability_error {
-                warn!(
-                    sandbox_id = %id,
-                    error,
-                    "resuming transition is visible but durability is unconfirmed"
-                );
+                // The restart sweep trusts the durable phase: were Resuming to
+                // stay unconfirmed on disk, a crash mid-restore would read as
+                // cleanly Paused and the restore's journaled TAP/IP/chroot
+                // would be dropped as a stale pause journal, never released.
+                // Park back at Paused and fail before allocating anything —
+                // the mirror of the pause path's durability-gated journal
+                // clear.
+                if let Err(revert) = self.records.transition(
+                    id,
+                    generation,
+                    SandboxTransition::Paused {
+                        snapshot_id: snapshot_id.clone(),
+                    },
+                ) {
+                    warn!(sandbox_id = %id, error = %revert, "resume durability revert failed");
+                }
+                return Err(VmmError::Unavailable(format!(
+                    "sandbox resume is visible but its durability is unconfirmed: {error}"
+                )));
             }
         }
         instance.lock().unwrap().state = SandboxState::Starting;

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -44,7 +44,7 @@ use super::*;
 pub(super) const PAUSE_SNAPSHOT_NAME: &str = "arcbox-pause";
 
 /// Where a copy-mode rootfs is parked inside `vm_dir` while paused.
-const PAUSED_ROOTFS_FILE: &str = "paused-rootfs.ext4";
+pub(super) const PAUSED_ROOTFS_FILE: &str = "paused-rootfs.ext4";
 
 /// Reason attribute values for pause/resume events.
 pub mod reason {

--- a/virt/arcbox-vm/src/sandbox/persistence.rs
+++ b/virt/arcbox-vm/src/sandbox/persistence.rs
@@ -101,6 +101,14 @@ pub(super) enum SandboxPhase {
     Stopped,
     Failed,
     Removing,
+    /// Pause in progress: checkpoint taken or being taken, runtime
+    /// resources not yet fully released.
+    Pausing,
+    /// Checkpointed with resources released; `pause_snapshot_id` names the
+    /// catalog entry a Resume restores from (CORE-21).
+    Paused,
+    /// Resume in progress: runtime resources are being re-created.
+    Resuming,
 }
 
 /// The stable result returned once a provisioning request has been accepted.
@@ -121,6 +129,14 @@ pub(super) struct SandboxRecord {
     pub(super) provision_outcome: Option<SandboxProvisionOutcome>,
     pub(super) created_at: DateTime<Utc>,
     pub(super) error: Option<String>,
+    /// Catalog id of the internal pause checkpoint. Set while the record is
+    /// `Paused`/`Resuming` so a Resume after an agent restart still finds
+    /// its snapshot; cleared when the sandbox is `Ready` again.
+    #[serde(default)]
+    pub(super) pause_snapshot_id: Option<String>,
+    /// When the sandbox reached `Paused` (None otherwise).
+    #[serde(default)]
+    pub(super) paused_at: Option<DateTime<Utc>>,
 }
 
 /// Result of reserving a durable provisioning intent.
@@ -142,6 +158,9 @@ pub(super) enum SandboxTransition {
     Stopped,
     Failed(String),
     Removing,
+    Pausing,
+    Paused { snapshot_id: String },
+    Resuming,
 }
 
 impl SandboxTransition {
@@ -153,6 +172,9 @@ impl SandboxTransition {
             Self::Stopped => SandboxPhase::Stopped,
             Self::Failed(_) => SandboxPhase::Failed,
             Self::Removing => SandboxPhase::Removing,
+            Self::Pausing => SandboxPhase::Pausing,
+            Self::Paused { .. } => SandboxPhase::Paused,
+            Self::Resuming => SandboxPhase::Resuming,
         }
     }
 }
@@ -171,6 +193,8 @@ impl SandboxRecord {
             provision_outcome: None,
             created_at,
             error: None,
+            pause_snapshot_id: None,
+            paused_at: None,
         }
     }
 
@@ -219,6 +243,8 @@ impl SandboxRecord {
             SandboxTransition::Ready => {
                 self.phase = SandboxPhase::Ready;
                 self.error = None;
+                self.pause_snapshot_id = None;
+                self.paused_at = None;
                 self.redact_runtime_inputs();
             }
             SandboxTransition::Stopping => {
@@ -238,6 +264,20 @@ impl SandboxRecord {
             SandboxTransition::Removing => {
                 self.phase = SandboxPhase::Removing;
                 self.redact_runtime_inputs();
+            }
+            SandboxTransition::Pausing => {
+                self.phase = SandboxPhase::Pausing;
+                self.error = None;
+            }
+            SandboxTransition::Paused { snapshot_id } => {
+                self.phase = SandboxPhase::Paused;
+                self.pause_snapshot_id = Some(snapshot_id);
+                self.paused_at = Some(Utc::now());
+                self.error = None;
+            }
+            SandboxTransition::Resuming => {
+                self.phase = SandboxPhase::Resuming;
+                self.error = None;
             }
         }
         Ok(())
@@ -268,12 +308,21 @@ impl SandboxPhase {
                 ) | (
                     Self::Starting,
                     Self::Ready | Self::Stopping | Self::Failed | Self::Removing
-                ) | (Self::Ready, Self::Stopping | Self::Failed | Self::Removing)
+                ) | (
+                    Self::Ready,
+                    Self::Stopping | Self::Pausing | Self::Failed | Self::Removing
+                ) | (
+                    Self::Stopping,
+                    Self::Stopped | Self::Failed | Self::Removing
+                ) | (Self::Stopped | Self::Failed, Self::Removing)
+                    // A failed pause reverts to Ready and a completed one
+                    // parks at Paused; a resume mirrors that exactly (a
+                    // failed one unwinds back to Paused).
                     | (
-                        Self::Stopping,
-                        Self::Stopped | Self::Failed | Self::Removing
+                        Self::Pausing | Self::Resuming,
+                        Self::Paused | Self::Ready | Self::Failed | Self::Removing
                     )
-                    | (Self::Stopped | Self::Failed, Self::Removing)
+                    | (Self::Paused, Self::Resuming | Self::Failed | Self::Removing)
             )
     }
 
@@ -286,6 +335,9 @@ impl SandboxPhase {
             Self::Stopped => "stopped",
             Self::Failed => "failed",
             Self::Removing => "removing",
+            Self::Pausing => "pausing",
+            Self::Paused => "paused",
+            Self::Resuming => "resuming",
         }
     }
 }
@@ -619,10 +671,15 @@ fn classify_existing_provision(
     Ok(match record.phase {
         SandboxPhase::Creating => ExistingProvision::Pending,
         SandboxPhase::Starting | SandboxPhase::Ready => ExistingProvision::Replay,
+        // A paused sandbox's provision outcome names a released IP, so a
+        // same-key create retry must not replay it as live.
         SandboxPhase::Stopping
         | SandboxPhase::Stopped
         | SandboxPhase::Failed
-        | SandboxPhase::Removing => ExistingProvision::Blocked,
+        | SandboxPhase::Removing
+        | SandboxPhase::Pausing
+        | SandboxPhase::Paused
+        | SandboxPhase::Resuming => ExistingProvision::Blocked,
     })
 }
 
@@ -661,10 +718,21 @@ fn validate_record(id: &str, record: &SandboxRecord) -> Result<()> {
             | SandboxPhase::Ready
             | SandboxPhase::Stopping
             | SandboxPhase::Stopped
+            | SandboxPhase::Pausing
+            | SandboxPhase::Paused
+            | SandboxPhase::Resuming
     ) && record.provision_outcome.is_none()
     {
         return Err(VmmError::Config(format!(
             "sandbox record has no provision outcome in phase {} for {id}",
+            record.phase.as_str()
+        )));
+    }
+    if matches!(record.phase, SandboxPhase::Paused | SandboxPhase::Resuming)
+        && record.pause_snapshot_id.is_none()
+    {
+        return Err(VmmError::Config(format!(
+            "sandbox record has no pause snapshot in phase {} for {id}",
             record.phase.as_str()
         )));
     }
@@ -955,6 +1023,138 @@ mod tests {
             store.replay_provision("failed", "key"),
             Err(VmmError::AlreadyExists(id)) if id == "failed"
         ));
+    }
+
+    #[test]
+    fn pause_resume_transitions_carry_the_snapshot_and_paused_at() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let record = created(store.provision_intent("box", "key", spec("box")).unwrap());
+        let generation = record.generation;
+        store
+            .transition(
+                "box",
+                generation,
+                SandboxTransition::Starting(SandboxProvisionOutcome {
+                    ip_address: "192.0.2.2".into(),
+                }),
+            )
+            .unwrap();
+        store
+            .transition("box", generation, SandboxTransition::Ready)
+            .unwrap();
+
+        // Pausing may not jump straight to Paused-from-Ready.
+        assert!(
+            store
+                .transition(
+                    "box",
+                    generation,
+                    SandboxTransition::Paused {
+                        snapshot_id: "snap".into()
+                    }
+                )
+                .is_err()
+        );
+        store
+            .transition("box", generation, SandboxTransition::Pausing)
+            .unwrap();
+        let paused = store
+            .transition(
+                "box",
+                generation,
+                SandboxTransition::Paused {
+                    snapshot_id: "snap".into(),
+                },
+            )
+            .unwrap()
+            .value;
+        assert_eq!(paused.phase, SandboxPhase::Paused);
+        assert_eq!(paused.pause_snapshot_id.as_deref(), Some("snap"));
+        assert!(paused.paused_at.is_some());
+
+        // A paused id must not replay its (released) provision outcome.
+        assert!(matches!(
+            store.replay_provision("box", "key"),
+            Err(VmmError::AlreadyExists(_))
+        ));
+
+        // Resume keeps the snapshot until Ready clears it.
+        let resuming = store
+            .transition("box", generation, SandboxTransition::Resuming)
+            .unwrap()
+            .value;
+        assert_eq!(resuming.pause_snapshot_id.as_deref(), Some("snap"));
+        // A failed resume unwinds back to Paused…
+        store
+            .transition(
+                "box",
+                generation,
+                SandboxTransition::Paused {
+                    snapshot_id: "snap".into(),
+                },
+            )
+            .unwrap();
+        // …and a successful one lands Ready with the pause state cleared.
+        store
+            .transition("box", generation, SandboxTransition::Resuming)
+            .unwrap();
+        let ready = store
+            .transition("box", generation, SandboxTransition::Ready)
+            .unwrap()
+            .value;
+        assert_eq!(ready.phase, SandboxPhase::Ready);
+        assert_eq!(ready.pause_snapshot_id, None);
+        assert_eq!(ready.paused_at, None);
+    }
+
+    #[test]
+    fn failed_pause_reverts_to_ready_and_paused_cannot_stop() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let record = created(store.provision_intent("box", "key", spec("box")).unwrap());
+        let generation = record.generation;
+        store
+            .transition(
+                "box",
+                generation,
+                SandboxTransition::Starting(SandboxProvisionOutcome {
+                    ip_address: String::new(),
+                }),
+            )
+            .unwrap();
+        store
+            .transition("box", generation, SandboxTransition::Ready)
+            .unwrap();
+        store
+            .transition("box", generation, SandboxTransition::Pausing)
+            .unwrap();
+        store
+            .transition("box", generation, SandboxTransition::Ready)
+            .unwrap();
+
+        store
+            .transition("box", generation, SandboxTransition::Pausing)
+            .unwrap();
+        store
+            .transition(
+                "box",
+                generation,
+                SandboxTransition::Paused {
+                    snapshot_id: "snap".into(),
+                },
+            )
+            .unwrap();
+        // Paused has no VM to drain: only Resume, Failed, or Removing apply.
+        assert!(
+            store
+                .transition("box", generation, SandboxTransition::Stopping)
+                .is_err()
+        );
+        store
+            .transition("box", generation, SandboxTransition::Removing)
+            .unwrap();
+        store.finish_remove("box", generation).unwrap();
     }
 
     #[test]

--- a/virt/arcbox-vm/src/sandbox/persistence.rs
+++ b/virt/arcbox-vm/src/sandbox/persistence.rs
@@ -272,7 +272,12 @@ impl SandboxRecord {
             SandboxTransition::Paused { snapshot_id } => {
                 self.phase = SandboxPhase::Paused;
                 self.pause_snapshot_id = Some(snapshot_id);
-                self.paused_at = Some(Utc::now());
+                // Stamped once per pause, not once per transition: a failed
+                // resume parks the record back at `Paused`, and overwriting
+                // here would report the sandbox as freshly paused — and push
+                // the time forward again on every retry. `Ready` clears the
+                // stamp, so a genuine re-pause still gets a fresh one.
+                self.paused_at.get_or_insert_with(Utc::now);
                 self.error = None;
             }
             SandboxTransition::Resuming => {
@@ -1085,8 +1090,10 @@ mod tests {
             .unwrap()
             .value;
         assert_eq!(resuming.pause_snapshot_id.as_deref(), Some("snap"));
-        // A failed resume unwinds back to Paused…
-        store
+        // A failed resume unwinds back to Paused, keeping the ORIGINAL
+        // paused_at — the sandbox has been paused since the pause call, and
+        // a retry loop must not keep pushing the stamp forward.
+        let reverted = store
             .transition(
                 "box",
                 generation,
@@ -1094,7 +1101,9 @@ mod tests {
                     snapshot_id: "snap".into(),
                 },
             )
-            .unwrap();
+            .unwrap()
+            .value;
+        assert_eq!(reverted.paused_at, paused.paused_at);
         // …and a successful one lands Ready with the pause state cleared.
         store
             .transition("box", generation, SandboxTransition::Resuming)
@@ -1106,6 +1115,23 @@ mod tests {
         assert_eq!(ready.phase, SandboxPhase::Ready);
         assert_eq!(ready.pause_snapshot_id, None);
         assert_eq!(ready.paused_at, None);
+
+        // A genuine re-pause after Ready gets a fresh stamp.
+        store
+            .transition("box", generation, SandboxTransition::Pausing)
+            .unwrap();
+        let repaused = store
+            .transition(
+                "box",
+                generation,
+                SandboxTransition::Paused {
+                    snapshot_id: "snap2".into(),
+                },
+            )
+            .unwrap()
+            .value;
+        assert!(repaused.paused_at.is_some());
+        assert!(repaused.paused_at >= paused.paused_at);
     }
 
     #[test]

--- a/virt/arcbox-vm/src/sandbox/reconcile.rs
+++ b/virt/arcbox-vm/src/sandbox/reconcile.rs
@@ -203,6 +203,7 @@ pub(super) async fn sweep_orphans(
     network: &NetworkManager,
     cow_manager: &CowManager,
     snapshots: &crate::snapshot::SnapshotCatalog,
+    store: &SandboxRecordStore,
 ) -> Result<OrphanSweep> {
     // Snapshots staged by a checkpoint that died mid-flight: unfinished by
     // definition, and each can hold a full memory dump.
@@ -248,7 +249,18 @@ pub(super) async fn sweep_orphans(
             kill_orphaned_firecracker(pid).await?;
         }
     }
-    cow_manager.reconcile_stale()?;
+    // Cleanly paused sandboxes (durably Paused, no cleanup journal) keep
+    // their detached COW overlay — it is retained disk state, not an orphan.
+    // A Paused record that still has a journal died mid-pause; its resources
+    // (overlay included) are swept and normalization degrades it to Failed.
+    let journaled: HashSet<String> = records.iter().map(|(_, r)| r.id.clone()).collect();
+    let keep_cow: HashSet<String> = store
+        .load_all()?
+        .into_iter()
+        .filter(|record| record.phase == SandboxPhase::Paused && !journaled.contains(&record.id))
+        .map(|record| record.id)
+        .collect();
+    cow_manager.reconcile_stale(&keep_cow)?;
 
     let mut swept = HashSet::new();
     let mut runtime_dirs = Vec::new();
@@ -324,6 +336,40 @@ pub(super) fn normalize_durable_records(
                     .confirmed("sandbox restart normalization")?;
                 inactive.push(inactive_instance(record, SandboxState::Failed, data_dir));
             }
+            // An interrupted pause/resume died between resource states; the
+            // sweep already tore down whatever its journal listed (including
+            // the disk overlay), so the sandbox is unrecoverable. Unlike the
+            // live phases above, a missing journal is normal here — Pausing
+            // clears it after releasing everything, just before the Paused
+            // commit.
+            SandboxPhase::Pausing | SandboxPhase::Resuming => {
+                let record = store
+                    .transition(
+                        &record.id,
+                        record.generation,
+                        SandboxTransition::Failed(AGENT_RESTART_ERROR.into()),
+                    )?
+                    .confirmed("sandbox restart normalization")?;
+                inactive.push(inactive_instance(record, SandboxState::Failed, data_dir));
+            }
+            SandboxPhase::Paused => {
+                // A journal on a Paused record means the pause's release never
+                // finished cleanly and the sweep just destroyed the retained
+                // resources — degrade honestly rather than promise a resume
+                // that cannot work.
+                if swept.is_some_and(|ids| ids.contains(&record.id)) {
+                    let record = store
+                        .transition(
+                            &record.id,
+                            record.generation,
+                            SandboxTransition::Failed(AGENT_RESTART_ERROR.into()),
+                        )?
+                        .confirmed("sandbox restart normalization")?;
+                    inactive.push(inactive_instance(record, SandboxState::Failed, data_dir));
+                } else {
+                    inactive.push(inactive_instance(record, SandboxState::Paused, data_dir));
+                }
+            }
             SandboxPhase::Stopped => {
                 inactive.push(inactive_instance(record, SandboxState::Stopped, data_dir));
             }
@@ -357,6 +403,10 @@ fn inactive_instance(
     instance.state = state;
     instance.created_at = record.created_at;
     instance.error = record.error;
+    if state == SandboxState::Paused {
+        instance.pause_snapshot_id = record.pause_snapshot_id;
+        instance.paused_at = record.paused_at;
+    }
     instance
 }
 
@@ -621,6 +671,30 @@ mod tests {
                                 .unwrap();
                         }
                     }
+                    SandboxPhase::Pausing | SandboxPhase::Paused | SandboxPhase::Resuming => {
+                        store
+                            .transition(id, generation, SandboxTransition::Ready)
+                            .unwrap();
+                        store
+                            .transition(id, generation, SandboxTransition::Pausing)
+                            .unwrap();
+                        if phase != SandboxPhase::Pausing {
+                            store
+                                .transition(
+                                    id,
+                                    generation,
+                                    SandboxTransition::Paused {
+                                        snapshot_id: "snap".into(),
+                                    },
+                                )
+                                .unwrap();
+                        }
+                        if phase == SandboxPhase::Resuming {
+                            store
+                                .transition(id, generation, SandboxTransition::Resuming)
+                                .unwrap();
+                        }
+                    }
                     _ => unreachable!("phase handled above"),
                 }
             }
@@ -796,6 +870,43 @@ mod tests {
         );
         assert!(store.load("removing").unwrap().is_none());
         assert!(!inactive.contains_key("removing"));
+    }
+
+    #[test]
+    fn paused_records_survive_restart_unless_their_release_was_interrupted() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        record_in_phase(&store, "clean", SandboxPhase::Paused);
+        record_in_phase(&store, "torn", SandboxPhase::Paused);
+        record_in_phase(&store, "mid-pause", SandboxPhase::Pausing);
+        record_in_phase(&store, "mid-resume", SandboxPhase::Resuming);
+
+        // Only "torn" had a cleanup journal, i.e. the sweep destroyed its
+        // retained resources. The interrupted pause/resume fail regardless.
+        let swept = HashSet::from(["torn".to_owned()]);
+        let inactive = normalize_durable_records(&store, data_dir.path(), Some(&swept)).unwrap();
+        let inactive: HashMap<_, _> = inactive
+            .into_iter()
+            .map(|instance| (instance.id.clone(), instance))
+            .collect();
+
+        let clean = &inactive["clean"];
+        assert_eq!(clean.state, SandboxState::Paused);
+        assert_eq!(clean.pause_snapshot_id.as_deref(), Some("snap"));
+        assert!(clean.paused_at.is_some());
+        assert_eq!(
+            store.load("clean").unwrap().unwrap().phase,
+            SandboxPhase::Paused
+        );
+
+        for id in ["torn", "mid-pause", "mid-resume"] {
+            assert_eq!(inactive[id].state, SandboxState::Failed, "{id}");
+            assert_eq!(
+                store.load(id).unwrap().unwrap().phase,
+                SandboxPhase::Failed,
+                "{id}"
+            );
+        }
     }
 
     #[test]

--- a/virt/arcbox-vm/src/sandbox/reconcile.rs
+++ b/virt/arcbox-vm/src/sandbox/reconcile.rs
@@ -249,22 +249,29 @@ pub(super) async fn sweep_orphans(
             kill_orphaned_firecracker(pid).await?;
         }
     }
-    // Cleanly paused sandboxes (durably Paused, no cleanup journal) keep
-    // their detached COW overlay — it is retained disk state, not an orphan.
-    // A Paused record that still has a journal died mid-pause; its resources
-    // (overlay included) are swept and normalization degrades it to Failed.
-    let journaled: HashSet<String> = records.iter().map(|(_, r)| r.id.clone()).collect();
-    let keep_cow: HashSet<String> = store
+    // Durably Paused sandboxes keep their retained disk state (the detached
+    // COW overlay or parked rootfs): Paused is committed only after
+    // `release_for_pause` (or the resume unwind) released every runtime
+    // resource, so a cleanup journal found next to it is a leftover of the
+    // crash window between that commit and the journal clear — not evidence
+    // of a torn release. Those journals are dropped as stale; every other
+    // journaled sandbox is swept.
+    let paused: HashSet<String> = store
         .load_all()?
         .into_iter()
-        .filter(|record| record.phase == SandboxPhase::Paused && !journaled.contains(&record.id))
+        .filter(|record| record.phase == SandboxPhase::Paused)
         .map(|record| record.id)
         .collect();
-    cow_manager.reconcile_stale(&keep_cow)?;
+    cow_manager.reconcile_stale(&paused)?;
 
     let mut swept = HashSet::new();
     let mut runtime_dirs = Vec::new();
     for (dir, mut record) in records {
+        if paused.contains(&record.id) {
+            info!(sandbox_id = %record.id, "dropping stale pause journal, keeping retained state");
+            clear_state_record(&dir)?;
+            continue;
+        }
         info!(sandbox_id = %record.id, "reconciling orphaned sandbox");
 
         if let Some(cow) = record.cow.take() {
@@ -352,23 +359,12 @@ pub(super) fn normalize_durable_records(
                     .confirmed("sandbox restart normalization")?;
                 inactive.push(inactive_instance(record, SandboxState::Failed, data_dir));
             }
+            // Paused commits only after every runtime resource was released,
+            // and the sweep preserves durably Paused retained state (clearing
+            // any stale journal), so a paused sandbox always survives a
+            // restart resumable.
             SandboxPhase::Paused => {
-                // A journal on a Paused record means the pause's release never
-                // finished cleanly and the sweep just destroyed the retained
-                // resources — degrade honestly rather than promise a resume
-                // that cannot work.
-                if swept.is_some_and(|ids| ids.contains(&record.id)) {
-                    let record = store
-                        .transition(
-                            &record.id,
-                            record.generation,
-                            SandboxTransition::Failed(AGENT_RESTART_ERROR.into()),
-                        )?
-                        .confirmed("sandbox restart normalization")?;
-                    inactive.push(inactive_instance(record, SandboxState::Failed, data_dir));
-                } else {
-                    inactive.push(inactive_instance(record, SandboxState::Paused, data_dir));
-                }
+                inactive.push(inactive_instance(record, SandboxState::Paused, data_dir));
             }
             SandboxPhase::Stopped => {
                 inactive.push(inactive_instance(record, SandboxState::Stopped, data_dir));
@@ -873,18 +869,15 @@ mod tests {
     }
 
     #[test]
-    fn paused_records_survive_restart_unless_their_release_was_interrupted() {
+    fn paused_records_survive_restart_while_interrupted_transitions_fail() {
         let data_dir = tempfile::tempdir().unwrap();
         let store = SandboxRecordStore::new(data_dir.path()).unwrap();
         record_in_phase(&store, "clean", SandboxPhase::Paused);
-        record_in_phase(&store, "torn", SandboxPhase::Paused);
         record_in_phase(&store, "mid-pause", SandboxPhase::Pausing);
         record_in_phase(&store, "mid-resume", SandboxPhase::Resuming);
 
-        // Only "torn" had a cleanup journal, i.e. the sweep destroyed its
-        // retained resources. The interrupted pause/resume fail regardless.
-        let swept = HashSet::from(["torn".to_owned()]);
-        let inactive = normalize_durable_records(&store, data_dir.path(), Some(&swept)).unwrap();
+        let inactive =
+            normalize_durable_records(&store, data_dir.path(), Some(&HashSet::new())).unwrap();
         let inactive: HashMap<_, _> = inactive
             .into_iter()
             .map(|instance| (instance.id.clone(), instance))
@@ -899,7 +892,9 @@ mod tests {
             SandboxPhase::Paused
         );
 
-        for id in ["torn", "mid-pause", "mid-resume"] {
+        // An interrupted pause/resume never reached a durable Paused commit;
+        // its resources were swept, so it degrades honestly.
+        for id in ["mid-pause", "mid-resume"] {
             assert_eq!(inactive[id].state, SandboxState::Failed, "{id}");
             assert_eq!(
                 store.load(id).unwrap().unwrap().phase,
@@ -907,6 +902,40 @@ mod tests {
                 "{id}"
             );
         }
+    }
+
+    /// The crash window between the durable `Paused` commit and the journal
+    /// clear must not cost the sandbox its retained disk state: the restart
+    /// sweep drops the stale journal and keeps everything else.
+    #[tokio::test]
+    async fn stale_pause_journal_is_dropped_and_retained_state_survives() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        record_in_phase(&store, "napper", SandboxPhase::Paused);
+
+        let vm_dir = data_dir.path().join("sandboxes").join("napper");
+        std::fs::create_dir_all(&vm_dir).unwrap();
+        std::fs::write(vm_dir.join(STATE_FILE), br#"{"id": "napper"}"#).unwrap();
+        let parked_rootfs = vm_dir.join(super::super::pause::PAUSED_ROOTFS_FILE);
+        std::fs::write(&parked_rootfs, b"disk").unwrap();
+        let cow_dir = data_dir.path().join("cow");
+        std::fs::create_dir_all(&cow_dir).unwrap();
+        let cow_file = cow_dir.join("arcbox-cow-napper.img");
+        std::fs::write(&cow_file, b"overlay").unwrap();
+        drop(store);
+
+        let mut config = VmmConfig::default();
+        config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
+        let manager = super::super::SandboxManager::new(config).unwrap();
+        manager.await_reconcile().await.unwrap();
+
+        assert!(!vm_dir.join(STATE_FILE).exists());
+        assert!(parked_rootfs.exists());
+        assert!(cow_file.exists());
+        let instances = manager.instances.read().unwrap();
+        let inst = instances["napper"].lock().unwrap();
+        assert_eq!(inst.state, SandboxState::Paused);
+        assert_eq!(inst.pause_snapshot_id.as_deref(), Some("snap"));
     }
 
     #[test]

--- a/virt/arcbox-vm/src/sandbox/reconcile.rs
+++ b/virt/arcbox-vm/src/sandbox/reconcile.rs
@@ -346,9 +346,9 @@ pub(super) fn normalize_durable_records(
             // An interrupted pause/resume died between resource states; the
             // sweep already tore down whatever its journal listed (including
             // the disk overlay), so the sandbox is unrecoverable. Unlike the
-            // live phases above, a missing journal is normal here — Pausing
-            // clears it after releasing everything, just before the Paused
-            // commit.
+            // live phases above, a missing journal is normal here — a resume
+            // starts from a Paused record whose journal was already cleared
+            // (after the Paused commit) and re-journals as it re-allocates.
             SandboxPhase::Pausing | SandboxPhase::Resuming => {
                 let record = store
                     .transition(

--- a/virt/arcbox-vm/src/sandbox/types.rs
+++ b/virt/arcbox-vm/src/sandbox/types.rs
@@ -25,6 +25,12 @@ pub enum SandboxState {
     Stopped,
     /// Unrecoverable error occurred.
     Failed,
+    /// `Pause` called; checkpointing state, then releasing the VM.
+    Pausing,
+    /// Checkpointed to disk with runtime resources released; the record,
+    /// checkpoint, and disk overlay survive under the same id until
+    /// `Resume` or `Remove` (CORE-21).
+    Paused,
 }
 
 impl std::fmt::Display for SandboxState {
@@ -36,6 +42,8 @@ impl std::fmt::Display for SandboxState {
             Self::Stopping => write!(f, "stopping"),
             Self::Stopped => write!(f, "stopped"),
             Self::Failed => write!(f, "failed"),
+            Self::Pausing => write!(f, "pausing"),
+            Self::Paused => write!(f, "paused"),
         }
     }
 }
@@ -159,12 +167,20 @@ pub struct SandboxInstance {
     /// (CORE-78), the slot id (`pool-<uuid>`) its jailer chroot and dm/CoW
     /// names are keyed by. `None` for resources created under the
     /// sandbox's own id.
+    ///
+    /// Cleared by pause: releasing a paused sandbox renames its retained
+    /// overlay to the sandbox-id path and destroys the slot chroot, so a
+    /// resumed sandbox owns everything under its own id again.
     pub(super) pool_slot_id: Option<String>,
     /// Whether this guest runs the fixed invariant network identity
     /// (CORE-81). Set by the create path when the boot bakes the invariant
     /// `ip=` parameter, and inherited from [`crate::snapshot::SnapshotMeta`]
     /// on restore so chained checkpoints record the guest's actual addressing.
     pub(super) net_invariant: bool,
+    /// When the sandbox reached `Paused` (None otherwise).
+    pub paused_at: Option<DateTime<Utc>>,
+    /// Catalog id of the internal pause checkpoint (state == `Paused` only).
+    pub pause_snapshot_id: Option<String>,
 }
 
 impl SandboxInstance {
@@ -215,6 +231,8 @@ impl SandboxInstance {
             cow_handle: None,
             pool_slot_id: None,
             net_invariant: false,
+            paused_at: None,
+            pause_snapshot_id: None,
         }
     }
 
@@ -234,6 +252,10 @@ pub struct SandboxSummary {
     /// Allocated IP address (empty when network mode is `"none"`).
     pub ip_address: String,
     pub created_at: DateTime<Utc>,
+    /// When the sandbox reached `Paused` (None otherwise).
+    pub paused_at: Option<DateTime<Utc>>,
+    /// On-disk footprint of retained pause state (checkpoint + overlay).
+    pub storage_bytes: u64,
 }
 
 /// Detailed sandbox state for `Inspect`.
@@ -249,6 +271,10 @@ pub struct SandboxInfo {
     pub last_exited_at: Option<DateTime<Utc>>,
     pub last_exit_status: Option<ExitStatus>,
     pub error: Option<String>,
+    /// When the sandbox reached `Paused` (None otherwise).
+    pub paused_at: Option<DateTime<Utc>>,
+    /// On-disk footprint of retained pause state (checkpoint + overlay).
+    pub storage_bytes: u64,
 }
 
 /// Network details within `SandboxInfo`.
@@ -275,6 +301,9 @@ pub mod action {
     pub const STOPPED: &str = "stopped";
     pub const FAILED: &str = "failed";
     pub const REMOVED: &str = "removed";
+    pub const PAUSING: &str = "pausing";
+    pub const PAUSED: &str = "paused";
+    pub const RESUMED: &str = "resumed";
 }
 
 /// A sandbox lifecycle event broadcast to subscribers.

--- a/virt/arcbox-vm/src/sandbox/warm.rs
+++ b/virt/arcbox-vm/src/sandbox/warm.rs
@@ -326,8 +326,12 @@ async fn publish_warm_snapshot(
         &ticket.snapshots,
         config,
         sandbox_id,
-        name,
-        labels,
+        super::checkpoint::CheckpointRequest {
+            name,
+            labels,
+            expected_state: SandboxState::Ready,
+            resume_after: true,
+        },
     )
     .await?;
     ticket.cache.touch(&ticket.key);

--- a/virt/arcbox-vm/src/snapshot_cow.rs
+++ b/virt/arcbox-vm/src/snapshot_cow.rs
@@ -224,6 +224,27 @@ impl CowManager {
     /// Returns a [`CowHandle`] whose `dm_device` field can be passed to
     /// Firecracker as the rootfs block device.
     pub async fn setup(&self, sandbox_id: &str, rootfs_path: &str) -> Result<CowHandle> {
+        self.assemble(sandbox_id, rootfs_path, false).await
+    }
+
+    /// Re-assemble the dm-snapshot for a paused sandbox from its preserved
+    /// COW file (CORE-21 resume).
+    ///
+    /// The snapshot table uses persistent mode (`P`), so the exception store
+    /// in the retained overlay carries every block the sandbox wrote before
+    /// it was paused. Unlike [`Self::setup`], the COW file must already
+    /// exist and match the template size, and no failure path deletes it —
+    /// the overlay is the sandbox's disk.
+    pub async fn reattach(&self, sandbox_id: &str, rootfs_path: &str) -> Result<CowHandle> {
+        self.assemble(sandbox_id, rootfs_path, true).await
+    }
+
+    async fn assemble(
+        &self,
+        sandbox_id: &str,
+        rootfs_path: &str,
+        reuse_existing_cow: bool,
+    ) -> Result<CowHandle> {
         validate_dm_name_suffix(sandbox_id)?;
         #[cfg(test)]
         if let Some(probe) = &self.test_probe {
@@ -372,10 +393,38 @@ impl CowManager {
             (loop_dev, sectors)
         };
 
-        // --- 2. Create sparse COW file (O(1), no actual I/O) ---------------
+        // --- 2. Create (or, on reattach, verify) the sparse COW file --------
+        //
+        // On reattach the overlay is the sandbox's retained disk, so every
+        // rollback below passes `cow_file: None` — a failed re-assembly must
+        // never delete it.
         let cow_file = self.cow_dir.join(format!("arcbox-cow-{sandbox_id}.img"));
         let cow_size = sectors * 512;
-        if let Err((e, owns_file)) = create_sparse_file(&cow_file, cow_size).await {
+        if reuse_existing_cow {
+            let verified = std::fs::metadata(&cow_file)
+                .map_err(|e| {
+                    VmmError::DeviceMapper(format!(
+                        "preserved cow file {}: {e}",
+                        cow_file.display()
+                    ))
+                })
+                .and_then(|metadata| {
+                    if metadata.len() == cow_size {
+                        Ok(())
+                    } else {
+                        Err(VmmError::DeviceMapper(format!(
+                            "preserved cow file {} is {} bytes but template needs {cow_size}",
+                            cow_file.display(),
+                            metadata.len()
+                        )))
+                    }
+                });
+            if let Err(e) = verified {
+                return Err(self
+                    .rollback_setup(sandbox_id, &template, None, None, None, e)
+                    .await);
+            }
+        } else if let Err((e, owns_file)) = create_sparse_file(&cow_file, cow_size).await {
             return Err(self
                 .rollback_setup(
                     sandbox_id,
@@ -387,6 +436,8 @@ impl CowManager {
                 )
                 .await);
         }
+        let rollback_cow_file = (!reuse_existing_cow).then_some(cow_file.clone());
+        let rollback_cow_file = rollback_cow_file.as_deref();
 
         // --- 3. Attach COW file as a loop device ----------------------------
         let cow_loop_result = {
@@ -399,7 +450,7 @@ impl CowManager {
             Ok(dev) => dev,
             Err(e) => {
                 return Err(self
-                    .rollback_setup(sandbox_id, &template, None, None, Some(&cow_file), e)
+                    .rollback_setup(sandbox_id, &template, None, None, rollback_cow_file, e)
                     .await);
             }
         };
@@ -416,7 +467,7 @@ impl CowManager {
                     &template,
                     Some(&dm_name),
                     Some(&cow_loop),
-                    Some(&cow_file),
+                    rollback_cow_file,
                     e,
                 )
                 .await);
@@ -524,6 +575,63 @@ impl CowManager {
         } else {
             Err(VmmError::DeviceMapper(failures.join("; ")))
         }
+    }
+
+    /// Tear down the dm device and COW loop but keep the COW file on disk.
+    ///
+    /// This is the pause half of CORE-21: the persistent (`P`) exception
+    /// store in the retained file preserves every written block, and
+    /// [`Self::reattach`] re-assembles the identical device on resume. A
+    /// failed step keeps the handle valid for retry, exactly like
+    /// [`Self::teardown_checked`].
+    pub async fn detach_keep_cow(&self, handle: &CowHandle) -> Result<()> {
+        #[cfg(test)]
+        if let Some(probe) = &self.test_probe {
+            probe.teardown(handle);
+            return Ok(());
+        }
+        let dmsetup = self
+            .dmsetup_bin
+            .as_deref()
+            .ok_or_else(|| VmmError::DeviceMapper("dmsetup binary not found".into()))?;
+        let mut failures = Vec::new();
+
+        if Path::new(&handle.dm_device).exists()
+            && let Err(error) = dmsetup_remove(dmsetup, &handle.dm_name).await
+        {
+            failures.push(format!("remove {}: {error}", handle.dm_name));
+        }
+        if failures.is_empty()
+            && loop_backs_path(&handle.cow_loop, &handle.cow_file)?
+            && let Err(error) = losetup_detach(BUSYBOX, &handle.cow_loop).await
+        {
+            failures.push(format!("detach {}: {error}", handle.cow_loop));
+        }
+
+        if failures.is_empty() {
+            self.release_template_ref(&handle.template_path, true)
+                .await?;
+            info!(sandbox = %handle.dm_name, "dm-snapshot detached, cow file retained");
+            Ok(())
+        } else {
+            Err(VmmError::DeviceMapper(failures.join("; ")))
+        }
+    }
+
+    /// Delete the COW file a pause left behind (sandbox Remove / TTL).
+    ///
+    /// Idempotent: a missing file is success. Any loop still backing the
+    /// file is detached first so the unlink actually frees the space.
+    pub async fn remove_preserved_cow(&self, sandbox_id: &str) -> Result<()> {
+        let cow_file = self.cow_dir.join(format!("arcbox-cow-{sandbox_id}.img"));
+        if !cow_file.exists() {
+            return Ok(());
+        }
+        for loop_device in loop_devices_for_backing_sync(&cow_file)? {
+            losetup_detach(BUSYBOX, &loop_device).await?;
+        }
+        remove_file_durable(&cow_file)?;
+        Ok(())
     }
 }
 

--- a/virt/arcbox-vm/src/snapshot_cow.rs
+++ b/virt/arcbox-vm/src/snapshot_cow.rs
@@ -192,13 +192,24 @@ impl CowManager {
         std::fs::File::open(&cow_dir)?.sync_all()?;
         std::fs::File::open(&data_dir)?.sync_all()?;
 
+        // Existence is not usability: driving device-mapper needs
+        // /dev/mapper/control, i.e. root inside the VM. A process that cannot
+        // talk to the driver (unprivileged dev host, CI runner) can never have
+        // created dm snapshots either, so it degrades to the same copy-mode
+        // fallback as a missing binary instead of failing every dm command.
         let dmsetup_bin = DMSETUP_CANDIDATES
             .iter()
             .find(|p| Path::new(p).exists())
-            .map(|s| (*s).to_string());
+            .map(|s| (*s).to_string())
+            .filter(|bin| {
+                Command::new(bin)
+                    .arg("version")
+                    .output()
+                    .is_ok_and(|out| out.status.success())
+            });
 
         if dmsetup_bin.is_none() {
-            warn!("dmsetup not found; dm-snapshot CoW will be unavailable");
+            warn!("dmsetup not found or unusable; dm-snapshot CoW will be unavailable");
         }
 
         Ok(Self {

--- a/virt/arcbox-vm/src/snapshot_cow/persistence.rs
+++ b/virt/arcbox-vm/src/snapshot_cow/persistence.rs
@@ -37,7 +37,16 @@ impl CowManager {
     /// devices left over from a previous crash. Called after orphaned
     /// Firecracker processes are dead; it is synchronous because every
     /// command is short and startup is already gated on reconciliation.
-    pub(crate) fn reconcile_stale(&self) -> Result<()> {
+    ///
+    /// `keep_cow_ids` names sandboxes whose COW file is *retained state*,
+    /// not an orphan: a paused sandbox keeps its (detached) overlay on disk
+    /// so Resume can re-assemble the dm-snapshot with every written block
+    /// intact (CORE-21). Deleting those files here would silently destroy a
+    /// paused sandbox's disk across an agent restart.
+    pub(crate) fn reconcile_stale(
+        &self,
+        keep_cow_ids: &std::collections::HashSet<String>,
+    ) -> Result<()> {
         let dmsetup = self.dmsetup_bin.as_deref();
 
         // 1. Remove stale dm devices first — they pin the loop devices
@@ -57,14 +66,19 @@ impl CowManager {
         }
 
         // 2. Detach loops backing stale COW files, then unlink the files.
+        //    Overlays retained by a paused sandbox are skipped wholesale.
         for entry in std::fs::read_dir(&self.cow_dir)? {
             let entry = entry?;
             let path = entry.path();
-            if path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(|n| n.starts_with("arcbox-cow-"))
-            {
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if let Some(rest) = name.strip_prefix("arcbox-cow-") {
+                let id = rest.strip_suffix(".img").unwrap_or(rest);
+                if keep_cow_ids.contains(id) {
+                    debug!(file = %path.display(), "keeping paused sandbox cow file");
+                    continue;
+                }
                 for loop_device in loop_devices_for_backing_sync(&path)? {
                     run_sync_checked(Command::new(BUSYBOX).args(["losetup", "-d", &loop_device]))?;
                 }


### PR DESCRIPTION
Implements CORE-21 slice 1: `SandboxService.Pause`/`Resume` become real, and every sandbox data-plane RPC transparently resumes a paused sandbox. The idle knobs (`idle_timeout_seconds` + `on_idle`, `SetLifecycle`) land in slice 2.

## Design

**Pause** checkpoints a `READY` sandbox (FC vmstate+mem into the snapshot catalog under the reserved internal name `arcbox-pause`), deliberately does **not** resume the VM afterwards, then releases Firecracker, the TAP+IP (quarantined through the same durable cleanup-ticket flow Stop uses, which also drops the sandbox's host DNS entry), and the jailer chroot — while **retaining the disk**: the persistent (`P`) dm-snapshot COW file stays on disk (copy-mode fallback parks the staged rootfs in `vm_dir`). Because the VM never runs past the snapshot, the checkpoint and the retained overlay cannot diverge — memory AND disk state are exactly the pause-time state.

**Resume** restores in place under the same id: fresh network allocation (`network_override` semantics — new TAP + IP, guest re-addressed over vsock, DNS re-registered on both sides), the identical overlay re-assembled from the retained COW file, `READY` again, pause checkpoint deleted. Failed pause reverts to `READY`; failed resume unwinds back to `PAUSED` (or degrades honestly to `FAILED`). Paused records survive agent restarts (the orphan sweep protects their overlay; interrupted pauses/resumes normalize to `FAILED`), still honor the hard `ttl_seconds`, and report `paused_at` + `storage_bytes`. `Remove` deletes the retained overlay and pause checkpoints; pause checkpoints are hidden from `ListSnapshots` and refused by `DeleteSnapshot`/`Restore`.

### Resolution: Pause-from-READY vs the state diagram's RUNNING edge

The contract was self-contradictory: the `Pause` RPC comment said "requires READY (no active execution)" while both state diagrams drew a `RUNNING → PAUSING` edge. **Resolved to READY-only** — pause checkpoints a quiescent sandbox; a `RUNNING` one has a live execution whose host-side session cannot survive the VM being checkpointed and killed, and CORE-21's auto-pause fires on the idle (READY) edge by definition. Both diagrams (`sandbox.proto`, `docs/sandbox-api.md`) now show `PAUSING` branching from `READY` only, with the rationale inline. `Pause` on `RUNNING` answers `FAILED_PRECONDITION`; `Pause` on `PAUSED` and `Resume` on `READY`/`RUNNING` are no-ops.

## Auto-resume coverage

The guest signals paused with a dedicated wire code (423, `VmmError::Paused` → `SandboxError::SandboxPaused`), so the daemon keys on it machine-readably:

- **Retry-on-423** (zero hot-path cost): `StartExecution`, `WriteStdin`, `StreamStdin` — one resume, one retry.
- **First-frame peek**: `ReadFile` — the verdict is caught before the response stream commits.
- **Pre-flight inspect**: `WriteFile` — its input stream cannot be replayed, so a paused sandbox is resumed before any chunk is consumed.
- **Deliberately not resumed**: `AttachExecution`, `WaitExecution`, `GetStdinStatus`, `Signal`, `Resize` address execution *history* served from the guest registry and cannot observe SANDBOX_PAUSED; `Inspect`/`List` never resume per contract.

Concurrent callers share one resume: the per-sandbox operation lock serializes them and the guest Resume is idempotent. `x-arcbox-no-auto-resume: 1` is now honored — opted-out callers (and any surfaced-paused control-plane error) get `FAILED_PRECONDITION` carrying the `SANDBOX_PAUSED` `ErrorInfo` Connect detail (`errors.proto`). Automation stays visible: `PAUSING(reason=pause)`, `PAUSED`, `RESUMED(reason=resume|auto_resume)` events; the reason crosses the internal wire on the new `SandboxResumeCommand` (additive `agent.proto` + MessageTypes 0x0044/0x0045, no protocol-version bump).

## Evidence

Sandbox e2e (`cargo test -p arcbox-e2e --test sandbox -- --ignored`) green on hardware (VZ/M3, 276s), including the new phase: pause honesty (state/`paused_at`/`storage_bytes`/idempotency) → opt-out header answers `FAILED_PRECONDITION` without waking the sandbox → transparent auto-resume on `StartExecution` → explicit resume after a second pause → **disk proof** (synced 64KiB marker on the ext4 overlay) and **memory proof** (1MiB tmpfs payload) both read back intact after each resume → `PAUSING`/`PAUSED`/`RESUMED(reason=…)` observed on a live Events stream → the pre-existing checkpoint/restore/Connect-JSON phases still green downstream of a paused-and-resumed origin. TypeScript SDK e2e (`--test sdk_ts`) green as regression. Unit: 366 tests across arcbox-vm/-constants/-protocol/-core/-api (state machine, durable phase edges, restart normalization incl. overlay protection, 423 mapping, opt-out header semantics). `clippy --workspace --exclude arcbox-agent -D warnings`, musl agent clippy (zero new warnings on changed lines), `fmt --all --check` all clean.

## Deferred (slice 2)

- Idle knobs: `idle_timeout_seconds` + `on_idle: PAUSE` detector, `SetLifecycle` (with CORE-60 TTL re-arm) — the guest-side idle timer will reuse `pause_sandbox` with `reason=idle_timeout`.
- `abctl sandbox pause/resume` CLI verbs.
- Port exposures are dropped at pause and must be re-exposed after resume (documented); carrying them across automatically needs the exposure registry to re-target the fresh IP.
