### PR TITLE
ci(sdk): OIDC publish workflows for @arcbox/sandbox and arcbox

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,7 @@ jobs:
 
       # uv, for the sdk/python lockfile refresh in the next step. Pinned so
       # the job that pushes to release branches fetches nothing mutable.
-      - uses: astral-sh/setup-uv@v9
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.12.1"
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,14 +28,25 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ steps.app-token.outputs.token }}
 
-      # Regenerate Cargo.lock on every open release PR so its release tag
-      # can build with --locked. The release-please `prs` output only
+      # uv, for the sdk/python lockfile refresh in the next step. Pinned so
+      # the job that pushes to release branches fetches nothing mutable.
+      - uses: astral-sh/setup-uv@v9
+        with:
+          version: "0.12.1"
+
+      # Regenerate the lockfiles on every open release PR so its release tag
+      # can build with --locked. Two of them: Cargo.lock carries every
+      # workspace member's version, and sdk/python/uv.lock carries the root
+      # `arcbox` version that release-please bumps in pyproject.toml.
+      # Neither updater touches its own lockfile, so without this the tagged
+      # tree is rejected by --locked and the release never reaches publish.
+      # The release-please `prs` output only
       # includes PRs created or updated during the current run. Discovery
       # must use the REST list endpoint with client-side label filtering:
       # a label-filtered `gh pr list` routes through the eventually
       # consistent search API and misses PRs release-please created
       # seconds earlier in this same run.
-      - name: Update Cargo.lock on release PRs
+      - name: Update lockfiles on release PRs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -48,18 +59,21 @@ jobs:
           while read -r pr; do
             PR_BRANCH=$(jq -r '.headRefName' <<< "$pr")
             PR_NUMBER=$(jq -r '.number' <<< "$pr")
-            echo "::group::Update Cargo.lock for PR #${PR_NUMBER} (${PR_BRANCH})"
+            echo "::group::Update lockfiles for PR #${PR_NUMBER} (${PR_BRANCH})"
             workdir=$(mktemp -d)
             git clone --depth 1 --branch "$PR_BRANCH" \
               "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$workdir"
             (
               cd "$workdir"
               cargo update --workspace
-              if git diff --quiet Cargo.lock; then
-                echo "Cargo.lock already up to date"
+              # Plain `uv lock` (never --upgrade): with no dependency edits
+              # it rewrites only the root version line release-please moved.
+              (cd sdk/python && uv lock)
+              if git diff --quiet Cargo.lock sdk/python/uv.lock; then
+                echo "lockfiles already up to date"
               else
-                git add Cargo.lock
-                git commit -m "chore: update Cargo.lock for release"
+                git add Cargo.lock sdk/python/uv.lock
+                git commit -m "chore: update lockfiles for release"
                 git push
               fi
             )

--- a/.github/workflows/release-sdk-python.yml
+++ b/.github/workflows/release-sdk-python.yml
@@ -7,7 +7,8 @@ name: SDK Python Release
 # release-please-config.json).
 #
 # Publishing uses PyPI trusted publishing (OIDC): no token — the job's
-# id-token permission lets uv mint a workflow-scoped credential. Unlike
+# id-token permission mints a workflow-scoped credential, and the upload
+# carries PEP 740 attestations. Unlike
 # npm, PyPI supports PENDING trusted publishers, so the publisher is
 # registered before the first upload and CI performs the first publish —
 # no local bootstrap: see sdk/python/README.md "Releasing".
@@ -44,9 +45,15 @@ jobs:
       - name: Determine tag
         id: tag
         working-directory: .
+        # The dispatch input arrives through the environment, never spliced
+        # into the script body: template expansion happens before bash runs,
+        # so a `case` guard on an already-interpolated string cannot protect
+        # the assignment itself. This job holds `id-token: write`.
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+            TAG="$INPUT_TAG"
           else
             TAG="${GITHUB_REF#refs/tags/}"
           fi
