### PR TITLE
feat(sandbox): lifecycle knobs, capability handshake, error registry attachment (CORE-21/60/13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "arcbox-docker",
  "arcbox-error",
  "async-stream",
+ "base64",
  "buffa",
  "buffa-types",
  "bytes",

--- a/app/arcbox-api/Cargo.toml
+++ b/app/arcbox-api/Cargo.toml
@@ -29,6 +29,7 @@ buffa = { version = "0.9.1", features = ["json"] }
 buffa-types = { version = "0.9.1", features = ["json"] }
 
 [dev-dependencies]
+base64 = "0.22.1"
 http = "1.5.0"
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/app/arcbox-api/src/connect/control.rs
+++ b/app/arcbox-api/src/connect/control.rs
@@ -61,6 +61,12 @@ impl pb::SandboxService for SandboxServiceImpl {
         let sandbox_id = req.id.clone();
         let _operation = self.operations.lock(&machine, &sandbox_id).await;
         let runtime = self.runtime.ready()?;
+        // CORE-13 fail-fast: refuse before dialing the guest instead of a
+        // boot that wedges into FAILED with an opaque KVM error.
+        let capability = runtime.sandbox_nested_virt();
+        if !capability.supported {
+            return Err(super::sandbox_errors::nested_virt_unsupported(&capability));
+        }
         let mut agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
         // The RPC error otherwise reaches only the caller; the daemon log
         // must record a failed lifecycle mutation on its own (CORE-82).
@@ -214,16 +220,33 @@ impl pb::SandboxService for SandboxServiceImpl {
         Response::ok(Empty::default())
     }
 
-    /// Contract-only stub (CORE-58 phase 1): served for real with
-    /// CORE-13 (nested-virt fail-fast).
+    /// Report what this daemon can do (CORE-13): version, sandbox protocol
+    /// level, feature flags, and whether nested virtualization is available
+    /// on the *current* backend and hardware — answered host-side without
+    /// touching the guest, so the SDK handshake works before any sandbox
+    /// exists.
     async fn get_capabilities(
         &self,
         _ctx: RequestContext,
         _request: ServiceRequest<'_, pb::GetCapabilitiesRequest>,
     ) -> ServiceResult<pb::GetCapabilitiesResponse> {
-        Err(ConnectError::unimplemented(
-            "capability reporting is not implemented yet (CORE-13)",
-        ))
+        let runtime = self.runtime.ready()?;
+        let nested = runtime.sandbox_nested_virt();
+        Response::ok(pb::GetCapabilitiesResponse {
+            daemon_version: env!("CARGO_PKG_VERSION").to_owned(),
+            protocol: arcbox_constants::sandbox::SANDBOX_API_PROTOCOL,
+            features: arcbox_constants::sandbox::SANDBOX_FEATURES
+                .iter()
+                .map(|feature| (*feature).to_owned())
+                .collect(),
+            nested_virt: pb::NestedVirtCapability {
+                supported: nested.supported,
+                reason: nested.reason,
+                ..Default::default()
+            }
+            .into(),
+            ..Default::default()
+        })
     }
 
     async fn inspect(

--- a/app/arcbox-api/src/connect/control.rs
+++ b/app/arcbox-api/src/connect/control.rs
@@ -193,17 +193,25 @@ impl pb::SandboxService for SandboxServiceImpl {
         Response::ok(Empty::default())
     }
 
-    /// Contract-only stub (CORE-58 phase 1): the TTL wire-up lands with
-    /// CORE-60 (the daemon-side mechanism already exists), the idle
-    /// knobs with CORE-21.
+    /// Replace lifecycle deadlines: `ttl_seconds` re-arms the hard cap
+    /// from now (CORE-60), `idle_timeout_seconds`/`on_idle` replace the
+    /// idle knobs (CORE-21). Absent fields are unchanged; works on paused
+    /// sandboxes too (the TTL keeps applying to them).
     async fn set_lifecycle(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::SetLifecycleRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::SetLifecycleRequest>,
     ) -> ServiceResult<Empty> {
-        Err(ConnectError::unimplemented(
-            "sandbox lifecycle updates are not implemented yet (CORE-60/CORE-21)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let _operation = self.operations.lock(&machine, &req.id).await;
+        let runtime = self.runtime.ready()?;
+        let mut agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
+        agent
+            .sandbox_set_lifecycle(req)
+            .await
+            .map_err(ApiError::from)?;
+        Response::ok(Empty::default())
     }
 
     /// Contract-only stub (CORE-58 phase 1): served for real with

--- a/app/arcbox-api/src/connect/mod.rs
+++ b/app/arcbox-api/src/connect/mod.rs
@@ -32,6 +32,7 @@ mod macos;
 mod migration;
 mod process;
 mod sandbox_cleanup;
+mod sandbox_errors;
 mod sandbox_locks;
 mod sandbox_resume;
 mod snapshot;

--- a/app/arcbox-api/src/connect/sandbox_errors.rs
+++ b/app/arcbox-api/src/connect/sandbox_errors.rs
@@ -1,0 +1,31 @@
+//! Sandbox error-registry attachment (CORE-58 phase 2).
+//!
+//! Daemon-originated sandbox errors attach the registry detail directly
+//! (see [`nested_virt_unsupported`]); guest agent errors are classified
+//! centrally in `crate::error`'s `ApiError → ConnectError` conversion,
+//! which every sandbox handler already funnels through. The shared
+//! `ErrorInfo` builder lives in `crate::error::error_info`.
+
+use arcbox_connect::sandbox_v1 as pb;
+use connectrpc::{ConnectError, ErrorCode as ConnectCode};
+
+use crate::error::error_info;
+
+/// The CORE-13 fail-fast error for `Create` on a host without nested virt.
+///
+/// `FAILED_PRECONDITION` carrying `NESTED_VIRT_UNSUPPORTED` with the
+/// daemon's authoritative reason, exactly what `GetCapabilities` reports.
+pub(super) fn nested_virt_unsupported(
+    capability: &arcbox_core::NestedVirtCapability,
+) -> ConnectError {
+    let mut error = ConnectError::new(
+        ConnectCode::FailedPrecondition,
+        format!("sandboxes cannot run on this host: {}", capability.reason),
+    );
+    error.details.push(error_info(
+        pb::ErrorCode::NestedVirtUnsupported,
+        "check `SandboxService.GetCapabilities` for this host's sandbox support",
+        &[("reason", capability.reason.as_str())],
+    ));
+    error
+}

--- a/app/arcbox-api/src/connect/sandbox_resume.rs
+++ b/app/arcbox-api/src/connect/sandbox_resume.rs
@@ -74,21 +74,48 @@ pub(super) async fn resume(
     let mut agent = runtime
         .get_agent(machine)
         .map_err(|e| ConnectError::from(ApiError::from(e)))?;
-    let resumed = agent
-        .sandbox_resume(SandboxResumeCommand {
-            id: sandbox_id.to_owned(),
-            reason: reason.to_owned(),
-            ..Default::default()
-        })
-        .await
-        // Same reason as create/stop/remove/pause: a failed lifecycle
-        // mutation must reach the daemon log on its own (CORE-82). It matters
-        // more here — an auto-resume has no caller expecting a Resume RPC, so
-        // the failure would otherwise surface only as the data-plane error.
-        .inspect_err(|error| {
-            tracing::warn!(machine, sandbox_id, reason, %error, "sandbox resume failed");
-        })
-        .map_err(|e| ConnectError::from(ApiError::from(e)))?;
+    // A resume can race the host finalization of the pause's network
+    // quarantine (guest-initiated pauses — the idle detector — publish
+    // their cleanup ticket through the async watch stream). The guest
+    // answers 503 for that transient, so retry within a bounded budget
+    // while the daemon's cleanup watcher completes the ticket; resume is
+    // idempotent, and the guest lock is released between attempts.
+    let resumed = {
+        const RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(8);
+        const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(250);
+        let deadline = tokio::time::Instant::now() + RETRY_BUDGET;
+        loop {
+            let attempt = agent
+                .sandbox_resume(SandboxResumeCommand {
+                    id: sandbox_id.to_owned(),
+                    reason: reason.to_owned(),
+                    ..Default::default()
+                })
+                .await;
+            match attempt {
+                Ok(resumed) => break resumed,
+                Err(CoreError::Agent { code: 503, message })
+                    if tokio::time::Instant::now() < deadline =>
+                {
+                    tracing::debug!(
+                        sandbox_id,
+                        message,
+                        "sandbox resume hit a retryable condition; retrying"
+                    );
+                    tokio::time::sleep(RETRY_DELAY).await;
+                }
+                Err(error) => {
+                    // Same reason as create/stop/remove/pause: a failed
+                    // lifecycle mutation must reach the daemon log on its own
+                    // (CORE-82). It matters more here — an auto-resume has no
+                    // caller expecting a Resume RPC, so the failure would
+                    // otherwise surface only as the data-plane error.
+                    tracing::warn!(machine, sandbox_id, reason, %error, "sandbox resume failed");
+                    return Err(ConnectError::from(ApiError::from(error)));
+                }
+            }
+        }
+    };
 
     let _host_state = runtime.lock_sandbox_host_state().await;
     if let Ok(ip) = resumed.ip_address.parse()

--- a/app/arcbox-api/src/error.rs
+++ b/app/arcbox-api/src/error.rs
@@ -113,10 +113,10 @@ fn classify_agent_error(code: i32, message: &str) -> Option<connectrpc::ErrorDet
             &[],
         )),
         // VmmError::WrongState → "VM '{id}' is in wrong state: expected
-        // {expected}, got {actual}". A FAILED sandbox is its own registry
-        // code; anything else is "exists but not ready for this call"
-        // (still STARTING, or busy RUNNING under the single-execution
-        // model).
+        // {expected}, got {actual}". FAILED and PAUSED are their own registry
+        // codes — both need an action, not a wait; anything else is "exists
+        // but not ready for this call" (still STARTING, busy RUNNING under
+        // the single-execution model, or mid-transition).
         412 if message.contains("is in wrong state") => {
             let observed = message.rsplit("got ").next().unwrap_or_default();
             match observed {
@@ -125,11 +125,22 @@ fn classify_agent_error(code: i32, message: &str) -> Option<connectrpc::ErrorDet
                     "inspect the sandbox for the failure reason, then remove it",
                     &[("state", observed)],
                 )),
-                "starting" | "running" | "stopping" | "stopped" | "pausing" => Some(error_info(
-                    pb::ErrorCode::SandboxNotReady,
-                    "wait for the sandbox to reach READY (watch `Events` or poll `Inspect`)",
+                // A control-plane call refused because the sandbox is paused
+                // — `Stop` is the reachable one, since PAUSED only leads to
+                // RESUMING, FAILED, or REMOVING. Waiting never clears it.
+                "paused" => Some(error_info(
+                    pb::ErrorCode::SandboxPaused,
+                    "resume the sandbox first (`SandboxService.Resume`), or remove it — \
+                     a paused sandbox has no VM to stop",
                     &[("state", observed)],
                 )),
+                "starting" | "running" | "stopping" | "stopped" | "pausing" | "resuming" => {
+                    Some(error_info(
+                        pb::ErrorCode::SandboxNotReady,
+                        "wait for the sandbox to reach READY (watch `Events` or poll `Inspect`)",
+                        &[("state", observed)],
+                    ))
+                }
                 // Other WrongState shapes (generation races, cleanup
                 // tickets) are precondition failures without a precise
                 // registry identity.
@@ -239,6 +250,24 @@ mod tests {
                 "VM 'box1' is in wrong state: expected Ready, got failed"
             ),
             Some(pb::ErrorCode::SandboxFailed)
+        );
+        // A control-plane refusal on a paused sandbox (Stop is the reachable
+        // one) carries the same code as the data-plane 423 — one condition,
+        // one registry identity — not "not ready", which never clears.
+        assert_eq!(
+            classified(
+                412,
+                "VM 'box1' is in wrong state: expected Ready | Running | Stopping, got paused"
+            ),
+            Some(pb::ErrorCode::SandboxPaused)
+        );
+        // Mid-transition states are a genuine wait.
+        assert_eq!(
+            classified(
+                412,
+                "VM 'box1' is in wrong state: expected Ready, got resuming"
+            ),
+            Some(pb::ErrorCode::SandboxNotReady)
         );
         assert_eq!(
             classified(

--- a/app/arcbox-api/src/error.rs
+++ b/app/arcbox-api/src/error.rs
@@ -82,11 +82,30 @@ impl From<ApiError> for connectrpc::ConnectError {
 fn sandbox_paused_detail() -> connectrpc::ErrorDetail {
     use arcbox_connect::sandbox_v1 as pb;
 
-    let info = pb::ErrorInfo {
-        code: pb::ErrorCode::SandboxPaused.into(),
-        suggestion: "resume the sandbox (`abctl sandbox resume <id>`), or retry \
-                     the data-plane call without `x-arcbox-no-auto-resume`"
-            .into(),
+    error_info(
+        pb::ErrorCode::SandboxPaused,
+        "resume the sandbox (`abctl sandbox resume <id>`), or retry \
+         the data-plane call without `x-arcbox-no-auto-resume`",
+        &[],
+    )
+}
+
+/// Build the `arcbox.sandbox.v1.ErrorInfo` Connect error detail from a
+/// registry code + actionable suggestion + structured context (CORE-58).
+/// The single builder every attachment site uses, so the type URL and
+/// shape SDKs parse stay in one place.
+pub(crate) fn error_info(
+    code: arcbox_connect::sandbox_v1::ErrorCode,
+    suggestion: &str,
+    context: &[(&str, &str)],
+) -> connectrpc::ErrorDetail {
+    let info = arcbox_connect::sandbox_v1::ErrorInfo {
+        code: code.into(),
+        suggestion: suggestion.to_owned(),
+        context: context
+            .iter()
+            .map(|(key, value)| ((*key).to_owned(), (*value).to_owned()))
+            .collect(),
         ..Default::default()
     };
     connectrpc::ErrorDetail::from_message("arcbox.sandbox.v1.ErrorInfo", &info)

--- a/app/arcbox-api/src/error.rs
+++ b/app/arcbox-api/src/error.rs
@@ -52,42 +52,106 @@ impl From<ApiError> for connectrpc::ConnectError {
                 CommonError::PermissionDenied(_) => ErrorCode::PermissionDenied,
                 _ => ErrorCode::Internal,
             },
-            // Agent-reported errors carry an HTTP-style code over the wire.
-            ApiError::Core(arcbox_core::CoreError::Agent { code, .. }) => match code {
-                400 => ErrorCode::InvalidArgument,
-                404 => ErrorCode::NotFound,
-                409 => ErrorCode::AlreadyExists,
-                412 => ErrorCode::FailedPrecondition,
-                // Stdin offset gap: the client resyncs via GetStdinStatus.
-                416 => ErrorCode::OutOfRange,
-                // Paused sandbox surfaced without a transparent resume
-                // (control-plane call, or the caller opted out): a
-                // FAILED_PRECONDITION carrying the machine-readable
-                // SANDBOX_PAUSED detail (CORE-21).
-                423 => {
-                    let mut error = Self::new(ErrorCode::FailedPrecondition, message);
-                    error.details.push(sandbox_paused_detail());
-                    return error;
+            // Agent-reported errors carry an HTTP-style code over the wire;
+            // the raw message classifies further into the error registry.
+            ApiError::Core(arcbox_core::CoreError::Agent {
+                code,
+                message: agent_message,
+            }) => {
+                let connect_code = match code {
+                    400 => ErrorCode::InvalidArgument,
+                    404 => ErrorCode::NotFound,
+                    409 => ErrorCode::AlreadyExists,
+                    412 | 423 => ErrorCode::FailedPrecondition,
+                    // Stdin offset gap: resync via GetStdinStatus.
+                    416 => ErrorCode::OutOfRange,
+                    503 => ErrorCode::Unavailable,
+                    _ => ErrorCode::Internal,
+                };
+                let mut error = Self::new(connect_code, message);
+                if let Some(detail) = classify_agent_error(*code, agent_message) {
+                    error.details.push(detail);
                 }
-                503 => ErrorCode::Unavailable,
-                _ => ErrorCode::Internal,
-            },
+                return error;
+            }
             _ => ErrorCode::Internal,
         };
         Self::new(code, message)
     }
 }
 
-/// The `SANDBOX_PAUSED` `ErrorInfo` Connect error detail (`errors.proto`).
-fn sandbox_paused_detail() -> connectrpc::ErrorDetail {
+/// Map a guest agent error onto the sandbox error registry (CORE-58).
+///
+/// The wire carries only an HTTP-style code + message, so registry
+/// precision comes from the message shapes this same tree produces (the
+/// daemon and agent ship from one master state, enforced by the protocol
+/// handshake): `VmmError`'s `Display` impls and the guest `SandboxError`
+/// constructors. The markers are pinned by the tests below — changing a
+/// message shape must update both together.
+fn classify_agent_error(code: i32, message: &str) -> Option<connectrpc::ErrorDetail> {
     use arcbox_connect::sandbox_v1 as pb;
 
-    error_info(
-        pb::ErrorCode::SandboxPaused,
-        "resume the sandbox (`abctl sandbox resume <id>`), or retry \
-         the data-plane call without `x-arcbox-no-auto-resume`",
-        &[],
-    )
+    match code {
+        // VmmError::NotFound → "VM not found: {id}"; the execution
+        // registry names its resource explicitly.
+        404 if message.starts_with("execution '") => Some(error_info(
+            pb::ErrorCode::ExecutionNotFound,
+            "list live executions with `abctl sandbox ps`, or start a new one",
+            &[],
+        )),
+        404 if message.starts_with("VM not found:") => Some(error_info(
+            pb::ErrorCode::SandboxNotFound,
+            "list sandboxes with `abctl sandbox list`",
+            &[],
+        )),
+        // Guest-side nested-virt probe failure (the daemon's own fail-fast
+        // gate attaches this detail directly; this covers agent-originated
+        // 412s, e.g. a stale capability view).
+        412 if message.contains("nested virtualization") => Some(error_info(
+            pb::ErrorCode::NestedVirtUnsupported,
+            "check `SandboxService.GetCapabilities` for this host's sandbox support",
+            &[],
+        )),
+        // VmmError::WrongState → "VM '{id}' is in wrong state: expected
+        // {expected}, got {actual}". A FAILED sandbox is its own registry
+        // code; anything else is "exists but not ready for this call"
+        // (still STARTING, or busy RUNNING under the single-execution
+        // model).
+        412 if message.contains("is in wrong state") => {
+            let observed = message.rsplit("got ").next().unwrap_or_default();
+            match observed {
+                "failed" => Some(error_info(
+                    pb::ErrorCode::SandboxFailed,
+                    "inspect the sandbox for the failure reason, then remove it",
+                    &[("state", observed)],
+                )),
+                "starting" | "running" | "stopping" | "stopped" | "pausing" => Some(error_info(
+                    pb::ErrorCode::SandboxNotReady,
+                    "wait for the sandbox to reach READY (watch `Events` or poll `Inspect`)",
+                    &[("state", observed)],
+                )),
+                // Other WrongState shapes (generation races, cleanup
+                // tickets) are precondition failures without a precise
+                // registry identity.
+                _ => None,
+            }
+        }
+        // Guest template parse/resolution rejections name the template.
+        400 if message.contains("template") => Some(error_info(
+            pb::ErrorCode::TemplateInvalid,
+            "use \"\" (built-in), \"docker:<image>\", or a catalog template name",
+            &[],
+        )),
+        // Paused sandbox surfaced without a transparent resume
+        // (control-plane call, or the caller opted out), CORE-21.
+        423 => Some(error_info(
+            pb::ErrorCode::SandboxPaused,
+            "resume the sandbox (`abctl sandbox resume <id>`), or retry \
+             the data-plane call without `x-arcbox-no-auto-resume`",
+            &[],
+        )),
+        _ => None,
+    }
 }
 
 /// Build the `arcbox.sandbox.v1.ErrorInfo` Connect error detail from a
@@ -116,5 +180,123 @@ impl ApiError {
     #[must_use]
     pub fn config(msg: impl Into<String>) -> Self {
         Self::Common(CommonError::config(msg))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arcbox_connect::sandbox_v1 as pb;
+    use buffa::Message as _;
+
+    fn decode_info(detail: &connectrpc::ErrorDetail) -> pb::ErrorInfo {
+        use base64::Engine as _;
+        assert_eq!(detail.type_url, "arcbox.sandbox.v1.ErrorInfo");
+        let bytes = base64::engine::general_purpose::STANDARD_NO_PAD
+            .decode(detail.value.as_deref().expect("detail value"))
+            .expect("base64 detail value");
+        pb::ErrorInfo::decode_from_slice(&bytes).expect("valid ErrorInfo payload")
+    }
+
+    fn registry_code(detail: &connectrpc::ErrorDetail) -> pb::ErrorCode {
+        decode_info(detail)
+            .code
+            .as_known()
+            .expect("known registry code")
+    }
+
+    fn classified(code: i32, message: &str) -> Option<pb::ErrorCode> {
+        classify_agent_error(code, message).map(|detail| registry_code(&detail))
+    }
+
+    /// Pins the guest message markers the classifier keys on. If one of
+    /// these fails after a message change, update the marker AND this test
+    /// together (`VmmError` Display impls / guest `SandboxError` sites).
+    #[test]
+    fn agent_errors_classify_into_the_registry() {
+        assert_eq!(
+            classified(404, "VM not found: box1"),
+            Some(pb::ErrorCode::SandboxNotFound)
+        );
+        assert_eq!(
+            classified(404, "execution 'e1' in sandbox 'box1'"),
+            Some(pb::ErrorCode::ExecutionNotFound)
+        );
+        assert_eq!(
+            classified(423, "sandbox 'box1' is paused"),
+            Some(pb::ErrorCode::SandboxPaused)
+        );
+        assert_eq!(
+            classified(
+                412,
+                "VM 'box1' is in wrong state: expected Ready, got running"
+            ),
+            Some(pb::ErrorCode::SandboxNotReady)
+        );
+        assert_eq!(
+            classified(
+                412,
+                "VM 'box1' is in wrong state: expected Ready, got failed"
+            ),
+            Some(pb::ErrorCode::SandboxFailed)
+        );
+        assert_eq!(
+            classified(
+                412,
+                "sandboxes require nested virtualization (/dev/kvm is missing in the guest)"
+            ),
+            Some(pb::ErrorCode::NestedVirtUnsupported)
+        );
+        assert_eq!(
+            classified(
+                400,
+                "unknown template \"typo\"; expected \"\" or \"docker:<image>\""
+            ),
+            Some(pb::ErrorCode::TemplateInvalid)
+        );
+    }
+
+    #[test]
+    fn unmatched_agent_errors_carry_no_registry_detail() {
+        assert_eq!(classified(500, "vsock error: boom"), None);
+        assert_eq!(classified(404, "snapshot abc not found"), None);
+        // Generation races are precondition failures without a precise
+        // registry identity.
+        assert_eq!(
+            classified(
+                412,
+                "VM 'box1' is in wrong state: expected the sandbox generation selected by \
+                 this operation, got a newer generation now owns this sandbox ID"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn wrong_state_context_carries_the_observed_state() {
+        let detail = classify_agent_error(
+            412,
+            "VM 'box1' is in wrong state: expected Ready, got running",
+        )
+        .expect("classified");
+        let info = decode_info(&detail);
+        assert_eq!(
+            info.context.get("state").map(String::as_str),
+            Some("running")
+        );
+    }
+
+    #[test]
+    fn paused_agent_error_maps_to_failed_precondition_with_detail() {
+        let error = connectrpc::ConnectError::from(ApiError::Core(arcbox_core::CoreError::Agent {
+            code: 423,
+            message: "sandbox 'box1' is paused".into(),
+        }));
+        assert_eq!(error.code, connectrpc::ErrorCode::FailedPrecondition);
+        assert_eq!(error.details.len(), 1);
+        assert_eq!(
+            registry_code(&error.details[0]),
+            pb::ErrorCode::SandboxPaused
+        );
     }
 }

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -19,8 +19,9 @@ use arcbox_connect::sandbox_v1::{
     GetStdinStatusRequest, InspectSandboxRequest, ListSandboxesRequest, ListSandboxesResponse,
     ListSnapshotsRequest, ListSnapshotsResponse, PauseSandboxRequest, ReadFileRequest,
     RemoveSandboxRequest, ResizeExecutionTtyRequest, RestoreRequest, RestoreResponse, SandboxEvent,
-    SandboxEventsRequest, SandboxInfo, SignalExecutionRequest, StartExecutionRequest, StdinStatus,
-    StopSandboxRequest, WaitExecutionRequest, WriteFileOpen, WriteStdinRequest, execution_event,
+    SandboxEventsRequest, SandboxInfo, SetLifecycleRequest, SignalExecutionRequest,
+    StartExecutionRequest, StdinStatus, StopSandboxRequest, WaitExecutionRequest, WriteFileOpen,
+    WriteStdinRequest, execution_event,
 };
 use arcbox_connect::v1::{
     AgentPingRequest as PingRequest, AgentPingResponse as PingResponse, ContainerFsPathsRequest,
@@ -1140,6 +1141,23 @@ impl AgentClient {
             MessageType::SandboxResumeResponse,
         )
         .await
+    }
+
+    /// Replaces a sandbox's lifecycle deadlines in the guest VM (CORE-60):
+    /// TTL re-armed from now, idle timeout/policy replaced. Absent fields
+    /// are left unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_set_lifecycle(&mut self, req: SetLifecycleRequest) -> Result<()> {
+        let (response_type, _) = self
+            .rpc_call(
+                MessageType::SandboxSetLifecycleRequest,
+                &req.encode_to_vec(),
+            )
+            .await?;
+        Self::expect_ack_response_type(response_type, MessageType::SandboxSetLifecycleResponse)
     }
 
     /// Removes a sandbox from the guest VM.

--- a/app/arcbox-core/src/lib.rs
+++ b/app/arcbox-core/src/lib.rs
@@ -46,6 +46,7 @@ pub mod remote_image;
 #[cfg(target_os = "macos")]
 pub mod route_reconciler;
 pub mod runtime;
+pub mod sandbox_capability;
 pub mod stats_hub;
 pub mod trace;
 pub mod vm;
@@ -70,6 +71,7 @@ pub use macos::{
 pub use macos::{PullPhase, PullSource};
 pub use migration::MigrationManager;
 pub use runtime::{InitProgress, Runtime, SandboxPortExposure};
+pub use sandbox_capability::NestedVirtCapability;
 pub use vm::{SharedDirConfig, VmConfig, VmManager};
 pub use vm_lifecycle::{
     ActivityScope, DEFAULT_MACHINE_NAME, DefaultVmConfig, HealthMonitor, VmLifecycleConfig,

--- a/app/arcbox-core/src/sandbox_capability.rs
+++ b/app/arcbox-core/src/sandbox_capability.rs
@@ -1,0 +1,132 @@
+//! Nested-virtualization capability detection for sandboxes (CORE-13).
+//!
+//! Sandboxes are Firecracker microVMs inside the System VM, so they need
+//! `/dev/kvm` in the guest — which exists only when the host can nest:
+//! on macOS that means the VZ backend on hardware where
+//! `VZGenericPlatformConfiguration.isNestedVirtualizationSupported` is true
+//! (Apple Silicon M3+, macOS 15+); on Linux it means nested KVM enabled in
+//! the host kernel modules. The daemon answers this without booting
+//! anything so `GetCapabilities` and the `Create` fail-fast gate work even
+//! before the first sandbox request reaches the guest.
+
+use crate::runtime::Runtime;
+use arcbox_vmm::VmBackend;
+
+/// Whether this host can run sandboxes, and why not when it cannot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NestedVirtCapability {
+    /// True when sandboxes can run on the current backend and hardware.
+    pub supported: bool,
+    /// The authoritative reason when unsupported (empty when supported);
+    /// surfaced verbatim in `NESTED_VIRT_UNSUPPORTED` errors.
+    pub reason: String,
+}
+
+impl NestedVirtCapability {
+    fn supported() -> Self {
+        Self {
+            supported: true,
+            reason: String::new(),
+        }
+    }
+
+    fn unsupported(reason: impl Into<String>) -> Self {
+        Self {
+            supported: false,
+            reason: reason.into(),
+        }
+    }
+}
+
+impl Runtime {
+    /// Nested-virt capability for the System VM's *current* backend.
+    ///
+    /// The hardware probe is cached; the backend half is re-evaluated per
+    /// call because `switch_system_vm_backend` can change it at runtime.
+    #[must_use]
+    pub fn sandbox_nested_virt(&self) -> NestedVirtCapability {
+        nested_virt_for_backend(self.system_vm_backend())
+    }
+}
+
+/// Nested-virt capability for a given hypervisor backend on this host.
+#[must_use]
+pub fn nested_virt_for_backend(backend: VmBackend) -> NestedVirtCapability {
+    #[cfg(target_os = "macos")]
+    {
+        match backend {
+            VmBackend::Hv => NestedVirtCapability::unsupported(
+                "sandboxes require nested virtualization, which the HV backend does not \
+                 support; switch to the VZ backend (`abctl system backend vz`)",
+            ),
+            VmBackend::Vz => {
+                if vz_hardware_supports_nested() {
+                    NestedVirtCapability::supported()
+                } else {
+                    NestedVirtCapability::unsupported(
+                        "this Mac does not support nested virtualization; sandboxes require \
+                         Apple Silicon M3 or newer with macOS 15 or newer",
+                    )
+                }
+            }
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = backend;
+        if linux_kvm_supports_nested() {
+            NestedVirtCapability::supported()
+        } else {
+            NestedVirtCapability::unsupported(
+                "the host kernel does not expose nested KVM \
+                 (/sys/module/kvm_{intel,amd}/parameters/nested); sandboxes cannot run",
+            )
+        }
+    }
+}
+
+/// Cached `VZGenericPlatformConfiguration.isNestedVirtualizationSupported`.
+///
+/// A pure hardware/OS property — safe to probe once per process.
+#[cfg(target_os = "macos")]
+fn vz_hardware_supports_nested() -> bool {
+    static SUPPORTED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *SUPPORTED.get_or_init(arcbox_vz::GenericPlatform::is_nested_virt_supported)
+}
+
+/// Nested-KVM module parameters, mirroring the hypervisor crate's probe.
+#[cfg(not(target_os = "macos"))]
+fn linux_kvm_supports_nested() -> bool {
+    ["kvm_intel", "kvm_amd"].iter().any(|module| {
+        std::fs::read_to_string(format!("/sys/module/{module}/parameters/nested"))
+            .is_ok_and(|content| matches!(content.trim(), "1" | "Y" | "y"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn hv_backend_is_always_unsupported_with_an_actionable_reason() {
+        let capability = nested_virt_for_backend(VmBackend::Hv);
+        assert!(!capability.supported);
+        assert!(
+            capability.reason.contains("VZ backend"),
+            "{}",
+            capability.reason
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn vz_backend_reflects_the_hardware_probe() {
+        let capability = nested_virt_for_backend(VmBackend::Vz);
+        if capability.supported {
+            assert!(capability.reason.is_empty());
+        } else {
+            assert!(capability.reason.contains("M3"), "{}", capability.reason);
+        }
+    }
+}

--- a/common/arcbox-constants/src/lib.rs
+++ b/common/arcbox-constants/src/lib.rs
@@ -7,6 +7,7 @@ pub mod env;
 pub mod helper;
 pub mod paths;
 pub mod ports;
+pub mod sandbox;
 pub mod status;
 pub mod timeouts;
 pub mod virtiofs;

--- a/common/arcbox-constants/src/sandbox.rs
+++ b/common/arcbox-constants/src/sandbox.rs
@@ -1,0 +1,24 @@
+//! Sandbox API (Connect surface) constants shared by the daemon and tests.
+
+/// Sandbox API protocol level reported by `SandboxService.GetCapabilities`.
+///
+/// SDKs compare it against their floor and raise `PROTOCOL_MISMATCH` with
+/// an upgrade suggestion instead of sprinkling per-call version checks
+/// (CORE-13). Bump when the sandbox surface changes incompatibly; purely
+/// additive capabilities ship as [`SANDBOX_FEATURES`] flags instead.
+pub const SANDBOX_API_PROTOCOL: u32 = 1;
+
+/// Named feature flags for capabilities that postdate the protocol level.
+///
+/// Append-only: SDKs feature-detect by name, so renaming or removing a
+/// shipped flag silently disables the feature for older clients.
+pub const SANDBOX_FEATURES: &[&str] = &[
+    // Pause/Resume on a stable sandbox id (CORE-21).
+    "pause_resume",
+    // Data-plane calls transparently resume a paused sandbox (CORE-21).
+    "auto_resume",
+    // idle_timeout_seconds + on_idle are enforced (CORE-21).
+    "idle_policy",
+    // SetLifecycle re-arms TTL / replaces idle knobs (CORE-60).
+    "set_lifecycle",
+];

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -142,6 +142,11 @@ pub enum MessageType {
     /// the RESUMED event surfaces). Answered with
     /// [`Self::SandboxResumeResponse`].
     SandboxResumeRequest = 0x0045,
+    /// Replace a sandbox's lifecycle deadlines — TTL re-armed from now,
+    /// idle timeout/policy replaced (payload:
+    /// `arcbox.sandbox.v1.SetLifecycleRequest`, CORE-60). Answered with
+    /// [`Self::SandboxSetLifecycleResponse`].
+    SandboxSetLifecycleRequest = 0x0046,
 
     // Sandbox execution request types (0x0060 - 0x0066), from the
     // execution redesign (CORE-55/56).
@@ -247,6 +252,8 @@ pub enum MessageType {
     /// Answers [`Self::SandboxResumeRequest`] (payload:
     /// `arcbox.v1.SandboxResumeResponse` with the fresh IP).
     SandboxResumeResponse = 0x1045,
+    /// Acknowledges [`Self::SandboxSetLifecycleRequest`] (empty payload).
+    SandboxSetLifecycleResponse = 0x1046,
 
     // Sandbox workload response types (streaming).
     // 0x1035 (SandboxRunOutput) and 0x1036 (SandboxExecOutput) were
@@ -342,6 +349,7 @@ impl MessageType {
             0x0043 => Some(Self::SandboxDeleteSnapshotRequest),
             0x0044 => Some(Self::SandboxPauseRequest),
             0x0045 => Some(Self::SandboxResumeRequest),
+            0x0046 => Some(Self::SandboxSetLifecycleRequest),
             // Sandbox execution requests (execution redesign, CORE-55/56).
             0x0060 => Some(Self::SandboxExecStartRequest),
             0x0061 => Some(Self::SandboxExecAttachRequest),
@@ -389,6 +397,7 @@ impl MessageType {
             0x1029 => Some(Self::SandboxCleanupEvent),
             0x1044 => Some(Self::SandboxPauseResponse),
             0x1045 => Some(Self::SandboxResumeResponse),
+            0x1046 => Some(Self::SandboxSetLifecycleResponse),
             // Sandbox workload responses (streaming).
             0x1037 => Some(Self::SandboxEvent),
             0x1038 => Some(Self::SandboxFileData),
@@ -437,6 +446,7 @@ impl MessageType {
                 | Self::SandboxDeleteSnapshotRequest
                 | Self::SandboxPauseRequest
                 | Self::SandboxResumeRequest
+                | Self::SandboxSetLifecycleRequest
                 | Self::SandboxExecStartRequest
                 | Self::SandboxExecAttachRequest
                 | Self::SandboxStdinWriteRequest
@@ -577,8 +587,10 @@ mod tests {
             (0x0043, MessageType::SandboxDeleteSnapshotRequest),
             (0x0044, MessageType::SandboxPauseRequest),
             (0x0045, MessageType::SandboxResumeRequest),
+            (0x0046, MessageType::SandboxSetLifecycleRequest),
             (0x1044, MessageType::SandboxPauseResponse),
             (0x1045, MessageType::SandboxResumeResponse),
+            (0x1046, MessageType::SandboxSetLifecycleResponse),
             (0x1040, MessageType::SandboxCheckpointResponse),
             (0x1041, MessageType::SandboxRestoreResponse),
             (0x1042, MessageType::SandboxListSnapshotsResponse),
@@ -613,6 +625,7 @@ mod tests {
         assert!(MessageType::SandboxCheckpointRequest.is_sandbox_request());
         assert!(MessageType::SandboxPauseRequest.is_sandbox_request());
         assert!(MessageType::SandboxResumeRequest.is_sandbox_request());
+        assert!(MessageType::SandboxSetLifecycleRequest.is_sandbox_request());
         assert!(!MessageType::PingRequest.is_sandbox_request());
         assert!(!MessageType::SandboxCreateResponse.is_sandbox_request());
     }

--- a/docs/sandbox-api.md
+++ b/docs/sandbox-api.md
@@ -81,17 +81,16 @@ surface is on the wire ahead of its implementation; these RPCs answer
 
 - `TemplateService` (`template.proto`) — the template catalog (CORE-21;
   Build additionally gated on CORE-5/CORE-16).
-- `SetLifecycle` (CORE-60 / CORE-21 — the idle knobs land with the idle
-  detector), `GetCapabilities` (CORE-13).
 - `SandboxProcessService.ListExecutions/WaitForPort` (CORE-58 phase 2).
 - The `SandboxFilesystemService` path verbs — `Stat`, `ListDir`,
   `MakeDir`, `Remove`, `Move`, `WatchDir` (CORE-62).
-- `errors.proto` — the `ErrorCode` registry; handlers attach `ErrorInfo`
-  as a Connect error detail in a follow-up phase (CORE-58; `SANDBOX_PAUSED`
-  already ships it).
 
-`SandboxService.Pause/Resume` and daemon-side transparent auto-resume are
-implemented (CORE-21) — see **Pause / Resume** below.
+`SandboxService.Pause/Resume` with daemon-side transparent auto-resume
+(CORE-21), the idle detector (`idle_timeout_seconds` + `on_idle`),
+`SetLifecycle` (CORE-60), and `GetCapabilities` (CORE-13) are
+implemented — see their sections below. The `errors.proto` registry is
+attached as an `ErrorInfo` Connect error detail on the principal error
+paths (see **Error model**).
 
 ## Sandbox state machine
 
@@ -115,8 +114,9 @@ States are the `SandboxState` enum (`SANDBOX_STATE_*`); events carry the
   `READY` and accepts further `StartExecution` calls.
 - Destruction happens via `Stop`/`Remove`, `ttl_seconds` (hard maximum
   lifetime) expiry, or `idle_timeout_seconds` expiry with the default
-  `KILL` policy; `on_idle: PAUSE` checkpoints instead (CORE-21,
-  contract-only today).
+  `KILL` policy; `on_idle: PAUSE` checkpoints instead (CORE-21). Idle
+  means "no running execution": the timer arms on every `READY` edge and
+  cancels when an execution starts — file activity does **not** re-arm it.
 - `stopped` sandboxes have released their TAP/IP, CoW device, and chroot;
   only the inspectable record and logs remain until `Remove`.
 - `paused` sandboxes keep their record, an on-disk checkpoint, **and their
@@ -147,7 +147,7 @@ Key fields:
 | `no_default_cmd`, `no_default_env` | explicit-empty overrides of a catalog template's default cmd/env — proto3 repeated/map fields cannot distinguish omitted from empty (CORE-21, contract-only today) |
 | `network.mode` | `NETWORK_MODE_ENABLED` (default, IP from 172.20.0.0/16) or `NETWORK_MODE_NONE` |
 | `ttl_seconds` | hard maximum lifetime from creation (not reset by activity; re-armable via `SetLifecycle`); always destroys |
-| `idle_timeout_seconds`, `on_idle` | idle reaping: `KILL` (default) or `PAUSE` after inactivity (CORE-21, contract-only today) |
+| `idle_timeout_seconds`, `on_idle` | idle reaping after this many seconds without a running execution: `KILL` (default) destroys, `PAUSE` checkpoints (CORE-21); both knobs are replaceable via `SetLifecycle` |
 | `mounts`, `ssh_public_key` | **rejected in V1** with `FAILED_PRECONDITION` (see Proto stability) |
 
 ### Templates
@@ -292,7 +292,48 @@ mapping. Mappings are removed automatically on Stop/Remove/TTL. CLI:
   overlay footprint) in `Inspect`/`List`, survive daemon and VM restarts,
   and still honor `ttl_seconds` — the hard cap destroys a paused sandbox
   too. Idle-driven auto-pause (`idle_timeout_seconds` + `on_idle: PAUSE`)
-  is contract-only until the idle detector lands.
+  rides the same flow: the `PAUSING` event carries
+  `reason: idle_timeout`, and the next data-plane call resumes the
+  sandbox transparently.
+
+### SetLifecycle (CORE-60)
+
+`rpc SetLifecycle(SetLifecycleRequest) returns (Empty)`
+
+Replaces a sandbox's lifecycle deadlines; absent fields are left
+unchanged, so each knob adjusts independently:
+
+- `ttl_seconds`: the hard cap expires this many seconds **from now** —
+  calling repeatedly keeps a busy sandbox alive indefinitely (E2B
+  timeout semantics); `0` removes the limit. `Inspect.ttl_deadline`
+  reports the resulting deadline.
+- `idle_timeout_seconds`: replaces the idle window, re-arming a live
+  timer; `0` disables idle detection.
+- `on_idle` (`optional`): absent = unchanged; an explicit
+  `IDLE_ACTION_UNSPECIFIED` restores the daemon default (`KILL`).
+
+Allowed in any non-terminal state — updating a `PAUSED` sandbox works
+(its TTL keeps applying while asleep; new idle knobs take effect on the
+next `READY`). `STOPPING`/`STOPPED`/`FAILED` answer
+`FAILED_PRECONDITION`.
+
+### GetCapabilities (CORE-13)
+
+`rpc GetCapabilities(GetCapabilitiesRequest) returns (GetCapabilitiesResponse)`
+
+The SDK handshake, answered host-side (no guest round-trip, works before
+any sandbox exists):
+
+- `daemon_version` — informational.
+- `protocol` — the sandbox API protocol level (currently `1`); SDKs
+  compare it against their floor and raise `PROTOCOL_MISMATCH`.
+- `features` — append-only named flags: `pause_resume`, `auto_resume`,
+  `idle_policy`, `set_lifecycle`.
+- `nested_virt` — `{supported, reason}` for the **current** backend and
+  hardware (VZ on Apple Silicon M3+/macOS 15+). When unsupported,
+  `Create` fails fast with `FAILED_PRECONDITION` carrying the
+  `NESTED_VIRT_UNSUPPORTED` `ErrorInfo` detail and the same `reason`,
+  instead of booting into an opaque KVM failure.
 
 ### Stop / Remove
 
@@ -360,6 +401,16 @@ map onto gRPC statuses:
 | sandbox service initialisation failure | `UNAVAILABLE` |
 | daemon still starting (runtime not ready) | `UNAVAILABLE` |
 | everything else | `INTERNAL` |
+
+The daemon additionally attaches the `errors.proto` registry as an
+`arcbox.sandbox.v1.ErrorInfo` Connect error detail (code + actionable
+suggestion + structured context) on the principal paths, which SDKs map
+to typed exceptions: `SANDBOX_NOT_FOUND` / `EXECUTION_NOT_FOUND` on
+not-found, `SANDBOX_NOT_READY` (context `state`) / `SANDBOX_FAILED` on
+wrong-state, `SANDBOX_PAUSED`, `TEMPLATE_INVALID`, and
+`NESTED_VIRT_UNSUPPORTED` (both the host fail-fast and the guest probe).
+`TTL_EXPIRED` is not yet attachable: TTL expiry removes the record, so a
+later call sees plain `SANDBOX_NOT_FOUND`.
 
 ## Typical client flow
 

--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -318,6 +318,31 @@ where
                 }
             }
         }
+        MessageType::SandboxSetLifecycleRequest => {
+            use arcbox_connect::sandbox_v1::SetLifecycleRequest;
+            let req = match SetLifecycleRequest::decode_from_slice(payload) {
+                Ok(req) => req,
+                Err(error) => {
+                    send_sandbox_error(stream, trace_id, 400, &error.to_string()).await?;
+                    return Ok(());
+                }
+            };
+            let _operation = svc.lock_operation(&req.id).await;
+            match svc.set_lifecycle_request(req).await {
+                Ok(()) => {
+                    write_message(
+                        stream,
+                        MessageType::SandboxSetLifecycleResponse,
+                        trace_id,
+                        &[],
+                    )
+                    .await?;
+                }
+                Err(e) => {
+                    send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+                }
+            }
+        }
         MessageType::SandboxCleanupPrepareRequest => {
             use arcbox_connect::v1::SandboxCleanupTicket;
 

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -313,6 +313,26 @@ impl SandboxService {
         })
     }
 
+    /// Replace a sandbox's lifecycle deadlines (CORE-60): TTL re-armed from
+    /// now, idle timeout/policy replaced. Absent fields are unchanged; an
+    /// explicit `UNSPECIFIED` policy restores the daemon default (KILL).
+    pub(crate) async fn set_lifecycle_request(
+        &self,
+        req: sandbox_v1::SetLifecycleRequest,
+    ) -> Result<(), SandboxError> {
+        let update = arcbox_vm::LifecycleUpdate {
+            ttl_seconds: req.ttl_seconds,
+            idle_timeout_seconds: req.idle_timeout_seconds,
+            on_idle: req
+                .on_idle
+                .map(|value| idle_action_to_spec(value.as_known().unwrap_or_default())),
+        };
+        self.manager
+            .set_sandbox_lifecycle(&req.id, update)
+            .await
+            .map_err(SandboxError::from)
+    }
+
     /// Remove a sandbox.
     pub async fn remove(&self, payload: &[u8]) -> Result<(), SandboxError> {
         let req = sandbox_v1::RemoveSandboxRequest::decode_from_slice(payload)

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -104,7 +104,11 @@ impl SandboxService {
     /// Create a new [`SandboxService`] from the given config.
     pub fn new(config: VmmConfig) -> anyhow::Result<Self> {
         let default_rootfs = config.defaults.rootfs.clone();
-        let manager = Arc::new(SandboxManager::new(config).map_err(|e| anyhow::anyhow!("{e}"))?);
+        // `into_shared` starts the lifecycle monitor driving the idle/TTL
+        // expiry timers (CORE-21/60).
+        let manager = SandboxManager::new(config)
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+            .into_shared();
         let creates = Arc::new(CreateRegistry::default());
         Ok(Self {
             manager,
@@ -567,6 +571,19 @@ fn proto_to_spec(req: sandbox_v1::CreateSandboxRequest) -> SandboxSpec {
         network: SandboxNetworkSpec { mode: mode.into() },
         ttl_seconds: req.ttl_seconds,
         ssh_public_key: req.ssh_public_key,
+        idle_timeout_seconds: req.idle_timeout_seconds,
+        on_idle: idle_action_to_spec(req.on_idle.as_known().unwrap_or_default()),
+    }
+}
+
+/// Map the wire idle policy onto the manager's; `UNSPECIFIED` (and unknown
+/// future values) resolve to the daemon default, KILL.
+fn idle_action_to_spec(action: sandbox_v1::IdleAction) -> arcbox_vm::IdleAction {
+    match action {
+        sandbox_v1::IdleAction::Pause => arcbox_vm::IdleAction::Pause,
+        sandbox_v1::IdleAction::Kill | sandbox_v1::IdleAction::Unspecified => {
+            arcbox_vm::IdleAction::Kill
+        }
     }
 }
 

--- a/guest/arcbox-agent/src/sandbox/convert.rs
+++ b/guest/arcbox-agent/src/sandbox/convert.rs
@@ -3,7 +3,7 @@
 
 use arcbox_connect::sandbox_v1;
 use arcbox_vm::{
-    CheckpointInfo, CheckpointSummary, ExecutionChannel, ExecutionSnapshot, ExitStatus,
+    CheckpointInfo, CheckpointSummary, ExecutionChannel, ExecutionSnapshot, ExitStatus, IdleAction,
     SandboxEvent as VmSandboxEvent, SandboxInfo, SandboxState, SandboxSummary, StdinState,
 };
 use buffa_types::google::protobuf::Timestamp;
@@ -172,7 +172,18 @@ pub(super) fn info_to_proto(info: SandboxInfo) -> sandbox_v1::SandboxInfo {
         error: info.error.unwrap_or_default(),
         paused_at: info.paused_at.map(timestamp).into(),
         storage_bytes: info.storage_bytes,
+        ttl_deadline: info.ttl_deadline.map(timestamp).into(),
+        idle_timeout_seconds: info.idle_timeout_seconds,
+        on_idle: idle_action_to_proto(info.on_idle).into(),
         ..Default::default()
+    }
+}
+
+/// Map the manager's effective idle policy onto the wire enum.
+pub(super) fn idle_action_to_proto(action: IdleAction) -> sandbox_v1::IdleAction {
+    match action {
+        IdleAction::Kill => sandbox_v1::IdleAction::Kill,
+        IdleAction::Pause => sandbox_v1::IdleAction::Pause,
     }
 }
 

--- a/guest/arcbox-agent/src/sandbox/events.rs
+++ b/guest/arcbox-agent/src/sandbox/events.rs
@@ -59,7 +59,12 @@ impl SandboxService {
         loop {
             tokio::select! {
                 event = lifecycle.recv() => match event {
-                    Ok(event) if event.is_terminal() => {
+                    // Terminal teardowns release the network, and a pause
+                    // quarantines it the same way (CORE-21) — emit the
+                    // ticket promptly in both cases so the host finalizes
+                    // before a resume needs the allocation back, instead of
+                    // waiting for the 1 s rescan below.
+                    Ok(event) if event.is_terminal() || event.action == "paused" => {
                         if let Some(ticket) = self
                             .pending_cleanup_ticket(&event.sandbox_id)
                             .await

--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -37,11 +37,12 @@ use crate::daemon::{DaemonConfig, DaemonHandle, connect_unix};
 use crate::metrics::RunMetrics;
 use crate::{env_flag, repo_root};
 
-/// Generous ceiling for daemon startup (asset staging + VM boot + agent).
-/// Sized for a cold CDN fetch of the runtime binaries: measured startups
-/// reach 150-180s when the CDN is slow, and the guest runtime
-/// materialization added to the budget in v0.8.
-const READY_TIMEOUT: Duration = Duration::from_secs(300);
+/// Generous ceiling for daemon startup: asset staging + the cold
+/// ~255 MiB runtime-binary download into the isolated data dir (dockerd,
+/// containerd, k3s, FEX, ...) + the guest runtime materialization added in
+/// v0.8 + VM boot + agent. Measured 2026-08-06: a constrained uplink put
+/// the download alone at ~180 s.
+const READY_TIMEOUT: Duration = Duration::from_secs(360);
 /// Ceiling for a sandbox to reach `ready` (includes the first default
 /// rootfs build inside the guest).
 const SANDBOX_READY_TIMEOUT: Duration = Duration::from_secs(120);

--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -22,12 +22,13 @@ use arcbox_grpc::sandbox_v1::sandbox_service_client::SandboxServiceClient;
 use arcbox_grpc::sandbox_v1::sandbox_snapshot_service_client::SandboxSnapshotServiceClient;
 use arcbox_protocol::sandbox_v1::{
     AttachExecutionRequest, CheckpointRequest, CreateSandboxRequest, Execution, ExecutionEvent,
-    FileChunk, GetStdinStatusRequest, InspectSandboxRequest, ListSandboxesRequest,
-    PauseSandboxRequest, ReadFileRequest, RemoveSandboxRequest, ResourceLimits, RestoreRequest,
-    ResumeSandboxRequest, SandboxEventKind, SandboxEventsRequest, SandboxState, Signal,
-    SignalExecutionRequest, StartExecutionRequest, StdioChannel, StopSandboxRequest,
-    WaitExecutionRequest, WatchEventsResponse, WriteFileOpen, WriteFileRequest, WriteStdinRequest,
-    execution_event, exit_status, watch_events_response, write_file_request,
+    FileChunk, GetCapabilitiesRequest, GetStdinStatusRequest, IdleAction, InspectSandboxRequest,
+    ListSandboxesRequest, PauseSandboxRequest, ReadFileRequest, RemoveSandboxRequest,
+    ResourceLimits, RestoreRequest, ResumeSandboxRequest, SandboxEventKind, SandboxEventsRequest,
+    SandboxState, SetLifecycleRequest, Signal, SignalExecutionRequest, StartExecutionRequest,
+    StdioChannel, StopSandboxRequest, WaitExecutionRequest, WatchEventsResponse, WriteFileOpen,
+    WriteFileRequest, WriteStdinRequest, execution_event, exit_status, watch_events_response,
+    write_file_request,
 };
 use tonic::transport::Channel;
 use tracing::{info, warn};
@@ -397,6 +398,22 @@ async fn drive_sandboxes(
     metrics.record(
         "sandbox_pause_resume",
         pause_started.elapsed().as_secs_f64(),
+    );
+
+    // -- CORE-13: capability handshake -------------------------------------
+    let capabilities_started = Instant::now();
+    assert_capabilities(&mut sandboxes).await?;
+    metrics.record(
+        "sandbox_capabilities",
+        capabilities_started.elapsed().as_secs_f64(),
+    );
+
+    // -- CORE-21/60: idle auto-pause + SetLifecycle re-arm -----------------
+    let lifecycle_started = Instant::now();
+    idle_lifecycle_scenario(&mut sandboxes, &mut processes).await?;
+    metrics.record(
+        "sandbox_idle_lifecycle",
+        lifecycle_started.elapsed().as_secs_f64(),
     );
 
     // -- Checkpoint / Restore --------------------------------------------
@@ -903,6 +920,168 @@ async fn exec_signal_and_keepalive(
         other => bail!("expected a SIGKILL death, got {other:?}"),
     }
     info!("stream-free signal delivered and reported as a signal death");
+    Ok(())
+}
+
+/// CORE-13 acceptance: the capability handshake answers real data —
+/// version, protocol level, the lifecycle feature flags, and nested-virt
+/// support (which must hold on any host this smoke can run on).
+async fn assert_capabilities(sandboxes: &mut SandboxServiceClient<Channel>) -> Result<()> {
+    let caps = sandboxes
+        .get_capabilities(with_machine(GetCapabilitiesRequest {}))
+        .await
+        .context("GetCapabilities failed")?
+        .into_inner();
+    if caps.daemon_version.is_empty() {
+        bail!("GetCapabilities reported an empty daemon_version");
+    }
+    if caps.protocol < 1 {
+        bail!(
+            "GetCapabilities protocol must be >= 1, got {}",
+            caps.protocol
+        );
+    }
+    for feature in [
+        "pause_resume",
+        "auto_resume",
+        "idle_policy",
+        "set_lifecycle",
+    ] {
+        if !caps.features.iter().any(|f| f == feature) {
+            bail!("missing feature flag {feature:?} in {:?}", caps.features);
+        }
+    }
+    let nested = caps
+        .nested_virt
+        .ok_or_else(|| anyhow::anyhow!("GetCapabilities left nested_virt unset"))?;
+    if !nested.supported {
+        bail!(
+            "this smoke requires nested virtualization but the daemon reports: {}",
+            nested.reason
+        );
+    }
+    info!(
+        version = %caps.daemon_version,
+        protocol = caps.protocol,
+        "capabilities verified"
+    );
+    Ok(())
+}
+
+/// CORE-21/60 acceptance: a sandbox created with `idle_timeout_seconds: 2`
+/// and `on_idle: PAUSE` auto-pauses on the idle edge (visible as PAUSING
+/// with reason=idle_timeout), a data-plane exec transparently resumes it,
+/// and SetLifecycle then disarms the idle window (Some(0)) while re-arming
+/// the TTL hard cap from now — with the absent `on_idle` left unchanged.
+async fn idle_lifecycle_scenario(
+    sandboxes: &mut SandboxServiceClient<Channel>,
+    processes: &mut SandboxProcessServiceClient<Channel>,
+) -> Result<()> {
+    const ID: &str = "smoke-idle";
+
+    // Subscribe before creating so no transition is missed.
+    let mut events = sandboxes
+        .events(with_machine(SandboxEventsRequest {
+            sandbox_id: ID.into(),
+            ..Default::default()
+        }))
+        .await
+        .context("Events subscribe failed")?
+        .into_inner();
+
+    let created = sandboxes
+        .create(with_machine(CreateSandboxRequest {
+            id: ID.into(),
+            limits: Some(ResourceLimits {
+                vcpus: 1,
+                memory_mib: 256,
+            }),
+            idle_timeout_seconds: 2,
+            on_idle: IdleAction::Pause as i32,
+            ..Default::default()
+        }))
+        .await
+        .context("Create smoke-idle failed")?
+        .into_inner();
+    info!(id = %created.id, "idle-policy sandbox created");
+    wait_for_state(sandboxes, ID, SandboxState::Ready, SANDBOX_READY_TIMEOUT).await?;
+
+    // No execution runs, so the 2 s idle window expires and auto-pauses.
+    next_event(&mut events, SandboxEventKind::Pausing, Some("idle_timeout")).await?;
+    next_event(&mut events, SandboxEventKind::Paused, None).await?;
+    let info = inspect(sandboxes, ID).await?;
+    if info.state() != SandboxState::Paused {
+        bail!("expected auto-paused sandbox, got {:?}", info.state());
+    }
+    if info.idle_timeout_seconds != 2 || info.on_idle() != IdleAction::Pause {
+        bail!(
+            "idle knobs not reported: timeout={} on_idle={:?}",
+            info.idle_timeout_seconds,
+            info.on_idle()
+        );
+    }
+    info!("idle detector auto-paused the sandbox");
+
+    // A data-plane exec transparently resumes it (latency blip, no error).
+    let stdout = run_and_collect(processes, ID, &["/bin/echo", "idle-wake"]).await?;
+    if !stdout.contains("idle-wake") {
+        bail!("post-auto-resume exec output missing marker: {stdout:?}");
+    }
+    next_event(&mut events, SandboxEventKind::Resumed, Some("auto_resume")).await?;
+
+    // Disarm the idle window and re-arm the TTL from now (CORE-60). This
+    // races the freshly re-armed 2 s idle timer and must land well inside
+    // it (one local unary call).
+    let rearm_epoch = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_secs(),
+    )?;
+    sandboxes
+        .set_lifecycle(with_machine(SetLifecycleRequest {
+            id: ID.into(),
+            ttl_seconds: Some(600),
+            idle_timeout_seconds: Some(0),
+            on_idle: None,
+        }))
+        .await
+        .context("SetLifecycle failed")?;
+
+    // Outlive the original window: with idle detection disarmed the
+    // sandbox must stay READY past the 2 s that previously paused it.
+    tokio::time::sleep(Duration::from_secs(4)).await;
+    let info = inspect(sandboxes, ID).await?;
+    if info.state() != SandboxState::Ready {
+        bail!("idle window re-arm did not stick; state {:?}", info.state());
+    }
+    if info.idle_timeout_seconds != 0 {
+        bail!(
+            "idle_timeout_seconds not replaced: {}",
+            info.idle_timeout_seconds
+        );
+    }
+    if info.on_idle() != IdleAction::Pause {
+        bail!(
+            "absent on_idle must stay unchanged, got {:?}",
+            info.on_idle()
+        );
+    }
+    let deadline = info
+        .ttl_deadline
+        .ok_or_else(|| anyhow::anyhow!("ttl_deadline unset after SetLifecycle"))?;
+    let ahead = deadline.seconds - rearm_epoch;
+    if !(540..=660).contains(&ahead) {
+        bail!("ttl_deadline not re-armed from now: {ahead}s ahead");
+    }
+    info!("SetLifecycle re-armed the TTL and disarmed the idle window");
+
+    sandboxes
+        .remove(with_machine(RemoveSandboxRequest {
+            id: ID.into(),
+            force: true,
+        }))
+        .await
+        .context("Remove smoke-idle failed")?;
     Ok(())
 }
 

--- a/tests/e2e/src/sdk_py.rs
+++ b/tests/e2e/src/sdk_py.rs
@@ -19,8 +19,11 @@ use crate::daemon::{DaemonConfig, DaemonHandle};
 use crate::metrics::RunMetrics;
 use crate::{env_flag, repo_root};
 
-/// Generous ceiling for daemon startup (asset staging + VM boot + agent).
-const READY_TIMEOUT: Duration = Duration::from_secs(180);
+/// Generous ceiling for daemon startup: asset staging, the cold
+/// ~255 MiB runtime-binary download into the isolated data dir, VM boot,
+/// and the agent — the same budget as the sandbox smoke (measured
+/// 2026-08-07, where the sibling sdk_ts harness reached READY in 214 s).
+const READY_TIMEOUT: Duration = Duration::from_secs(360);
 /// Ceiling for the whole pytest run: two sandbox boots (sync + async
 /// flavors) plus a handful of executions each. This only catches a
 /// wedged runner.

--- a/tests/e2e/src/sdk_ts.rs
+++ b/tests/e2e/src/sdk_ts.rs
@@ -19,8 +19,10 @@ use crate::daemon::{DaemonConfig, DaemonHandle};
 use crate::metrics::RunMetrics;
 use crate::{env_flag, repo_root};
 
-/// Generous ceiling for daemon startup (asset staging + VM boot + agent).
-const READY_TIMEOUT: Duration = Duration::from_secs(180);
+/// Generous ceiling for daemon startup: asset staging + the cold
+/// ~255 MiB runtime-binary download into the isolated data dir + VM boot
+/// + agent (same budget as the sandbox smoke; measured 2026-08-06).
+const READY_TIMEOUT: Duration = Duration::from_secs(360);
 /// Ceiling for the whole vitest run: one sandbox boot (which may include
 /// the first in-guest rootfs build) plus a handful of executions. Vitest's
 /// own per-test timeout is 300s; this only catches a wedged runner.

--- a/tests/e2e/src/sdk_ts.rs
+++ b/tests/e2e/src/sdk_ts.rs
@@ -19,9 +19,10 @@ use crate::daemon::{DaemonConfig, DaemonHandle};
 use crate::metrics::RunMetrics;
 use crate::{env_flag, repo_root};
 
-/// Generous ceiling for daemon startup: asset staging + the cold
-/// ~255 MiB runtime-binary download into the isolated data dir + VM boot
-/// + agent (same budget as the sandbox smoke; measured 2026-08-06).
+/// Generous ceiling for daemon startup: asset staging, the cold
+/// ~255 MiB runtime-binary download into the isolated data dir, VM boot,
+/// and the agent — the same budget as the sandbox smoke (measured
+/// 2026-08-06).
 const READY_TIMEOUT: Duration = Duration::from_secs(360);
 /// Ceiling for the whole vitest run: one sandbox boot (which may include
 /// the first in-guest rootfs build) plus a handful of executions. Vitest's

--- a/virt/arcbox-vm/Cargo.toml
+++ b/virt/arcbox-vm/Cargo.toml
@@ -27,7 +27,7 @@ toml.workspace         = true
 sha2.workspace         = true
 
 [dev-dependencies]
-tokio              = { workspace = true, features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["rt", "macros", "test-util"] }
 anyhow.workspace   = true
 tracing-subscriber.workspace = true
 tempfile.workspace = true

--- a/virt/arcbox-vm/src/lib.rs
+++ b/virt/arcbox-vm/src/lib.rs
@@ -53,9 +53,9 @@ pub use error::{Result, VmmError};
 pub use network::{ExposeTarget, NetworkAllocation, NetworkManager};
 pub use sandbox::pause_reason;
 pub use sandbox::{
-    CheckpointInfo, CheckpointSummary, RestoreSandboxSpec, SandboxEvent, SandboxId, SandboxInfo,
-    SandboxManager, SandboxMountSpec, SandboxNetworkIdentity, SandboxNetworkInfo,
-    SandboxNetworkSpec, SandboxSpec, SandboxState, SandboxSummary,
+    CheckpointInfo, CheckpointSummary, IdleAction, LifecycleUpdate, RestoreSandboxSpec,
+    SandboxEvent, SandboxId, SandboxInfo, SandboxManager, SandboxMountSpec, SandboxNetworkIdentity,
+    SandboxNetworkInfo, SandboxNetworkSpec, SandboxSpec, SandboxState, SandboxSummary,
 };
 pub use sandbox::{
     ExecutionChannel, ExecutionOutput, ExecutionSnapshot, ExecutionSpec, StdinState,

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -40,6 +40,7 @@ mod pause;
 mod persistence;
 mod pool;
 mod reconcile;
+mod timers;
 mod types;
 mod warm;
 mod workload;
@@ -49,9 +50,9 @@ pub use execution::{
 };
 pub use pause::reason as pause_reason;
 pub use types::{
-    CheckpointInfo, CheckpointSummary, RestoreSandboxSpec, SandboxEvent, SandboxId, SandboxInfo,
-    SandboxInstance, SandboxMountSpec, SandboxNetworkInfo, SandboxNetworkSpec, SandboxSpec,
-    SandboxState, SandboxSummary,
+    CheckpointInfo, CheckpointSummary, IdleAction, LifecycleUpdate, RestoreSandboxSpec,
+    SandboxEvent, SandboxId, SandboxInfo, SandboxInstance, SandboxMountSpec, SandboxNetworkInfo,
+    SandboxNetworkSpec, SandboxSpec, SandboxState, SandboxSummary,
 };
 
 const EVENT_CHANNEL_CAPACITY: usize = 256;
@@ -78,6 +79,11 @@ pub struct SandboxManager {
     /// Publishes the startup reconciliation result. Lifecycle and read APIs
     /// gate on it so callers never observe partial recovered state.
     reconcile_done: tokio::sync::watch::Receiver<Option<ReconcileResult>>,
+    /// Per-sandbox TTL / idle expiry timers (CORE-21/60); see `timers.rs`.
+    timers: timers::LifecycleTimers,
+    /// Weak self-handle set by [`Self::into_shared`]; idle timers need it to
+    /// reach the pause/remove flows from a detached task.
+    self_handle: std::sync::OnceLock<std::sync::Weak<Self>>,
 }
 
 impl SandboxManager {
@@ -184,7 +190,25 @@ impl SandboxManager {
             warm: Arc::new(warm::WarmCache::default()),
             executions,
             reconcile_done,
+            timers: timers::LifecycleTimers::default(),
+            self_handle: std::sync::OnceLock::new(),
         })
+    }
+
+    /// Wrap the manager in an `Arc` and start the lifecycle monitor that
+    /// arms/cancels the idle and TTL timers off the event stream.
+    ///
+    /// Production embedders (the guest agent's `SandboxService`) must use
+    /// this; a plain [`Self::new`] manager never fires idle timers (unit
+    /// tests exercising unrelated surfaces rely on that inertness).
+    #[must_use]
+    pub fn into_shared(self) -> Arc<Self> {
+        let manager = Arc::new(self);
+        let _ = manager.self_handle.set(Arc::downgrade(&manager));
+        if tokio::runtime::Handle::try_current().is_ok() {
+            timers::spawn_lifecycle_monitor(&manager);
+        }
+        manager
     }
 
     /// Wait until the startup orphan sweep has completed.

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -491,6 +491,7 @@ impl SandboxManager {
             instance.labels.clone_from(&record.effective_spec.labels);
             instance.spec = record.effective_spec;
             instance.created_at = record.created_at;
+            instance.ttl_deadline = record.ttl_deadline;
         }
 
         // Reserve network metadata, journal it, then materialize the TAP. This
@@ -965,7 +966,6 @@ impl SandboxManager {
             inst.ready_at = Some(Utc::now());
         }
         reservation.commit();
-        let ttl_armed_for = Arc::downgrade(&arc);
 
         let warm_create = matches!(request.origin, RestoreOrigin::WarmCreate);
         if warm_create {
@@ -979,36 +979,10 @@ impl SandboxManager {
             .events_tx
             .send(SandboxEvent::new(&new_id, action::READY));
 
-        // TTL expiry task — identity-guarded so a stale timer can't remove a
-        // same-id sandbox re-created after this one (see expire_sandbox).
-        if request.spec.ttl_seconds > 0 {
-            let instances = Arc::clone(&self.instances);
-            let network = Arc::clone(&self.network);
-            let events_tx = self.events_tx.clone();
-            let config2 = Arc::clone(&self.config);
-            let cow2 = Arc::clone(&self.cow_manager);
-            let records = Arc::clone(&self.records);
-            let snapshots = Arc::clone(&self.snapshots);
-            let id2 = new_id.clone();
-            let ttl = request.spec.ttl_seconds;
-            let armed_for = ttl_armed_for;
-            tokio::spawn(async move {
-                tokio::time::sleep(Duration::from_secs(ttl as u64)).await;
-                super::cleanup::expire_sandbox(
-                    &id2,
-                    Some(generation),
-                    &armed_for,
-                    &instances,
-                    &network,
-                    &events_tx,
-                    &config2,
-                    &cow2,
-                    &records,
-                    &snapshots,
-                )
-                .await;
-            });
-        }
+        // Arm the TTL expiry timer if a deadline was set — identity-guarded
+        // so a stale timer can't remove a same-id sandbox re-created after
+        // this one (see expire_sandbox), re-armable via SetLifecycle.
+        self.arm_ttl_timer(&new_id);
 
         // On a pool hit, spawn_ms covers records + network + the claim
         // itself (the phases that still ran) and stage_ms is genuinely 0 —

--- a/virt/arcbox-vm/src/sandbox/cleanup.rs
+++ b/virt/arcbox-vm/src/sandbox/cleanup.rs
@@ -185,20 +185,25 @@ fn armed_instance(
     }
 }
 
-/// TTL expiry: force-remove `id`, but only if the instance registered under it
+/// Deadline expiry: remove `id`, but only if the instance registered under it
 /// is still the one this timer was armed for.
 ///
 /// A sandbox that was removed and re-created under the same id (deterministic
 /// caller-supplied ids make this common) installs a fresh `Arc`. The captured
 /// `Weak` then points at a different — or dropped — instance, so the stale
 /// timer becomes a no-op instead of force-removing the unrelated new sandbox.
+///
+/// `force` distinguishes the two expiry classes: the TTL hard cap destroys
+/// regardless of activity (`true`), while the idle detector must never kill
+/// a sandbox that turned busy in the firing window — non-forced removal
+/// rejects `Running`/`Starting` (`false`). `cause` labels the logs.
 #[allow(
     clippy::type_complexity,
     reason = "manager storage type is shared here"
 )]
 #[allow(
     clippy::too_many_arguments,
-    reason = "detached TTL task captures the manager-owned resource set"
+    reason = "detached expiry task captures the manager-owned resource set"
 )]
 pub(super) async fn expire_sandbox(
     id: &str,
@@ -211,6 +216,8 @@ pub(super) async fn expire_sandbox(
     cow_manager: &Arc<CowManager>,
     records: &Arc<SandboxRecordStore>,
     snapshots: &Arc<crate::snapshot::SnapshotCatalog>,
+    force: bool,
+    cause: &str,
 ) {
     let mut retry_delay = TTL_REMOVE_RETRY_INITIAL;
     loop {
@@ -220,7 +227,7 @@ pub(super) async fn expire_sandbox(
         };
         match remove_sandbox_impl(
             id,
-            true,
+            force,
             &expected,
             instances,
             network,
@@ -237,14 +244,19 @@ pub(super) async fn expire_sandbox(
                 warn!(
                     sandbox_id = %id,
                     error,
+                    cause,
                     retry_millis = retry_delay.as_millis(),
-                    "TTL sandbox removal is not yet confirmed; retrying"
+                    "expired sandbox removal is not yet confirmed; retrying"
                 );
                 tokio::time::sleep(retry_delay).await;
                 retry_delay = retry_delay.saturating_mul(2).min(TTL_REMOVE_RETRY_MAX);
             }
+            Err(VmmError::WrongState { .. }) if !force => {
+                debug!(sandbox_id = %id, cause, "sandbox became busy before expiry; skipping");
+                return;
+            }
             Err(error) => {
-                error!(sandbox_id = %id, error = %error, "TTL sandbox removal failed");
+                error!(sandbox_id = %id, error = %error, cause, "expired sandbox removal failed");
                 return;
             }
         }
@@ -409,6 +421,9 @@ pub(super) fn inst_to_info(inst: &SandboxInstance) -> SandboxInfo {
         paused_at: inst.paused_at,
         // Filled by the manager for paused sandboxes (it owns the paths).
         storage_bytes: 0,
+        ttl_deadline: inst.ttl_deadline,
+        idle_timeout_seconds: inst.spec.idle_timeout_seconds,
+        on_idle: inst.spec.on_idle,
     }
 }
 
@@ -527,6 +542,8 @@ mod tests {
                         &cow_manager,
                         &records,
                         &snapshots,
+                        true,
+                        "TTL",
                     )
                     .await;
                     Ok(())
@@ -662,6 +679,8 @@ mod tests {
                 &cow_manager,
                 &records,
                 &snapshots,
+                true,
+                "TTL",
             ),
         )
         .await

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -184,12 +184,16 @@ impl SandboxManager {
             ProvisionIntent::Blocked(_) => return Err(VmmError::AlreadyExists(id)),
         };
         let generation = record.generation;
+        let ttl_deadline = record.ttl_deadline;
         let spec = record.effective_spec;
         let arc = reservation.instance();
         let mut creating_instance = arc.lock().unwrap();
         creating_instance.record_generation = Some(generation);
         creating_instance.labels.clone_from(&spec.labels);
         creating_instance.spec.clone_from(&spec);
+        // Computed by the durable record so a same-key create retry keeps
+        // the original cap instead of re-deriving it from a later "now".
+        creating_instance.ttl_deadline = ttl_deadline;
 
         // Reserve the IP without touching the host, durably journal it, then
         // materialize the TAP. No external resource exists before its cleanup
@@ -289,15 +293,13 @@ impl SandboxManager {
             }
         };
 
-        // Populate the reserved instance. Keep a Weak to identify this exact
-        // generation when its TTL timer fires (see expire_sandbox).
+        // Populate the reserved instance.
         creating_instance.network.clone_from(&net_alloc);
         // The boot bakes the invariant `ip=` identity unless the caller
         // supplied an explicit ip= (see do_boot); record which one this guest
         // runs so checkpoints carry the right restore contract.
         creating_instance.net_invariant =
             creating_instance.network.is_some() && !spec.boot_args.contains("ip=");
-        let ttl_armed_for = Arc::downgrade(&arc);
 
         // Retain the boot task so force/TTL removal can cancel and join it
         // before deleting the crash-recovery journal.
@@ -309,13 +311,12 @@ impl SandboxManager {
             let cow_manager = Arc::clone(&self.cow_manager);
             let records = Arc::clone(&self.records);
             let id_clone = id.clone();
-            let spec_clone = spec.clone();
             let net_alloc_clone = net_alloc;
             let (resource_handoff_tx, resource_handoff) = tokio::sync::oneshot::channel();
             let handle = tokio::spawn(async move {
                 boot_sandbox(
                     id_clone,
-                    spec_clone,
+                    spec,
                     net_alloc_clone,
                     vm_dir,
                     instances,
@@ -341,35 +342,9 @@ impl SandboxManager {
         // Publish only after removal can observe and join the boot task.
         let _ = self.events_tx.send(SandboxEvent::new(&id, action::CREATED));
 
-        // Spawn TTL expiry task if requested.
-        if spec.ttl_seconds > 0 {
-            let instances = Arc::clone(&self.instances);
-            let network = Arc::clone(&self.network);
-            let events_tx = self.events_tx.clone();
-            let config2 = Arc::clone(&self.config);
-            let cow2 = Arc::clone(&self.cow_manager);
-            let records = Arc::clone(&self.records);
-            let snapshots = Arc::clone(&self.snapshots);
-            let id2 = id.clone();
-            let ttl = spec.ttl_seconds;
-            let armed_for = ttl_armed_for;
-            tokio::spawn(async move {
-                tokio::time::sleep(Duration::from_secs(ttl as u64)).await;
-                super::cleanup::expire_sandbox(
-                    &id2,
-                    Some(generation),
-                    &armed_for,
-                    &instances,
-                    &network,
-                    &events_tx,
-                    &config2,
-                    &cow2,
-                    &records,
-                    &snapshots,
-                )
-                .await;
-            });
-        }
+        // Arm the TTL expiry timer if a deadline was set (re-armable via
+        // SetLifecycle, CORE-60).
+        self.arm_ttl_timer(&id);
 
         info!(sandbox_id = %id, "sandbox create requested (async boot started)");
         if let Some(error) = starting_durability_error {

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -563,13 +563,36 @@ impl SandboxManager {
         Ok(())
     }
 
+    /// Files a checkpoint occupies on disk, for storage accounting.
+    ///
+    /// Empty when the id is unknown — a paused sandbox whose checkpoint went
+    /// missing reports the disk overlay alone rather than failing the read.
+    fn checkpoint_paths(&self, snapshot_id: &str) -> Vec<PathBuf> {
+        self.snapshots
+            .find_by_id(snapshot_id)
+            .map(|meta| {
+                std::iter::once(meta.vmstate_path)
+                    .chain(meta.mem_path)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     /// Return the current state and metadata of a sandbox.
     pub fn inspect_sandbox(&self, id: &SandboxId) -> Result<SandboxInfo> {
         let instance = self.get_instance(id)?;
-        let inst = instance.lock().unwrap();
-        let mut info = inst_to_info(&inst);
-        if inst.state == SandboxState::Paused {
-            info.storage_bytes = self.paused_storage_bytes(&inst);
+        // Locate the retained artifacts under the lock; size them after it
+        // is dropped — the sizing stats files and scans the catalog, and
+        // holding the instance lock across that blocks every lifecycle
+        // transition on this sandbox.
+        let (mut info, artifacts) = {
+            let inst = instance.lock().unwrap();
+            let artifacts =
+                (inst.state == SandboxState::Paused).then(|| self.paused_artifacts(&inst));
+            (inst_to_info(&inst), artifacts)
+        };
+        if let Some(artifacts) = artifacts {
+            info.storage_bytes = artifacts.storage_bytes(|id| self.checkpoint_paths(id));
         }
         Ok(info)
     }
@@ -587,7 +610,13 @@ impl SandboxManager {
         // (as before) is the one place that could deadlock a future writer that
         // locks in the opposite order.
         let instances: Vec<_> = self.instances.read().unwrap().values().cloned().collect();
-        Ok(instances
+        // Two passes on purpose. Under the instance lock, only field reads:
+        // sizing a paused sandbox's retained state stats files and scans the
+        // snapshot catalog, so doing it here would put blocking I/O on the
+        // async executor while holding a lock every lifecycle transition
+        // needs. The second pass pays one catalog listing for the whole
+        // response instead of one per paused sandbox.
+        let mut summaries: Vec<(SandboxSummary, Option<super::pause::PausedArtifacts>)> = instances
             .iter()
             .filter_map(|arc| {
                 let inst = arc.lock().unwrap();
@@ -604,7 +633,7 @@ impl SandboxManager {
                         return None;
                     }
                 }
-                Some(SandboxSummary {
+                let summary = SandboxSummary {
                     id: inst.id.clone(),
                     state: inst.state,
                     labels: inst.labels.clone(),
@@ -615,14 +644,29 @@ impl SandboxManager {
                         .unwrap_or_default(),
                     created_at: inst.created_at,
                     paused_at: inst.paused_at,
-                    storage_bytes: if inst.state == SandboxState::Paused {
-                        self.paused_storage_bytes(&inst)
-                    } else {
-                        0
-                    },
-                })
+                    storage_bytes: 0,
+                };
+                let artifacts =
+                    (inst.state == SandboxState::Paused).then(|| self.paused_artifacts(&inst));
+                Some((summary, artifacts))
             })
-            .collect())
+            .collect();
+
+        if summaries.iter().any(|(_, artifacts)| artifacts.is_some()) {
+            let catalog = self.snapshots.list_all().unwrap_or_default();
+            for (summary, artifacts) in &mut summaries {
+                if let Some(artifacts) = artifacts {
+                    summary.storage_bytes = artifacts.storage_bytes(|id| {
+                        catalog
+                            .iter()
+                            .find(|info| info.id == id)
+                            .map(snapshot_files)
+                            .unwrap_or_default()
+                    });
+                }
+            }
+        }
+        Ok(summaries.into_iter().map(|(summary, _)| summary).collect())
     }
 
     /// Subscribe to sandbox lifecycle events.
@@ -708,4 +752,15 @@ impl SandboxManager {
         let uds = self.require_alive_vsock(id)?;
         crate::file_io::write_file(&uds, path, mode, data).await
     }
+}
+
+/// Files a listed checkpoint occupies on disk, for storage accounting.
+///
+/// The listing counterpart of [`SandboxManager::checkpoint_paths`]: it reads
+/// an already-loaded [`SnapshotInfo`] so a multi-sandbox response pays one
+/// catalog scan rather than one per paused sandbox.
+fn snapshot_files(info: &crate::snapshot::SnapshotInfo) -> Vec<PathBuf> {
+    std::iter::once(info.vmstate_path.clone())
+        .chain(info.mem_path.clone())
+        .collect()
 }

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -847,31 +847,58 @@ impl SandboxManager {
             .join(format!("arcbox-cow-{id}.img"))
     }
 
-    /// On-disk footprint of a paused sandbox's retained state: checkpoint
-    /// (vmstate + mem) plus the disk overlay (allocated blocks of the
-    /// sparse COW file, or the parked rootfs copy).
-    pub(super) fn paused_storage_bytes(&self, inst: &SandboxInstance) -> u64 {
+    /// Locate a paused sandbox's retained artifacts.
+    ///
+    /// Pure field reads — no filesystem access — so it is the only half of
+    /// the storage accounting that may run under the instance lock. The
+    /// sizing itself ([`PausedArtifacts::storage_bytes`]) stats files and,
+    /// for the checkpoint, needs a catalog lookup; doing that under the
+    /// lock would block every lifecycle transition on the sandbox behind
+    /// blocking I/O on the async executor.
+    pub(super) fn paused_artifacts(&self, inst: &SandboxInstance) -> PausedArtifacts {
+        PausedArtifacts {
+            pause_snapshot_id: inst.pause_snapshot_id.clone(),
+            preserved_cow: self.preserved_cow_file(&inst.id),
+            parked_rootfs: inst.vm_dir.join(PAUSED_ROOTFS_FILE),
+        }
+    }
+}
+
+/// Where a paused sandbox's retained state lives on disk.
+///
+/// Collected under the instance lock, sized outside it.
+pub(super) struct PausedArtifacts {
+    /// Catalog id of the internal pause checkpoint.
+    pause_snapshot_id: Option<String>,
+    /// Retained dm-snapshot overlay (absent in copy-mode).
+    preserved_cow: PathBuf,
+    /// Copy-mode fallback: the staged rootfs parked in `vm_dir`.
+    parked_rootfs: PathBuf,
+}
+
+impl PausedArtifacts {
+    /// On-disk footprint: the checkpoint (vmstate + mem) plus the disk
+    /// overlay — allocated blocks, so a sparse COW is counted at its real
+    /// cost.
+    ///
+    /// `checkpoint_paths` resolves a pause-checkpoint id to its files. A
+    /// caller sizing many sandboxes should close over one catalog listing
+    /// rather than paying a catalog scan per sandbox.
+    pub(super) fn storage_bytes(&self, checkpoint_paths: impl FnOnce(&str) -> Vec<PathBuf>) -> u64 {
         use std::os::unix::fs::MetadataExt as _;
 
-        let mut total = 0u64;
-        if let Some(snapshot_id) = inst.pause_snapshot_id.as_deref()
-            && let Ok(meta) = self.snapshots.find_by_id(snapshot_id)
-        {
-            for path in std::iter::once(&meta.vmstate_path).chain(meta.mem_path.iter()) {
-                if let Ok(metadata) = std::fs::metadata(path) {
-                    total = total.saturating_add(metadata.blocks().saturating_mul(512));
-                }
-            }
-        }
-        for path in [
-            self.preserved_cow_file(&inst.id),
-            inst.vm_dir.join(PAUSED_ROOTFS_FILE),
-        ] {
-            if let Ok(metadata) = std::fs::metadata(&path) {
-                total = total.saturating_add(metadata.blocks().saturating_mul(512));
-            }
-        }
-        total
+        let allocated = |path: &Path| {
+            std::fs::metadata(path).map_or(0, |metadata| metadata.blocks().saturating_mul(512))
+        };
+        let checkpoint = self
+            .pause_snapshot_id
+            .as_deref()
+            .map(checkpoint_paths)
+            .unwrap_or_default();
+        checkpoint
+            .iter()
+            .chain([&self.preserved_cow, &self.parked_rootfs])
+            .fold(0u64, |total, path| total.saturating_add(allocated(path)))
     }
 }
 

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -1070,4 +1070,53 @@ mod tests {
         assert!(manager.snapshots.find_by_id(&pause_meta.id).is_err());
         assert!(manager.snapshots.find_by_id(&user_meta.id).is_ok());
     }
+
+    /// `List` and `Inspect` must agree on a paused sandbox's footprint.
+    /// They resolve the checkpoint differently — `Inspect` by `find_by_id`,
+    /// `List` by a linear scan of one `list_all()` so a multi-sandbox
+    /// response pays a single catalog read — so a drift in either id match
+    /// would silently report 0 on one surface while the other stayed right.
+    #[tokio::test]
+    async fn list_and_inspect_report_the_same_paused_storage() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = manager(dir.path()).await;
+
+        let pending = manager.snapshots.begin("napper").unwrap();
+        std::fs::write(pending.dir().join("vmstate"), vec![0u8; 128 * 1024]).unwrap();
+        std::fs::write(pending.dir().join("mem"), vec![0u8; 256 * 1024]).unwrap();
+        let meta = pending
+            .commit(SnapshotDraft {
+                name: Some(PAUSE_SNAPSHOT_NAME.to_owned()),
+                labels: HashMap::new(),
+                snapshot_type: crate::config::SnapshotType::Full,
+                parent_id: None,
+                kernel_path: None,
+                rootfs_path: None,
+                net_invariant: false,
+            })
+            .unwrap();
+
+        // The retained disk overlay, alongside the checkpoint.
+        let cow_dir = dir.path().join("cow");
+        std::fs::create_dir_all(&cow_dir).unwrap();
+        std::fs::write(cow_dir.join("arcbox-cow-napper.img"), vec![0u8; 64 * 1024]).unwrap();
+
+        let arc = insert_instance(&manager, "napper", SandboxState::Paused);
+        arc.lock().unwrap().pause_snapshot_id = Some(meta.id);
+        // A live sandbox reports nothing: the field is retained-state only.
+        insert_instance(&manager, "awake", SandboxState::Ready);
+
+        let inspected = manager.inspect_sandbox(&"napper".to_owned()).unwrap();
+        let listed = manager.list_sandboxes(None, &HashMap::new()).unwrap();
+        let paused = listed.iter().find(|s| s.id == "napper").unwrap();
+        let awake = listed.iter().find(|s| s.id == "awake").unwrap();
+
+        assert!(
+            inspected.storage_bytes >= (128 + 256 + 64) * 1024,
+            "inspect must count the checkpoint and the overlay, got {}",
+            inspected.storage_bytes
+        );
+        assert_eq!(paused.storage_bytes, inspected.storage_bytes);
+        assert_eq!(awake.storage_bytes, 0);
+    }
 }

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -50,6 +50,8 @@ pub(super) const PAUSED_ROOTFS_FILE: &str = "paused-rootfs.ext4";
 pub mod reason {
     /// Client-driven `Pause`.
     pub const PAUSE: &str = "pause";
+    /// Idle-detector pause (`on_idle: PAUSE`, CORE-21).
+    pub const IDLE_TIMEOUT: &str = "idle_timeout";
     /// Client-driven `Resume`.
     pub const RESUME: &str = "resume";
     /// Daemon-side transparent resume on a data-plane call.
@@ -102,14 +104,28 @@ impl SandboxManager {
     /// answers `WrongState` — an active execution must finish (or be
     /// stopped) first, matching the contract's "requires READY".
     pub async fn pause_sandbox(&self, id: &SandboxId) -> Result<()> {
+        self.pause_sandbox_with_reason(id, reason::PAUSE).await
+    }
+
+    /// [`Self::pause_sandbox`] with an explicit PAUSING-event reason —
+    /// the idle detector reports `idle_timeout` (see [`reason`]).
+    pub(super) async fn pause_sandbox_with_reason(
+        &self,
+        id: &SandboxId,
+        pause_reason: &str,
+    ) -> Result<()> {
         self.await_reconcile().await?;
         let instance = self.get_instance(id)?;
         let cleanup_lock = instance.lock().unwrap().cleanup_lock.clone();
         let _cleanup_guard = cleanup_lock.lock().await;
         super::ensure_current_instance(&self.instances, id, &instance)?;
 
+        // Claim `Ready → Pausing` atomically: setting the state in the same
+        // critical section as the check means a concurrent Run cannot slip
+        // its `Ready → Running` claim in between and end up checkpointed
+        // mid-execution.
         let (generation, vm) = {
-            let inst = instance.lock().unwrap();
+            let mut inst = instance.lock().unwrap();
             match inst.state {
                 SandboxState::Paused => return Ok(()),
                 SandboxState::Ready => {}
@@ -121,38 +137,56 @@ impl SandboxManager {
                     });
                 }
             }
-            (inst.record_generation, inst.vm.as_ref().map(Arc::clone))
-        };
-        // Resume restores into a fresh jailer chroot; direct-mode vmstate
-        // pins origin paths, so a direct-mode pause could never resume.
-        // Fail fast before touching anything.
-        let jailer = self.config.firecracker.jailer.as_ref().ok_or_else(|| {
-            VmmError::Config(
-                "sandbox pause requires jailer isolation; direct mode cannot resume".into(),
-            )
-        })?;
-        let vm = vm.ok_or_else(|| VmmError::WrongState {
-            id: id.clone(),
-            expected: "a sandbox with a live VM handle".into(),
-            actual: "no VM handle".into(),
-        })?;
-
-        if let Some(generation) = generation {
-            let commit = self
-                .records
-                .transition(id, generation, SandboxTransition::Pausing)?;
-            if let Some(error) = commit.durability_error {
-                warn!(
-                    sandbox_id = %id,
-                    error,
-                    "pausing transition is visible but durability is unconfirmed"
-                );
+            // Resume restores into a fresh jailer chroot; direct-mode
+            // vmstate pins origin paths, so a direct-mode pause could never
+            // resume. Fail fast before claiming anything.
+            if self.config.firecracker.jailer.is_none() {
+                return Err(VmmError::Config(
+                    "sandbox pause requires jailer isolation; direct mode cannot resume".into(),
+                ));
             }
+            let vm = inst
+                .vm
+                .as_ref()
+                .map(Arc::clone)
+                .ok_or_else(|| VmmError::WrongState {
+                    id: id.clone(),
+                    expected: "a sandbox with a live VM handle".into(),
+                    actual: "no VM handle".into(),
+                })?;
+            inst.state = SandboxState::Pausing;
+            (inst.record_generation, vm)
+        };
+        let jailer = self
+            .config
+            .firecracker
+            .jailer
+            .as_ref()
+            .expect("checked in the claim above");
+
+        if let Some(generation) = generation
+            && let Err(error) = (|| -> Result<()> {
+                let commit = self
+                    .records
+                    .transition(id, generation, SandboxTransition::Pausing)?;
+                if let Some(error) = commit.durability_error {
+                    warn!(
+                        sandbox_id = %id,
+                        error,
+                        "pausing transition is visible but durability is unconfirmed"
+                    );
+                }
+                Ok(())
+            })()
+        {
+            // The durable claim failed: release the in-memory claim so the
+            // sandbox stays usable.
+            instance.lock().unwrap().state = SandboxState::Ready;
+            return Err(error);
         }
-        instance.lock().unwrap().state = SandboxState::Pausing;
         let _ = self
             .events_tx
-            .send(SandboxEvent::new(id, action::PAUSING).with_attr("reason", reason::PAUSE));
+            .send(SandboxEvent::new(id, action::PAUSING).with_attr("reason", pause_reason));
 
         // Checkpoint through the shared implementation — it owns the
         // chroot-owner (pool slot) and addressing-mode bookkeeping — but with

--- a/virt/arcbox-vm/src/sandbox/persistence.rs
+++ b/virt/arcbox-vm/src/sandbox/persistence.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 use uuid::Uuid;
 
+use super::types::IdleAction;
 use super::{SandboxId, SandboxSpec, validate_id};
 use crate::error::{Result, VmmError};
 
@@ -137,6 +138,12 @@ pub(super) struct SandboxRecord {
     /// When the sandbox reached `Paused` (None otherwise).
     #[serde(default)]
     pub(super) paused_at: Option<DateTime<Utc>>,
+    /// When the hard maximum lifetime fires (None = no limit). Seeded from
+    /// `effective_spec.ttl_seconds`; replaced by `SetLifecycle` (CORE-60).
+    /// Survives `redact_runtime_inputs` — unlike the seed seconds, the
+    /// deadline is durable lifecycle state, not a runtime input.
+    #[serde(default)]
+    pub(super) ttl_deadline: Option<DateTime<Utc>>,
 }
 
 /// Result of reserving a durable provisioning intent.
@@ -182,6 +189,8 @@ impl SandboxTransition {
 impl SandboxRecord {
     fn new(id: &str, request_key: &str, effective_spec: SandboxSpec) -> Self {
         let created_at = Utc::now();
+        let ttl_deadline = (effective_spec.ttl_seconds > 0)
+            .then(|| created_at + chrono::Duration::seconds(i64::from(effective_spec.ttl_seconds)));
 
         Self {
             version: RECORD_VERSION,
@@ -195,6 +204,7 @@ impl SandboxRecord {
             error: None,
             pause_snapshot_id: None,
             paused_at: None,
+            ttl_deadline,
         }
     }
 
@@ -514,6 +524,36 @@ impl SandboxRecordStore {
         let durability_error = self.save_unlocked(&record)?;
         Ok(DurableCommit {
             value: record,
+            durability_error,
+        })
+    }
+
+    /// Persists the resolved lifecycle knobs without changing the phase.
+    ///
+    /// Called by `SetLifecycle` (CORE-60) with the post-update values so a
+    /// paused sandbox reloaded after an agent restart keeps its (re-armed)
+    /// TTL deadline and idle policy.
+    pub(super) fn update_lifecycle(
+        &self,
+        id: &str,
+        generation: Uuid,
+        ttl_deadline: Option<DateTime<Utc>>,
+        idle_timeout_seconds: u32,
+        on_idle: IdleAction,
+    ) -> Result<DurableCommit<()>> {
+        let _guard = self.lock()?;
+        let mut record = self
+            .load_unlocked(id)?
+            .ok_or_else(|| VmmError::NotFound(id.to_owned()))?;
+        if record.generation != generation {
+            return Err(generation_mismatch(id, record.generation, generation));
+        }
+        record.ttl_deadline = ttl_deadline;
+        record.effective_spec.idle_timeout_seconds = idle_timeout_seconds;
+        record.effective_spec.on_idle = on_idle;
+        let durability_error = self.save_unlocked(&record)?;
+        Ok(DurableCommit {
+            value: (),
             durability_error,
         })
     }

--- a/virt/arcbox-vm/src/sandbox/reconcile.rs
+++ b/virt/arcbox-vm/src/sandbox/reconcile.rs
@@ -399,6 +399,9 @@ fn inactive_instance(
     instance.state = state;
     instance.created_at = record.created_at;
     instance.error = record.error;
+    // The TTL cap survives restarts: a reloaded paused sandbox still
+    // expires (the lifecycle monitor re-arms the timer after reconcile).
+    instance.ttl_deadline = record.ttl_deadline;
     if state == SandboxState::Paused {
         instance.pause_snapshot_id = record.pause_snapshot_id;
         instance.paused_at = record.paused_at;

--- a/virt/arcbox-vm/src/sandbox/timers.rs
+++ b/virt/arcbox-vm/src/sandbox/timers.rs
@@ -228,15 +228,34 @@ impl SandboxManager {
     /// The armed task holds only `Weak`s plus the resource set the expiry
     /// needs, so it never keeps the manager alive; a `SetLifecycle` re-arm
     /// replaces the slot and aborts the sleeping task.
+    ///
+    /// No-op without a shared handle ([`SandboxManager::into_shared`]), like
+    /// [`Self::arm_idle_timer`]: the fired task claims its timer slot through
+    /// the manager, and a task that cannot claim one must not act — reading
+    /// the two functions opposite ways on the same condition is how a stale
+    /// timer would slip past both staleness guards below.
     pub(super) fn arm_ttl_timer(&self, id: &SandboxId) {
+        let Some(self_handle) = self.self_handle.get().cloned() else {
+            return;
+        };
         let Ok(instance) = self.get_instance(id) else {
             self.timers.ttl.cancel(id);
             return;
         };
-        let (deadline, generation) = {
+        let (deadline, generation, state) = {
             let inst = instance.lock().unwrap();
-            (inst.ttl_deadline, inst.record_generation)
+            (inst.ttl_deadline, inst.record_generation, inst.state)
         };
+        // A terminal sandbox has nothing left to expire, and the live path
+        // cancels its TTL on the STOPPED/FAILED edge. Without this guard the
+        // restart resync re-arms one — `inactive_instance` restores
+        // `ttl_deadline` for every recovered record regardless of state — so
+        // whether a stopped sandbox's record gets reaped would depend on
+        // whether the agent happened to bounce.
+        if matches!(state, SandboxState::Stopped | SandboxState::Failed) {
+            self.timers.ttl.cancel(id);
+            return;
+        }
         let Some(deadline) = deadline else {
             self.timers.ttl.cancel(id);
             return;
@@ -244,7 +263,6 @@ impl SandboxManager {
         if tokio::runtime::Handle::try_current().is_err() {
             return;
         }
-        let self_handle = self.self_handle.get().cloned();
         let armed_for = Arc::downgrade(&instance);
         let instances = Arc::clone(&self.instances);
         let network = Arc::clone(&self.network);
@@ -258,18 +276,22 @@ impl SandboxManager {
             tokio::spawn(async move {
                 sleep_until_utc(deadline).await;
                 // Claim the slot so a late cancel cannot abort mid-removal.
-                if let Some(manager) = self_handle.as_ref().and_then(std::sync::Weak::upgrade) {
-                    if !manager.timers.ttl.try_claim(&id, epoch) {
-                        return;
-                    }
-                    // Re-armed deadlines replace the task; a moved deadline
-                    // observed here means the claim raced one — bail.
-                    let still_due = armed_for
-                        .upgrade()
-                        .is_some_and(|inst| inst.lock().unwrap().ttl_deadline == Some(deadline));
-                    if !still_due {
-                        return;
-                    }
+                // A gone manager means the whole sandbox layer is being torn
+                // down: there is nothing to claim the slot against and no one
+                // left to expire for, so bail rather than fall through.
+                let Some(manager) = self_handle.upgrade() else {
+                    return;
+                };
+                if !manager.timers.ttl.try_claim(&id, epoch) {
+                    return;
+                }
+                // Re-armed deadlines replace the task; a moved deadline
+                // observed here means the claim raced one — bail.
+                let still_due = armed_for
+                    .upgrade()
+                    .is_some_and(|inst| inst.lock().unwrap().ttl_deadline == Some(deadline));
+                if !still_due {
+                    return;
                 }
                 info!(sandbox_id = %id, "sandbox TTL expired; removing");
                 super::cleanup::expire_sandbox(

--- a/virt/arcbox-vm/src/sandbox/timers.rs
+++ b/virt/arcbox-vm/src/sandbox/timers.rs
@@ -739,4 +739,31 @@ mod tests {
         }
         assert!(!manager.instances.read().unwrap().contains_key("box"));
     }
+
+    /// A terminal sandbox recovered by the restart sweep carries a
+    /// `ttl_deadline` (`inactive_instance` restores it unconditionally), but
+    /// the live path cancels TTL on the STOPPED/FAILED edge. Arming one
+    /// anyway would make reaping a stopped record depend on whether the
+    /// agent happened to bounce.
+    #[tokio::test(start_paused = true)]
+    async fn ttl_timer_is_not_armed_for_a_terminal_sandbox() {
+        for state in [SandboxState::Stopped, SandboxState::Failed] {
+            let dir = tempfile::tempdir().unwrap();
+            let manager = shared_manager(dir.path()).await;
+            std::fs::create_dir_all(dir.path().join("sandboxes/box")).unwrap();
+            insert_instance(&manager, "box", state, SandboxSpec::default());
+            manager.instances.read().unwrap()["box"]
+                .lock()
+                .unwrap()
+                .ttl_deadline = Some(Utc::now() + chrono::Duration::seconds(2));
+
+            manager.arm_ttl_timer(&"box".to_owned());
+
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            assert!(
+                manager.instances.read().unwrap().contains_key("box"),
+                "a {state} sandbox must not be expired by a re-armed TTL"
+            );
+        }
+    }
 }

--- a/virt/arcbox-vm/src/sandbox/timers.rs
+++ b/virt/arcbox-vm/src/sandbox/timers.rs
@@ -1,0 +1,720 @@
+//! Lifecycle expiry timers: the hard TTL cap and idle detection (CORE-21/60).
+//!
+//! Two independent knobs, never conflated:
+//!
+//! - **TTL** (`ttl_deadline`) caps total lifetime regardless of activity and
+//!   always destroys — pausing does not apply, and a paused sandbox still
+//!   expires. `SetLifecycle` replaces the deadline from *now*.
+//! - **Idle** (`spec.idle_timeout_seconds` + `spec.on_idle`) reacts to
+//!   inactivity: the timer is armed on every `Ready` edge (boot ready,
+//!   execution exit, resume) and cancelled when an execution starts. Idle
+//!   means "no running execution" — file activity does NOT re-arm.
+//!
+//! The monitor task drives arming off the manager's own event stream, so the
+//! transition sites (boot task, exit watchers, pause/resume) stay unaware of
+//! timers. Every armed timer is epoch-stamped: re-arming or cancelling bumps
+//! the slot epoch, and a woken task first *claims* its slot (removing it only
+//! if the epoch still matches) so a stale timer can neither fire nor be
+//! aborted mid-teardown.
+
+use super::types::action;
+use super::*;
+
+/// Epoch-stamped timer registries for TTL and idle expiry.
+#[derive(Default)]
+pub(super) struct LifecycleTimers {
+    ttl: TimerMap,
+    idle: TimerMap,
+}
+
+#[derive(Default)]
+struct TimerMap {
+    slots: Mutex<HashMap<SandboxId, TimerSlot>>,
+    next_epoch: std::sync::atomic::AtomicU64,
+}
+
+struct TimerSlot {
+    epoch: u64,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl TimerMap {
+    /// Replace the sandbox's timer: abort the old task (if any) and install
+    /// the one produced by `spawn`, which receives the slot's epoch.
+    fn arm(&self, id: &SandboxId, spawn: impl FnOnce(u64) -> tokio::task::JoinHandle<()>) {
+        let epoch = self
+            .next_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let handle = spawn(epoch);
+        let mut slots = self.slots.lock().unwrap();
+        if let Some(old) = slots.insert(id.clone(), TimerSlot { epoch, handle }) {
+            old.handle.abort();
+        }
+    }
+
+    /// Abort and drop the sandbox's timer, if one is armed.
+    fn cancel(&self, id: &str) {
+        let slot = self.slots.lock().unwrap().remove(id);
+        if let Some(slot) = slot {
+            slot.handle.abort();
+        }
+    }
+
+    /// Claim the slot for a firing timer: remove it only when `epoch` still
+    /// names the armed task. A `false` return means the timer was re-armed
+    /// or cancelled while sleeping and must not act. After a successful
+    /// claim the slot is gone, so a late `cancel` can no longer abort the
+    /// task mid-action.
+    fn try_claim(&self, id: &str, epoch: u64) -> bool {
+        let mut slots = self.slots.lock().unwrap();
+        if slots.get(id).is_some_and(|slot| slot.epoch == epoch) {
+            slots.remove(id);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Spawn the event-driven monitor that arms/cancels lifecycle timers.
+///
+/// Holds only a `Weak` on the manager: the task exits when the manager is
+/// dropped (the event channel closes with it).
+pub(super) fn spawn_lifecycle_monitor(manager: &Arc<SandboxManager>) {
+    let weak = Arc::downgrade(manager);
+    let mut events = manager.events_tx.subscribe();
+    tokio::spawn(async move {
+        // Reloaded (paused) sandboxes keep their TTL: re-arm after the
+        // startup sweep has published the recovered instances.
+        {
+            let Some(manager) = weak.upgrade() else {
+                return;
+            };
+            if manager.await_reconcile().await.is_ok() {
+                manager.resync_lifecycle_timers();
+            }
+        }
+        loop {
+            match events.recv().await {
+                Ok(event) => {
+                    let Some(manager) = weak.upgrade() else {
+                        return;
+                    };
+                    manager.on_lifecycle_event(&event);
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    let Some(manager) = weak.upgrade() else {
+                        return;
+                    };
+                    manager.resync_lifecycle_timers();
+                }
+                Err(broadcast::error::RecvError::Closed) => return,
+            }
+        }
+    });
+}
+
+impl SandboxManager {
+    /// Replace a sandbox's lifecycle deadlines (CORE-60).
+    ///
+    /// `ttl_seconds` re-arms the hard cap from *now* (0 removes it);
+    /// `idle_timeout_seconds` replaces the idle window, re-arming any live
+    /// timer; `on_idle` replaces the policy. `None` fields are unchanged.
+    /// Allowed in any non-terminal state — a paused sandbox keeps honoring
+    /// its (re-armed) TTL, and new idle knobs apply on the next `Ready`.
+    pub async fn set_sandbox_lifecycle(
+        &self,
+        id: &SandboxId,
+        update: LifecycleUpdate,
+    ) -> Result<()> {
+        self.await_reconcile().await?;
+        let instance = self.get_instance(id)?;
+        let (generation, ttl_deadline, idle_timeout_seconds, on_idle) = {
+            let mut inst = instance.lock().unwrap();
+            match inst.state {
+                SandboxState::Stopping | SandboxState::Stopped | SandboxState::Failed => {
+                    return Err(VmmError::WrongState {
+                        id: id.clone(),
+                        expected: "a live sandbox (not stopping, stopped, or failed)".into(),
+                        actual: inst.state.to_string(),
+                    });
+                }
+                _ => {}
+            }
+            if let Some(ttl) = update.ttl_seconds {
+                inst.ttl_deadline =
+                    (ttl > 0).then(|| Utc::now() + chrono::Duration::seconds(i64::from(ttl)));
+            }
+            if let Some(idle) = update.idle_timeout_seconds {
+                inst.spec.idle_timeout_seconds = idle;
+            }
+            if let Some(policy) = update.on_idle {
+                inst.spec.on_idle = policy;
+            }
+            (
+                inst.record_generation,
+                inst.ttl_deadline,
+                inst.spec.idle_timeout_seconds,
+                inst.spec.on_idle,
+            )
+        };
+        let commit = generation
+            .map(|generation| {
+                self.records.update_lifecycle(
+                    id,
+                    generation,
+                    ttl_deadline,
+                    idle_timeout_seconds,
+                    on_idle,
+                )
+            })
+            .transpose()?;
+        if update.ttl_seconds.is_some() {
+            self.arm_ttl_timer(id);
+        }
+        if update.idle_timeout_seconds.is_some() || update.on_idle.is_some() {
+            self.arm_idle_timer(id);
+        }
+        info!(
+            sandbox_id = %id,
+            ttl_deadline = ?ttl_deadline,
+            idle_timeout_seconds,
+            on_idle = ?on_idle,
+            "sandbox lifecycle updated"
+        );
+        commit
+            .map(|commit| commit.confirmed("sandbox lifecycle update"))
+            .transpose()?;
+        Ok(())
+    }
+
+    /// React to one lifecycle event: arm the idle timer on every `Ready`
+    /// edge, cancel it while work is in flight, and drop both timers on
+    /// teardown.
+    fn on_lifecycle_event(&self, event: &SandboxEvent) {
+        match event.action.as_str() {
+            action::READY | action::IDLE | action::RESUMED => {
+                self.arm_idle_timer(&event.sandbox_id);
+            }
+            action::RUNNING | action::PAUSING | action::STOPPING => {
+                self.timers.idle.cancel(&event.sandbox_id);
+            }
+            action::STOPPED | action::FAILED | action::REMOVED => {
+                self.timers.idle.cancel(&event.sandbox_id);
+                self.timers.ttl.cancel(&event.sandbox_id);
+            }
+            _ => {}
+        }
+    }
+
+    /// Rebuild every timer from current instance state (startup, or after
+    /// the monitor lagged behind the event stream).
+    fn resync_lifecycle_timers(&self) {
+        let instances: Vec<_> = self
+            .instances
+            .read()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        for id in instances {
+            self.arm_ttl_timer(&id);
+            self.arm_idle_timer(&id);
+        }
+    }
+
+    /// Arm (or clear) the TTL timer from the instance's current deadline.
+    ///
+    /// The armed task holds only `Weak`s plus the resource set the expiry
+    /// needs, so it never keeps the manager alive; a `SetLifecycle` re-arm
+    /// replaces the slot and aborts the sleeping task.
+    pub(super) fn arm_ttl_timer(&self, id: &SandboxId) {
+        let Ok(instance) = self.get_instance(id) else {
+            self.timers.ttl.cancel(id);
+            return;
+        };
+        let (deadline, generation) = {
+            let inst = instance.lock().unwrap();
+            (inst.ttl_deadline, inst.record_generation)
+        };
+        let Some(deadline) = deadline else {
+            self.timers.ttl.cancel(id);
+            return;
+        };
+        if tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        let self_handle = self.self_handle.get().cloned();
+        let armed_for = Arc::downgrade(&instance);
+        let instances = Arc::clone(&self.instances);
+        let network = Arc::clone(&self.network);
+        let events_tx = self.events_tx.clone();
+        let config = Arc::clone(&self.config);
+        let cow_manager = Arc::clone(&self.cow_manager);
+        let records = Arc::clone(&self.records);
+        let snapshots = Arc::clone(&self.snapshots);
+        let id = id.clone();
+        self.timers.ttl.arm(&id.clone(), move |epoch| {
+            tokio::spawn(async move {
+                sleep_until_utc(deadline).await;
+                // Claim the slot so a late cancel cannot abort mid-removal.
+                if let Some(manager) = self_handle.as_ref().and_then(std::sync::Weak::upgrade) {
+                    if !manager.timers.ttl.try_claim(&id, epoch) {
+                        return;
+                    }
+                    // Re-armed deadlines replace the task; a moved deadline
+                    // observed here means the claim raced one — bail.
+                    let still_due = armed_for
+                        .upgrade()
+                        .is_some_and(|inst| inst.lock().unwrap().ttl_deadline == Some(deadline));
+                    if !still_due {
+                        return;
+                    }
+                }
+                info!(sandbox_id = %id, "sandbox TTL expired; removing");
+                super::cleanup::expire_sandbox(
+                    &id,
+                    generation,
+                    &armed_for,
+                    &instances,
+                    &network,
+                    &events_tx,
+                    &config,
+                    &cow_manager,
+                    &records,
+                    &snapshots,
+                    true,
+                    "TTL",
+                )
+                .await;
+            })
+        });
+    }
+
+    /// Arm (or clear) the idle timer for a `Ready` sandbox.
+    ///
+    /// No-op without a shared handle ([`SandboxManager::into_shared`]): the
+    /// expiry action needs the manager's pause/remove flows.
+    pub(super) fn arm_idle_timer(&self, id: &SandboxId) {
+        let Some(weak_manager) = self.self_handle.get().cloned() else {
+            return;
+        };
+        let Ok(instance) = self.get_instance(id) else {
+            self.timers.idle.cancel(id);
+            return;
+        };
+        let timeout_seconds = {
+            let inst = instance.lock().unwrap();
+            if inst.state != SandboxState::Ready || inst.spec.idle_timeout_seconds == 0 {
+                None
+            } else {
+                Some(inst.spec.idle_timeout_seconds)
+            }
+        };
+        let Some(timeout_seconds) = timeout_seconds else {
+            self.timers.idle.cancel(id);
+            return;
+        };
+        if tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        let armed_for = Arc::downgrade(&instance);
+        let id = id.clone();
+        self.timers.idle.arm(&id.clone(), move |epoch| {
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(u64::from(timeout_seconds))).await;
+                let Some(manager) = weak_manager.upgrade() else {
+                    return;
+                };
+                if !manager.timers.idle.try_claim(&id, epoch) {
+                    return;
+                }
+                manager.apply_idle_policy(&id, &armed_for).await;
+            })
+        });
+    }
+
+    /// Apply the sandbox's `on_idle` policy after its idle timeout fired.
+    ///
+    /// Re-verifies the armed generation and the `Ready` state first; both
+    /// the pause flow (atomic `Ready → Pausing` claim) and the non-forced
+    /// remove reject a sandbox that turned busy in the remaining window, so
+    /// a race at worst logs and leaves the sandbox untouched.
+    async fn apply_idle_policy(
+        &self,
+        id: &SandboxId,
+        armed_for: &std::sync::Weak<Mutex<SandboxInstance>>,
+    ) {
+        let current = self.instances.read().unwrap().get(id).cloned();
+        let Some(instance) = armed_for.upgrade() else {
+            return;
+        };
+        if !current.is_some_and(|current| Arc::ptr_eq(&current, &instance)) {
+            return;
+        }
+        let (policy, generation) = {
+            let inst = instance.lock().unwrap();
+            if inst.state != SandboxState::Ready {
+                return;
+            }
+            (inst.spec.on_idle, inst.record_generation)
+        };
+        match policy {
+            IdleAction::Pause => {
+                match self
+                    .pause_sandbox_with_reason(id, super::pause::reason::IDLE_TIMEOUT)
+                    .await
+                {
+                    Ok(()) => info!(sandbox_id = %id, "idle timeout: sandbox paused"),
+                    Err(VmmError::WrongState { .. }) => {
+                        debug!(sandbox_id = %id, "sandbox became busy before the idle pause");
+                    }
+                    Err(error) => {
+                        warn!(sandbox_id = %id, error = %error, "idle pause failed");
+                    }
+                }
+            }
+            IdleAction::Kill => {
+                info!(sandbox_id = %id, "idle timeout: removing sandbox");
+                super::cleanup::expire_sandbox(
+                    id,
+                    generation,
+                    armed_for,
+                    &self.instances,
+                    &self.network,
+                    &self.events_tx,
+                    &self.config,
+                    &self.cow_manager,
+                    &self.records,
+                    &self.snapshots,
+                    false,
+                    "idle",
+                )
+                .await;
+            }
+        }
+    }
+}
+
+/// Sleep until a wall-clock deadline (already-past deadlines return at once).
+async fn sleep_until_utc(deadline: DateTime<Utc>) {
+    let remaining = (deadline - Utc::now()).to_std().unwrap_or(Duration::ZERO);
+    tokio::time::sleep(remaining).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn shared_manager(data_dir: &Path) -> Arc<SandboxManager> {
+        let mut config = VmmConfig::default();
+        config.firecracker.data_dir = data_dir.to_string_lossy().into_owned();
+        let manager = SandboxManager::new(config).unwrap().into_shared();
+        manager.await_reconcile().await.unwrap();
+        manager
+    }
+
+    fn insert_instance(
+        manager: &SandboxManager,
+        id: &str,
+        state: SandboxState,
+        spec: SandboxSpec,
+    ) -> Arc<Mutex<SandboxInstance>> {
+        let vm_dir = PathBuf::from(&manager.config.firecracker.data_dir)
+            .join("sandboxes")
+            .join(id);
+        let mut inst = SandboxInstance::new(
+            id.to_owned(),
+            SandboxSpec {
+                id: Some(id.to_owned()),
+                ..spec
+            },
+            None,
+            vm_dir,
+        );
+        inst.state = state;
+        let arc = Arc::new(Mutex::new(inst));
+        manager
+            .instances
+            .write()
+            .unwrap()
+            .insert(id.to_owned(), Arc::clone(&arc));
+        arc
+    }
+
+    #[tokio::test]
+    async fn set_lifecycle_rearms_ttl_from_now_and_replaces_idle_knobs() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = shared_manager(dir.path()).await;
+        insert_instance(&manager, "box", SandboxState::Ready, SandboxSpec::default());
+
+        let before = Utc::now();
+        manager
+            .set_sandbox_lifecycle(
+                &"box".to_owned(),
+                LifecycleUpdate {
+                    ttl_seconds: Some(600),
+                    idle_timeout_seconds: Some(30),
+                    on_idle: Some(IdleAction::Pause),
+                },
+            )
+            .await
+            .unwrap();
+
+        let info = manager.inspect_sandbox(&"box".to_owned()).unwrap();
+        let deadline = info.ttl_deadline.expect("ttl deadline armed");
+        assert!(deadline >= before + chrono::Duration::seconds(600));
+        assert!(deadline <= Utc::now() + chrono::Duration::seconds(600));
+        assert_eq!(info.idle_timeout_seconds, 30);
+        assert_eq!(info.on_idle, IdleAction::Pause);
+
+        // Absent fields are unchanged; ttl 0 removes the cap.
+        manager
+            .set_sandbox_lifecycle(
+                &"box".to_owned(),
+                LifecycleUpdate {
+                    ttl_seconds: Some(0),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let info = manager.inspect_sandbox(&"box".to_owned()).unwrap();
+        assert_eq!(info.ttl_deadline, None);
+        assert_eq!(info.idle_timeout_seconds, 30);
+        assert_eq!(info.on_idle, IdleAction::Pause);
+    }
+
+    #[tokio::test]
+    async fn set_lifecycle_rejects_terminal_states_and_missing_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = shared_manager(dir.path()).await;
+        assert!(matches!(
+            manager
+                .set_sandbox_lifecycle(&"ghost".to_owned(), LifecycleUpdate::default())
+                .await,
+            Err(VmmError::NotFound(_))
+        ));
+
+        for state in [
+            SandboxState::Stopping,
+            SandboxState::Stopped,
+            SandboxState::Failed,
+        ] {
+            let id = format!("terminal-{state}");
+            insert_instance(&manager, &id, state, SandboxSpec::default());
+            assert!(matches!(
+                manager
+                    .set_sandbox_lifecycle(&id, LifecycleUpdate::default())
+                    .await,
+                Err(VmmError::WrongState { .. })
+            ));
+        }
+
+        // Paused sandboxes accept updates: the TTL keeps applying to them.
+        insert_instance(
+            &manager,
+            "asleep",
+            SandboxState::Paused,
+            SandboxSpec::default(),
+        );
+        manager
+            .set_sandbox_lifecycle(
+                &"asleep".to_owned(),
+                LifecycleUpdate {
+                    ttl_seconds: Some(120),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_timer_arms_on_ready_and_cancels_on_running() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = shared_manager(dir.path()).await;
+        let spec = SandboxSpec {
+            idle_timeout_seconds: 5,
+            on_idle: IdleAction::Pause,
+            ..Default::default()
+        };
+        insert_instance(&manager, "box", SandboxState::Ready, spec);
+
+        manager.arm_idle_timer(&"box".to_owned());
+        assert!(
+            manager
+                .timers
+                .idle
+                .slots
+                .lock()
+                .unwrap()
+                .contains_key("box")
+        );
+
+        // An execution start cancels the timer.
+        manager.on_lifecycle_event(&SandboxEvent::new("box", action::RUNNING));
+        assert!(
+            !manager
+                .timers
+                .idle
+                .slots
+                .lock()
+                .unwrap()
+                .contains_key("box")
+        );
+
+        // A non-Ready sandbox or a zero timeout never arms.
+        manager.instances.read().unwrap()["box"]
+            .lock()
+            .unwrap()
+            .state = SandboxState::Running;
+        manager.on_lifecycle_event(&SandboxEvent::new("box", action::IDLE));
+        assert!(
+            !manager
+                .timers
+                .idle
+                .slots
+                .lock()
+                .unwrap()
+                .contains_key("box")
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_expiry_pause_policy_pauses_instead_of_removing() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = shared_manager(dir.path()).await;
+        let spec = SandboxSpec {
+            idle_timeout_seconds: 2,
+            on_idle: IdleAction::Pause,
+            ..Default::default()
+        };
+        insert_instance(&manager, "box", SandboxState::Ready, spec);
+
+        manager.arm_idle_timer(&"box".to_owned());
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        // The fired timer claims its slot, then routes to the pause flow
+        // (which fails fast here — no jailer/VM — leaving the sandbox
+        // intact). The full reason=idle_timeout pause is e2e-covered.
+        for _ in 0..50 {
+            if !manager
+                .timers
+                .idle
+                .slots
+                .lock()
+                .unwrap()
+                .contains_key("box")
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            !manager
+                .timers
+                .idle
+                .slots
+                .lock()
+                .unwrap()
+                .contains_key("box"),
+            "the idle timer must have fired and claimed its slot"
+        );
+        assert!(
+            manager.instances.read().unwrap().contains_key("box"),
+            "the PAUSE policy must never remove the sandbox"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_expiry_kill_removes_the_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = shared_manager(dir.path()).await;
+        std::fs::create_dir_all(dir.path().join("sandboxes/box")).unwrap();
+        let spec = SandboxSpec {
+            idle_timeout_seconds: 2,
+            on_idle: IdleAction::Kill,
+            ..Default::default()
+        };
+        insert_instance(&manager, "box", SandboxState::Ready, spec);
+
+        manager.arm_idle_timer(&"box".to_owned());
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        // The removal runs on a detached task; poll briefly for the map drop.
+        for _ in 0..50 {
+            if !manager.instances.read().unwrap().contains_key("box") {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(!manager.instances.read().unwrap().contains_key("box"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stale_idle_timer_does_not_fire_after_rearm() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = shared_manager(dir.path()).await;
+        let spec = SandboxSpec {
+            idle_timeout_seconds: 2,
+            on_idle: IdleAction::Kill,
+            ..Default::default()
+        };
+        insert_instance(&manager, "box", SandboxState::Ready, spec);
+
+        manager.arm_idle_timer(&"box".to_owned());
+        // Re-arm with a longer window; the first timer's epoch is stale.
+        manager.instances.read().unwrap()["box"]
+            .lock()
+            .unwrap()
+            .spec
+            .idle_timeout_seconds = 3600;
+        manager.arm_idle_timer(&"box".to_owned());
+
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        assert!(
+            manager.instances.read().unwrap().contains_key("box"),
+            "stale timer must not remove the re-armed sandbox"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn ttl_timer_honors_a_rearmed_deadline() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = shared_manager(dir.path()).await;
+        std::fs::create_dir_all(dir.path().join("sandboxes/box")).unwrap();
+        insert_instance(&manager, "box", SandboxState::Ready, SandboxSpec::default());
+        manager.instances.read().unwrap()["box"]
+            .lock()
+            .unwrap()
+            .ttl_deadline = Some(Utc::now() + chrono::Duration::seconds(2));
+        manager.arm_ttl_timer(&"box".to_owned());
+
+        // Re-arm far into the future before the first deadline hits.
+        manager
+            .set_sandbox_lifecycle(
+                &"box".to_owned(),
+                LifecycleUpdate {
+                    ttl_seconds: Some(3600),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        assert!(
+            manager.instances.read().unwrap().contains_key("box"),
+            "re-armed TTL must outlive the original deadline"
+        );
+
+        // The re-armed deadline still fires.
+        tokio::time::sleep(Duration::from_secs(3600)).await;
+        for _ in 0..50 {
+            if !manager.instances.read().unwrap().contains_key("box") {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(!manager.instances.read().unwrap().contains_key("box"));
+    }
+}

--- a/virt/arcbox-vm/src/sandbox/types.rs
+++ b/virt/arcbox-vm/src/sandbox/types.rs
@@ -50,6 +50,36 @@ impl std::fmt::Display for SandboxState {
 
 // Spec types (input to SandboxManager methods)
 
+/// What happens when a sandbox's idle timeout expires (CORE-21).
+///
+/// Mirrors `arcbox.sandbox.v1.IdleAction`; `UNSPECIFIED` resolves to the
+/// daemon default ([`IdleAction::Kill`]) at the service boundary, so this
+/// type only carries effective policies.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IdleAction {
+    /// Destroy the sandbox and release all resources (Remove semantics).
+    #[default]
+    Kill,
+    /// Checkpoint to disk under the same id and release the VM.
+    Pause,
+}
+
+/// A partial lifecycle update applied by `SetLifecycle` (CORE-60).
+///
+/// `None` fields are left unchanged, so each knob can be adjusted
+/// independently.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LifecycleUpdate {
+    /// Replace the hard maximum lifetime: expire this many seconds from
+    /// now (`Some(0)` removes the limit).
+    pub ttl_seconds: Option<u32>,
+    /// Replace the idle timeout (`Some(0)` disables idle detection).
+    pub idle_timeout_seconds: Option<u32>,
+    /// Replace the idle policy.
+    pub on_idle: Option<IdleAction>,
+}
+
 /// Network configuration supplied at sandbox creation time.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SandboxNetworkSpec {
@@ -105,6 +135,12 @@ pub struct SandboxSpec {
     pub ttl_seconds: u32,
     /// SSH public key injected via MMDS (None = no SSH setup).
     pub ssh_public_key: Option<String>,
+    /// Apply [`Self::on_idle`] after this many seconds without a running
+    /// execution (0 = no idle detection). Re-armed on every `Ready` edge;
+    /// file activity does NOT re-arm (CORE-21).
+    pub idle_timeout_seconds: u32,
+    /// What to do when the idle timeout expires.
+    pub on_idle: IdleAction,
 }
 
 /// Parameters to restore a sandbox from a checkpoint.
@@ -181,6 +217,10 @@ pub struct SandboxInstance {
     pub paused_at: Option<DateTime<Utc>>,
     /// Catalog id of the internal pause checkpoint (state == `Paused` only).
     pub pause_snapshot_id: Option<String>,
+    /// When the hard maximum lifetime fires (None = no limit). Seeded from
+    /// `spec.ttl_seconds` at creation; replaced from-now by `SetLifecycle`
+    /// (CORE-60).
+    pub ttl_deadline: Option<DateTime<Utc>>,
 }
 
 impl SandboxInstance {
@@ -233,6 +273,7 @@ impl SandboxInstance {
             net_invariant: false,
             paused_at: None,
             pause_snapshot_id: None,
+            ttl_deadline: None,
         }
     }
 
@@ -275,6 +316,12 @@ pub struct SandboxInfo {
     pub paused_at: Option<DateTime<Utc>>,
     /// On-disk footprint of retained pause state (checkpoint + overlay).
     pub storage_bytes: u64,
+    /// When the hard maximum lifetime fires (None = no limit).
+    pub ttl_deadline: Option<DateTime<Utc>>,
+    /// Idle timeout in seconds (0 = no idle detection).
+    pub idle_timeout_seconds: u32,
+    /// Action applied when the idle timeout expires.
+    pub on_idle: IdleAction,
 }
 
 /// Network details within `SandboxInfo`.


### PR DESCRIPTION
Slice 2 of the sandbox lifecycle work — the final SDK-unblocking daemon changes for CORE-21 (idle policy), CORE-60 (re-armable lifecycle deadlines), and CORE-13 (capability handshake + nested-virt fail-fast), plus the CORE-58 error-registry attachment.

> **Stacked on #563** (`feat/sandbox-pause-resume`, the pause machinery this builds on). Merge #563 first, then retarget/merge this one.

## What's in it (one commit per slice)

1. **`feat(vm)` — idle detection + on_idle policy, re-armable TTL** (`virt/arcbox-vm/src/sandbox/timers.rs`)
   - A per-sandbox idle timer arms on every `Ready` edge (boot ready, execution exit, resume) via an event-driven lifecycle monitor, and cancels when an execution starts. Idle = no running execution; file activity does not re-arm.
   - Expiry applies `on_idle`: **PAUSE** routes through the slice-1 pause flow with `reason=idle_timeout`; **KILL**/UNSPECIFIED through a *non-forced* expiry remove that skips a sandbox that turned busy in the firing window.
   - TTL timers are deadline-driven (`ttl_deadline` on the instance and the durable record), so they re-arm from *now* and survive pause/resume + agent restarts. Timer slots are epoch-stamped: a firing timer *claims* its slot, so a stale timer can neither act nor be aborted mid-teardown.
   - The `Ready → Pausing` claim is now atomic with its state check, closing the checkpoint-mid-execution window.
2. **`feat(sandbox)` — SetLifecycle end to end**: new vsock pair `0x0046/0x1046`, guest dispatch, `AgentClient::sandbox_set_lifecycle`, daemon Connect handler. `ttl_seconds` re-arms from now (0 removes), `idle_timeout_seconds` replaces the window (re-arming a live timer), `optional on_idle` carries presence semantics (absent = unchanged, explicit UNSPECIFIED = restore KILL). Works on paused sandboxes (their TTL keeps applying).
3. **`feat(api)` — real GetCapabilities + Create fail-fast**: answers host-side (`daemon_version`, `protocol = SANDBOX_API_PROTOCOL = 1`, features `pause_resume`/`auto_resume`/`idle_policy`/`set_lifecycle`, `nested_virt`). Detection reuses the VZ shim's `isNestedVirtualizationSupported` (cached) gated on the current backend; nested-KVM module params on Linux. `Create` on an unsupported host answers `FAILED_PRECONDITION` + `NESTED_VIRT_UNSUPPORTED` `ErrorInfo` instead of a wedging boot.
4. **`feat(api)` — error-registry attachment sweep**: one classifier at the single `ApiError → ConnectError` funnel attaches `arcbox.sandbox.v1.ErrorInfo` (code + suggestion + context) for `SANDBOX_NOT_FOUND`, `EXECUTION_NOT_FOUND`, `SANDBOX_NOT_READY` (context `state`), `SANDBOX_FAILED`, `NESTED_VIRT_UNSUPPORTED`, `TEMPLATE_INVALID`, and the existing `SANDBOX_PAUSED`. Markers are our own `Display` shapes, pinned by tests. (`TTL_EXPIRED` is not attachable today: expiry removes the record, so later calls see `SANDBOX_NOT_FOUND` — noted in the docs.)
5. **`feat(e2e)` + docs**: the sandbox smoke gains a capability-handshake phase and an idle-lifecycle phase (create with `idle_timeout=2`/`on_idle=PAUSE` → observe `PAUSING reason=idle_timeout` on the events stream → data-plane exec auto-resumes → SetLifecycle disarms idle + re-arms TTL, verified via `Inspect.ttl_deadline`). `docs/sandbox-api.md` drops the contract-only markers and documents the new surfaces.

Plus two fixes the e2e run itself surfaced:

- **Idle-pause → resume network-finalization race**: a guest-initiated pause published its network-cleanup ticket only via the 1 s rescan, so an immediate resume hit 503. The guest cleanup watch now emits the ticket promptly on `PAUSED`, and the daemon's shared resume retries the transient 503 in a bounded budget.
- **e2e READY budgets**: the isolated data dir cold-downloads ~255 MiB of runtime binaries; 180 s was marginal on a constrained uplink. Both harnesses now budget 360 s (still a hard gate).

## Verification (all on Apple Silicon hardware, VZ)

| Gate | Result |
|---|---|
| `cargo test -p arcbox-vm/-api/-core/-constants/-e2e --lib` | all green (142/21/188/6/15) |
| `cargo clippy --workspace --exclude arcbox-agent --all-targets -- -D warnings` | exit 0 |
| musl agent clippy (`aarch64-unknown-linux-musl`) | zero new warnings on changed lines |
| `cargo check --workspace` / `cargo fmt --check` | exit 0 |
| sandbox e2e (`--test sandbox -- --ignored`) | **passed** incl. idle auto-pause, auto-resume-after-idle-pause, SetLifecycle re-arm, capabilities |
| sdk_ts regression (`--test sdk_ts -- --ignored`) | **passed** |

## Deferred

- `TTL_EXPIRED` ErrorInfo needs a tombstone/retention design (record is deleted on expiry).
- `FILE_NOT_FOUND` classification: guest file errors cross as opaque 500 strings; needs a structured wire code first.
- CLI (`abctl sandbox`) subcommands for SetLifecycle/capabilities — SDK-first per the mission.
