### PR TITLE
fix(sandbox): fix the TAP-teardown race and surface swallowed RPC failures

### DIFF
--- a/app/arcbox-api/src/connect/control.rs
+++ b/app/arcbox-api/src/connect/control.rs
@@ -57,10 +57,19 @@ impl pb::SandboxService for SandboxServiceImpl {
     ) -> ServiceResult<pb::CreateSandboxResponse> {
         let machine = ctx.sandbox_machine_id()?;
         let req = request.to_owned_message();
-        let _operation = self.operations.lock(&machine, &req.id).await;
+        let sandbox_id = req.id.clone();
+        let _operation = self.operations.lock(&machine, &sandbox_id).await;
         let runtime = self.runtime.ready()?;
         let mut agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
-        let resp = agent.sandbox_create(req).await.map_err(ApiError::from)?;
+        // The RPC error otherwise reaches only the caller; the daemon log
+        // must record a failed lifecycle mutation on its own (CORE-82).
+        let resp = agent
+            .sandbox_create(req)
+            .await
+            .inspect_err(|error| {
+                tracing::warn!(machine = %machine, sandbox_id = %sandbox_id, %error, "sandbox create failed");
+            })
+            .map_err(ApiError::from)?;
         let _host_state = runtime.lock_sandbox_host_state().await;
 
         // Register sandbox DNS so the host can resolve sandbox-id.arcbox.local.
@@ -86,7 +95,13 @@ impl pb::SandboxService for SandboxServiceImpl {
         let _operation = self.operations.lock(&machine, &sandbox_id).await;
         let runtime = self.runtime.ready()?;
         let mut agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
-        let response = agent.sandbox_stop(req).await.map_err(ApiError::from)?;
+        let response = agent
+            .sandbox_stop(req)
+            .await
+            .inspect_err(|error| {
+                tracing::warn!(machine = %machine, sandbox_id = %sandbox_id, %error, "sandbox stop failed");
+            })
+            .map_err(ApiError::from)?;
         if let Some(ticket) = response.ticket.as_option() {
             sandbox_cleanup::complete(runtime, &mut agent, ticket)
                 .await
@@ -107,7 +122,13 @@ impl pb::SandboxService for SandboxServiceImpl {
         let _operation = self.operations.lock(&machine, &sandbox_id).await;
         let runtime = self.runtime.ready()?;
         let mut agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
-        let response = agent.sandbox_remove(req).await.map_err(ApiError::from)?;
+        let response = agent
+            .sandbox_remove(req)
+            .await
+            .inspect_err(|error| {
+                tracing::warn!(machine = %machine, sandbox_id = %sandbox_id, %error, "sandbox remove failed");
+            })
+            .map_err(ApiError::from)?;
         if let Some(ticket) = response.ticket.as_option() {
             sandbox_cleanup::complete(runtime, &mut agent, ticket)
                 .await
@@ -342,6 +363,9 @@ impl pb::SandboxService for SandboxServiceImpl {
         let rx = agent
             .sandbox_events(request.to_owned_message())
             .await
+            .inspect_err(|error| {
+                tracing::warn!(machine = %machine, %error, "sandbox events subscribe failed");
+            })
             .map_err(ApiError::from)?;
         let stream = ReceiverStream::new(rx).map(|r| {
             r.map(|event| WatchEventsResponse {

--- a/app/arcbox-api/src/connect/snapshot.rs
+++ b/app/arcbox-api/src/connect/snapshot.rs
@@ -44,15 +44,21 @@ impl pb::SandboxSnapshotService for SandboxSnapshotServiceImpl {
     ) -> ServiceResult<pb::CheckpointResponse> {
         let machine = ctx.sandbox_machine_id()?;
         let req = request.to_owned_message();
-        let _operation = self.operations.lock(&machine, &req.sandbox_id).await;
+        let sandbox_id = req.sandbox_id.clone();
+        let _operation = self.operations.lock(&machine, &sandbox_id).await;
         let mut agent = self
             .runtime
             .ready()?
             .get_agent(&machine)
             .map_err(ApiError::from)?;
+        // The RPC error otherwise reaches only the caller; the daemon log
+        // must record a failed lifecycle mutation on its own (CORE-82).
         let resp = agent
             .sandbox_checkpoint(req)
             .await
+            .inspect_err(|error| {
+                tracing::warn!(machine = %machine, sandbox_id = %sandbox_id, %error, "sandbox checkpoint failed");
+            })
             .map_err(ApiError::from)?;
         Response::ok(resp)
     }
@@ -64,10 +70,17 @@ impl pb::SandboxSnapshotService for SandboxSnapshotServiceImpl {
     ) -> ServiceResult<pb::RestoreResponse> {
         let machine = ctx.sandbox_machine_id()?;
         let req = request.to_owned_message();
-        let _operation = self.operations.lock(&machine, &req.id).await;
+        let sandbox_id = req.id.clone();
+        let _operation = self.operations.lock(&machine, &sandbox_id).await;
         let runtime = self.runtime.ready()?;
         let mut agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
-        let resp = agent.sandbox_restore(req).await.map_err(ApiError::from)?;
+        let resp = agent
+            .sandbox_restore(req)
+            .await
+            .inspect_err(|error| {
+                tracing::warn!(machine = %machine, sandbox_id = %sandbox_id, %error, "sandbox restore failed");
+            })
+            .map_err(ApiError::from)?;
         let _host_state = runtime.lock_sandbox_host_state().await;
 
         // Register restored sandbox DNS.

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -211,16 +211,19 @@ impl AgentClient {
 
         let buf = wire::build_message(msg_type, trace_id, payload);
 
+        // Errors name the RPC: a per-call vsock connection failing surfaces
+        // far from its caller (a warn in some supervisor loop), and without
+        // the message type the log cannot say which RPC died (CORE-82).
         let response = match &mut self.transport {
             AgentTransport::Async(t) => {
                 // Send request.
                 t.send(buf)
                     .await
-                    .map_err(|e| CoreError::Machine(format!("failed to send request: {e}")))?;
+                    .map_err(|e| CoreError::Machine(format!("{msg_type:?} send failed: {e}")))?;
                 // Receive response.
-                t.recv()
-                    .await
-                    .map_err(|e| CoreError::Machine(format!("failed to receive response: {e}")))?
+                t.recv().await.map_err(|e| {
+                    CoreError::Machine(format!("{msg_type:?} response receive failed: {e}"))
+                })?
             }
             AgentTransport::Blocking(t) => {
                 // block_in_place tells the tokio multi-thread scheduler that
@@ -228,10 +231,12 @@ impl AgentClient {
                 // This prevents the 5s poll timeout from stalling other tasks.
                 tokio::task::block_in_place(|| {
                     let deadline = Instant::now() + BLOCKING_RPC_TIMEOUT;
-                    t.send(&buf, deadline)
-                        .map_err(|e| CoreError::Machine(format!("failed to send request: {e}")))?;
-                    t.recv(deadline)
-                        .map_err(|e| CoreError::Machine(format!("failed to receive response: {e}")))
+                    t.send(&buf, deadline).map_err(|e| {
+                        CoreError::Machine(format!("{msg_type:?} send failed: {e}"))
+                    })?;
+                    t.recv(deadline).map_err(|e| {
+                        CoreError::Machine(format!("{msg_type:?} response receive failed: {e}"))
+                    })
                 })?
             }
         };
@@ -261,9 +266,10 @@ impl AgentClient {
             AgentTransport::Blocking(t) => {
                 let deadline = Instant::now() + BLOCKING_RPC_TIMEOUT;
                 t.send(&buf, deadline)
-                    .map_err(|e| CoreError::Machine(format!("failed to send request: {e}")))?;
-                t.recv(deadline)
-                    .map_err(|e| CoreError::Machine(format!("failed to receive response: {e}")))?
+                    .map_err(|e| CoreError::Machine(format!("{msg_type:?} send failed: {e}")))?;
+                t.recv(deadline).map_err(|e| {
+                    CoreError::Machine(format!("{msg_type:?} response receive failed: {e}"))
+                })?
             }
             AgentTransport::Async(_) => {
                 return Err(CoreError::Machine(

--- a/guest/arcbox-agent/src/agent/linux/agent.rs
+++ b/guest/arcbox-agent/src/agent/linux/agent.rs
@@ -72,10 +72,13 @@ impl Agent {
                             // surfaces as BrokenPipe / ConnectionReset /
                             // UnexpectedEof. Log at warn — the daemon will
                             // reopen on its next poll iteration.
+                            // `{:#}` prints the whole context chain — the
+                            // top context alone hides which message the
+                            // connection was carrying when it died.
                             if is_peer_closed_error(&e) {
-                                tracing::warn!("Connection closed by peer: {}", e);
+                                tracing::warn!("Connection closed by peer: {e:#}");
                             } else {
-                                tracing::error!("Connection error: {}", e);
+                                tracing::error!("Connection error: {e:#}");
                             }
                         }
                     });

--- a/guest/arcbox-agent/src/agent/linux/rpc.rs
+++ b/guest/arcbox-agent/src/agent/linux/rpc.rs
@@ -70,7 +70,12 @@ where
         if msg_type.is_sandbox_request() {
             if let Err(e) = handle_sandbox_message(&mut stream, msg_type, &trace_id, &payload).await
             {
-                tracing::warn!(trace_id = %trace_id, error = %e, "sandbox handler error");
+                tracing::warn!(
+                    trace_id = %trace_id,
+                    request = ?msg_type,
+                    error = %format!("{e:#}"),
+                    "sandbox handler error"
+                );
             }
             continue;
         }

--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -141,8 +141,7 @@ where
     let svc = match sandbox_service() {
         Ok(s) => Arc::clone(s),
         Err((code, reason)) => {
-            let err = ErrorResponse::new(*code, reason.as_str());
-            write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+            send_sandbox_error(stream, trace_id, *code, reason).await?;
             return Ok(());
         }
     };
@@ -536,6 +535,12 @@ where
 }
 
 /// Write a single `Error` frame back to the caller.
+///
+/// Also logs the failure: the frame is the only copy of the error, and the
+/// caller may have dropped the connection before reading it — without this
+/// line a failed sandbox RPC leaves the guest log silent (CORE-82). The
+/// request type is the `Received message type …` line just above on the same
+/// connection.
 async fn send_sandbox_error<S>(
     stream: &mut S,
     trace_id: &str,
@@ -545,6 +550,7 @@ async fn send_sandbox_error<S>(
 where
     S: tokio::io::AsyncWrite + Unpin,
 {
+    tracing::warn!(trace_id, code, message, "sandbox RPC failed");
     let err = ErrorResponse::new(code, message);
     write_message(stream, MessageType::Error, trace_id, &err.encode()).await
 }
@@ -573,8 +579,7 @@ where
         }) {
         Ok(parsed) => parsed,
         Err(msg) => {
-            let err = ErrorResponse::new(400, msg);
-            write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+            send_sandbox_error(stream, trace_id, 400, &msg).await?;
             return Ok(());
         }
     };
@@ -584,8 +589,7 @@ where
     let identity = match svc.sandbox_network_identity(&req.id) {
         Ok(identity) => identity,
         Err(e) => {
-            let err = ErrorResponse::new(e.status_code(), e.to_string());
-            write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+            send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
             return Ok(());
         }
     };
@@ -610,8 +614,7 @@ where
             .await?;
         }
         Err(e) => {
-            let err = ErrorResponse::new(500, e.to_string());
-            write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+            send_sandbox_error(stream, trace_id, 500, &e.to_string()).await?;
         }
     }
     Ok(())
@@ -642,8 +645,7 @@ where
             }) {
             Ok(parsed) => parsed,
             Err(msg) => {
-                let err = ErrorResponse::new(400, msg);
-                write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+                send_sandbox_error(stream, trace_id, 400, &msg).await?;
                 return Ok(());
             }
         };
@@ -652,8 +654,7 @@ where
     let identity = match svc.sandbox_network_identity(&req.id) {
         Ok(identity) => identity,
         Err(error) => {
-            let response = ErrorResponse::new(error.status_code(), error.to_string());
-            write_message(stream, MessageType::Error, trace_id, &response.encode()).await?;
+            send_sandbox_error(stream, trace_id, error.status_code(), &error.to_string()).await?;
             return Ok(());
         }
     };
@@ -674,8 +675,7 @@ where
             .await?;
         }
         Err(e) => {
-            let err = ErrorResponse::new(500, e.to_string());
-            write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+            send_sandbox_error(stream, trace_id, 500, &e.to_string()).await?;
         }
     }
     Ok(())

--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -550,7 +550,11 @@ async fn send_sandbox_error<S>(
 where
     S: tokio::io::AsyncWrite + Unpin,
 {
-    tracing::warn!(trace_id, code, message, "sandbox RPC failed");
+    // `message` is tracing's reserved field for the event message itself:
+    // passing it as a field renders the error text unlabelled, looking like
+    // a second message spliced onto the first. `error` matches this file's
+    // convention and renders quoted.
+    tracing::warn!(trace_id, code, error = message, "sandbox RPC failed");
     let err = ErrorResponse::new(code, message);
     write_message(stream, MessageType::Error, trace_id, &err.encode()).await
 }

--- a/guest/arcbox-agent/src/rpc.rs
+++ b/guest/arcbox-agent/src/rpc.rs
@@ -278,11 +278,17 @@ pub async fn write_message<W: AsyncWrite + Unpin>(
     }
     buf.extend_from_slice(payload);
 
+    // Name the frame in the error: on a torn-down connection the resulting
+    // "Connection closed by peer" warn must say which response/stream write
+    // was lost, or the failure cannot be attributed (CORE-82).
     writer
         .write_all(&buf)
         .await
-        .context("failed to write message")?;
-    writer.flush().await.context("failed to flush")?;
+        .with_context(|| format!("failed to write {msg_type:?} message"))?;
+    writer
+        .flush()
+        .await
+        .with_context(|| format!("failed to flush {msg_type:?} message"))?;
 
     Ok(())
 }

--- a/virt/arcbox-vm/src/network.rs
+++ b/virt/arcbox-vm/src/network.rs
@@ -715,6 +715,13 @@ fn destroy_tap_checked(tap_name: &str) -> Result<()> {
     }
 
     // Fallback: if the interface still exists, use ip link delete.
+    //
+    // The existence check and the delete race the kernel: clearing
+    // TUNSETPERSIST above and dropping the fd removes a non-persistent TAP
+    // asynchronously, so the sysfs entry can outlive the decision to delete
+    // and vanish before `ip` runs. "Cannot find device" therefore means the
+    // teardown already happened, which is exactly the state this function
+    // exists to reach — treat it as success. Any other failure still errors.
     if std::path::Path::new(&format!("/sys/class/net/{tap_name}")).exists() {
         let output = std::process::Command::new("/usr/sbin/ip")
             .args(["link", "delete", tap_name])
@@ -723,10 +730,13 @@ fn destroy_tap_checked(tap_name: &str) -> Result<()> {
                 VmmError::Network(format!("run ip link delete {tap_name}: {error}"))
             })?;
         if !output.status.success() {
-            return Err(VmmError::Network(format!(
-                "ip link delete {tap_name}: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            )));
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if !stderr.contains("Cannot find device") {
+                return Err(VmmError::Network(format!(
+                    "ip link delete {tap_name}: {}",
+                    stderr.trim()
+                )));
+            }
         }
     }
     if std::path::Path::new(&format!("/sys/class/net/{tap_name}")).exists() {

--- a/virt/arcbox-vm/src/network.rs
+++ b/virt/arcbox-vm/src/network.rs
@@ -719,10 +719,18 @@ fn destroy_tap_checked(tap_name: &str) -> Result<()> {
     // The existence check and the delete race the kernel: clearing
     // TUNSETPERSIST above and dropping the fd removes a non-persistent TAP
     // asynchronously, so the sysfs entry can outlive the decision to delete
-    // and vanish before `ip` runs. "Cannot find device" therefore means the
-    // teardown already happened, which is exactly the state this function
-    // exists to reach — treat it as success. Any other failure still errors.
-    if std::path::Path::new(&format!("/sys/class/net/{tap_name}")).exists() {
+    // and vanish before `ip` runs. A delete that fails because the device
+    // is already gone has reached exactly the state this function exists to
+    // reach, so the post-check below — not the exit status — decides: the
+    // device being absent is success no matter why `ip` complained.
+    //
+    // Deliberately not a message match: the System VM ships busybox `ip`
+    // ("can't find device 'x'", exit 2) while a dev host has iproute2
+    // ("Cannot find device \"x\"", exit 1), so any wording test would pass
+    // CI and still fail in production.
+    let sysfs = format!("/sys/class/net/{tap_name}");
+    let mut delete_error = None;
+    if std::path::Path::new(&sysfs).exists() {
         let output = std::process::Command::new("/usr/sbin/ip")
             .args(["link", "delete", tap_name])
             .output()
@@ -730,19 +738,14 @@ fn destroy_tap_checked(tap_name: &str) -> Result<()> {
                 VmmError::Network(format!("run ip link delete {tap_name}: {error}"))
             })?;
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            if !stderr.contains("Cannot find device") {
-                return Err(VmmError::Network(format!(
-                    "ip link delete {tap_name}: {}",
-                    stderr.trim()
-                )));
-            }
+            delete_error = Some(String::from_utf8_lossy(&output.stderr).trim().to_owned());
         }
     }
-    if std::path::Path::new(&format!("/sys/class/net/{tap_name}")).exists() {
-        return Err(VmmError::Network(format!(
-            "TAP {tap_name} still exists after deletion"
-        )));
+    if std::path::Path::new(&sysfs).exists() {
+        return Err(VmmError::Network(match delete_error {
+            Some(stderr) => format!("ip link delete {tap_name}: {stderr}"),
+            None => format!("TAP {tap_name} still exists after deletion"),
+        }));
     }
     Ok(())
 }

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -139,6 +139,11 @@ impl SandboxManager {
         let (ip_address, starting_durability_error) = match setup {
             Ok(result) => result,
             Err(error) => {
+                // The reply frame carries the only other copy of this error;
+                // log it here so a create that dies between the network
+                // activation and the Starting journal commit is attributable
+                // from the guest log alone (CORE-82).
+                warn!(sandbox_id = %id, error = %error, "sandbox create setup failed; rolling back");
                 let mut rollback_errors = Vec::new();
                 let mut network_cleanup_failed = false;
                 if let Some(net) = &net_alloc
@@ -171,9 +176,15 @@ impl SandboxManager {
                     }
                     drop(creating_instance);
                     reservation.commit();
+                    let rollback = rollback_errors.join("; ");
+                    error!(
+                        sandbox_id = %id,
+                        error = %error,
+                        rollback = %rollback,
+                        "sandbox create rollback incomplete; instance left Failed"
+                    );
                     return Err(VmmError::Other(format!(
-                        "{error}; sandbox rollback is incomplete: {}",
-                        rollback_errors.join("; ")
+                        "{error}; sandbox rollback is incomplete: {rollback}"
                     )));
                 }
                 let abort = self.records.abort_provision(&id, generation)?;


### PR DESCRIPTION
CORE-82 forensics + diagnostics. Project **Sandbox Cold Start**.

## What the investigation found

The issue's framing ("services wedge after READY") is **refuted by the preserved evidence**. In both occurrences the sandbox **Create RPC failed fast in the guest** (~20 ms after TAP activation), its error string was swallowed at three independent layers, and everything after — the `Connection closed by peer` write failure, the repeating `sandbox cleanup watch disconnected` warns — is normal teardown fallout from the probe aborting and SIGTERM-ing the daemon 24–42 ms later. Reconstructed with measured guest↔host clock skew; both preserved dirs still on disk. Full timeline and proof chain on the Linear issue.

The failure locus is narrowed to the tail of `NetworkManager::activate` (TAP ioctls / translation install) or the `SandboxTransition::Starting` durable write, with three ranked hypotheses — but the evidence does not pin one, so this PR ships diagnostics rather than a speculative fix.

## What this PR changes

- **Guest**: `send_sandbox_error` warns (trace_id/code/message) before writing the Error frame, and every direct Error-frame writer routes through it; `create_sandbox_keyed` warns on setup failure and errors on incomplete rollback; `write_message` names the message type in write/flush error context, so the next `Connection closed by peer` identifies its own frame; the dispatcher's handler-error warn carries the request type.
- **Host**: `AgentClient` send/recv errors carry the wire `MessageType` on both transports; daemon-side create/stop/remove/checkpoint/restore/events-subscribe failures are warned with machine + sandbox id. Lifecycle mutations only — no hot-path spam.

The next occurrence self-explains: `sandbox RPC failed` with the exact code+message lands directly under the `Received message type SandboxCreateRequest` line, and `sandbox create setup failed; rolling back` names the failing step — which of the three hypotheses it is falls out of the message.

## Validation

`cargo fmt --all --check`; `cargo clippy -p arcbox-vm --all-targets`, `cargo clippy -p arcbox-agent --target aarch64-unknown-linux-musl` (0 new warnings on changed lines), `cargo clippy --workspace --exclude arcbox-agent -- -D warnings`; `cargo test -p arcbox-vm -p arcbox-agent -p arcbox-api -p arcbox-core` green. Hardware: probe + full sandbox smoke green with these commits in the stack.