@@ -104,16 +111,19 @@ jobs:
             echo "published=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # --frozen, not --locked: release-please bumps the version in
-      # pyproject.toml but not the root entry uv.lock carries for the same
-      # package, so at a release tag the two legitimately disagree and
-      # --locked refuses to install ("the lockfile needs to be updated"),
-      # failing every release before it reaches the tests. --frozen installs
-      # the locked dependency set as-is; the root package still builds at
-      # the tag's pyproject version, which is what gets published.
+      # --locked is load-bearing: it is the only check that the resolved
+      # dependency set the gates run against is the one the published wheel
+      # declares. release-please bumps pyproject.toml without touching the
+      # root entry in uv.lock, which would make this fail — so the release
+      # PR job refreshes uv.lock the same way it already refreshes
+      # Cargo.lock (`release-please.yml`, "Update lockfiles on release
+      # PRs"). Relaxing this to --frozen instead would let an unlocked
+      # dependency edit ship: gates green against the old resolution, wheel
+      # declaring the new constraint. The Rust half of this repo made that
+      # trade once and reverted it.
       - name: Install dependencies
         if: steps.registry.outputs.published != 'true'
-        run: uv sync --frozen
+        run: uv sync --locked
 
       - name: Lint
         if: steps.registry.outputs.published != 'true'
@@ -139,10 +149,16 @@ jobs:
         if: steps.registry.outputs.published != 'true'
         run: uv build
 
-      # uv auto-detects trusted publishing in GitHub Actions (its GitHub
-      # integration guide runs a bare `uv publish`); `always` makes the
-      # OIDC exchange mandatory so a broken exchange fails loudly instead
-      # of falling back to hunting for ambient credentials.
+      # pypa/gh-action-pypi-publish rather than `uv publish`: both publish
+      # through the same OIDC trusted-publisher exchange, but uv emits no
+      # PEP 740 attestations ("attestations must be created separately
+      # before publishing", astral-sh/uv#15618) while this action signs the
+      # distributions by default. Without it the two SDKs would ship
+      # materially different supply-chain guarantees — npm trusted
+      # publishing attaches provenance to @arcbox/sandbox automatically.
+      # Pinned by commit: it runs in the job that mints publish credentials.
       - name: Publish to PyPI
         if: steps.registry.outputs.published != 'true'
-        run: uv publish --trusted-publishing always
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: sdk/python/dist

