### PR TITLE
chore(assets): pin boot assets 0.8.4 with the two-arch microvm kernel

### DIFF
--- a/assets.lock
+++ b/assets.lock
@@ -14,9 +14,9 @@
 # and the [boot] bump.
 
 [boot]
-version = "0.8.2"
+version = "0.8.4"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "0bf2db1815abc8ebc7291eff94199dfaa0e3a5af8e6a9cd160657f005725a431"
+manifest_sha256 = "fc32a0b6d1c1051a0eeea81d714f38cdfc108000f883a8d6c261cce993c2af89"
 
 [[tools]]
 name = "docker"


### PR DESCRIPTION
Closes the CORE-79 release train on the arcbox side: boot bundle **0.8.4** carries kernel **v0.0.24** for both microVM arches.

- **x86_64**: the arcbox `microvm` flavor replaces the stock FC CI kernel (hardware-reduced ACPI boot, DSDT-enumerated virtio-mmio, **requires Firecracker ≥ 1.8**) — prep for sandboxes on bare-metal Linux and the platform PaaS fleet (platform#141 adopts the same kernel in bootkit).
- **arm64**: same release's rebuild (sha `661246ed…`), byte-different from 0.8.2's kernel, functionally identical.
- **v0.8.3 is skipped/poisoned**: the kernel release's automatic `repository_dispatch` rebuild raced the boot-assets pin PR and published v0.8.3 to the immutable CDN path with stale 0.0.23 pins, so its CDN and GitHub release contents disagree (details in boot-assets#50 comments). CDN↔GH manifest equality for 0.8.4 verified before this pin (`fc32a0b6…` on both).

**Hardware-validated** (cold-start probe, 6 iters, prod download path via `abctl boot prefetch`): warm create 29 ms READY / 172 ms first exec, restore RPC 27 ms / first exec 137 ms, cold 656 ms, warm exec 14-17 ms — all at baseline.