### PR TITLE
feat(sandbox): serve eligible creates from warm template snapshots

### DIFF
--- a/assets.lock
+++ b/assets.lock
@@ -14,9 +14,9 @@
 # and the [boot] bump.
 
 [boot]
-version = "0.8.0"
+version = "0.8.2"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "4438fdadb94f70d31911dd7588c6cc61250040c22df4f913f2d573f9a7a7186e"
+manifest_sha256 = "0bf2db1815abc8ebc7291eff94199dfaa0e3a5af8e6a9cd160657f005725a431"
 
 [[tools]]
 name = "docker"

--- a/guest/arcbox-agent/src/config.rs
+++ b/guest/arcbox-agent/src/config.rs
@@ -50,6 +50,7 @@ fn guest_defaults() -> VmmConfig {
             socket_timeout_secs: None,
             sandbox_datapath: arcbox_vm::config::SandboxDatapath::default(),
             pool_size: 1,
+            warm_create: true,
         },
         network: NetworkConfig {
             cidr: "172.20.0.0/16".into(),

--- a/guest/arcbox-agent/src/error.rs
+++ b/guest/arcbox-agent/src/error.rs
@@ -75,7 +75,9 @@ impl From<arcbox_vm::VmmError> for SandboxError {
             VmmError::AlreadyExists(_) => Self::AlreadyExists(e.to_string()),
             VmmError::WrongState { .. } => Self::WrongState(e.to_string()),
             VmmError::StdinGap { .. } => Self::StdinGap(e.to_string()),
-            VmmError::Unavailable(_) => Self::Unavailable(e.to_string()),
+            VmmError::Unavailable(_) | VmmError::AckUnconfirmed { .. } => {
+                Self::Unavailable(e.to_string())
+            }
             // Invalid caller input (e.g. a rejected sandbox id) is a 400, not a
             // 500 — otherwise a bad request surfaces as INTERNAL to the client.
             VmmError::Config(_) => Self::InvalidArgument(e.to_string()),

--- a/guest/arcbox-agent/tests/sandbox_service_manager.rs
+++ b/guest/arcbox-agent/tests/sandbox_service_manager.rs
@@ -36,9 +36,11 @@ fn test_config() -> VmmConfig {
             mmds_size_limit: None,
             socket_timeout_secs: Some(15),
             sandbox_datapath: arcbox_vm::config::SandboxDatapath::default(),
-            // Direct mode cannot restore (and so never pools); keep the
-            // test run free of background pre-warm spawns regardless.
+            // Direct mode cannot restore (and so never pools or serves
+            // warm creates); keep the run free of background checkpoint
+            // and pre-warm work regardless.
             pool_size: 0,
+            warm_create: false,
         },
         network: NetworkConfig {
             cidr: "172.31.0.0/16".to_string(),

--- a/virt/arcbox-vm/Cargo.toml
+++ b/virt/arcbox-vm/Cargo.toml
@@ -24,13 +24,13 @@ nix            = { workspace = true, features = ["process", "term", "signal"] }
 libc.workspace         = true
 chrono.workspace       = true
 toml.workspace         = true
+sha2.workspace         = true
 
 [dev-dependencies]
 tokio              = { workspace = true, features = ["rt", "macros"] }
 anyhow.workspace   = true
 tracing-subscriber.workspace = true
 tempfile.workspace = true
-sha2.workspace = true
 
 [lints]
 workspace = true

--- a/virt/arcbox-vm/src/config.rs
+++ b/virt/arcbox-vm/src/config.rs
@@ -326,10 +326,23 @@ pub struct FirecrackerConfig {
     /// most two distinct snapshot ids (LRU-evicted). `0` disables pooling.
     #[serde(default = "default_pool_size")]
     pub pool_size: usize,
+    /// Serve eligible Creates from warm template snapshots (CORE-77).
+    ///
+    /// The first create of a template shape cold-boots and checkpoints the
+    /// idle guest; every later create of the same shape restores from that
+    /// snapshot instead of booting a kernel. Requires jailer isolation;
+    /// only networked creates without a custom boot recipe participate.
+    /// `false` restores plain cold boots for every create.
+    #[serde(default = "default_warm_create")]
+    pub warm_create: bool,
 }
 
 fn default_pool_size() -> usize {
     1
+}
+
+fn default_warm_create() -> bool {
+    true
 }
 
 /// How the pool-IP <-> fixed-guest-IP translation of an invariant sandbox TAP
@@ -394,6 +407,7 @@ impl Default for VmmConfig {
                 socket_timeout_secs: None,
                 sandbox_datapath: SandboxDatapath::default(),
                 pool_size: default_pool_size(),
+                warm_create: default_warm_create(),
             },
             network: NetworkConfig {
                 cidr: "172.20.0.0/16".into(),
@@ -594,6 +608,22 @@ mod tests {
             toml::from_str("binary = \"/usr/bin/firecracker\"\ndata_dir = \"/var/lib/vmm\"\n")
                 .unwrap();
         assert_eq!(cfg.pool_size, 1);
+    }
+
+    #[test]
+    fn warm_create_defaults_on_and_parses_the_escape_hatch() {
+        assert!(VmmConfig::default().firecracker.warm_create);
+        // A config written before the knob existed still loads with the default.
+        let cfg: FirecrackerConfig =
+            toml::from_str("binary = \"/usr/bin/firecracker\"\ndata_dir = \"/var/lib/vmm\"\n")
+                .unwrap();
+        assert!(cfg.warm_create);
+        // The escape hatch is reachable by config alone.
+        let cfg: FirecrackerConfig = toml::from_str(
+            "binary = \"/usr/bin/firecracker\"\ndata_dir = \"/var/lib/vmm\"\nwarm_create = false\n",
+        )
+        .unwrap();
+        assert!(!cfg.warm_create);
     }
 
     #[test]

--- a/virt/arcbox-vm/src/error.rs
+++ b/virt/arcbox-vm/src/error.rs
@@ -59,6 +59,19 @@ pub enum VmmError {
     #[error("service unavailable: {0}")]
     Unavailable(String),
 
+    /// The operation's side effects committed — the sandbox exists and is
+    /// running — but the acknowledging record's durability is unconfirmed.
+    /// Distinct from [`VmmError::Unavailable`] so callers with a fallback
+    /// (warm create) can tell "nothing happened, retry freely" from "it
+    /// happened, do NOT re-execute".
+    #[error("sandbox {id} committed, but ACK durability is unconfirmed: {detail}")]
+    AckUnconfirmed {
+        /// The sandbox whose operation committed.
+        id: String,
+        /// The underlying durability failure.
+        detail: String,
+    },
+
     /// A stdin write starts past the accepted byte count — the caller must
     /// resume from `accepted` (its offsets have a gap).
     #[error("stdin offset {offset} is past the {accepted} accepted bytes")]

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -40,6 +40,7 @@ mod persistence;
 mod pool;
 mod reconcile;
 mod types;
+mod warm;
 mod workload;
 
 pub use execution::{

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -69,6 +69,8 @@ pub struct SandboxManager {
     cow_manager: Arc<CowManager>,
     /// Pre-warmed restore slots (CORE-78); see `pool.rs`.
     pool: Arc<pool::SlotPool>,
+    /// Warm template snapshot bookkeeping (CORE-77); see `warm.rs`.
+    warm: Arc<warm::WarmCache>,
     /// Addressable executions (CORE-55); see `execution.rs`.
     executions: Arc<execution::ExecutionRegistry>,
     /// Publishes the startup reconciliation result. Lifecycle and read APIs
@@ -172,6 +174,7 @@ impl SandboxManager {
             events_tx,
             cow_manager,
             pool: Arc::new(pool::SlotPool::default()),
+            warm: Arc::new(warm::WarmCache::default()),
             executions,
             reconcile_done,
         })

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -399,8 +399,10 @@ async fn fail_started_boot(
 ///
 /// Uses the same workload path as `Run` (`start_run_workload`), so state
 /// transitions and events are identical; the output itself has no consumer
-/// and is discarded chunk by chunk to keep the exit handler flowing.
-async fn run_initial_cmd(
+/// and is discarded chunk by chunk to keep the exit handler flowing. Also
+/// driven by the warm-create restore path (CORE-77), which owes a restored
+/// Create the same initial workload a cold boot runs.
+pub(super) async fn run_initial_cmd(
     id: &SandboxId,
     spec: SandboxSpec,
     vsock_uds_path: &Path,

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -36,6 +36,7 @@ pub(super) async fn boot_sandbox(
     cow_manager: Arc<CowManager>,
     records: Arc<SandboxRecordStore>,
     generation: Uuid,
+    warm_publish: Option<super::warm::WarmPublishTicket>,
     resource_handoff: tokio::sync::oneshot::Sender<()>,
 ) {
     match do_boot(
@@ -201,6 +202,16 @@ pub(super) async fn boot_sandbox(
 
             let _ = events_tx.send(SandboxEvent::new(&id, action::READY));
             info!(sandbox_id = %id, "sandbox booted and ready");
+
+            // First eligible create of this boot shape (CORE-77): capture
+            // the warm snapshot while the guest is still idle, before the
+            // initial cmd dirties it. Synchronous on purpose — the cmd must
+            // not run before the checkpoint — and failures only warn: cache
+            // population never fails a healthy boot.
+            if let Some(ticket) = &warm_publish {
+                super::warm::publish_after_boot(&id, ticket, &instances, &config, &cow_manager)
+                    .await;
+            }
 
             // Launch the initial workload, if the spec carries one. The
             // sandbox stays alive when it exits (Running → Ready + "idle"),

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -200,18 +200,24 @@ pub(super) async fn boot_sandbox(
                 return;
             }
 
-            let _ = events_tx.send(SandboxEvent::new(&id, action::READY));
-            info!(sandbox_id = %id, "sandbox booted and ready");
-
             // First eligible create of this boot shape (CORE-77): capture
             // the warm snapshot while the guest is still idle, before the
             // initial cmd dirties it. Synchronous on purpose — the cmd must
             // not run before the checkpoint — and failures only warn: cache
             // population never fails a healthy boot.
+            //
+            // This MUST precede the READY event: checkpointing pauses the
+            // guest for the duration, and a client that acts on READY the
+            // moment it arrives would hit that pause with an execution and
+            // hang. READY promises the sandbox accepts executions, so it
+            // cannot fire while the guest is about to stop answering.
             if let Some(ticket) = &warm_publish {
                 super::warm::publish_after_boot(&id, ticket, &instances, &config, &cow_manager)
                     .await;
             }
+
+            let _ = events_tx.send(SandboxEvent::new(&id, action::READY));
+            info!(sandbox_id = %id, "sandbox booted and ready");
 
             // Launch the initial workload, if the spec carries one. The
             // sandbox stays alive when it exits (Running → Ready + "idle"),

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -992,9 +992,10 @@ impl SandboxManager {
         }
 
         if let Some(error) = ready_commit.durability_error {
-            return Err(VmmError::Unavailable(format!(
-                "sandbox {new_id} was restored, but ACK durability is unconfirmed: {error}"
-            )));
+            return Err(VmmError::AckUnconfirmed {
+                id: new_id,
+                detail: error,
+            });
         }
         Ok((new_id, ip_address))
     }

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -26,6 +26,172 @@ async fn move_file(from: &Path, to: &Path) -> std::io::Result<()> {
     }
 }
 
+/// Parameters for the internal restore path
+/// ([`SandboxManager::restore_from_snapshot`]), shared by the Restore RPC
+/// and internal callers.
+pub(super) struct RestoreRequest {
+    /// Source checkpoint id.
+    pub(super) snapshot_id: String,
+    /// Assign a fresh TAP + IP to the restored sandbox.
+    pub(super) network_override: bool,
+    /// Spec journaled with the provision intent and installed on the
+    /// instance. Restore consumes its identity fields (`id`, `labels`,
+    /// `ttl_seconds`); the boot-recipe fields are ignored — the snapshot
+    /// carries the boot state.
+    pub(super) spec: SandboxSpec,
+}
+
+/// Pause a `Ready` sandbox, capture a full snapshot into the catalog, and
+/// resume it.
+///
+/// Free-standing (rather than a method) so the boot task can publish warm
+/// snapshots (CORE-77) through the exact code path the Checkpoint RPC uses.
+pub(super) async fn checkpoint_impl(
+    instances: &super::InstanceMap,
+    snapshots: &SnapshotCatalog,
+    config: &VmmConfig,
+    sandbox_id: &SandboxId,
+    name: String,
+    labels: HashMap<String, String>,
+) -> Result<CheckpointInfo> {
+    // Verify state and capture the kernel/rootfs paths for jailer
+    // re-staging, the id the sandbox's chroot is actually keyed by
+    // — a sandbox restored from a pre-warmed pool slot lives in the
+    // slot's chroot, and FC resolves snapshot paths inside it — plus
+    // the guest's network addressing mode and the VM API handle.
+    let (kernel_path, rootfs_path, chroot_owner, net_invariant, vm) = {
+        let instance = instances
+            .read()
+            .unwrap()
+            .get(sandbox_id)
+            .cloned()
+            .ok_or_else(|| VmmError::NotFound(sandbox_id.clone()))?;
+        let inst = instance.lock().unwrap();
+        if inst.state != SandboxState::Ready {
+            return Err(VmmError::WrongState {
+                id: sandbox_id.clone(),
+                expected: "Ready".into(),
+                actual: inst.state.to_string(),
+            });
+        }
+        let vm = inst
+            .vm
+            .as_ref()
+            .map(Arc::clone)
+            .ok_or_else(|| VmmError::WrongState {
+                id: sandbox_id.clone(),
+                expected: "Ready (VM handle available)".into(),
+                actual: inst.state.to_string(),
+            })?;
+        // Only needed for jailer mode; safe to capture regardless.
+        (
+            inst.spec.kernel.clone(),
+            inst.spec.rootfs.clone(),
+            inst.pool_slot_id
+                .clone()
+                .unwrap_or_else(|| sandbox_id.clone()),
+            inst.net_invariant,
+            vm,
+        )
+    };
+
+    // Staging directory outside the catalog: the snapshot becomes visible
+    // only on commit, and dropping `pending` on any error below takes the
+    // directory and whatever partial vmstate/mem it holds with it.
+    let pending = snapshots.begin(sandbox_id)?;
+    let snapshot_id = pending.id().to_owned();
+    let staging_dir = pending.dir();
+
+    // Pause before snapshotting.
+    vm.pause().await.map_err(VmmError::from)?;
+
+    // Everything between pause and resume is fallible (chroot dir setup,
+    // chown, the snapshot RPC). Run it in a block whose result is handled
+    // only AFTER an unconditional resume — a bare `?` here previously left
+    // the guest paused forever, wedging every later RPC. Returns the chroot
+    // snapshot dir (jailer mode) to move afterward.
+    //
+    // In jailer mode FC runs inside a chroot and can only write to paths
+    // within it, so the snapshot is written to a chroot-local dir and moved
+    // into staging after resume.
+    let paused: Result<Option<PathBuf>> = async {
+        let (fc_vmstate_path, fc_mem_path, chroot_snap_dir_opt) =
+            if let Some(ref jc) = config.firecracker.jailer {
+                let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
+                let cr = chroot_root(&config.firecracker.binary, base, &chroot_owner);
+                let chroot_snap = cr.join("snapshots").join(&snapshot_id);
+                std::fs::create_dir_all(&chroot_snap).map_err(VmmError::Io)?;
+                // Firecracker runs as jc.uid/jc.gid; chown the directory so
+                // it can create the snapshot files.
+                let uid = nix::unistd::Uid::from_raw(jc.uid);
+                let gid = nix::unistd::Gid::from_raw(jc.gid);
+                nix::unistd::chown(&chroot_snap, Some(uid), Some(gid))
+                    .map_err(|e| VmmError::Process(format!("chown snapshot dir: {e}")))?;
+                // Paths as seen by Firecracker inside the chroot.
+                let fc_vmstate = format!("/snapshots/{snapshot_id}/vmstate");
+                let fc_mem = format!("/snapshots/{snapshot_id}/mem");
+                (fc_vmstate, fc_mem, Some(chroot_snap))
+            } else {
+                (
+                    staging_dir.join("vmstate").to_str().unwrap().to_owned(),
+                    staging_dir.join("mem").to_str().unwrap().to_owned(),
+                    None,
+                )
+            };
+
+        vm.create_snapshot(&fc_vmstate_path, &fc_mem_path)
+            .await
+            .map_err(VmmError::from)?;
+        Ok(chroot_snap_dir_opt)
+    }
+    .await;
+
+    // Always resume, regardless of how the paused section fared.
+    let _ = vm.resume().await;
+
+    let chroot_snap_dir_opt = paused?;
+
+    // If jailer mode, move snapshot files from the chroot into staging.
+    if let Some(chroot_snap) = chroot_snap_dir_opt {
+        move_file(&chroot_snap.join("vmstate"), &staging_dir.join("vmstate"))
+            .await
+            .map_err(VmmError::Io)?;
+        if chroot_snap.join("mem").exists() {
+            move_file(&chroot_snap.join("mem"), &staging_dir.join("mem"))
+                .await
+                .map_err(VmmError::Io)?;
+        }
+        let _ = tokio::fs::remove_dir_all(&chroot_snap).await;
+    }
+
+    // Store kernel/rootfs template paths so restore can re-derive them.
+    // Jailer mode needs them for chroot staging; direct mode needs the
+    // rootfs path to set up a fresh dm-snapshot and retarget the
+    // vmstate-recorded symlink.
+    let meta = pending.commit(SnapshotDraft {
+        name: Some(name),
+        labels,
+        snapshot_type: crate::config::SnapshotType::Full,
+        parent_id: None,
+        kernel_path: Some(kernel_path),
+        rootfs_path: Some(rootfs_path),
+        net_invariant,
+    })?;
+
+    let snap_dir_path = meta
+        .vmstate_path
+        .parent()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    info!(sandbox_id, snapshot_id = %meta.id, "sandbox checkpointed");
+    Ok(CheckpointInfo {
+        snapshot_id: meta.id,
+        snapshot_dir: snap_dir_path,
+        created_at: meta.created_at.to_rfc3339(),
+    })
+}
+
 impl SandboxManager {
     /// Rootfs images that existing snapshots need to stay restorable.
     ///
@@ -35,135 +201,23 @@ impl SandboxManager {
         self.snapshots.referenced_rootfs_paths()
     }
 
+    /// Checkpoint a `Ready` sandbox into the snapshot catalog.
     pub async fn checkpoint_sandbox(
         &self,
         sandbox_id: &SandboxId,
         name: String,
         labels: HashMap<String, String>,
     ) -> Result<CheckpointInfo> {
-        // Verify state and capture the kernel/rootfs paths for jailer
-        // re-staging, the id the sandbox's chroot is actually keyed by
-        // — a sandbox restored from a pre-warmed pool slot lives in the
-        // slot's chroot, and FC resolves snapshot paths inside it — plus
-        // the guest's network addressing mode.
-        let (kernel_path, rootfs_path, chroot_owner, net_invariant) = {
-            let instance = self.get_instance(sandbox_id)?;
-            let inst = instance.lock().unwrap();
-            if inst.state != SandboxState::Ready {
-                return Err(VmmError::WrongState {
-                    id: sandbox_id.clone(),
-                    expected: "Ready".into(),
-                    actual: inst.state.to_string(),
-                });
-            }
-            // Only needed for jailer mode; safe to capture regardless.
-            (
-                inst.spec.kernel.clone(),
-                inst.spec.rootfs.clone(),
-                inst.pool_slot_id
-                    .clone()
-                    .unwrap_or_else(|| sandbox_id.clone()),
-                inst.net_invariant,
-            )
-        };
-
-        let vm = self.get_vm_handle(sandbox_id)?;
-
-        // Staging directory outside the catalog: the snapshot becomes visible
-        // only on commit, and dropping `pending` on any error below takes the
-        // directory and whatever partial vmstate/mem it holds with it.
-        let pending = self.snapshots.begin(sandbox_id)?;
-        let snapshot_id = pending.id().to_owned();
-        let staging_dir = pending.dir();
-
-        // Pause before snapshotting.
-        vm.pause().await.map_err(VmmError::from)?;
-
-        // Everything between pause and resume is fallible (chroot dir setup,
-        // chown, the snapshot RPC). Run it in a block whose result is handled
-        // only AFTER an unconditional resume — a bare `?` here previously left
-        // the guest paused forever, wedging every later RPC. Returns the chroot
-        // snapshot dir (jailer mode) to move afterward.
-        //
-        // In jailer mode FC runs inside a chroot and can only write to paths
-        // within it, so the snapshot is written to a chroot-local dir and moved
-        // into staging after resume.
-        let paused: Result<Option<PathBuf>> = async {
-            let (fc_vmstate_path, fc_mem_path, chroot_snap_dir_opt) =
-                if let Some(ref jc) = self.config.firecracker.jailer {
-                    let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-                    let cr = chroot_root(&self.config.firecracker.binary, base, &chroot_owner);
-                    let chroot_snap = cr.join("snapshots").join(&snapshot_id);
-                    std::fs::create_dir_all(&chroot_snap).map_err(VmmError::Io)?;
-                    // Firecracker runs as jc.uid/jc.gid; chown the directory so
-                    // it can create the snapshot files.
-                    let uid = nix::unistd::Uid::from_raw(jc.uid);
-                    let gid = nix::unistd::Gid::from_raw(jc.gid);
-                    nix::unistd::chown(&chroot_snap, Some(uid), Some(gid))
-                        .map_err(|e| VmmError::Process(format!("chown snapshot dir: {e}")))?;
-                    // Paths as seen by Firecracker inside the chroot.
-                    let fc_vmstate = format!("/snapshots/{snapshot_id}/vmstate");
-                    let fc_mem = format!("/snapshots/{snapshot_id}/mem");
-                    (fc_vmstate, fc_mem, Some(chroot_snap))
-                } else {
-                    (
-                        staging_dir.join("vmstate").to_str().unwrap().to_owned(),
-                        staging_dir.join("mem").to_str().unwrap().to_owned(),
-                        None,
-                    )
-                };
-
-            vm.create_snapshot(&fc_vmstate_path, &fc_mem_path)
-                .await
-                .map_err(VmmError::from)?;
-            Ok(chroot_snap_dir_opt)
-        }
-        .await;
-
-        // Always resume, regardless of how the paused section fared.
-        let _ = vm.resume().await;
-
-        let chroot_snap_dir_opt = paused?;
-
-        // If jailer mode, move snapshot files from the chroot into staging.
-        if let Some(chroot_snap) = chroot_snap_dir_opt {
-            move_file(&chroot_snap.join("vmstate"), &staging_dir.join("vmstate"))
-                .await
-                .map_err(VmmError::Io)?;
-            if chroot_snap.join("mem").exists() {
-                move_file(&chroot_snap.join("mem"), &staging_dir.join("mem"))
-                    .await
-                    .map_err(VmmError::Io)?;
-            }
-            let _ = tokio::fs::remove_dir_all(&chroot_snap).await;
-        }
-
-        // Store kernel/rootfs template paths so restore can re-derive them.
-        // Jailer mode needs them for chroot staging; direct mode needs the
-        // rootfs path to set up a fresh dm-snapshot and retarget the
-        // vmstate-recorded symlink.
-        let meta = pending.commit(SnapshotDraft {
-            name: Some(name),
+        self.check_reconcile()?;
+        checkpoint_impl(
+            &self.instances,
+            &self.snapshots,
+            &self.config,
+            sandbox_id,
+            name,
             labels,
-            snapshot_type: crate::config::SnapshotType::Full,
-            parent_id: None,
-            kernel_path: Some(kernel_path),
-            rootfs_path: Some(rootfs_path),
-            net_invariant,
-        })?;
-
-        let snap_dir_path = meta
-            .vmstate_path
-            .parent()
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or_default();
-
-        info!(sandbox_id, snapshot_id = %meta.id, "sandbox checkpointed");
-        Ok(CheckpointInfo {
-            snapshot_id: meta.id,
-            snapshot_dir: snap_dir_path,
-            created_at: meta.created_at.to_rfc3339(),
-        })
+        )
+        .await
     }
 
     #[allow(
@@ -254,12 +308,42 @@ impl SandboxManager {
         spec: RestoreSandboxSpec,
         restore_key: &str,
     ) -> Result<(SandboxId, String)> {
+        let RestoreSandboxSpec {
+            id,
+            snapshot_id,
+            labels,
+            network_override,
+            ttl_seconds,
+        } = spec;
+        self.restore_from_snapshot(
+            RestoreRequest {
+                snapshot_id,
+                network_override,
+                spec: SandboxSpec {
+                    id,
+                    labels,
+                    ttl_seconds,
+                    ..Default::default()
+                },
+            },
+            restore_key,
+        )
+        .await
+    }
+
+    /// Internal restore path shared by the Restore RPC and internal callers.
+    pub(super) async fn restore_from_snapshot(
+        &self,
+        request: RestoreRequest,
+        restore_key: &str,
+    ) -> Result<(SandboxId, String)> {
         // Gate on the startup sweep before touching per-id resources (see
         // create_sandbox / await_reconcile).
         self.await_reconcile().await?;
 
-        let caller_supplied_id = spec.id.as_ref().is_some_and(|id| !id.is_empty());
-        let new_id = spec
+        let caller_supplied_id = request.spec.id.as_ref().is_some_and(|id| !id.is_empty());
+        let new_id = request
+            .spec
             .id
             .clone()
             .filter(|s| !s.is_empty())
@@ -269,7 +353,7 @@ impl SandboxManager {
         // The snapshot id is caller-supplied and flows into snapshot dir paths
         // (create_dir_all / copy / remove_dir_all) — validate it too, or a
         // `../` id would traverse out of the snapshots directory.
-        super::validate_id("snapshot id", &spec.snapshot_id)?;
+        super::validate_id("snapshot id", &request.snapshot_id)?;
 
         // Phase clocks for the completion log: restore latency is a product
         // metric (CORE-75) and the breakdown is what makes a regression
@@ -284,7 +368,7 @@ impl SandboxManager {
 
         // Resolve read-only prerequisites before claiming durable ownership.
         // Once the intent exists, every failure goes through rollback.
-        let snap_meta = self.snapshots.find_by_id(&spec.snapshot_id)?;
+        let snap_meta = self.snapshots.find_by_id(&request.snapshot_id)?;
         let jailer = self.config.firecracker.jailer.as_ref().ok_or_else(|| {
             VmmError::Config(
                 "checkpoint restore requires jailer isolation; direct mode embeds shared origin paths"
@@ -299,12 +383,8 @@ impl SandboxManager {
         let vm_dir = PathBuf::from(&self.config.firecracker.data_dir)
             .join("sandboxes")
             .join(&new_id);
-        let restore_spec = SandboxSpec {
-            id: Some(new_id.clone()),
-            labels: spec.labels.clone(),
-            ttl_seconds: spec.ttl_seconds,
-            ..Default::default()
-        };
+        let mut restore_spec = request.spec.clone();
+        restore_spec.id = Some(new_id.clone());
         let reservation = super::reserve_id(
             &self.instances,
             &new_id,
@@ -339,7 +419,7 @@ impl SandboxManager {
 
         // Reserve network metadata, journal it, then materialize the TAP. This
         // mirrors Create so an agent crash never leaves an unowned interface.
-        let net_alloc = if spec.network_override {
+        let net_alloc = if request.network_override {
             match self.network.reserve(&new_id) {
                 Ok(allocation) => Some(allocation),
                 Err(error) => {
@@ -404,7 +484,7 @@ impl SandboxManager {
         // reconfiguration as the only restore work. From the claim on, the
         // slot's resources are owned by this restore and unwind through
         // rollback_restore like freshly created ones.
-        let claimed = self.claim_restore_slot(&spec.snapshot_id);
+        let claimed = self.claim_restore_slot(&request.snapshot_id);
         let pool_hit = claimed.is_some();
         let (process, actual_vsock_path, effective_vmstate, effective_mem, t_spawned, t_staged) =
             if let Some(slot) = claimed {
@@ -817,7 +897,7 @@ impl SandboxManager {
 
         // TTL expiry task — identity-guarded so a stale timer can't remove a
         // same-id sandbox re-created after this one (see expire_sandbox).
-        if spec.ttl_seconds > 0 {
+        if request.spec.ttl_seconds > 0 {
             let instances = Arc::clone(&self.instances);
             let network = Arc::clone(&self.network);
             let events_tx = self.events_tx.clone();
@@ -825,7 +905,7 @@ impl SandboxManager {
             let cow2 = Arc::clone(&self.cow_manager);
             let records = Arc::clone(&self.records);
             let id2 = new_id.clone();
-            let ttl = spec.ttl_seconds;
+            let ttl = request.spec.ttl_seconds;
             let armed_for = ttl_armed_for;
             tokio::spawn(async move {
                 tokio::time::sleep(Duration::from_secs(ttl as u64)).await;
@@ -853,7 +933,7 @@ impl SandboxManager {
         let ms = |d: Duration| u64::try_from(d.as_millis()).unwrap_or(u64::MAX);
         info!(
             sandbox_id = %new_id,
-            snapshot_id = %spec.snapshot_id,
+            snapshot_id = %request.snapshot_id,
             pool_hit,
             spawn_ms = ms(t_spawned.duration_since(restore_started)),
             stage_ms = ms(t_staged.duration_since(t_spawned)),
@@ -865,7 +945,7 @@ impl SandboxManager {
 
         // Populate/refill the pool for this snapshot in the background:
         // the successful restore is what makes it eligible for pooling.
-        self.spawn_pool_refill(&spec.snapshot_id);
+        self.spawn_pool_refill(&request.snapshot_id);
         if let Some(error) = ready_commit.durability_error {
             return Err(VmmError::Unavailable(format!(
                 "sandbox {new_id} was restored, but ACK durability is unconfirmed: {error}"

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -36,9 +36,22 @@ pub(super) struct RestoreRequest {
     pub(super) network_override: bool,
     /// Spec journaled with the provision intent and installed on the
     /// instance. Restore consumes its identity fields (`id`, `labels`,
-    /// `ttl_seconds`); the boot-recipe fields are ignored — the snapshot
+    /// `ttl_seconds`) — plus, on the warm-create origin, the initial
+    /// workload fields; the boot-recipe fields are ignored — the snapshot
     /// carries the boot state.
     pub(super) spec: SandboxSpec,
+    /// Which API surface this restore serves; decides the event contract.
+    pub(super) origin: RestoreOrigin,
+}
+
+/// Which caller a restore serves.
+pub(super) enum RestoreOrigin {
+    /// The Restore RPC: the sandbox announces itself with READY alone.
+    Restore,
+    /// The warm-create reroute (CORE-77): watchers must see the Create
+    /// contract — CREATED then READY — and the spec's initial `cmd` runs
+    /// after Ready exactly as a cold boot would run it.
+    WarmCreate,
 }
 
 /// Pause a `Ready` sandbox, capture a full snapshot into the catalog, and
@@ -209,6 +222,9 @@ impl SandboxManager {
         labels: HashMap<String, String>,
     ) -> Result<CheckpointInfo> {
         self.check_reconcile()?;
+        // The warm-create cache (CORE-77) trusts its label as the lookup
+        // key; a caller must not be able to plant one.
+        super::warm::reject_reserved_labels(&labels)?;
         checkpoint_impl(
             &self.instances,
             &self.snapshots,
@@ -325,6 +341,7 @@ impl SandboxManager {
                     ttl_seconds,
                     ..Default::default()
                 },
+                origin: RestoreOrigin::Restore,
             },
             restore_key,
         )
@@ -408,6 +425,10 @@ impl SandboxManager {
             ProvisionIntent::Blocked(_) => return Err(VmmError::AlreadyExists(new_id)),
         };
         let generation = record.generation;
+        // Kept out of the instance for the warm-create origin's initial
+        // workload; the durable copy is redacted once the record leaves the
+        // provisioning phases.
+        let effective_spec = record.effective_spec.clone();
         {
             let arc = reservation.instance();
             let mut instance = arc.lock().unwrap();
@@ -882,7 +903,7 @@ impl SandboxManager {
             inst.network.clone_from(&net_alloc);
             inst.process = Some(process);
             inst.vm = Some(vm);
-            inst.vsock_uds_path = Some(actual_vsock_path);
+            inst.vsock_uds_path = Some(actual_vsock_path.clone());
             inst.cow_handle = pending_cow.take();
             inst.net_invariant = snap_meta.net_invariant;
             inst.state = SandboxState::Ready;
@@ -891,6 +912,14 @@ impl SandboxManager {
         reservation.commit();
         let ttl_armed_for = Arc::downgrade(&arc);
 
+        let warm_create = matches!(request.origin, RestoreOrigin::WarmCreate);
+        if warm_create {
+            // The Create event contract: watchers see CREATED then READY for
+            // this id in that order, exactly as a cold boot emits them.
+            let _ = self
+                .events_tx
+                .send(SandboxEvent::new(&new_id, action::CREATED));
+        }
         let _ = self
             .events_tx
             .send(SandboxEvent::new(&new_id, action::READY));
@@ -935,6 +964,7 @@ impl SandboxManager {
             sandbox_id = %new_id,
             snapshot_id = %request.snapshot_id,
             pool_hit,
+            warm_create,
             spawn_ms = ms(t_spawned.duration_since(restore_started)),
             stage_ms = ms(t_staged.duration_since(t_spawned)),
             load_ms = ms(t_loaded.duration_since(t_staged)),
@@ -946,6 +976,21 @@ impl SandboxManager {
         // Populate/refill the pool for this snapshot in the background:
         // the successful restore is what makes it eligible for pooling.
         self.spawn_pool_refill(&request.snapshot_id);
+
+        // A warm create still owes the Create contract's initial workload:
+        // run it through the same path as a cold boot, after Ready. Kept off
+        // the timing log above — the workload is the user's, not restore's.
+        if warm_create && !effective_spec.cmd.is_empty() {
+            super::boot::run_initial_cmd(
+                &new_id,
+                effective_spec,
+                &actual_vsock_path,
+                &self.instances,
+                &self.events_tx,
+            )
+            .await;
+        }
+
         if let Some(error) = ready_commit.durability_error {
             return Err(VmmError::Unavailable(format!(
                 "sandbox {new_id} was restored, but ACK durability is unconfirmed: {error}"

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -92,15 +92,16 @@ impl SandboxManager {
                         // through to the cold boot (which republishes) rather
                         // than surfacing a snapshot-not-found to the caller.
                         //
-                        // The restore is pinned to this create's id so the
-                        // instance registry can discriminate how it failed:
-                        // a pre-commit failure unwinds its claim (id absent,
-                        // safe to cold-boot), while a post-commit failure
-                        // (ACK durability) leaves the sandbox running and
-                        // READY under this id — falling through there would
-                        // boot a duplicate and then fail on the id
-                        // reservation, so it propagates exactly as on the
-                        // direct Restore path.
+                        // The failure class decides the fallback, carried
+                        // in the error itself: `AckUnconfirmed` is the one
+                        // post-commit failure — the sandbox is running and
+                        // READY under this id — so cold-booting there would
+                        // recreate a live (or, if the client already acted
+                        // on READY and deleted it, just-deleted) sandbox.
+                        // Every other failure unwound its claim pre-commit
+                        // and cold-boots safely. The restore is pinned to
+                        // this create's id so both outcomes concern the id
+                        // the caller asked for.
                         let mut warm_spec = spec.clone();
                         warm_spec.id = Some(id.clone());
                         match self
@@ -116,7 +117,7 @@ impl SandboxManager {
                             .await
                         {
                             Ok(result) => return Ok(result),
-                            Err(error) if self.instances.read().unwrap().contains_key(&id) => {
+                            Err(error @ VmmError::AckUnconfirmed { .. }) => {
                                 return Err(error);
                             }
                             Err(error) => {
@@ -370,9 +371,7 @@ impl SandboxManager {
 
         info!(sandbox_id = %id, "sandbox create requested (async boot started)");
         if let Some(error) = starting_durability_error {
-            return Err(VmmError::Unavailable(format!(
-                "sandbox {id} was created, but ACK durability is unconfirmed: {error}"
-            )));
+            return Err(VmmError::AckUnconfirmed { id, detail: error });
         }
         Ok((id, ip_address))
     }

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -85,17 +85,42 @@ impl SandboxManager {
                             snapshot_id,
                             "warm create: restoring cached template snapshot"
                         );
-                        return self
+                        // The cache entry can die between this lookup and the
+                        // restore: a concurrent publish of another key evicts
+                        // by LRU and deletes the snapshot. That is a cache
+                        // miss arriving late, not a create failure — fall
+                        // through to the cold boot (which republishes) rather
+                        // than surfacing a snapshot-not-found to the caller.
+                        // The restore path unwinds its own claim on failure,
+                        // so the id is free again here.
+                        match self
                             .restore_from_snapshot(
                                 super::checkpoint::RestoreRequest {
-                                    snapshot_id,
+                                    snapshot_id: snapshot_id.clone(),
                                     network_override: true,
-                                    spec,
+                                    spec: spec.clone(),
                                     origin: super::checkpoint::RestoreOrigin::WarmCreate,
                                 },
                                 request_key,
                             )
-                            .await;
+                            .await
+                        {
+                            Ok(result) => return Ok(result),
+                            Err(error) => {
+                                warn!(
+                                    sandbox_id = %id,
+                                    snapshot_id,
+                                    %error,
+                                    "warm restore failed; cold-booting instead"
+                                );
+                                warm_publish = Some(super::warm::WarmPublishTicket {
+                                    key,
+                                    cache: Arc::clone(&self.warm),
+                                    snapshots: Arc::clone(&self.snapshots),
+                                    pool: Arc::clone(&self.pool),
+                                });
+                            }
+                        }
                     }
                     Ok(None) => {
                         warm_publish = Some(super::warm::WarmPublishTicket {

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -74,10 +74,12 @@ impl SandboxManager {
         // reservation, durable intent, and fresh network identity
         // (`network_override`, free with net-invariant snapshots). On a miss
         // the boot task publishes the snapshot once the guest is Ready.
+        let mut warm_publish = None;
         if super::warm::warm_eligible(&self.config, &spec, caller_supplied_boot) {
             match super::warm::derive_warm_key(&spec) {
                 Ok(key) => match super::warm::find_warm_snapshot(&self.snapshots, &key) {
                     Ok(Some(snapshot_id)) => {
+                        self.warm.touch(&key);
                         info!(
                             sandbox_id = %id,
                             snapshot_id,
@@ -95,7 +97,14 @@ impl SandboxManager {
                             )
                             .await;
                     }
-                    Ok(None) => {}
+                    Ok(None) => {
+                        warm_publish = Some(super::warm::WarmPublishTicket {
+                            key,
+                            cache: Arc::clone(&self.warm),
+                            snapshots: Arc::clone(&self.snapshots),
+                            pool: Arc::clone(&self.pool),
+                        });
+                    }
                     Err(error) => {
                         // The publish path would scan the same catalog, so a
                         // failed lookup cold-boots without cache interaction.
@@ -277,6 +286,7 @@ impl SandboxManager {
                     cow_manager,
                     records,
                     generation,
+                    warm_publish,
                     resource_handoff_tx,
                 )
                 .await;

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -91,14 +91,24 @@ impl SandboxManager {
                         // miss arriving late, not a create failure — fall
                         // through to the cold boot (which republishes) rather
                         // than surfacing a snapshot-not-found to the caller.
-                        // The restore path unwinds its own claim on failure,
-                        // so the id is free again here.
+                        //
+                        // The restore is pinned to this create's id so the
+                        // instance registry can discriminate how it failed:
+                        // a pre-commit failure unwinds its claim (id absent,
+                        // safe to cold-boot), while a post-commit failure
+                        // (ACK durability) leaves the sandbox running and
+                        // READY under this id — falling through there would
+                        // boot a duplicate and then fail on the id
+                        // reservation, so it propagates exactly as on the
+                        // direct Restore path.
+                        let mut warm_spec = spec.clone();
+                        warm_spec.id = Some(id.clone());
                         match self
                             .restore_from_snapshot(
                                 super::checkpoint::RestoreRequest {
                                     snapshot_id: snapshot_id.clone(),
                                     network_override: true,
-                                    spec: spec.clone(),
+                                    spec: warm_spec,
                                     origin: super::checkpoint::RestoreOrigin::WarmCreate,
                                 },
                                 request_key,
@@ -106,6 +116,9 @@ impl SandboxManager {
                             .await
                         {
                             Ok(result) => return Ok(result),
+                            Err(error) if self.instances.read().unwrap().contains_key(&id) => {
+                                return Err(error);
+                            }
                             Err(error) => {
                                 warn!(
                                     sandbox_id = %id,

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -618,17 +618,4 @@ impl SandboxManager {
         let uds = self.require_alive_vsock(id)?;
         crate::file_io::write_file(&uds, path, mode, data).await
     }
-
-    pub(super) fn get_vm_handle(&self, id: &SandboxId) -> Result<Arc<fc_sdk::Vm>> {
-        let instance = self.get_instance(id)?;
-        let inst = instance.lock().unwrap();
-        inst.vm
-            .as_ref()
-            .map(Arc::clone)
-            .ok_or_else(|| VmmError::WrongState {
-                id: id.clone(),
-                expected: "Ready or Running (VM handle not yet available)".into(),
-                actual: inst.state.to_string(),
-            })
-    }
 }

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -32,6 +32,10 @@ impl SandboxManager {
         // has run — otherwise a re-created same-id sandbox races it.
         self.await_reconcile().await?;
 
+        // Whether the caller pinned its own boot recipe. Captured before the
+        // defaults fill — a custom kernel or cmdline is never warm-created.
+        let caller_supplied_boot = !spec.kernel.is_empty() || !spec.boot_args.is_empty();
+
         // Apply daemon defaults for fields not supplied by the caller.
         let defaults = &self.config.defaults;
         if spec.kernel.is_empty() {
@@ -63,6 +67,46 @@ impl SandboxManager {
         // jailer --id, dm/TAP names). Auto-generated UUIDs pass unchanged.
         super::validate_id("sandbox id", &id)?;
         spec.id = Some(id.clone());
+
+        // Warm create (CORE-77): a Create whose boot shape matches a cached
+        // template snapshot restores instead of cold-booting. Decided before
+        // any resource allocation — the restore path owns its own id
+        // reservation, durable intent, and fresh network identity
+        // (`network_override`, free with net-invariant snapshots). On a miss
+        // the boot task publishes the snapshot once the guest is Ready.
+        if super::warm::warm_eligible(&self.config, &spec, caller_supplied_boot) {
+            match super::warm::derive_warm_key(&spec) {
+                Ok(key) => match super::warm::find_warm_snapshot(&self.snapshots, &key) {
+                    Ok(Some(snapshot_id)) => {
+                        info!(
+                            sandbox_id = %id,
+                            snapshot_id,
+                            "warm create: restoring cached template snapshot"
+                        );
+                        return self
+                            .restore_from_snapshot(
+                                super::checkpoint::RestoreRequest {
+                                    snapshot_id,
+                                    network_override: true,
+                                    spec,
+                                    origin: super::checkpoint::RestoreOrigin::WarmCreate,
+                                },
+                                request_key,
+                            )
+                            .await;
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        // The publish path would scan the same catalog, so a
+                        // failed lookup cold-boots without cache interaction.
+                        warn!(sandbox_id = %id, %error, "warm snapshot lookup failed; cold-booting");
+                    }
+                },
+                Err(error) => {
+                    debug!(sandbox_id = %id, %error, "rootfs fingerprint failed; skipping warm create");
+                }
+            }
+        }
 
         let vm_dir = PathBuf::from(&self.config.firecracker.data_dir)
             .join("sandboxes")

--- a/virt/arcbox-vm/src/sandbox/pool.rs
+++ b/virt/arcbox-vm/src/sandbox/pool.rs
@@ -382,6 +382,27 @@ async fn stage_slot(
     }
 }
 
+/// Drain and tear down every ready slot staged from one snapshot (or from
+/// all of them). Teardown failures are logged and left to the startup
+/// sweep — the slots' crash journals keep them reclaimable.
+pub(super) async fn drain_pool_slots(
+    pool: &SlotPool,
+    config: &VmmConfig,
+    cow_manager: &CowManager,
+    snapshot_id: Option<&str>,
+) {
+    for slot in pool.drain(snapshot_id) {
+        let slot_id = slot.slot_id.clone();
+        if let Err(error) = destroy_slot(config, cow_manager, slot).await {
+            warn!(
+                slot_id,
+                error = %error,
+                "pool slot teardown incomplete; the startup sweep will retry"
+            );
+        }
+    }
+}
+
 /// Tear down a slot completely: process, CoW resources, chroot, journal.
 ///
 /// On error the slot's crash journal is left in place so the startup
@@ -499,19 +520,9 @@ impl SandboxManager {
     }
 
     /// Tear down pooled slots: all of them, or those staged from one
-    /// snapshot. Teardown failures are logged and left to the startup
-    /// sweep — the slots' crash journals keep them reclaimable.
+    /// snapshot.
     pub(super) async fn drain_pool(&self, snapshot_id: Option<&str>) {
-        for slot in self.pool.drain(snapshot_id) {
-            let slot_id = slot.slot_id.clone();
-            if let Err(error) = destroy_slot(&self.config, &self.cow_manager, slot).await {
-                warn!(
-                    slot_id,
-                    error = %error,
-                    "pool slot teardown incomplete; the startup sweep will retry"
-                );
-            }
-        }
+        drain_pool_slots(&self.pool, &self.config, &self.cow_manager, snapshot_id).await;
     }
 
     /// Release manager-held background resources: tears down every

--- a/virt/arcbox-vm/src/sandbox/warm.rs
+++ b/virt/arcbox-vm/src/sandbox/warm.rs
@@ -1,0 +1,369 @@
+//! Warm template snapshots (CORE-77).
+//!
+//! `CreateSandbox` restores from a cached snapshot when one exists for the
+//! effective boot shape, instead of cold-booting a kernel. The cache IS the
+//! [`SnapshotCatalog`]: a warm snapshot is an ordinary snapshot carrying the
+//! reserved [`WARM_KEY_LABEL`], whose value is a hash of everything a memory
+//! snapshot bakes in — the resolved kernel/rootfs paths, the kernel cmdline,
+//! the VM geometry, and a content fingerprint of the rootfs file (the default
+//! template rebuilds in place via temp+rename, so dev/inode/mtime/size change
+//! whenever the content does; `docker:` templates are content-addressed
+//! already, but the fingerprint is uniform and cheap).
+//!
+//! Lookup scans the catalog for the label; a miss cold-boots and publishes
+//! the snapshot from the freshly Ready guest (see `publish_after_boot`).
+
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+use super::*;
+use crate::snapshot::SnapshotCatalog;
+
+/// Reserved snapshot label carrying the warm key. The Checkpoint RPC rejects
+/// caller-supplied labels with this name so no caller can plant a cache
+/// entry that template creates would then restore from.
+pub(super) const WARM_KEY_LABEL: &str = "arcbox.warm_key";
+
+/// Identity of one warm-cacheable boot shape: hex SHA-256 over the resolved
+/// boot recipe, the VM geometry, and the rootfs content fingerprint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct WarmKey(String);
+
+impl WarmKey {
+    pub(super) fn hex(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Content fingerprint of the rootfs file behind a resolved template path.
+///
+/// A memory snapshot is only valid against the exact rootfs bytes it booted
+/// from, and template paths are reused across rebuilds — the fingerprint is
+/// what invalidates the cache when the content changes underneath the path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct RootfsFingerprint {
+    dev: u64,
+    ino: u64,
+    mtime: i64,
+    mtime_nsec: i64,
+    size: u64,
+}
+
+impl RootfsFingerprint {
+    fn read(path: &Path) -> std::io::Result<Self> {
+        use std::os::unix::fs::MetadataExt;
+        let meta = std::fs::metadata(path)?;
+        Ok(Self {
+            dev: meta.dev(),
+            ino: meta.ino(),
+            mtime: meta.mtime(),
+            mtime_nsec: meta.mtime_nsec(),
+            size: meta.size(),
+        })
+    }
+}
+
+/// Derive the warm key for an effective (defaults-applied) create spec,
+/// fingerprinting the rootfs file on disk.
+pub(super) fn derive_warm_key(spec: &SandboxSpec) -> std::io::Result<WarmKey> {
+    let fingerprint = RootfsFingerprint::read(Path::new(&spec.rootfs))?;
+    Ok(derive(spec, fingerprint))
+}
+
+fn derive(spec: &SandboxSpec, fingerprint: RootfsFingerprint) -> WarmKey {
+    let mut hasher = Sha256::new();
+    // vcpus and memory are part of the key on purpose: a memory snapshot
+    // restores only onto identical geometry.
+    for text in [&spec.kernel, &spec.rootfs, &spec.boot_args] {
+        hasher.update(text.as_bytes());
+        hasher.update([0u8]);
+    }
+    for number in [
+        u64::from(spec.vcpus),
+        spec.memory_mib,
+        fingerprint.dev,
+        fingerprint.ino,
+        fingerprint.size,
+    ] {
+        hasher.update(number.to_le_bytes());
+    }
+    for number in [fingerprint.mtime, fingerprint.mtime_nsec] {
+        hasher.update(number.to_le_bytes());
+    }
+    WarmKey(format!("{:x}", hasher.finalize()))
+}
+
+/// Whether an effective (defaults-applied) create spec may be served from —
+/// and captured into — the warm cache.
+///
+/// `caller_supplied_boot` is captured before the defaults fill: a caller
+/// pinning its own kernel or cmdline opted out of the template shape, and
+/// anything doubtful cold-boots. Restore also requires jailer isolation and
+/// a networked spec (the restore path re-addresses via `network_override`,
+/// which net-invariant snapshots make free); an explicit `ip=` would bake a
+/// caller-chosen identity into the snapshot, so it disqualifies too.
+pub(super) fn warm_eligible(
+    config: &VmmConfig,
+    spec: &SandboxSpec,
+    caller_supplied_boot: bool,
+) -> bool {
+    config.firecracker.warm_create
+        && config.firecracker.jailer.is_some()
+        && !caller_supplied_boot
+        && spec.network.mode == "tap"
+        && !spec.boot_args.contains("ip=")
+        && spec.mounts.is_empty()
+        && spec.ssh_public_key.is_none()
+}
+
+/// Reject caller-supplied labels that would collide with the reserved
+/// warm-cache label.
+pub(super) fn reject_reserved_labels(labels: &HashMap<String, String>) -> Result<()> {
+    if labels.contains_key(WARM_KEY_LABEL) {
+        return Err(VmmError::Config(format!(
+            "snapshot label {WARM_KEY_LABEL} is reserved for the warm-create cache"
+        )));
+    }
+    Ok(())
+}
+
+/// One published warm snapshot: catalog id, key, and creation time.
+pub(super) struct WarmEntry {
+    pub(super) snapshot_id: String,
+    pub(super) key: String,
+    pub(super) created_at: DateTime<Utc>,
+}
+
+/// Every warm snapshot currently in the catalog.
+pub(super) fn warm_entries(catalog: &SnapshotCatalog) -> Result<Vec<WarmEntry>> {
+    Ok(catalog
+        .list_all()?
+        .into_iter()
+        .filter_map(|snapshot| {
+            snapshot.labels.get(WARM_KEY_LABEL).map(|key| WarmEntry {
+                snapshot_id: snapshot.id,
+                key: key.clone(),
+                created_at: snapshot.created_at,
+            })
+        })
+        .collect())
+}
+
+/// Find the cached snapshot for `key`, newest first.
+///
+/// Publish keeps at most one snapshot per key; preferring the newest makes
+/// the crash window between publishing a replacement and deleting its
+/// predecessor harmless.
+pub(super) fn find_warm_snapshot(
+    catalog: &SnapshotCatalog,
+    key: &WarmKey,
+) -> Result<Option<String>> {
+    Ok(warm_entries(catalog)?
+        .into_iter()
+        .filter(|entry| entry.key == key.hex())
+        .max_by_key(|entry| entry.created_at)
+        .map(|entry| entry.snapshot_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::JailerConfig;
+    use crate::snapshot::SnapshotDraft;
+
+    fn base_fingerprint() -> RootfsFingerprint {
+        RootfsFingerprint {
+            dev: 5,
+            ino: 42,
+            mtime: 1_700_000_000,
+            mtime_nsec: 123,
+            size: 64 << 20,
+        }
+    }
+
+    fn base_spec() -> SandboxSpec {
+        SandboxSpec {
+            kernel: "/run/kernel/vmlinux".into(),
+            rootfs: "/data/rootfs.ext4".into(),
+            boot_args: "console=ttyS0 quiet".into(),
+            vcpus: 2,
+            memory_mib: 512,
+            network: SandboxNetworkSpec { mode: "tap".into() },
+            ..Default::default()
+        }
+    }
+
+    fn warm_config() -> VmmConfig {
+        let mut config = VmmConfig::default();
+        config.firecracker.jailer = Some(JailerConfig {
+            binary: "/usr/bin/jailer".into(),
+            uid: 0,
+            gid: 0,
+            chroot_base_dir: None,
+            netns: None,
+            new_pid_ns: false,
+            cgroup_version: None,
+            parent_cgroup: None,
+            resource_limits: vec![],
+        });
+        config
+    }
+
+    #[test]
+    fn key_is_stable_for_an_identical_shape() {
+        assert_eq!(
+            derive(&base_spec(), base_fingerprint()),
+            derive(&base_spec(), base_fingerprint())
+        );
+    }
+
+    type SpecEdit = Box<dyn Fn(&mut SandboxSpec)>;
+    type FingerprintEdit = Box<dyn Fn(&mut RootfsFingerprint)>;
+
+    #[test]
+    fn key_tracks_every_boot_recipe_and_geometry_field() {
+        let base = derive(&base_spec(), base_fingerprint());
+        let variants: Vec<SpecEdit> = vec![
+            Box::new(|s| s.kernel = "/run/kernel/vmlinux-new".into()),
+            Box::new(|s| s.rootfs = "/data/rootfs-other.ext4".into()),
+            Box::new(|s| s.boot_args.push_str(" debug")),
+            Box::new(|s| s.vcpus = 4),
+            Box::new(|s| s.memory_mib = 1024),
+        ];
+        for mutate in variants {
+            let mut spec = base_spec();
+            mutate(&mut spec);
+            assert_ne!(derive(&spec, base_fingerprint()), base, "{spec:?}");
+        }
+        // Fields outside the boot shape must NOT change the key: labels,
+        // cmd, ttl are per-sandbox, not per-template.
+        let mut spec = base_spec();
+        spec.labels.insert("team".into(), "x".into());
+        spec.cmd = vec!["sleep".into()];
+        spec.ttl_seconds = 60;
+        assert_eq!(derive(&spec, base_fingerprint()), base);
+    }
+
+    #[test]
+    fn key_tracks_every_fingerprint_field() {
+        let base = derive(&base_spec(), base_fingerprint());
+        let variants: Vec<FingerprintEdit> = vec![
+            Box::new(|f| f.dev += 1),
+            Box::new(|f| f.ino += 1),
+            Box::new(|f| f.mtime += 1),
+            Box::new(|f| f.mtime_nsec += 1),
+            Box::new(|f| f.size += 1),
+        ];
+        for mutate in variants {
+            let mut fingerprint = base_fingerprint();
+            mutate(&mut fingerprint);
+            assert_ne!(derive(&base_spec(), fingerprint), base, "{fingerprint:?}");
+        }
+    }
+
+    #[test]
+    fn rebuilding_the_rootfs_in_place_changes_the_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"template v1").unwrap();
+        let mut spec = base_spec();
+        spec.rootfs = rootfs.to_str().unwrap().to_owned();
+
+        let first = derive_warm_key(&spec).unwrap();
+        assert_eq!(derive_warm_key(&spec).unwrap(), first, "stat is stable");
+
+        // The template builder's rebuild discipline: write a sibling, then
+        // rename over the fixed path — same path, new inode.
+        let staging = dir.path().join(".rootfs.tmp");
+        std::fs::write(&staging, b"template v2").unwrap();
+        std::fs::rename(&staging, &rootfs).unwrap();
+        assert_ne!(derive_warm_key(&spec).unwrap(), first);
+    }
+
+    #[test]
+    fn eligibility_requires_the_template_shape() {
+        let config = warm_config();
+        assert!(warm_eligible(&config, &base_spec(), false));
+
+        // A caller-pinned boot recipe opts out even when the effective spec
+        // looks like the defaults.
+        assert!(!warm_eligible(&config, &base_spec(), true));
+
+        let mut no_warm = warm_config();
+        no_warm.firecracker.warm_create = false;
+        assert!(!warm_eligible(&no_warm, &base_spec(), false));
+
+        // Restore needs jailer isolation; direct mode must never checkpoint
+        // a snapshot it cannot restore.
+        assert!(!warm_eligible(&VmmConfig::default(), &base_spec(), false));
+
+        let mut no_net = base_spec();
+        no_net.network.mode = "none".into();
+        assert!(!warm_eligible(&config, &no_net, false));
+
+        let mut explicit_ip = base_spec();
+        explicit_ip.boot_args.push_str(" ip=10.0.0.9::10.0.0.1");
+        assert!(!warm_eligible(&config, &explicit_ip, false));
+
+        let mut mounted = base_spec();
+        mounted.mounts.push(SandboxMountSpec {
+            source: "/src".into(),
+            target: "/dst".into(),
+            readonly: true,
+        });
+        assert!(!warm_eligible(&config, &mounted, false));
+
+        let mut ssh = base_spec();
+        ssh.ssh_public_key = Some("ssh-ed25519 AAAA".into());
+        assert!(!warm_eligible(&config, &ssh, false));
+    }
+
+    #[test]
+    fn reserved_label_is_rejected() {
+        assert!(reject_reserved_labels(&HashMap::new()).is_ok());
+        let mut labels = HashMap::new();
+        labels.insert("env".to_owned(), "prod".to_owned());
+        assert!(reject_reserved_labels(&labels).is_ok());
+        labels.insert(WARM_KEY_LABEL.to_owned(), "deadbeef".to_owned());
+        assert!(reject_reserved_labels(&labels).is_err());
+    }
+
+    fn publish_labeled(catalog: &SnapshotCatalog, vm_id: &str, key: Option<&str>) -> String {
+        let pending = catalog.begin(vm_id).unwrap();
+        std::fs::write(pending.dir().join("vmstate"), b"vmstate").unwrap();
+        let labels = key
+            .map(|key| HashMap::from([(WARM_KEY_LABEL.to_owned(), key.to_owned())]))
+            .unwrap_or_default();
+        pending
+            .commit(SnapshotDraft {
+                name: None,
+                labels,
+                snapshot_type: crate::config::SnapshotType::Full,
+                parent_id: None,
+                kernel_path: None,
+                rootfs_path: None,
+                net_invariant: true,
+            })
+            .unwrap()
+            .id
+    }
+
+    #[test]
+    fn lookup_matches_the_label_and_prefers_the_newest() {
+        let dir = tempfile::tempdir().unwrap();
+        let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
+        let key = WarmKey("aa11".into());
+
+        assert_eq!(find_warm_snapshot(&catalog, &key).unwrap(), None);
+        publish_labeled(&catalog, "box-1", None);
+        publish_labeled(&catalog, "box-1", Some("other-key"));
+        assert_eq!(find_warm_snapshot(&catalog, &key).unwrap(), None);
+
+        let older = publish_labeled(&catalog, "box-1", Some("aa11"));
+        let newer = publish_labeled(&catalog, "box-2", Some("aa11"));
+        let found = find_warm_snapshot(&catalog, &key).unwrap().unwrap();
+        assert_eq!(found, newer);
+        assert_ne!(found, older);
+    }
+}

--- a/virt/arcbox-vm/src/sandbox/warm.rs
+++ b/virt/arcbox-vm/src/sandbox/warm.rs
@@ -42,13 +42,17 @@ impl WarmKey {
     }
 }
 
-/// Content fingerprint of the rootfs file behind a resolved template path.
+/// Content fingerprint of a boot input behind a resolved template path.
 ///
-/// A memory snapshot is only valid against the exact rootfs bytes it booted
-/// from, and template paths are reused across rebuilds — the fingerprint is
-/// what invalidates the cache when the content changes underneath the path.
+/// A memory snapshot is only valid against the exact rootfs and kernel
+/// bytes it booted from, and both paths are reused across rebuilds (the
+/// bundle installer overwrites the kernel in place on a version bump) —
+/// the fingerprints invalidate the cache when content changes underneath a
+/// path. The kernel case is the more dangerous one: the snapshot *is* the
+/// old kernel's memory image, so a stale hit would silently keep
+/// resurrecting the pre-bump kernel.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct RootfsFingerprint {
+pub(super) struct FileFingerprint {
     dev: u64,
     ino: u64,
     mtime: i64,
@@ -56,7 +60,7 @@ pub(super) struct RootfsFingerprint {
     size: u64,
 }
 
-impl RootfsFingerprint {
+impl FileFingerprint {
     fn read(path: &Path) -> std::io::Result<Self> {
         use std::os::unix::fs::MetadataExt;
         let meta = std::fs::metadata(path)?;
@@ -71,13 +75,14 @@ impl RootfsFingerprint {
 }
 
 /// Derive the warm key for an effective (defaults-applied) create spec,
-/// fingerprinting the rootfs file on disk.
+/// fingerprinting the kernel and rootfs files on disk.
 pub(super) fn derive_warm_key(spec: &SandboxSpec) -> std::io::Result<WarmKey> {
-    let fingerprint = RootfsFingerprint::read(Path::new(&spec.rootfs))?;
-    Ok(derive(spec, fingerprint))
+    let kernel = FileFingerprint::read(Path::new(&spec.kernel))?;
+    let rootfs = FileFingerprint::read(Path::new(&spec.rootfs))?;
+    Ok(derive(spec, kernel, rootfs))
 }
 
-fn derive(spec: &SandboxSpec, fingerprint: RootfsFingerprint) -> WarmKey {
+fn derive(spec: &SandboxSpec, kernel: FileFingerprint, rootfs: FileFingerprint) -> WarmKey {
     let mut hasher = Sha256::new();
     // vcpus and memory are part of the key on purpose: a memory snapshot
     // restores only onto identical geometry.
@@ -85,17 +90,18 @@ fn derive(spec: &SandboxSpec, fingerprint: RootfsFingerprint) -> WarmKey {
         hasher.update(text.as_bytes());
         hasher.update([0u8]);
     }
-    for number in [
-        u64::from(spec.vcpus),
-        spec.memory_mib,
-        fingerprint.dev,
-        fingerprint.ino,
-        fingerprint.size,
-    ] {
+    for number in [u64::from(spec.vcpus), spec.memory_mib] {
         hasher.update(number.to_le_bytes());
     }
-    for number in [fingerprint.mtime, fingerprint.mtime_nsec] {
-        hasher.update(number.to_le_bytes());
+    // Field order fixes each fingerprint's position in the digest, so the
+    // kernel and rootfs contributions cannot be confused for one another.
+    for fingerprint in [kernel, rootfs] {
+        for number in [fingerprint.dev, fingerprint.ino, fingerprint.size] {
+            hasher.update(number.to_le_bytes());
+        }
+        for number in [fingerprint.mtime, fingerprint.mtime_nsec] {
+            hasher.update(number.to_le_bytes());
+        }
     }
     WarmKey(format!("{:x}", hasher.finalize()))
 }
@@ -367,8 +373,18 @@ mod tests {
     use crate::config::JailerConfig;
     use crate::snapshot::SnapshotDraft;
 
-    fn base_fingerprint() -> RootfsFingerprint {
-        RootfsFingerprint {
+    fn kernel_fingerprint() -> FileFingerprint {
+        FileFingerprint {
+            dev: 5,
+            ino: 7,
+            mtime: 1_690_000_000,
+            mtime_nsec: 456,
+            size: 9 << 20,
+        }
+    }
+
+    fn base_fingerprint() -> FileFingerprint {
+        FileFingerprint {
             dev: 5,
             ino: 42,
             mtime: 1_700_000_000,
@@ -408,17 +424,17 @@ mod tests {
     #[test]
     fn key_is_stable_for_an_identical_shape() {
         assert_eq!(
-            derive(&base_spec(), base_fingerprint()),
-            derive(&base_spec(), base_fingerprint())
+            derive(&base_spec(), kernel_fingerprint(), base_fingerprint()),
+            derive(&base_spec(), kernel_fingerprint(), base_fingerprint())
         );
     }
 
     type SpecEdit = Box<dyn Fn(&mut SandboxSpec)>;
-    type FingerprintEdit = Box<dyn Fn(&mut RootfsFingerprint)>;
+    type FingerprintEdit = Box<dyn Fn(&mut FileFingerprint)>;
 
     #[test]
     fn key_tracks_every_boot_recipe_and_geometry_field() {
-        let base = derive(&base_spec(), base_fingerprint());
+        let base = derive(&base_spec(), kernel_fingerprint(), base_fingerprint());
         let variants: Vec<SpecEdit> = vec![
             Box::new(|s| s.kernel = "/run/kernel/vmlinux-new".into()),
             Box::new(|s| s.rootfs = "/data/rootfs-other.ext4".into()),
@@ -429,7 +445,11 @@ mod tests {
         for mutate in variants {
             let mut spec = base_spec();
             mutate(&mut spec);
-            assert_ne!(derive(&spec, base_fingerprint()), base, "{spec:?}");
+            assert_ne!(
+                derive(&spec, kernel_fingerprint(), base_fingerprint()),
+                base,
+                "{spec:?}"
+            );
         }
         // Fields outside the boot shape must NOT change the key: labels,
         // cmd, ttl are per-sandbox, not per-template.
@@ -437,12 +457,15 @@ mod tests {
         spec.labels.insert("team".into(), "x".into());
         spec.cmd = vec!["sleep".into()];
         spec.ttl_seconds = 60;
-        assert_eq!(derive(&spec, base_fingerprint()), base);
+        assert_eq!(
+            derive(&spec, kernel_fingerprint(), base_fingerprint()),
+            base
+        );
     }
 
     #[test]
-    fn key_tracks_every_fingerprint_field() {
-        let base = derive(&base_spec(), base_fingerprint());
+    fn key_tracks_every_fingerprint_field_of_both_files() {
+        let base = derive(&base_spec(), kernel_fingerprint(), base_fingerprint());
         let variants: Vec<FingerprintEdit> = vec![
             Box::new(|f| f.dev += 1),
             Box::new(|f| f.ino += 1),
@@ -450,30 +473,60 @@ mod tests {
             Box::new(|f| f.mtime_nsec += 1),
             Box::new(|f| f.size += 1),
         ];
-        for mutate in variants {
+        for mutate in &variants {
             let mut fingerprint = base_fingerprint();
             mutate(&mut fingerprint);
-            assert_ne!(derive(&base_spec(), fingerprint), base, "{fingerprint:?}");
+            assert_ne!(
+                derive(&base_spec(), kernel_fingerprint(), fingerprint),
+                base,
+                "rootfs {fingerprint:?}"
+            );
         }
+        for mutate in &variants {
+            let mut fingerprint = kernel_fingerprint();
+            mutate(&mut fingerprint);
+            assert_ne!(
+                derive(&base_spec(), fingerprint, base_fingerprint()),
+                base,
+                "kernel {fingerprint:?}"
+            );
+        }
+        // Swapping the two fingerprints must not collide: their positions
+        // in the digest are what tells them apart.
+        assert_ne!(
+            derive(&base_spec(), base_fingerprint(), kernel_fingerprint()),
+            base
+        );
     }
 
     #[test]
-    fn rebuilding_the_rootfs_in_place_changes_the_key() {
+    fn rebuilding_a_boot_input_in_place_changes_the_key() {
         let dir = tempfile::tempdir().unwrap();
+        let kernel = dir.path().join("vmlinux");
         let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&kernel, b"kernel v1").unwrap();
         std::fs::write(&rootfs, b"template v1").unwrap();
         let mut spec = base_spec();
+        spec.kernel = kernel.to_str().unwrap().to_owned();
         spec.rootfs = rootfs.to_str().unwrap().to_owned();
 
         let first = derive_warm_key(&spec).unwrap();
         assert_eq!(derive_warm_key(&spec).unwrap(), first, "stat is stable");
 
-        // The template builder's rebuild discipline: write a sibling, then
-        // rename over the fixed path — same path, new inode.
+        // The rebuild discipline for both inputs: write a sibling, then
+        // rename over the fixed path — same path, new inode. The kernel
+        // case is exactly what a bundle version bump does to
+        // runtime/kernel/vmlinux.
         let staging = dir.path().join(".rootfs.tmp");
         std::fs::write(&staging, b"template v2").unwrap();
         std::fs::rename(&staging, &rootfs).unwrap();
-        assert_ne!(derive_warm_key(&spec).unwrap(), first);
+        let second = derive_warm_key(&spec).unwrap();
+        assert_ne!(second, first);
+
+        let staging = dir.path().join(".vmlinux.tmp");
+        std::fs::write(&staging, b"kernel v2").unwrap();
+        std::fs::rename(&staging, &kernel).unwrap();
+        assert_ne!(derive_warm_key(&spec).unwrap(), second);
     }
 
     #[test]

--- a/virt/arcbox-vm/src/sandbox/warm.rs
+++ b/virt/arcbox-vm/src/sandbox/warm.rs
@@ -13,12 +13,18 @@
 //! Lookup scans the catalog for the label; a miss cold-boots and publishes
 //! the snapshot from the freshly Ready guest (see `publish_after_boot`).
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use sha2::{Digest, Sha256};
 
 use super::*;
 use crate::snapshot::SnapshotCatalog;
+
+/// Most distinct warm keys cached at once, mirroring the restore pool's
+/// distinct-snapshot cap. Evicting a key deletes its snapshot (and drains
+/// any pool slots staged from it).
+const MAX_WARM_KEYS: usize = 2;
 
 /// Reserved snapshot label carrying the warm key. The Checkpoint RPC rejects
 /// caller-supplied labels with this name so no caller can plant a cache
@@ -164,6 +170,195 @@ pub(super) fn find_warm_snapshot(
         .filter(|entry| entry.key == key.hex())
         .max_by_key(|entry| entry.created_at)
         .map(|entry| entry.snapshot_id))
+}
+
+/// In-memory cache bookkeeping: key recency for LRU eviction and the
+/// per-key publish single-flight. The durable cache state is the catalog;
+/// this only orders and serializes operations on it, so losing it on
+/// restart costs nothing (untouched keys rank by snapshot age instead).
+#[derive(Default)]
+pub(super) struct WarmCache {
+    inner: Mutex<WarmCacheInner>,
+}
+
+#[derive(Default)]
+struct WarmCacheInner {
+    /// Keys by last use (lookup hit or publish), least recent first.
+    recency: Vec<String>,
+    /// Keys with a publish in flight.
+    publishing: HashSet<String>,
+}
+
+impl WarmCache {
+    /// Record a use of `key`, making it the most recently used.
+    pub(super) fn touch(&self, key: &WarmKey) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.recency.retain(|entry| entry != key.hex());
+        inner.recency.push(key.hex().to_owned());
+    }
+
+    /// Claim the single publish slot for `key`. `false` means another
+    /// first-create is already checkpointing this key — skip, its result
+    /// serves every later create.
+    pub(super) fn begin_publish(&self, key: &WarmKey) -> bool {
+        self.inner
+            .lock()
+            .unwrap()
+            .publishing
+            .insert(key.hex().to_owned())
+    }
+
+    /// Release the publish slot claimed by [`Self::begin_publish`].
+    pub(super) fn end_publish(&self, key: &WarmKey) {
+        self.inner.lock().unwrap().publishing.remove(key.hex());
+    }
+
+    /// Which keys to evict so at most [`MAX_WARM_KEYS`] remain, given every
+    /// distinct key in the catalog with its newest snapshot's creation
+    /// time. Keys never used in this process rank below every used key,
+    /// oldest snapshot first.
+    pub(super) fn plan_evictions(&self, catalog: &[(String, DateTime<Utc>)]) -> Vec<String> {
+        let mut inner = self.inner.lock().unwrap();
+        // Recency only matters for keys that still exist; pruning here also
+        // keeps the list from accumulating deleted keys.
+        inner
+            .recency
+            .retain(|entry| catalog.iter().any(|(key, _)| key == entry));
+        let Some(excess) = catalog.len().checked_sub(MAX_WARM_KEYS).filter(|n| *n > 0) else {
+            return Vec::new();
+        };
+        let mut ranked: Vec<&(String, DateTime<Utc>)> = catalog.iter().collect();
+        // Ascending eviction priority: untouched keys first (oldest
+        // snapshot first), then touched keys least recent first.
+        ranked.sort_by_key(|(key, created_at)| {
+            let recency = inner
+                .recency
+                .iter()
+                .position(|entry| entry == key)
+                .map_or(-1, |position| i64::try_from(position).unwrap_or(i64::MAX));
+            (recency, *created_at)
+        });
+        ranked
+            .into_iter()
+            .take(excess)
+            .map(|(key, _)| key.clone())
+            .collect()
+    }
+}
+
+/// Everything the boot task needs to publish a warm snapshot once its
+/// sandbox reaches Ready (CORE-77).
+pub(super) struct WarmPublishTicket {
+    pub(super) key: WarmKey,
+    pub(super) cache: Arc<WarmCache>,
+    pub(super) snapshots: Arc<SnapshotCatalog>,
+    pub(super) pool: Arc<super::pool::SlotPool>,
+}
+
+/// Publish the warm snapshot for a freshly Ready, still-idle sandbox.
+///
+/// Single-flighted per key, and every failure is a warn — cache population
+/// must never fail a healthy boot.
+pub(super) async fn publish_after_boot(
+    sandbox_id: &SandboxId,
+    ticket: &WarmPublishTicket,
+    instances: &super::InstanceMap,
+    config: &VmmConfig,
+    cow_manager: &CowManager,
+) {
+    if !ticket.cache.begin_publish(&ticket.key) {
+        debug!(
+            sandbox_id,
+            "a warm snapshot publish for this key is already in flight"
+        );
+        return;
+    }
+    let started = std::time::Instant::now();
+    let published = publish_warm_snapshot(sandbox_id, ticket, instances, config, cow_manager).await;
+    ticket.cache.end_publish(&ticket.key);
+    match published {
+        Ok(Some(snapshot_id)) => {
+            let checkpoint_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+            info!(
+                sandbox_id,
+                snapshot_id, checkpoint_ms, "warm template snapshot published"
+            );
+        }
+        Ok(None) => {}
+        Err(error) => {
+            warn!(
+                sandbox_id,
+                %error,
+                "warm snapshot publish failed; later creates keep cold-booting"
+            );
+        }
+    }
+}
+
+/// Checkpoint into the catalog under the warm label, then enforce the cache
+/// shape: one snapshot per key, at most [`MAX_WARM_KEYS`] distinct keys.
+/// Returns `None` when the key was already cached by a concurrent create.
+async fn publish_warm_snapshot(
+    sandbox_id: &SandboxId,
+    ticket: &WarmPublishTicket,
+    instances: &super::InstanceMap,
+    config: &VmmConfig,
+    cow_manager: &CowManager,
+) -> Result<Option<String>> {
+    // A concurrent first-create may have published while this guest booted.
+    if warm_entries(&ticket.snapshots)?
+        .iter()
+        .any(|entry| entry.key == ticket.key.hex())
+    {
+        return Ok(None);
+    }
+
+    let name = format!("warm-{}", &ticket.key.hex()[..12]);
+    let labels = HashMap::from([(WARM_KEY_LABEL.to_owned(), ticket.key.hex().to_owned())]);
+    let info = super::checkpoint::checkpoint_impl(
+        instances,
+        &ticket.snapshots,
+        config,
+        sandbox_id,
+        name,
+        labels,
+    )
+    .await?;
+    ticket.cache.touch(&ticket.key);
+
+    // Everything superseded is deleted, draining its pre-warmed pool slots
+    // first (mirrors delete_checkpoint): older snapshots of this key — a
+    // crash-window leftover — and every snapshot of an evicted key.
+    let entries = warm_entries(&ticket.snapshots)?;
+    let mut newest: HashMap<String, DateTime<Utc>> = HashMap::new();
+    for entry in &entries {
+        newest
+            .entry(entry.key.clone())
+            .and_modify(|at| *at = (*at).max(entry.created_at))
+            .or_insert(entry.created_at);
+    }
+    let keys: Vec<(String, DateTime<Utc>)> = newest.into_iter().collect();
+    let evicted = ticket.cache.plan_evictions(&keys);
+    for entry in entries {
+        let replaced = entry.key == ticket.key.hex() && entry.snapshot_id != info.snapshot_id;
+        if replaced || evicted.contains(&entry.key) {
+            super::pool::drain_pool_slots(
+                &ticket.pool,
+                config,
+                cow_manager,
+                Some(&entry.snapshot_id),
+            )
+            .await;
+            if let Err(error) = ticket.snapshots.delete_by_id(&entry.snapshot_id) {
+                warn!(
+                    snapshot_id = %entry.snapshot_id,
+                    %error,
+                    "failed to delete a superseded warm snapshot"
+                );
+            }
+        }
+    }
+    Ok(Some(info.snapshot_id))
 }
 
 #[cfg(test)]
@@ -347,6 +542,62 @@ mod tests {
             })
             .unwrap()
             .id
+    }
+
+    #[test]
+    fn publish_is_single_flighted_per_key() {
+        let cache = WarmCache::default();
+        let key_a = WarmKey("aa".into());
+        let key_b = WarmKey("bb".into());
+
+        assert!(cache.begin_publish(&key_a));
+        assert!(!cache.begin_publish(&key_a), "second publisher must skip");
+        assert!(cache.begin_publish(&key_b), "keys single-flight separately");
+        cache.end_publish(&key_a);
+        assert!(cache.begin_publish(&key_a), "slot frees on end_publish");
+    }
+
+    fn at(seconds: i64) -> DateTime<Utc> {
+        DateTime::from_timestamp(seconds, 0).unwrap()
+    }
+
+    #[test]
+    fn evictions_keep_the_cap_and_respect_recency() {
+        let cache = WarmCache::default();
+        let catalog = vec![
+            ("a".to_owned(), at(100)),
+            ("b".to_owned(), at(200)),
+            ("c".to_owned(), at(300)),
+        ];
+
+        // Within the cap: nothing to evict.
+        assert!(cache.plan_evictions(&catalog[..2]).is_empty());
+
+        // No recency recorded: the oldest snapshot goes.
+        assert_eq!(cache.plan_evictions(&catalog), vec!["a".to_owned()]);
+
+        // Touching the oldest protects it; the untouched oldest goes.
+        cache.touch(&WarmKey("a".into()));
+        assert_eq!(cache.plan_evictions(&catalog), vec!["b".to_owned()]);
+
+        // Touched keys outrank untouched ones, least recently used first.
+        cache.touch(&WarmKey("b".into()));
+        cache.touch(&WarmKey("c".into()));
+        assert_eq!(cache.plan_evictions(&catalog), vec!["a".to_owned()]);
+    }
+
+    #[test]
+    fn evictions_ignore_recency_of_deleted_keys() {
+        let cache = WarmCache::default();
+        cache.touch(&WarmKey("gone".into()));
+        let catalog = vec![
+            ("a".to_owned(), at(100)),
+            ("b".to_owned(), at(200)),
+            ("c".to_owned(), at(300)),
+        ];
+        // "gone" is not in the catalog, so it neither protects anything nor
+        // shows up as a victim.
+        assert_eq!(cache.plan_evictions(&catalog), vec!["a".to_owned()]);
     }
 
     #[test]

--- a/virt/arcbox-vm/tests/e2e.rs
+++ b/virt/arcbox-vm/tests/e2e.rs
@@ -62,6 +62,8 @@ fn try_config(data_dir: &str) -> Option<VmmConfig> {
             // Direct mode cannot restore (and so never pools); keep the
             // e2e run free of background pre-warm spawns regardless.
             pool_size: 0,
+            // Direct mode is warm-ineligible anyway; keep it explicit.
+            warm_create: false,
         },
         network: NetworkConfig {
             cidr: "172.99.0.0/24".into(),


### PR DESCRIPTION
Stacked on #568 (← #567 ← master); merge in order. Closes CORE-77, project **Sandbox Cold Start**. **This is the layer that turns the campaign's restore-path work into the number an ordinary `Create` user sees.**

## What

`CreateSandbox` now transparently restores from a warm snapshot when one exists for the request's boot shape, instead of cold-booting a kernel. First create of a shape cold-boots and auto-checkpoints (while the guest is still idle, before the initial `cmd`); every later create restores.

- **Warm key**: SHA-256 over resolved kernel path, rootfs path, boot args, **vcpus + memory_mib** (a memory snapshot only restores onto identical geometry) and the rootfs file fingerprint `(dev, ino, mtime, size)` — so a rebuilt default template (temp+rename ⇒ new inode) invalidates automatically, and content-addressed docker templates key naturally.
- **Cache**: ordinary catalog snapshots carrying a reserved `arcbox.warm_key` label (the Checkpoint RPC rejects caller-supplied ones, so nobody can plant an entry). One snapshot per key, at most 2 keys (LRU, mirroring the pool cap), publishes single-flighted per key.
- **Eligibility**: `firecracker.warm_create` (new knob, default true) + jailer mode + no caller kernel/boot_args override + TAP networking + no `ip=`/mounts/ssh key. Anything else cold-boots with no cache interaction.
- **Event contract preserved**: the warm path emits CREATED then READY for the sandbox id in the same order a boot does, both before Create returns, and `run_initial_cmd` still runs after Ready.

## The bug this PR's own hardware validation caught

The first version published the snapshot *after* the READY event. Checkpointing pauses the guest, so a client acting on READY the instant it arrived hit the pause with an execution and hung — the probe's first command timed out on the very create that published. Fixed by publishing before the announcement (own commit): READY promises the sandbox accepts executions, so it must not fire while the guest is about to stop answering.

## Hardware-validated (full stack #567+#568+this)

Probe's **networked create** group — the ordinary user path:

| | before | after |
|---|---|---|
| create → READY p50 | ~1.13 s | **26 ms** |
| create → first command output p50 | ~1.19 s | **207 ms** |

First create of a shape stays cold (~2.35 s including the ~590 ms checkpoint). The `no-network` group is warm-ineligible by design and still cold-boots, which is the control. Full sandbox smoke green (non-eligible shapes, restore modes, expose, docker template).

## Validation

`cargo fmt`; clippy clean on host + musl bins; `cargo test -p arcbox-vm` 167 green (+11: key sensitivity, eligibility matrix, single-flight, LRU, catalog lookup, config knob). No proto changes — the escape hatch is `warm_create = false`.

Note for SDK owners: `CreateSandboxResponse.state` still reports `starting` on a warm hit (service layer hardcodes it); events and Inspect carry the truth.