--- a/.github/workflows/release-sdk-python.yml
+++ b/.github/workflows/release-sdk-python.yml
@@ -1,0 +1,141 @@
+name: SDK Python Release
+
+# Publishes arcbox (the Python SDK) to PyPI on its own cadence,
+# independent of the main arcbox release train — mirrors
+# release-sdk-typescript.yml. The tag is minted by release-please when
+# the sdk-python component's release PR merges (see
+# release-please-config.json).
+#
+# Publishing uses PyPI trusted publishing (OIDC): no token — the job's
+# id-token permission lets uv mint a workflow-scoped credential. Unlike
+# npm, PyPI supports PENDING trusted publishers, so the publisher is
+# registered before the first upload and CI performs the first publish —
+# no local bootstrap: see sdk/python/README.md "Releasing".
+
+on:
+  push:
+    tags:
+      - 'sdk-python-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. sdk-python-v0.1.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish arcbox to PyPI
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # Required for PyPI trusted publishing: lets the job mint the OIDC
+      # token PyPI exchanges for a publish credential.
+      id-token: write
+    defaults:
+      run:
+        working-directory: sdk/python
+
+    steps:
+      - name: Determine tag
+        id: tag
+        working-directory: .
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          case "$TAG" in
+            sdk-python-v*) ;;
+            *)
+              echo "::error::tag '$TAG' does not match sdk-python-v*"
+              exit 1
+              ;;
+          esac
+          VERSION="${TAG#sdk-python-v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing $TAG (PyPI version $VERSION)"
+
+      # Check out the tag being released, not the dispatching ref — a
+      # workflow_dispatch from master must still publish the tag's tree,
+      # or the published distribution would not match the release.
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      # uv pinned to the same range as pyproject.toml's uv_build
+      # requirement; uv sync provisions the interpreter pinned by
+      # sdk/python/.python-version.
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v9
+        with:
+          version: '>=0.12.1,<0.13'
+          enable-cache: true
+          cache-dependency-glob: sdk/python/uv.lock
+
+      - name: Verify tag matches pyproject.toml
+        run: |
+          PKG_VERSION=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          if [ "$PKG_VERSION" != "${{ steps.tag.outputs.version }}" ]; then
+            echo "::error::pyproject.toml version ($PKG_VERSION) != tag version (${{ steps.tag.outputs.version }})"
+            exit 1
+          fi
+
+      # Idempotency: a re-dispatch (or a re-delivered tag event) must not
+      # fail on an already-published release — PyPI rejects re-uploading
+      # a version, so skip cleanly instead (same lesson as the npm and
+      # crates.io publish paths).
+      - name: Check PyPI for existing version
+        id: registry
+        run: |
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+            "https://pypi.org/pypi/arcbox/${{ steps.tag.outputs.version }}/json")
+          if [ "$STATUS" = "200" ]; then
+            echo "::notice::arcbox ${{ steps.tag.outputs.version }} already on PyPI; skipping publish"
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.registry.outputs.published != 'true'
+        run: uv sync --locked
+
+      - name: Lint
+        if: steps.registry.outputs.published != 'true'
+        run: uv run ruff check .
+
+      - name: Format check
+        if: steps.registry.outputs.published != 'true'
+        run: uv run ruff format --check .
+
+      - name: Typecheck
+        if: steps.registry.outputs.published != 'true'
+        run: uv run pyright
+
+      - name: Sync-tree lockstep check
+        if: steps.registry.outputs.published != 'true'
+        run: uv run python scripts/gen_sync.py --check
+
+      - name: Test
+        if: steps.registry.outputs.published != 'true'
+        run: uv run pytest
+
+      - name: Build
+        if: steps.registry.outputs.published != 'true'
+        run: uv build
+
+      # uv auto-detects trusted publishing in GitHub Actions (its GitHub
+      # integration guide runs a bare `uv publish`); `always` makes the
+      # OIDC exchange mandatory so a broken exchange fails loudly instead
+      # of falling back to hunting for ambient credentials.
+      - name: Publish to PyPI
+        if: steps.registry.outputs.published != 'true'
+        run: uv publish --trusted-publishing always

--- a/.github/workflows/release-sdk-python.yml
+++ b/.github/workflows/release-sdk-python.yml
@@ -73,19 +73,23 @@ jobs:
       # workflow_dispatch from master must still publish the tag's tree,
       # or the published distribution would not match the release.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ steps.tag.outputs.tag }}
+          # This job mints a publish credential; never leave the repo token
+          # persisted on disk beside it.
+          persist-credentials: false
 
       # uv pinned to the same range as pyproject.toml's uv_build
       # requirement; uv sync provisions the interpreter pinned by
       # sdk/python/.python-version.
       - name: Setup uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: '>=0.12.1,<0.13'
-          enable-cache: true
-          cache-dependency-glob: sdk/python/uv.lock
+          # No cache restore: a publish job must resolve from the lockfile
+          # alone, not from a cache another workflow could have poisoned.
+          enable-cache: false
 
       - name: Verify tag matches pyproject.toml
         run: |

--- a/.github/workflows/release-sdk-python.yml
+++ b/.github/workflows/release-sdk-python.yml
@@ -104,9 +104,16 @@ jobs:
             echo "published=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # --frozen, not --locked: release-please bumps the version in
+      # pyproject.toml but not the root entry uv.lock carries for the same
+      # package, so at a release tag the two legitimately disagree and
+      # --locked refuses to install ("the lockfile needs to be updated"),
+      # failing every release before it reaches the tests. --frozen installs
+      # the locked dependency set as-is; the root package still builds at
+      # the tag's pyproject version, which is what gets published.
       - name: Install dependencies
         if: steps.registry.outputs.published != 'true'
-        run: uv sync --locked
+        run: uv sync --frozen
 
       - name: Lint
         if: steps.registry.outputs.published != 'true'

--- a/.github/workflows/release-sdk-typescript.yml
+++ b/.github/workflows/release-sdk-typescript.yml
@@ -72,16 +72,19 @@ jobs:
       # workflow_dispatch from master must still publish the tag's tree,
       # or the published package would not match the release.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ steps.tag.outputs.tag }}
+          # This job mints a publish credential; never leave the repo token
+          # persisted on disk beside it.
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0  # zizmor: ignore[cache-poisoning] -- setup-node caching is opt-in via the cache input, which this step does not set
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: sdk/typescript/package-lock.json
+          # No cache restore: a publish job must build from the lockfile
+          # alone, not from a cache another workflow could have poisoned.
 
       # Trusted publishing requires npm >= 11.5.1 (Node 22 bundles 10.x).
       - name: Update npm for trusted publishing

--- a/.github/workflows/release-sdk-typescript.yml
+++ b/.github/workflows/release-sdk-typescript.yml
@@ -1,0 +1,138 @@
+name: SDK TypeScript Release
+
+# Publishes @arcbox/sandbox to npm on its own cadence, independent of the
+# main arcbox release train — mirrors release-fleet-agent.yml. The tag is
+# minted by release-please when the sdk-typescript component's release PR
+# merges (see release-please-config.json).
+#
+# Publishing uses npm trusted publishing (OIDC): no NPM_TOKEN secret, no
+# registry-url wiring — the job's id-token permission lets npm mint a
+# workflow-scoped credential, and provenance attestations are generated
+# automatically. One-time bootstrap (first publish is local, then the
+# Trusted Publisher is configured on npmjs.com pointing at this workflow
+# file): see sdk/typescript/README.md "Releasing".
+
+on:
+  push:
+    tags:
+      - 'sdk-typescript-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. sdk-typescript-v0.1.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish @arcbox/sandbox to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # Required for npm trusted publishing: lets the job mint the OIDC
+      # token npm exchanges for a publish credential.
+      id-token: write
+    defaults:
+      run:
+        working-directory: sdk/typescript
+
+    steps:
+      - name: Determine tag
+        id: tag
+        working-directory: .
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          case "$TAG" in
+            sdk-typescript-v*) ;;
+            *)
+              echo "::error::tag '$TAG' does not match sdk-typescript-v*"
+              exit 1
+              ;;
+          esac
+          VERSION="${TAG#sdk-typescript-v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing $TAG (npm version $VERSION)"
+
+      # Check out the tag being released, not the dispatching ref — a
+      # workflow_dispatch from master must still publish the tag's tree,
+      # or the published package would not match the release.
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      # Trusted publishing requires npm >= 11.5.1 (Node 22 bundles 10.x).
+      - name: Update npm for trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+
+      - name: Verify tag matches package.json
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_VERSION" != "${{ steps.tag.outputs.version }}" ]; then
+            echo "::error::package.json version ($PKG_VERSION) != tag version (${{ steps.tag.outputs.version }})"
+            exit 1
+          fi
+
+      # Idempotency: a re-dispatch (or a re-delivered tag event) must not
+      # fail on an already-published release — npm rejects republishing a
+      # version, so skip cleanly instead (same lesson as the crates.io
+      # publish retry in release.yml).
+      - name: Check registry for existing version
+        id: registry
+        run: |
+          STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+            "https://registry.npmjs.org/@arcbox%2fsandbox/${{ steps.tag.outputs.version }}")
+          if [ "$STATUS" = "200" ]; then
+            echo "::notice::@arcbox/sandbox@${{ steps.tag.outputs.version }} already on the registry; skipping publish"
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.registry.outputs.published != 'true'
+        run: npm ci
+
+      - name: Lint
+        if: steps.registry.outputs.published != 'true'
+        run: npm run lint
+
+      - name: Format check
+        if: steps.registry.outputs.published != 'true'
+        run: npm run format:check
+
+      - name: Typecheck
+        if: steps.registry.outputs.published != 'true'
+        run: npm run typecheck
+
+      - name: Test
+        if: steps.registry.outputs.published != 'true'
+        run: npm test
+
+      - name: Build
+        if: steps.registry.outputs.published != 'true'
+        run: npm run build:publish
+
+      # No --provenance: trusted publishing generates provenance
+      # attestations by default. No NODE_AUTH_TOKEN: OIDC replaces it.
+      - name: Publish to npm
+        if: steps.registry.outputs.published != 'true'
+        run: npm publish --access public

--- a/.github/workflows/release-sdk-typescript.yml
+++ b/.github/workflows/release-sdk-typescript.yml
@@ -44,9 +44,15 @@ jobs:
       - name: Determine tag
         id: tag
         working-directory: .
+        # The dispatch input arrives through the environment, never spliced
+        # into the script body: template expansion happens before bash runs,
+        # so a `case` guard on an already-interpolated string cannot protect
+        # the assignment itself. This job holds `id-token: write`.
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+            TAG="$INPUT_TAG"
           else
             TAG="${GITHUB_REF#refs/tags/}"
           fi
@@ -80,7 +86,7 @@ jobs:
       # Trusted publishing requires npm >= 11.5.1 (Node 22 bundles 10.x).
       - name: Update npm for trusted publishing
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11.5.1
           npm --version
 
       - name: Verify tag matches package.json
@@ -133,6 +139,12 @@ jobs:
 
       # No --provenance: trusted publishing generates provenance
       # attestations by default. No NODE_AUTH_TOKEN: OIDC replaces it.
+      # --ignore-scripts so the tarball is the artifact the steps above
+      # built and tested. package.json's prepublishOnly re-runs
+      # `rm -rf dist && bunchee` plus the whole suite inside publish, which
+      # would discard the validated dist/ and ship a rebuild nothing
+      # checked — the gate-then-build-then-publish shape only means
+      # something if the published bytes are the gated bytes.
       - name: Publish to npm
         if: steps.registry.outputs.published != 'true'
-        run: npm publish --access public
+        run: npm publish --access public --ignore-scripts

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -116,10 +116,10 @@ ARCBOX_SDK_E2E=1 uv run pytest tests/test_e2e.py
 ## Toolchain notes
 
 - **uv** is the package/project manager (`uv_build` backend, `uv.lock`
-  committed). Publishing is CI-only: `uv build && uv publish` under
-  PyPI trusted publishing (OIDC) — see [Releasing](#releasing), which
-  also covers the workflow still being absent; no `UV_PUBLISH_TOKEN`
-  anywhere.
+  committed). Publishing is CI-only: `uv build`, then upload via
+  `pypa/gh-action-pypi-publish` under PyPI trusted publishing (OIDC,
+  with PEP 740 attestations — `uv publish` emits none, astral-sh/uv#15618)
+  — see [Releasing](#releasing); no `UV_PUBLISH_TOKEN` anywhere.
 - **ruff** is both linter and formatter (`E,F,W,I,UP,B,SIM,RUF`).
 - **pyright** (strict) is the authoritative type checker. Evaluated
   alternatives (2026-08): **ty** 0.0.65 reports 16 false positives here
@@ -158,25 +158,20 @@ of the main arcbox release train:
    (`.github/workflows/release-sdk-python.yml`) triggers on: it checks
    out the tag's tree, re-runs the full gate suite (`ruff check`, `ruff
    format --check`, `pyright`, `pytest`, `gen_sync.py --check`), builds
-   with `uv build`, and publishes with `uv publish` via [trusted
-   publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) —
+   with `uv build`, and publishes via `pypa/gh-action-pypi-publish` under
+   [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC,
+   PEP 740 attestations included) —
    tokenless: the job's `id-token: write` permission is exchanged for a
    short-lived PyPI credential. The job skips cleanly if the version is
    already on PyPI, so a re-dispatch never fails on an
    already-published release.
 
-> **The publish workflow is not in the repo yet.** Registering the
-> component (this change) and adding the workflow are separate pushes —
-> a workflow file needs a token carrying the `workflow` scope. Until
-> `release-sdk-python.yml` lands, step 4 does not happen: release-please
-> still mints `sdk-python-vX.Y.Z` and the GitHub release, but nothing
-> uploads to PyPI, and adding the workflow later does **not** replay the
-> missed tag push. So land the workflow before cutting the first
-> release: a hand publish would need an API token, which is the one
-> thing the pending-publisher bootstrap below exists to avoid. If a tag
-> does get minted early, the recovery is to re-dispatch the workflow
-> against that existing tag once it lands — it takes a tag as a
-> `workflow_dispatch` input for exactly this — not to publish by hand.
+> A tag minted while the publish workflow was absent (or a tag whose
+> run failed) is **not replayed** by a later push — re-dispatch the
+> workflow against the existing tag instead (it takes the tag as a
+> `workflow_dispatch` input), never publish by hand: a hand publish
+> would need an API token, which the pending-publisher bootstrap below
+> exists to avoid.
 
 One-time bootstrap — unlike npm, PyPI supports [pending
 publishers](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/):

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -106,17 +106,10 @@ of the main arcbox release train:
    registry, so a re-dispatch never fails on an already-published
    release.
 
-> **The publish workflow is not in the repo yet.** Registering the
-> component (this change) and adding the workflow are separate pushes —
-> a workflow file needs a token carrying the `workflow` scope. Until
-> `release-sdk-typescript.yml` lands, step 4 does not happen:
-> release-please still mints `sdk-typescript-vX.Y.Z` and the GitHub
-> release, but nothing publishes to npm, and adding the workflow later
-> does **not** replay the missed tag push. So a version tagged before
-> the workflow lands must be published by hand (step 1 of the bootstrap
-> below, which is a manual `npm publish` regardless), or the workflow
-> re-dispatched against the existing tag once it exists — it takes a tag
-> as a `workflow_dispatch` input for exactly this.
+> A tag minted while the publish workflow was absent (or a tag whose
+> run failed) is **not replayed** by a later push — re-dispatch the
+> workflow against the existing tag instead: it takes the tag as a
+> `workflow_dispatch` input for exactly this.
 
 One-time bootstrap (trusted publishing can only be configured for a
 package that already exists on the registry):


### PR DESCRIPTION
Adds the two tag-triggered SDK publish workflows that could not land with the SDK PRs (the OAuth token used there lacks `workflow` scope; pushed over SSH now).

- `release-sdk-typescript.yml` — fires on `sdk-typescript-v*`, guards tag↔package.json version, pre-checks the npm registry for an already-published version (clean skip), runs the full gate suite, `bunchee` build, then publishes via **npm trusted publishing** (OIDC, `id-token: write`, no NODE_AUTH_TOKEN; provenance automatic).
- `release-sdk-python.yml` — fires on `sdk-python-v*`, guards tag↔pyproject version, pre-checks PyPI, `astral-sh/setup-uv`, gates (ruff/pyright/pytest/gen_sync lockstep), `uv build`, then `uv publish --trusted-publishing always`.

Both take `workflow_dispatch` with an explicit tag for manual re-runs.

Bootstrap prerequisites (one-time, outside this repo): npm needs the `@arcbox` org plus a first local publish before a Trusted Publisher can be configured; PyPI accepts a **pending** publisher for `arcbox` so CI can do its first publish. Both documented in the SDK READMEs.

Superseded and dropped: the parked `fix/release-publish-skip-existing` crates.io fix — master already handles the already-published case, and better (it parses the failure and resumes with that member excluded, retrying only on 429).