### PR TITLE
fix(cli): harden production UX (CORE-96, CORE-97, CORE-99, CORE-100, CORE-101)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ dependencies = [
  "arcbox-core",
  "arcbox-docker",
  "arcbox-error",
+ "arcbox-transport",
  "async-stream",
  "base64",
  "buffa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ dependencies = [
 name = "arcbox-cli"
 version = "0.6.3"
 dependencies = [
+ "anstream",
  "anyhow",
  "arcbox-asset",
  "arcbox-connect",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "ifbridge",
  "libc",
  "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -6029,9 +6030,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",

--- a/app/arcbox-api/Cargo.toml
+++ b/app/arcbox-api/Cargo.toml
@@ -27,6 +27,7 @@ arcbox-connect.workspace = true
 connectrpc = { git = "https://github.com/connectrpc/connect-rust", rev = "c5c1a6faa5d7f4d681662731db61e1fbe7796eec", version = "0.8.1" }
 buffa = { version = "0.9.1", features = ["json"] }
 buffa-types = { version = "0.9.1", features = ["json"] }
+arcbox-transport.workspace = true
 
 [dev-dependencies]
 base64 = "0.22.1"

--- a/app/arcbox-api/src/connect/machine.rs
+++ b/app/arcbox-api/src/connect/machine.rs
@@ -10,6 +10,8 @@ use connectrpc::{
 };
 use tokio_stream::StreamExt as _;
 
+use crate::error::ApiError;
+
 use super::SharedRuntime;
 
 use super::ConnectRuntimeExt as _;
@@ -164,7 +166,7 @@ impl pb::MachineService for MachineServiceImpl {
             .machine_manager()
             .create(config)
             .await
-            .map_err(|e| ConnectError::internal(e.to_string()))?;
+            .map_err(ApiError::from)?;
 
         Response::ok(pb::CreateMachineResponse {
             id: req.name,
@@ -184,7 +186,7 @@ impl pb::MachineService for MachineServiceImpl {
             .machine_manager()
             .start(&id)
             .await
-            .map_err(|e| ConnectError::internal(e.to_string()))?;
+            .map_err(ApiError::from)?;
 
         Response::ok(pb::Empty::default())
     }
@@ -224,7 +226,7 @@ impl pb::MachineService for MachineServiceImpl {
         })
         .await
         .map_err(|e| ConnectError::internal(format!("stop task panicked: {e}")))?
-        .map_err(|e| ConnectError::internal(e.to_string()))?;
+        .map_err(ApiError::from)?;
 
         Response::ok(pb::Empty::default())
     }
@@ -240,7 +242,7 @@ impl pb::MachineService for MachineServiceImpl {
         runtime
             .machine_manager()
             .remove(&req.id, req.force)
-            .map_err(|e| ConnectError::internal(e.to_string()))?;
+            .map_err(ApiError::from)?;
 
         Response::ok(pb::Empty::default())
     }
@@ -370,11 +372,8 @@ impl pb::MachineService for MachineServiceImpl {
             .runtime
             .ready()?
             .get_agent(&id)
-            .map_err(|e| ConnectError::internal(e.to_string()))?;
-        let response = agent
-            .ping()
-            .await
-            .map_err(|e| ConnectError::internal(e.to_string()))?;
+            .map_err(ApiError::from)?;
+        let response = agent.ping().await.map_err(ApiError::from)?;
 
         Response::ok(pb::MachinePingResponse {
             message: response.message,
@@ -394,11 +393,8 @@ impl pb::MachineService for MachineServiceImpl {
             .runtime
             .ready()?
             .get_agent(&id)
-            .map_err(|e| ConnectError::internal(e.to_string()))?;
-        let info = agent
-            .get_system_info()
-            .await
-            .map_err(|e| ConnectError::internal(e.to_string()))?;
+            .map_err(ApiError::from)?;
+        let info = agent.get_system_info().await.map_err(ApiError::from)?;
 
         Response::ok(pb::MachineSystemInfo {
             kernel_version: info.kernel_version,
@@ -434,11 +430,8 @@ impl pb::MachineService for MachineServiceImpl {
             .runtime
             .ready()?
             .get_agent(&id)
-            .map_err(|e| ConnectError::internal(e.to_string()))?;
-        let resp = agent
-            .disk_trim()
-            .await
-            .map_err(|e| ConnectError::internal(e.to_string()))?;
+            .map_err(ApiError::from)?;
+        let resp = agent.disk_trim().await.map_err(ApiError::from)?;
         tracing::debug!(machine = %id, result = %resp.result, "disk compact: fstrim done");
 
         Response::ok(pb::Empty::default())
@@ -460,12 +453,9 @@ impl pb::MachineService for MachineServiceImpl {
             .runtime
             .ready()?
             .get_agent(&req.id)
-            .map_err(|e| ConnectError::internal(e.to_string()))?;
+            .map_err(ApiError::from)?;
 
-        let mut rx = agent
-            .machine_exec(req)
-            .await
-            .map_err(|e| ConnectError::internal(e.to_string()))?;
+        let mut rx = agent.machine_exec(req).await.map_err(ApiError::from)?;
 
         let stream = async_stream::stream! {
             while let Some(item) = rx.recv().await {
@@ -477,12 +467,8 @@ impl pb::MachineService for MachineServiceImpl {
                             break;
                         }
                     }
-                    Err(arcbox_core::error::CoreError::Agent { code: 400, message }) => {
-                        yield Err(ConnectError::invalid_argument(message));
-                        break;
-                    }
                     Err(e) => {
-                        yield Err(ConnectError::internal(e.to_string()));
+                        yield Err(ConnectError::from(ApiError::from(e)));
                         break;
                     }
                 }
@@ -526,7 +512,7 @@ impl pb::MachineService for MachineServiceImpl {
             .runtime
             .ready()?
             .get_agent(&exec_req.id)
-            .map_err(|e| ConnectError::internal(e.to_string()))?;
+            .map_err(ApiError::from)?;
 
         // Feed remaining gRPC input (stdin + TTY resizes) into a channel for
         // the core layer. Stream end sends the empty-stdin EOF sentinel.
@@ -551,7 +537,7 @@ impl pb::MachineService for MachineServiceImpl {
         let mut out_rx = agent
             .machine_exec_session(exec_req, in_rx)
             .await
-            .map_err(|e| ConnectError::internal(e.to_string()))?;
+            .map_err(ApiError::from)?;
 
         let out_stream = async_stream::stream! {
             while let Some(item) = out_rx.recv().await {
@@ -563,12 +549,8 @@ impl pb::MachineService for MachineServiceImpl {
                             break;
                         }
                     }
-                    Err(arcbox_core::error::CoreError::Agent { code: 400, message }) => {
-                        yield Err(ConnectError::invalid_argument(message));
-                        break;
-                    }
                     Err(e) => {
-                        yield Err(ConnectError::internal(e.to_string()));
+                        yield Err(ConnectError::from(ApiError::from(e)));
                         break;
                     }
                 }

--- a/app/arcbox-api/src/error.rs
+++ b/app/arcbox-api/src/error.rs
@@ -43,15 +43,17 @@ impl From<ApiError> for connectrpc::ConnectError {
 
         let message = err.to_string();
         let code = match &err {
-            ApiError::Common(common) => match common {
-                CommonError::Config(_) => ErrorCode::InvalidArgument,
-                CommonError::NotFound(_) => ErrorCode::NotFound,
-                CommonError::AlreadyExists(_) => ErrorCode::AlreadyExists,
-                CommonError::InvalidState(_) => ErrorCode::FailedPrecondition,
-                CommonError::Timeout(_) => ErrorCode::DeadlineExceeded,
-                CommonError::PermissionDenied(_) => ErrorCode::PermissionDenied,
-                _ => ErrorCode::Internal,
-            },
+            ApiError::Common(common) | ApiError::Core(arcbox_core::CoreError::Common(common)) => {
+                match common {
+                    CommonError::Config(_) => ErrorCode::InvalidArgument,
+                    CommonError::NotFound(_) => ErrorCode::NotFound,
+                    CommonError::AlreadyExists(_) => ErrorCode::AlreadyExists,
+                    CommonError::InvalidState(_) => ErrorCode::FailedPrecondition,
+                    CommonError::Timeout(_) => ErrorCode::DeadlineExceeded,
+                    CommonError::PermissionDenied(_) => ErrorCode::PermissionDenied,
+                    _ => ErrorCode::Internal,
+                }
+            }
             // Agent-reported errors carry an HTTP-style code over the wire;
             // the raw message classifies further into the error registry.
             ApiError::Core(arcbox_core::CoreError::Agent {
@@ -74,6 +76,14 @@ impl From<ApiError> for connectrpc::ConnectError {
                 }
                 return error;
             }
+            ApiError::Core(arcbox_core::CoreError::Transport {
+                source:
+                    arcbox_transport::error::TransportError::NotConnected
+                    | arcbox_transport::error::TransportError::ConnectionRefused(_)
+                    | arcbox_transport::error::TransportError::ConnectionReset
+                    | arcbox_transport::error::TransportError::Common(CommonError::Io(_)),
+                ..
+            }) => ErrorCode::Unavailable,
             _ => ErrorCode::Internal,
         };
         Self::new(code, message)
@@ -327,5 +337,35 @@ mod tests {
             registry_code(&error.details[0]),
             pb::ErrorCode::SandboxPaused
         );
+    }
+
+    #[test]
+    fn core_resource_errors_keep_their_connect_codes() {
+        let missing = connectrpc::ConnectError::from(ApiError::Core(
+            arcbox_core::CoreError::not_found("machine dev"),
+        ));
+        assert_eq!(missing.code, connectrpc::ErrorCode::NotFound);
+
+        let stopped = connectrpc::ConnectError::from(ApiError::Core(
+            arcbox_core::CoreError::invalid_state("machine 'dev' is not running"),
+        ));
+        assert_eq!(stopped.code, connectrpc::ErrorCode::FailedPrecondition);
+
+        let command =
+            connectrpc::ConnectError::from(ApiError::Core(arcbox_core::CoreError::Agent {
+                code: 404,
+                message: "command not found: nope".into(),
+            }));
+        assert_eq!(command.code, connectrpc::ErrorCode::NotFound);
+
+        let transport = connectrpc::ConnectError::from(ApiError::Core(
+            arcbox_transport::error::TransportError::ConnectionReset.into(),
+        ));
+        assert_eq!(transport.code, connectrpc::ErrorCode::Unavailable);
+
+        let protocol = connectrpc::ConnectError::from(ApiError::Core(
+            arcbox_transport::error::TransportError::Protocol("bad frame".into()).into(),
+        ));
+        assert_eq!(protocol.code, connectrpc::ErrorCode::Internal);
     }
 }

--- a/app/arcbox-cli/Cargo.toml
+++ b/app/arcbox-cli/Cargo.toml
@@ -51,6 +51,7 @@ connectrpc = { version = "0.8.1", features = ["client"], git = "https://github.c
 buffa = { version = "0.9.1", features = ["json"] }
 tower.workspace = true
 buffa-types = { version = "0.9.1", features = ["json"] }
+anstream = { version = "1.0.0", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 macos-resolver = { workspace = true }

--- a/app/arcbox-cli/README.md
+++ b/app/arcbox-cli/README.md
@@ -50,6 +50,14 @@ kubectl get nodes
 docker run hello-world
 ```
 
+## Exit status
+
+- `0`: command succeeded.
+- `1`: an `abctl` operation or daemon connection failed.
+- `2`: command-line arguments were invalid.
+- Remote commands (`machine exec`, `sandbox run` / `exec`, and `claude`) propagate the
+  command's exit status; sandbox signal exits use the shell convention `128 + signal`.
+
 ## Configuration
 
 Socket path resolution order:

--- a/app/arcbox-cli/src/commands/logs.rs
+++ b/app/arcbox-cli/src/commands/logs.rs
@@ -1,11 +1,13 @@
 //! `abctl logs` — view daemon and component log files.
 
-use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::io::{self, BufRead, BufReader, IsTerminal, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use clap::{Args, ValueEnum};
+
+use arcbox_cli::terminal;
 
 /// Arguments for the logs command.
 #[derive(Debug, Args)]
@@ -45,6 +47,7 @@ pub enum LogComponent {
 /// Execute the logs command.
 pub async fn execute(args: LogsArgs) -> Result<()> {
     let log_path = resolve_log_path(&args);
+    let ansi = terminal::ansi_enabled(io::stdout().is_terminal());
 
     if !log_path.exists() {
         bail!(
@@ -55,9 +58,9 @@ pub async fn execute(args: LogsArgs) -> Result<()> {
     }
 
     if args.follow {
-        tail_follow(&log_path, args.lines).await
+        tail_follow(&log_path, args.lines, ansi).await
     } else {
-        tail_lines(&log_path, args.lines)
+        tail_lines(&log_path, args.lines, ansi)
     }
 }
 
@@ -97,7 +100,11 @@ fn resolve_log_path(args: &LogsArgs) -> PathBuf {
 /// Print the last `n` lines of a file by scanning backwards from the end.
 ///
 /// Reads at most 64 KB chunks from the tail to avoid loading the entire file.
-fn tail_lines(path: &Path, n: usize) -> Result<()> {
+fn tail_lines(path: &Path, n: usize, ansi: bool) -> Result<()> {
+    tail_lines_to(path, n, ansi, &mut io::stdout().lock())
+}
+
+fn tail_lines_to(path: &Path, n: usize, ansi: bool, output: &mut impl Write) -> Result<()> {
     let mut file =
         std::fs::File::open(path).with_context(|| format!("Failed to open {}", path.display()))?;
     let file_len = file.metadata()?.len();
@@ -135,7 +142,19 @@ fn tail_lines(path: &Path, n: usize) -> Result<()> {
     file.seek(SeekFrom::Start(start_offset))?;
     let reader = BufReader::new(file);
     for line in reader.lines() {
-        println!("{}", line?);
+        write_log(output, line?.as_bytes(), ansi)?;
+        output.write_all(b"\n")?;
+    }
+    Ok(())
+}
+
+fn write_log(output: &mut impl Write, bytes: &[u8], ansi: bool) -> io::Result<()> {
+    if ansi {
+        return output.write_all(bytes);
+    }
+
+    for printable in anstream::adapter::strip_bytes(bytes) {
+        output.write_all(printable)?;
     }
     Ok(())
 }
@@ -144,8 +163,8 @@ fn tail_lines(path: &Path, n: usize) -> Result<()> {
 ///
 /// Detects log rotation (file replaced via rename) by checking whether the
 /// inode or file size changes, and reopens the path when it does.
-async fn tail_follow(path: &Path, n: usize) -> Result<()> {
-    tail_lines(path, n)?;
+async fn tail_follow(path: &Path, n: usize, ansi: bool) -> Result<()> {
+    tail_lines(path, n, ansi)?;
 
     let mut file =
         std::fs::File::open(path).with_context(|| format!("Failed to open {}", path.display()))?;
@@ -171,7 +190,9 @@ async fn tail_follow(path: &Path, n: usize) -> Result<()> {
                 tokio::time::sleep(Duration::from_millis(200)).await;
             }
             Ok(_) => {
-                print!("{line}");
+                let mut output = io::stdout().lock();
+                write_log(&mut output, line.as_bytes(), ansi)?;
+                output.flush()?;
             }
             Err(e) => {
                 bail!("Error reading log file: {e}");
@@ -199,4 +220,31 @@ fn resolve_data_dir(data_dir: Option<&PathBuf>) -> PathBuf {
         data_dir.map(PathBuf::as_path),
     )
     .data_dir
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redirected_tail_strips_ansi_bytes() {
+        let mut log = tempfile::NamedTempFile::new().unwrap();
+        log.write_all(b"plain\n\x1b[31merror\x1b[0m\n").unwrap();
+
+        let mut output = Vec::new();
+        tail_lines_to(log.path(), 2, false, &mut output).unwrap();
+
+        assert_eq!(output, b"plain\nerror\n");
+        assert!(!output.contains(&0x1b));
+    }
+
+    #[test]
+    fn interactive_tail_preserves_ansi_bytes() {
+        let input = b"\x1b[32mok\x1b[0m";
+        let mut output = Vec::new();
+
+        write_log(&mut output, input, true).unwrap();
+
+        assert_eq!(output, input);
+    }
 }

--- a/app/arcbox-cli/src/commands/machine.rs
+++ b/app/arcbox-cli/src/commands/machine.rs
@@ -745,7 +745,8 @@ mod tests {
         let error = exec_exit_code(None, "dev", "date").unwrap_err();
         assert_eq!(
             crate::error::render(&error, false),
-            "Error: Could not read output from 'date' in machine 'dev'."
+            "Error: Could not read output from 'date' in machine 'dev'. Re-run with --debug for \
+             details."
         );
         assert!(
             crate::error::render(&error, true)

--- a/app/arcbox-cli/src/commands/machine.rs
+++ b/app/arcbox-cli/src/commands/machine.rs
@@ -265,7 +265,7 @@ async fn execute_start(args: StartArgs) -> Result<()> {
             ..Default::default()
         })
         .await
-        .context("Failed to start machine")?;
+        .map_err(|error| crate::error::machine_operation(error, &args.name, "start"))?;
 
     const MAX_AGENT_WAIT_ATTEMPTS: u32 = 20;
     let mut delay = std::time::Duration::from_millis(200);
@@ -280,8 +280,11 @@ async fn execute_start(args: StartArgs) -> Result<()> {
             Ok(_) => break,
             Err(e) => {
                 if attempt == MAX_AGENT_WAIT_ATTEMPTS {
-                    return Err(anyhow::Error::new(e))
-                        .context("Failed to wait for machine agent readiness");
+                    return Err(crate::error::machine_request(
+                        e,
+                        &args.name,
+                        "agent readiness",
+                    ));
                 }
                 tokio::time::sleep(delay).await;
                 delay = std::cmp::min(delay.saturating_mul(2), std::time::Duration::from_secs(2));
@@ -320,7 +323,7 @@ async fn execute_stop(args: StopArgs) -> Result<()> {
             ..Default::default()
         })
         .await
-        .context("Failed to stop machine")?;
+        .map_err(|error| crate::error::machine_operation(error, &args.name, "stop"))?;
 
     println!("Machine '{}' stopped", args.name);
 
@@ -340,7 +343,7 @@ async fn execute_remove(args: RemoveArgs) -> Result<()> {
             ..Default::default()
         })
         .await
-        .context("Failed to remove machine")?;
+        .map_err(|error| crate::error::machine_operation(error, &args.name, "remove"))?;
 
     println!("Machine '{}' removed", args.name);
 
@@ -411,7 +414,7 @@ async fn execute_status(args: StatusArgs) -> Result<()> {
             ..Default::default()
         })
         .await
-        .context("Failed to get machine status")?
+        .map_err(|error| crate::error::machine_operation(error, &args.name, "inspect"))?
         .into_owned();
 
     // Unset sub-messages deref to their default instances, which carry the
@@ -442,7 +445,7 @@ async fn execute_inspect(args: InspectArgs) -> Result<()> {
             ..Default::default()
         })
         .await
-        .context("Failed to inspect machine")?
+        .map_err(|error| crate::error::machine_operation(error, &args.name, "inspect"))?
         .into_owned();
 
     // Sub-message derefs fall back to default instances (zero/empty), which
@@ -478,7 +481,7 @@ async fn execute_ping(args: PingArgs) -> Result<()> {
             ..Default::default()
         })
         .await
-        .context("Failed to ping agent")?
+        .map_err(|error| crate::error::machine_request(error, &args.name, "ping"))?
         .into_owned();
     let elapsed = started.elapsed();
 
@@ -499,7 +502,7 @@ async fn execute_info(args: InfoArgs) -> Result<()> {
             ..Default::default()
         })
         .await
-        .context("Failed to get system info")?
+        .map_err(|error| crate::error::machine_request(error, &args.name, "system information"))?
         .into_owned();
 
     let total_mb = info.total_memory / 1024 / 1024;
@@ -534,6 +537,7 @@ async fn execute_ssh(args: SshArgs) -> Result<()> {
 /// Runs an interactive PTY session in a machine: local terminal in raw mode,
 /// stdin and SIGWINCH resizes pumped up, merged PTY output written to stdout.
 async fn exec_session_interactive(name: &str, cmd: Vec<String>) -> Result<()> {
+    let command = cmd.first().cloned().unwrap_or_default();
     let (msg_tx, mut msg_rx) = tokio::sync::mpsc::channel::<MachineExecInput>(16);
 
     let tty_size = TerminalSize::current().ok().map(|s| ProtoTerminalSize {
@@ -612,10 +616,9 @@ async fn exec_session_interactive(name: &str, cmd: Vec<String>) -> Result<()> {
     // stream into independently owned halves: the send half moves into a
     // forwarder task, the receive half stays here.
     let client = machine_client();
-    let stream = client
-        .exec_session()
-        .await
-        .context("Failed to open machine exec session")?;
+    let stream = client.exec_session().await.map_err(|error| {
+        crate::error::machine_request(error, name, "interactive command execution")
+    })?;
     let (mut send, mut recv) = stream.into_split();
 
     // Forwarder: inputs from the pumps → wire. When every pump has dropped
@@ -631,12 +634,11 @@ async fn exec_session_interactive(name: &str, cmd: Vec<String>) -> Result<()> {
         send.close_send();
     });
 
-    let mut exit_code = 0i32;
-    let mut received_done = false;
+    let mut exit_code = None;
     while let Some(item) = recv
         .message::<pb::MachineExecOutput>()
         .await
-        .context("Failed to read session output")?
+        .map_err(|error| crate::error::machine_exec_output(error, name, &command))?
     {
         let output = item.to_owned_message();
         if !output.data.is_empty() {
@@ -647,17 +649,14 @@ async fn exec_session_interactive(name: &str, cmd: Vec<String>) -> Result<()> {
             std::io::stdout().flush()?;
         }
         if output.done {
-            exit_code = output.exit_code;
-            received_done = true;
+            exit_code = Some(output.exit_code);
         }
     }
 
     // Restore the terminal before exiting.
     drop(raw_guard);
 
-    if !received_done {
-        anyhow::bail!("session stream closed without a terminal status frame");
-    }
+    let exit_code = exec_exit_code(exit_code, name, &command)?;
     if exit_code != 0 {
         std::process::exit(exit_code);
     }
@@ -675,6 +674,7 @@ async fn exec_via_grpc(
     env: HashMap<String, String>,
     tty: bool,
 ) -> Result<()> {
+    let command = cmd.first().cloned().unwrap_or_default();
     let client = machine_client();
     let mut stream = client
         .exec(MachineExecRequest {
@@ -687,13 +687,13 @@ async fn exec_via_grpc(
             ..Default::default()
         })
         .await
-        .context("Failed to execute command in machine")?;
+        .map_err(|error| crate::error::machine_request(error, name, "command execution"))?;
 
-    let mut exit_code = 0i32;
+    let mut exit_code = None;
     while let Some(item) = stream
         .message::<pb::MachineExecOutput>()
         .await
-        .context("Failed to read exec output")?
+        .map_err(|error| crate::error::machine_exec_output(error, name, &command))?
     {
         let output = item.to_owned_message();
         if !output.data.is_empty() {
@@ -711,12 +711,45 @@ async fn exec_via_grpc(
             }
         }
         if output.done {
-            exit_code = output.exit_code;
+            exit_code = Some(output.exit_code);
         }
     }
 
+    let exit_code = exec_exit_code(exit_code, name, &command)?;
     if exit_code != 0 {
         std::process::exit(exit_code);
     }
     Ok(())
+}
+
+fn exec_exit_code(exit_code: Option<i32>, name: &str, command: &str) -> Result<i32> {
+    exit_code.ok_or_else(|| {
+        crate::error::machine_exec_output(
+            connectrpc::ConnectError::internal(
+                "exec stream closed without a terminal status frame",
+            ),
+            name,
+            command,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exec_requires_a_terminal_status_frame() {
+        assert_eq!(exec_exit_code(Some(7), "dev", "false").unwrap(), 7);
+
+        let error = exec_exit_code(None, "dev", "date").unwrap_err();
+        assert_eq!(
+            crate::error::render(&error, false),
+            "Error: Could not read output from 'date' in machine 'dev'."
+        );
+        assert!(
+            crate::error::render(&error, true)
+                .contains("exec stream closed without a terminal status frame")
+        );
+    }
 }

--- a/app/arcbox-cli/src/commands/sandbox.rs
+++ b/app/arcbox-cli/src/commands/sandbox.rs
@@ -505,7 +505,7 @@ async fn execute_stop(args: StopArgs) -> Result<()> {
             ..Default::default()
         })
         .await
-        .context("Failed to stop sandbox")?;
+        .map_err(|error| crate::error::sandbox_request(error, &args.id, "stopping"))?;
 
     println!("Sandbox '{}' stopped", args.id);
     Ok(())
@@ -522,7 +522,7 @@ async fn execute_remove(args: RemoveArgs) -> Result<()> {
             ..Default::default()
         })
         .await
-        .context("Failed to remove sandbox")?;
+        .map_err(|error| crate::error::sandbox_request(error, &args.id, "removal"))?;
 
     println!("Sandbox '{}' removed", args.id);
     Ok(())
@@ -587,11 +587,11 @@ async fn execute_inspect(args: InspectArgs) -> Result<()> {
 
     let info: pb::SandboxInfo = client
         .inspect(InspectSandboxRequest {
-            id: args.id,
+            id: args.id.clone(),
             ..Default::default()
         })
         .await
-        .context("Failed to inspect sandbox")?
+        .map_err(|error| crate::error::sandbox_request(error, &args.id, "inspection"))?
         .into_owned();
 
     let last_exit_status = info
@@ -711,7 +711,7 @@ pub(super) async fn exec_session(
     client
         .start_execution(start)
         .await
-        .context("Failed to start execution in sandbox")?;
+        .map_err(|error| crate::error::sandbox_request(error, &sandbox_id, "command execution"))?;
 
     // Enable raw terminal mode when TTY is requested.
     let raw_guard = if tty {
@@ -919,13 +919,13 @@ pub(super) async fn exec_session(
         // real outcome rather than reporting a synthetic failure.
         None => client
             .wait_execution(WaitExecutionRequest {
-                sandbox_id,
-                execution_id,
+                sandbox_id: sandbox_id.clone(),
+                execution_id: execution_id.clone(),
                 timeout_seconds: EXEC_WAIT_TIMEOUT_SECS,
                 ..Default::default()
             })
             .await
-            .context("attach stream closed without an exit event")?
+            .map_err(|error| crate::error::execution_wait(error, &sandbox_id, &execution_id))?
             .into_owned(),
     };
     Ok(exit_code_of(&execution))
@@ -939,20 +939,33 @@ async fn execute_events(args: EventsArgs) -> Result<()> {
         Some(value) => parse_event_kind(value)?,
         None => SandboxEventKind::Unspecified,
     };
+    let sandbox_id = args.id.unwrap_or_default();
     let mut stream = client
         .events(SandboxEventsRequest {
-            sandbox_id: args.id.unwrap_or_default(),
+            sandbox_id: sandbox_id.clone(),
             kind: kind.into(),
             ..Default::default()
         })
         .await
-        .context("Failed to subscribe to sandbox events")?;
+        .map_err(|error| {
+            if sandbox_id.is_empty() {
+                anyhow::Error::new(error).context("Failed to subscribe to sandbox events")
+            } else {
+                crate::error::sandbox_request(error, &sandbox_id, "event subscription")
+            }
+        })?;
 
     println!("Listening for sandbox events (Ctrl+C to stop)...");
     while let Some(frame) = stream
         .message::<pb::WatchEventsResponse>()
         .await
-        .context("Failed to read sandbox event")?
+        .map_err(|error| {
+            if sandbox_id.is_empty() {
+                anyhow::Error::new(error).context("Failed to read sandbox event")
+            } else {
+                crate::error::sandbox_request(error, &sandbox_id, "event streaming")
+            }
+        })?
         .map(|item| item.to_owned_message())
     {
         let Some(watch_events_response::Payload::Event(event)) = frame.payload else {
@@ -976,15 +989,16 @@ async fn execute_events(args: EventsArgs) -> Result<()> {
 async fn execute_checkpoint(args: CheckpointArgs) -> Result<()> {
     let (transport, config) = sandbox_channel();
     let client = SandboxSnapshotServiceClient::new(transport.clone(), config.clone());
+    let id = args.id;
 
     let resp: pb::CheckpointResponse = client
         .checkpoint(CheckpointRequest {
-            sandbox_id: args.id,
+            sandbox_id: id.clone(),
             name: args.name,
             ..Default::default()
         })
         .await
-        .context("Failed to checkpoint sandbox")?
+        .map_err(|error| crate::error::sandbox_request(error, &id, "checkpointing"))?
         .into_owned();
 
     println!("Snapshot created");
@@ -1000,15 +1014,16 @@ async fn execute_restore(args: RestoreArgs) -> Result<()> {
     let (transport, config) = sandbox_channel();
     let client = SandboxSnapshotServiceClient::new(transport.clone(), config.clone());
 
+    let snapshot_id = args.snapshot_id;
     let resp: pb::RestoreResponse = client
         .restore(RestoreRequest {
             id: args.sandbox_id.unwrap_or_default(),
-            snapshot_id: args.snapshot_id,
+            snapshot_id: snapshot_id.clone(),
             ttl_seconds: args.ttl,
             ..Default::default()
         })
         .await
-        .context("Failed to restore sandbox")?
+        .map_err(|error| crate::error::snapshot_request(error, &snapshot_id, "restoration"))?
         .into_owned();
 
     println!("Sandbox restored");
@@ -1024,15 +1039,19 @@ async fn execute_list_snapshots(args: ListSnapshotsArgs) -> Result<()> {
     // Follow continuation tokens so the human view stays complete.
     let mut snapshots = Vec::new();
     let mut page_token = String::new();
+    let sandbox_id = args.sandbox_id;
     loop {
         let mut resp: pb::ListSnapshotsResponse = client
             .list_snapshots(ListSnapshotsRequest {
-                sandbox_id: args.sandbox_id.clone().unwrap_or_default(),
+                sandbox_id: sandbox_id.clone().unwrap_or_default(),
                 page_token: page_token.clone(),
                 ..Default::default()
             })
             .await
-            .context("Failed to list snapshots")?
+            .map_err(|error| match sandbox_id.as_deref() {
+                Some(id) => crate::error::sandbox_request(error, id, "snapshot listing"),
+                None => anyhow::Error::new(error).context("Failed to list snapshots"),
+            })?
             .into_owned();
         snapshots.append(&mut resp.snapshots);
         if resp.next_page_token.is_empty() {
@@ -1072,7 +1091,7 @@ async fn execute_delete_snapshot(args: DeleteSnapshotArgs) -> Result<()> {
             ..Default::default()
         })
         .await
-        .context("Failed to delete snapshot")?;
+        .map_err(|error| crate::error::snapshot_request(error, &args.snapshot_id, "deletion"))?;
 
     println!("Snapshot '{}' deleted", args.snapshot_id);
     Ok(())
@@ -1123,7 +1142,7 @@ async fn execute_cp(args: CpArgs) -> Result<()> {
             const CHUNK: usize = 1024 * 1024;
             let open = WriteFileRequest {
                 payload: WriteFileOpen {
-                    id,
+                    id: id.clone(),
                     path,
                     mode,
                     ..Default::default()
@@ -1156,18 +1175,22 @@ async fn execute_cp(args: CpArgs) -> Result<()> {
             client
                 .write_file(connectrpc::client::stream_iter(requests))
                 .await
-                .context("Failed to write file into sandbox")?;
+                .map_err(|error| {
+                    crate::error::sandbox_request(error, &id, "copying a file into it")
+                })?;
             println!("Copied {total} bytes to {}", args.dst);
         }
         (CpEndpoint::Sandbox { id, path }, CpEndpoint::Local(dst)) => {
             let mut stream = client
                 .read_file(ReadFileRequest {
-                    id,
+                    id: id.clone(),
                     path,
                     ..Default::default()
                 })
                 .await
-                .context("Failed to read file from sandbox")?;
+                .map_err(|error| {
+                    crate::error::sandbox_request(error, &id, "copying a file from it")
+                })?;
 
             let mut out = tokio::fs::File::create(&dst)
                 .await
@@ -1176,7 +1199,9 @@ async fn execute_cp(args: CpArgs) -> Result<()> {
             while let Some(chunk) = stream
                 .message::<pb::FileChunk>()
                 .await
-                .context("Failed to read file stream")?
+                .map_err(|error| {
+                    crate::error::sandbox_request(error, &id, "copying a file from it")
+                })?
                 .map(|item| item.to_owned_message())
             {
                 if !chunk.data.is_empty() {
@@ -1215,7 +1240,7 @@ async fn execute_expose(args: ExposeArgs) -> Result<()> {
             ..Default::default()
         })
         .await
-        .context("Failed to expose sandbox port")?
+        .map_err(|error| crate::error::sandbox_request(error, &args.id, "port exposure"))?
         .into_owned();
     println!(
         "{}:{}/{} exposed on localhost:{}",
@@ -1236,7 +1261,7 @@ async fn execute_unexpose(args: UnexposeArgs) -> Result<()> {
             ..Default::default()
         })
         .await
-        .context("Failed to unexpose sandbox port")?;
+        .map_err(|error| crate::error::sandbox_request(error, &args.id, "port removal"))?;
     println!("{}:{}/{} unexposed", args.id, args.port, args.protocol);
     Ok(())
 }

--- a/app/arcbox-cli/src/commands/top.rs
+++ b/app/arcbox-cli/src/commands/top.rs
@@ -145,10 +145,11 @@ fn write_table(
 ) -> io::Result<()> {
     if matches!(mode, TopMode::Live) {
         output.write_all(b"\x1b[2J\x1b[H")?;
-    }
-    output.write_all(stats.render().as_bytes())?;
-    if matches!(mode, TopMode::Live) {
-        output.write_all(b"\nq quit | Ctrl-C quit\n")?;
+        // Raw mode clears OPOST, so bare newlines would stair-step the table.
+        output.write_all(stats.render().replace('\n', "\r\n").as_bytes())?;
+        output.write_all(b"\r\nq quit | Ctrl-C quit\r\n")?;
+    } else {
+        output.write_all(stats.render().as_bytes())?;
     }
     output.flush()
 }
@@ -551,7 +552,9 @@ mod tests {
 
         write_table(&mut output, &stats, TopMode::Snapshot).unwrap();
 
+        assert_eq!(output, stats.render().as_bytes());
         assert!(!output.contains(&0x1b));
+        assert!(!output.contains(&b'\r'));
         assert!(!String::from_utf8(output).unwrap().contains("q quit"));
     }
 
@@ -566,9 +569,15 @@ mod tests {
 
         assert!(output.starts_with(b"\x1b[2J\x1b[H"));
         assert!(
-            String::from_utf8(output)
-                .unwrap()
-                .contains("q quit | Ctrl-C quit")
+            output
+                .windows(b"\r\nq quit | Ctrl-C quit\r\n".len())
+                .any(|bytes| bytes == b"\r\nq quit | Ctrl-C quit\r\n")
+        );
+        assert!(
+            output
+                .iter()
+                .enumerate()
+                .all(|(index, byte)| *byte != b'\n' || index > 0 && output[index - 1] == b'\r')
         );
     }
 }

--- a/app/arcbox-cli/src/commands/top.rs
+++ b/app/arcbox-cli/src/commands/top.rs
@@ -7,12 +7,16 @@
 
 use std::collections::HashMap;
 use std::fmt::Write as _;
+use std::future::Future;
+use std::io::{self, IsTerminal};
 
 use anyhow::{Context, Result, bail};
+use arcbox_cli::terminal::RawModeGuard;
 use arcbox_connect::v1 as pb;
 use arcbox_connect::v1::StatsServiceClient;
 use arcbox_connect::v1::{ContainerStats, MachineStats};
 use clap::Args;
+use tokio::io::AsyncReadExt;
 
 use super::OutputFormat;
 use crate::connect;
@@ -20,7 +24,7 @@ use crate::connect;
 /// Arguments for `abctl top`.
 #[derive(Debug, Args)]
 pub struct TopArgs {
-    /// Print a single computed sample and exit (implied by --format json).
+    /// Print one computed sample and exit (also used for non-interactive output).
     #[arg(long)]
     pub once: bool,
 }
@@ -36,10 +40,32 @@ pub async fn execute(args: TopArgs, format: OutputFormat) -> Result<()> {
         .await
         .context("subscribing to machine stats")?;
 
-    let once = args.once || matches!(format, OutputFormat::Json | OutputFormat::Quiet);
+    let mode = TopMode::new(
+        args.once,
+        format,
+        io::stdin().is_terminal(),
+        io::stdout().is_terminal(),
+    );
+    let _raw_mode = matches!(mode, TopMode::Live)
+        .then(RawModeGuard::new)
+        .transpose()?;
+    let quit = wait_for_quit(tokio::io::stdin(), tokio::signal::ctrl_c());
+    tokio::pin!(quit);
     let mut previous: Option<MachineStats> = None;
     loop {
-        let sample: MachineStats = match stream.message::<pb::MachineStats>().await? {
+        let message = if matches!(mode, TopMode::Live) {
+            tokio::select! {
+                biased;
+                result = &mut quit => {
+                    result?;
+                    return Ok(());
+                }
+                message = stream.message::<pb::MachineStats>() => message?,
+            }
+        } else {
+            stream.message::<pb::MachineStats>().await?
+        };
+        let sample: MachineStats = match message {
             Some(item) => item.to_owned_message(),
             None => bail!("stats stream ended (daemon shutting down?)"),
         };
@@ -60,17 +86,71 @@ pub async fn execute(args: TopArgs, format: OutputFormat) -> Result<()> {
                 println!("{}", serde_json::to_string_pretty(&computed)?);
             }
             OutputFormat::Table => {
-                if !args.once {
-                    // Clear screen and home the cursor between frames.
-                    print!("\x1b[2J\x1b[H");
-                }
-                print!("{}", computed.render());
+                write_table(&mut io::stdout().lock(), &computed, mode)?;
             }
         }
-        if once {
+        if matches!(mode, TopMode::Snapshot) {
             return Ok(());
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TopMode {
+    Snapshot,
+    Live,
+}
+
+impl TopMode {
+    fn new(once: bool, format: OutputFormat, stdin_tty: bool, stdout_tty: bool) -> Self {
+        if once
+            || !stdin_tty
+            || !stdout_tty
+            || matches!(format, OutputFormat::Json | OutputFormat::Quiet)
+        {
+            Self::Snapshot
+        } else {
+            Self::Live
+        }
+    }
+}
+
+async fn wait_for_quit<R, F>(mut input: R, interrupt: F) -> Result<()>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    F: Future<Output = io::Result<()>>,
+{
+    let mut key = [0];
+    tokio::pin!(interrupt);
+    loop {
+        tokio::select! {
+            biased;
+            read = input.read(&mut key) => match read.context("reading terminal input")? {
+                0 => return Ok(()),
+                _ if matches!(key[0], b'q' | b'Q' | b'\x03') => return Ok(()),
+                _ => {}
+            },
+            result = &mut interrupt => {
+                result.context("waiting for Ctrl-C")?;
+                return Ok(());
+            }
+        }
+    }
+}
+
+fn write_table(
+    output: &mut impl io::Write,
+    stats: &ComputedStats,
+    mode: TopMode,
+) -> io::Result<()> {
+    if matches!(mode, TopMode::Live) {
+        output.write_all(b"\x1b[2J\x1b[H")?;
+    }
+    output.write_all(stats.render().as_bytes())?;
+    if matches!(mode, TopMode::Live) {
+        output.write_all(b"\nq quit | Ctrl-C quit\n")?;
+    }
+    output.flush()
 }
 
 /// Rates and gauges derived from two consecutive samples.
@@ -417,5 +497,78 @@ mod tests {
 
         let c = ComputedStats::from_delta(&prev, &cur).unwrap();
         assert_eq!(c.containers[0].name, "0a1b2c3d4e5f");
+    }
+
+    #[test]
+    fn live_mode_requires_interactive_table_io() {
+        assert_eq!(
+            TopMode::new(false, OutputFormat::Table, true, true),
+            TopMode::Live
+        );
+        assert_eq!(
+            TopMode::new(true, OutputFormat::Table, true, true),
+            TopMode::Snapshot
+        );
+        assert_eq!(
+            TopMode::new(false, OutputFormat::Table, false, true),
+            TopMode::Snapshot
+        );
+        assert_eq!(
+            TopMode::new(false, OutputFormat::Table, true, false),
+            TopMode::Snapshot
+        );
+        assert_eq!(
+            TopMode::new(false, OutputFormat::Json, true, true),
+            TopMode::Snapshot
+        );
+    }
+
+    #[tokio::test]
+    async fn q_exits_the_input_loop_cleanly() {
+        use tokio::io::AsyncWriteExt;
+
+        let (mut writer, reader) = tokio::io::duplex(8);
+        writer.write_all(b"xq").await.unwrap();
+
+        wait_for_quit(reader, std::future::pending()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn interrupt_exits_the_input_loop_cleanly() {
+        let (_writer, reader) = tokio::io::duplex(1);
+
+        wait_for_quit(reader, std::future::ready(Ok::<(), std::io::Error>(())))
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn snapshot_table_has_no_terminal_control_bytes() {
+        let stats =
+            ComputedStats::from_delta(&sample(10_000, 100, 1000), &sample(12_000, 150, 1200))
+                .unwrap();
+        let mut output = Vec::new();
+
+        write_table(&mut output, &stats, TopMode::Snapshot).unwrap();
+
+        assert!(!output.contains(&0x1b));
+        assert!(!String::from_utf8(output).unwrap().contains("q quit"));
+    }
+
+    #[test]
+    fn live_table_exposes_controls() {
+        let stats =
+            ComputedStats::from_delta(&sample(10_000, 100, 1000), &sample(12_000, 150, 1200))
+                .unwrap();
+        let mut output = Vec::new();
+
+        write_table(&mut output, &stats, TopMode::Live).unwrap();
+
+        assert!(output.starts_with(b"\x1b[2J\x1b[H"));
+        assert!(
+            String::from_utf8(output)
+                .unwrap()
+                .contains("q quit | Ctrl-C quit")
+        );
     }
 }

--- a/app/arcbox-cli/src/commands/version.rs
+++ b/app/arcbox-cli/src/commands/version.rs
@@ -1,22 +1,91 @@
 //! Version command implementation.
 
+use super::OutputFormat;
 use anyhow::Result;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct VersionOutput {
+    arcbox_core_abctl_version: &'static str,
+    default_compatible_boot_assets_version: &'static str,
+    minimum_compatible_helper_version: &'static str,
+    os: &'static str,
+    arch: &'static str,
+}
+
+impl VersionOutput {
+    fn current() -> Self {
+        Self {
+            arcbox_core_abctl_version: env!("CARGO_PKG_VERSION"),
+            default_compatible_boot_assets_version: arcbox_core::boot_asset_version(),
+            minimum_compatible_helper_version: arcbox_constants::helper::MIN_HELPER_VERSION,
+            os: std::env::consts::OS,
+            arch: std::env::consts::ARCH,
+        }
+    }
+}
 
 /// Executes the version command.
-pub async fn execute() -> Result<()> {
-    println!("ArcBox version {}", env!("CARGO_PKG_VERSION"));
-    println!();
-    println!(
-        "Platform: {} / {}",
-        std::env::consts::OS,
-        std::env::consts::ARCH
-    );
-    println!("Rust: {}", rustc_version());
+pub async fn execute(format: OutputFormat) -> Result<()> {
+    let output = VersionOutput::current();
+    match format {
+        OutputFormat::Json => println!("{}", serde_json::to_string(&output)?),
+        OutputFormat::Table | OutputFormat::Quiet => println!("{}", render_human(&output)),
+    }
 
     Ok(())
 }
 
-fn rustc_version() -> &'static str {
-    // This is set by the build
-    option_env!("RUSTC_VERSION").unwrap_or("unknown")
+fn render_human(output: &VersionOutput) -> String {
+    format!(
+        "ArcBox components\n\
+         ArcBox Core / abctl (local build): {}\n\
+         Boot assets (default compatible): {}\n\
+         arcbox-helper (minimum compatible): {}\n\
+         Platform: {} / {}\n\n\
+         For current and latest boot assets, run 'abctl boot status'.",
+        output.arcbox_core_abctl_version,
+        output.default_compatible_boot_assets_version,
+        output.minimum_compatible_helper_version,
+        output.os,
+        output.arch,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn human_output_names_component_version_roles() {
+        let rendered = render_human(&VersionOutput::current());
+
+        assert!(rendered.contains("ArcBox Core / abctl (local build):"));
+        assert!(rendered.contains("Boot assets (default compatible):"));
+        assert!(rendered.contains("arcbox-helper (minimum compatible):"));
+        assert!(rendered.contains("run 'abctl boot status'"));
+        assert!(!rendered.contains("Rust:"));
+        assert!(!rendered.contains("unknown"));
+    }
+
+    #[test]
+    fn json_output_has_stable_component_fields() {
+        let value = serde_json::to_value(VersionOutput::current()).unwrap();
+
+        assert_eq!(
+            value["arcbox_core_abctl_version"],
+            env!("CARGO_PKG_VERSION")
+        );
+        assert_eq!(
+            value["default_compatible_boot_assets_version"],
+            arcbox_core::boot_asset_version()
+        );
+        assert_eq!(
+            value["minimum_compatible_helper_version"],
+            arcbox_constants::helper::MIN_HELPER_VERSION
+        );
+        assert_eq!(value["os"], std::env::consts::OS);
+        assert_eq!(value["arch"], std::env::consts::ARCH);
+        assert!(value.get("rust").is_none());
+    }
 }

--- a/app/arcbox-cli/src/error.rs
+++ b/app/arcbox-cli/src/error.rs
@@ -94,7 +94,9 @@ pub fn snapshot_request(error: ConnectError, id: &str, operation: &str) -> Error
             "Snapshot '{id}' is unavailable during {operation}. Retry the command; if the \
              problem persists, check `abctl daemon status`."
         ),
-        _ => format!("Could not perform {operation} for snapshot '{id}'."),
+        _ => format!(
+            "Could not perform {operation} for snapshot '{id}'. Re-run with --debug for details."
+        ),
     };
     actionable(message, error)
 }
@@ -111,7 +113,7 @@ pub fn execution_wait(error: ConnectError, sandbox_id: &str, execution_id: &str)
         ),
         _ => format!(
             "Could not determine the exit status of execution '{execution_id}' in sandbox \
-             '{sandbox_id}'."
+             '{sandbox_id}'. Re-run with --debug for details."
         ),
     };
     actionable(message, error)
@@ -270,12 +272,16 @@ mod tests {
             machine_request(ConnectError::internal("raw"), "dev", "ping"),
             machine_operation(ConnectError::internal("raw"), "dev", "start"),
             sandbox_request(ConnectError::internal("raw"), "box", "inspection"),
+            snapshot_request(ConnectError::internal("raw"), "snap", "restore"),
+            execution_wait(ConnectError::internal("raw"), "box", "exec"),
             machine_exec_output(ConnectError::internal("raw"), "dev", "date"),
         ];
         let expected = [
             "Error: Could not perform ping for machine 'dev'. Re-run with --debug for details.",
             "Error: Could not start machine 'dev'. Re-run with --debug for details.",
             "Error: Could not perform inspection for sandbox 'box'. Re-run with --debug for details.",
+            "Error: Could not perform restore for snapshot 'snap'. Re-run with --debug for details.",
+            "Error: Could not determine the exit status of execution 'exec' in sandbox 'box'. Re-run with --debug for details.",
             "Error: Could not read output from 'date' in machine 'dev'. Re-run with --debug for details.",
         ];
 

--- a/app/arcbox-cli/src/error.rs
+++ b/app/arcbox-cli/src/error.rs
@@ -36,7 +36,9 @@ pub fn machine_request(error: ConnectError, name: &str, operation: &str) -> Erro
             "Machine '{name}' is unavailable during {operation}. Retry the command; if the \
              problem persists, check `abctl daemon status`."
         ),
-        _ => format!("Could not perform {operation} for machine '{name}'."),
+        _ => format!(
+            "Could not perform {operation} for machine '{name}'. Re-run with --debug for details."
+        ),
     };
     actionable(message, error)
 }
@@ -54,7 +56,7 @@ pub fn machine_operation(error: ConnectError, name: &str, action: &str) -> Error
             "Machine '{name}' is unavailable. Retry the command; if the problem persists, \
              check `abctl daemon status`."
         ),
-        _ => format!("Could not {action} machine '{name}'."),
+        _ => format!("Could not {action} machine '{name}'. Re-run with --debug for details."),
     };
     actionable(message, error)
 }
@@ -72,7 +74,9 @@ pub fn sandbox_request(error: ConnectError, id: &str, operation: &str) -> Error 
             "Sandbox '{id}' is unavailable during {operation}. Retry the command; if the \
              problem persists, check `abctl daemon status`."
         ),
-        _ => format!("Could not perform {operation} for sandbox '{id}'."),
+        _ => format!(
+            "Could not perform {operation} for sandbox '{id}'. Re-run with --debug for details."
+        ),
     };
     actionable(message, error)
 }
@@ -121,7 +125,10 @@ pub fn machine_exec_output(error: ConnectError, name: &str, command: &str) -> Er
             ErrorCode::NotFound => {
                 format!("Command '{command}' was not found in machine '{name}'.")
             }
-            _ => format!("Could not read output from '{command}' in machine '{name}'."),
+            _ => format!(
+                "Could not read output from '{command}' in machine '{name}'. Re-run with --debug \
+                 for details."
+            ),
         }
     };
     actionable(message, error)
@@ -253,7 +260,27 @@ mod tests {
         );
         assert_eq!(
             output.to_string(),
-            "Could not read output from 'date' in machine 'dev'."
+            "Could not read output from 'date' in machine 'dev'. Re-run with --debug for details."
         );
+    }
+
+    #[test]
+    fn unclassified_errors_point_to_debug_details() {
+        let errors = [
+            machine_request(ConnectError::internal("raw"), "dev", "ping"),
+            machine_operation(ConnectError::internal("raw"), "dev", "start"),
+            sandbox_request(ConnectError::internal("raw"), "box", "inspection"),
+            machine_exec_output(ConnectError::internal("raw"), "dev", "date"),
+        ];
+        let expected = [
+            "Error: Could not perform ping for machine 'dev'. Re-run with --debug for details.",
+            "Error: Could not start machine 'dev'. Re-run with --debug for details.",
+            "Error: Could not perform inspection for sandbox 'box'. Re-run with --debug for details.",
+            "Error: Could not read output from 'date' in machine 'dev'. Re-run with --debug for details.",
+        ];
+
+        for (error, expected) in errors.iter().zip(expected) {
+            assert_eq!(render(error, false), expected);
+        }
     }
 }

--- a/app/arcbox-cli/src/error.rs
+++ b/app/arcbox-cli/src/error.rs
@@ -1,0 +1,259 @@
+//! User-facing CLI error context.
+
+use std::fmt;
+
+use anyhow::Error;
+use connectrpc::{ConnectError, ErrorCode};
+
+#[derive(Debug)]
+struct ActionableError {
+    message: String,
+    source: ConnectError,
+}
+
+impl fmt::Display for ActionableError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ActionableError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+pub fn machine_request(error: ConnectError, name: &str, operation: &str) -> Error {
+    let message = match error.code {
+        ErrorCode::NotFound => {
+            format!("Machine '{name}' was not found. List machines with `abctl machine list`.")
+        }
+        ErrorCode::FailedPrecondition => format!(
+            "Machine '{name}' must be running for {operation}. Start it with \
+             `abctl machine start {name}`."
+        ),
+        ErrorCode::Unavailable => format!(
+            "Machine '{name}' is unavailable during {operation}. Retry the command; if the \
+             problem persists, check `abctl daemon status`."
+        ),
+        _ => format!("Could not perform {operation} for machine '{name}'."),
+    };
+    actionable(message, error)
+}
+
+pub fn machine_operation(error: ConnectError, name: &str, action: &str) -> Error {
+    let message = match error.code {
+        ErrorCode::NotFound => {
+            format!("Machine '{name}' was not found. List machines with `abctl machine list`.")
+        }
+        ErrorCode::FailedPrecondition => format!(
+            "Machine '{name}' is not in a valid state for this operation. Inspect it with \
+             `abctl machine inspect {name}`."
+        ),
+        ErrorCode::Unavailable => format!(
+            "Machine '{name}' is unavailable. Retry the command; if the problem persists, \
+             check `abctl daemon status`."
+        ),
+        _ => format!("Could not {action} machine '{name}'."),
+    };
+    actionable(message, error)
+}
+
+pub fn sandbox_request(error: ConnectError, id: &str, operation: &str) -> Error {
+    let message = match error.code {
+        ErrorCode::NotFound => {
+            format!("Sandbox '{id}' was not found. List sandboxes with `abctl sandbox list`.")
+        }
+        ErrorCode::FailedPrecondition => format!(
+            "Sandbox '{id}' is not ready for {operation}. Inspect it with \
+             `abctl sandbox inspect {id}`."
+        ),
+        ErrorCode::Unavailable => format!(
+            "Sandbox '{id}' is unavailable during {operation}. Retry the command; if the \
+             problem persists, check `abctl daemon status`."
+        ),
+        _ => format!("Could not perform {operation} for sandbox '{id}'."),
+    };
+    actionable(message, error)
+}
+
+pub fn snapshot_request(error: ConnectError, id: &str, operation: &str) -> Error {
+    let message = match error.code {
+        ErrorCode::NotFound => {
+            format!("Snapshot '{id}' was not found. List snapshots with `abctl sandbox snapshots`.")
+        }
+        ErrorCode::FailedPrecondition => format!(
+            "Snapshot '{id}' is not in a valid state for {operation}. List snapshots with \
+             `abctl sandbox snapshots`."
+        ),
+        ErrorCode::Unavailable => format!(
+            "Snapshot '{id}' is unavailable during {operation}. Retry the command; if the \
+             problem persists, check `abctl daemon status`."
+        ),
+        _ => format!("Could not perform {operation} for snapshot '{id}'."),
+    };
+    actionable(message, error)
+}
+
+pub fn execution_wait(error: ConnectError, sandbox_id: &str, execution_id: &str) -> Error {
+    let message = match error.code {
+        ErrorCode::NotFound => {
+            format!("Execution '{execution_id}' was not found in sandbox '{sandbox_id}'.")
+        }
+        ErrorCode::Unavailable => format!(
+            "Sandbox '{sandbox_id}' is unavailable while waiting for execution \
+             '{execution_id}'. Retry the command; if the problem persists, check \
+             `abctl daemon status`."
+        ),
+        _ => format!(
+            "Could not determine the exit status of execution '{execution_id}' in sandbox \
+             '{sandbox_id}'."
+        ),
+    };
+    actionable(message, error)
+}
+
+pub fn machine_exec_output(error: ConnectError, name: &str, command: &str) -> Error {
+    let message = if connection_lost(&error) {
+        format!("Connection to machine '{name}' was lost while running '{command}'.")
+    } else {
+        match error.code {
+            ErrorCode::NotFound => {
+                format!("Command '{command}' was not found in machine '{name}'.")
+            }
+            _ => format!("Could not read output from '{command}' in machine '{name}'."),
+        }
+    };
+    actionable(message, error)
+}
+
+fn actionable(message: String, source: ConnectError) -> Error {
+    Error::new(ActionableError { message, source })
+}
+
+fn connection_lost(error: &ConnectError) -> bool {
+    if error.code == ErrorCode::Unavailable {
+        return true;
+    }
+    // connectrpc c5c1a6f reports body-read and missing-END_STREAM failures as these Internal messages.
+    error.code == ErrorCode::Internal
+        && error.message.as_deref().is_some_and(|message| {
+            message.starts_with("error reading response body:")
+                || message == "Connect streaming response ended without END_STREAM envelope"
+        })
+}
+
+pub fn render(error: &Error, debug: bool) -> String {
+    if debug {
+        format!("Error: {error:?}")
+    } else if let Some(actionable) = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<ActionableError>())
+    {
+        format!("Error: {actionable}")
+    } else {
+        format!("Error: {error:?}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_errors_are_actionable_and_keep_debug_context() {
+        let stopped = machine_request(
+            ConnectError::failed_precondition("invalid state: CID not assigned"),
+            "dev",
+            "ping",
+        );
+        assert_eq!(
+            render(&stopped, false),
+            "Error: Machine 'dev' must be running for ping. Start it with \
+             `abctl machine start dev`."
+        );
+        assert!(render(&stopped, true).contains("invalid state: CID not assigned"));
+
+        let missing = sandbox_request(
+            ConnectError::not_found("core error: VM not found"),
+            "gone",
+            "inspection",
+        );
+        assert_eq!(
+            render(&missing, false),
+            "Error: Sandbox 'gone' was not found. List sandboxes with \
+             `abctl sandbox list`."
+        );
+        assert!(render(&missing, true).contains("core error: VM not found"));
+
+        let already_running = machine_operation(
+            ConnectError::failed_precondition("machine already running"),
+            "dev",
+            "start",
+        );
+        assert_eq!(
+            render(&already_running, false),
+            "Error: Machine 'dev' is not in a valid state for this operation. Inspect it with \
+             `abctl machine inspect dev`."
+        );
+        assert!(render(&already_running, true).contains("machine already running"));
+
+        let missing_execution = execution_wait(
+            ConnectError::not_found("execution not found"),
+            "sandbox-1",
+            "exec-2",
+        );
+        assert_eq!(
+            render(&missing_execution, false),
+            "Error: Execution 'exec-2' was not found in sandbox 'sandbox-1'."
+        );
+
+        let unmapped = Error::msg("VM not found").context("Failed to inspect another resource");
+        let rendered = render(&unmapped, false);
+        assert!(rendered.contains("Failed to inspect another resource"));
+        assert!(rendered.contains("VM not found"));
+    }
+
+    #[test]
+    fn exec_errors_distinguish_command_transport_and_output_failures() {
+        let missing = machine_exec_output(
+            ConnectError::not_found("command not found: nope"),
+            "dev",
+            "nope",
+        );
+        assert_eq!(
+            missing.to_string(),
+            "Command 'nope' was not found in machine 'dev'."
+        );
+
+        let transport = machine_exec_output(
+            ConnectError::unavailable("h2 connection closed"),
+            "dev",
+            "date",
+        );
+        assert_eq!(
+            transport.to_string(),
+            "Connection to machine 'dev' was lost while running 'date'."
+        );
+
+        let truncated = machine_exec_output(
+            ConnectError::internal("Connect streaming response ended without END_STREAM envelope"),
+            "dev",
+            "date",
+        );
+        assert_eq!(
+            truncated.to_string(),
+            "Connection to machine 'dev' was lost while running 'date'."
+        );
+
+        let output = machine_exec_output(
+            ConnectError::internal("failed to decode response"),
+            "dev",
+            "date",
+        );
+        assert_eq!(
+            output.to_string(),
+            "Could not read output from 'date' in machine 'dev'."
+        );
+    }
+}

--- a/app/arcbox-cli/src/main.rs
+++ b/app/arcbox-cli/src/main.rs
@@ -114,7 +114,7 @@ fn run(cli: Cli) -> Result<()> {
             #[cfg(target_os = "macos")]
             Commands::Internal(cmd) => commands::internal::execute(cmd).await,
             Commands::Info => execute_info().await,
-            Commands::Version => commands::version::execute().await,
+            Commands::Version => commands::version::execute(cli.format).await,
         }
     });
 

--- a/app/arcbox-cli/src/main.rs
+++ b/app/arcbox-cli/src/main.rs
@@ -2,14 +2,17 @@
 
 use anyhow::Result;
 use clap::Parser;
+use std::io::IsTerminal as _;
+use std::process::ExitCode;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod commands;
 mod connect;
+mod error;
 
 use commands::{Cli, Commands};
 
-fn main() -> Result<()> {
+fn main() -> ExitCode {
     // Sentry must be initialized before the tokio runtime so that spawned
     // threads inherit the Hub from the main thread.
     // When SENTRY_DSN is unset, this is a no-op with zero overhead.
@@ -29,7 +32,17 @@ fn main() -> Result<()> {
     });
 
     let cli = Cli::parse();
+    let debug = cli.debug;
+    match run(cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{}", crate::error::render(&error, debug));
+            ExitCode::FAILURE
+        }
+    }
+}
 
+fn run(cli: Cli) -> Result<()> {
     // Set ARCBOX_SOCKET env var if --socket was provided.
     // This makes it available to gRPC socket resolution in machine commands.
     // SAFETY: This is called at the start of main(), before any threads are spawned,
@@ -58,7 +71,13 @@ fn main() -> Result<()> {
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| filter.into()),
         )
-        .with(tracing_subscriber::fmt::layer().with_target(false))
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_target(false)
+                .with_ansi(arcbox_cli::terminal::ansi_enabled(
+                    std::io::stderr().is_terminal(),
+                )),
+        )
         .init();
 
     let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/app/arcbox-cli/src/terminal.rs
+++ b/app/arcbox-cli/src/terminal.rs
@@ -10,6 +10,15 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::mpsc;
 
+/// Returns whether ANSI styling should be emitted for a terminal stream.
+pub fn ansi_enabled(is_terminal: bool) -> bool {
+    ansi_enabled_with_override(is_terminal, std::env::var_os("NO_COLOR").is_some())
+}
+
+const fn ansi_enabled_with_override(is_terminal: bool, no_color: bool) -> bool {
+    is_terminal && !no_color
+}
+
 /// Terminal size (width x height).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TerminalSize {
@@ -337,6 +346,13 @@ impl AttachConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ansi_requires_a_terminal_without_no_color() {
+        assert!(ansi_enabled_with_override(true, false));
+        assert!(!ansi_enabled_with_override(false, false));
+        assert!(!ansi_enabled_with_override(true, true));
+    }
 
     #[test]
     fn test_terminal_size_current() {

--- a/app/arcbox-core/Cargo.toml
+++ b/app/arcbox-core/Cargo.toml
@@ -44,6 +44,7 @@ zstd = "0.13.3"
 base64 = "0.22.1"
 arcbox-connect.workspace = true
 buffa = "0.9.1"
+semver = "1.0.28"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 arcbox-route.workspace = true

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -163,9 +163,10 @@ impl AgentClient {
 
         match &mut self.transport {
             AgentTransport::Async(t) => {
-                t.connect()
-                    .await
-                    .map_err(|e| CoreError::Machine(format!("failed to connect to agent: {e}")))?;
+                t.connect().await.map_err(|source| CoreError::Transport {
+                    context: "failed to connect to agent",
+                    source,
+                })?;
             }
             AgentTransport::Blocking(_) => {
                 // Blocking transport is connected at creation time (from_fd).
@@ -1410,7 +1411,10 @@ impl AgentClient {
         self.transport
             .async_send(buf)
             .await
-            .map_err(|e| CoreError::Machine(format!("failed to send exec request: {}", e)))?;
+            .map_err(|source| CoreError::Transport {
+                context: "failed to send exec request",
+                source,
+            })?;
 
         let (tx, rx) = mpsc::channel(STREAM_CHANNEL_CAPACITY);
         tokio::spawn(async move {
@@ -1419,7 +1423,10 @@ impl AgentClient {
                     Ok(r) => r,
                     Err(e) => {
                         let _ = tx
-                            .send(Err(CoreError::Machine(format!("recv error: {}", e))))
+                            .send(Err(CoreError::Transport {
+                                context: "failed to receive exec output",
+                                source: e,
+                            }))
                             .await;
                         break;
                     }
@@ -1497,12 +1504,18 @@ impl AgentClient {
         self.transport
             .async_send(buf)
             .await
-            .map_err(|e| CoreError::Machine(format!("failed to send exec request: {}", e)))?;
+            .map_err(|source| CoreError::Transport {
+                context: "failed to send exec session request",
+                source,
+            })?;
 
-        let (mut sender, mut receiver) = self
-            .transport
-            .into_split()
-            .map_err(|e| CoreError::Machine(format!("failed to split transport: {e}")))?;
+        let (mut sender, mut receiver) =
+            self.transport
+                .into_split()
+                .map_err(|source| CoreError::Transport {
+                    context: "failed to split exec session transport",
+                    source,
+                })?;
 
         let (out_tx, out_rx) = mpsc::channel(STREAM_CHANNEL_CAPACITY);
 
@@ -1550,7 +1563,10 @@ impl AgentClient {
                     Ok(r) => r,
                     Err(e) => {
                         let _ = out_tx
-                            .send(Err(CoreError::Machine(format!("recv error: {}", e))))
+                            .send(Err(CoreError::Transport {
+                                context: "failed to receive exec session output",
+                                source: e,
+                            }))
                             .await;
                         break;
                     }

--- a/app/arcbox-core/src/boot_assets/provider.rs
+++ b/app/arcbox-core/src/boot_assets/provider.rs
@@ -5,7 +5,9 @@ use crate::error::{CoreError, Result};
 use arcbox_boot::asset_manager::{AssetManager, AssetManagerConfig};
 use arcbox_boot::download::{PrepareProgress, ProgressCallback as InnerProgressCallback};
 use arcbox_constants::cmdline::HV_EARLYCON_DIRECTIVE;
+use semver::Version;
 use sha2::Digest;
+use std::cmp::Ordering;
 use std::path::{Path, PathBuf};
 
 /// Boot assets required for VM startup.
@@ -221,7 +223,10 @@ impl BootAssetProvider {
         ))
     }
 
-    /// Lists all cached version directories.
+    /// Lists cached version directories in ascending semantic-version order.
+    ///
+    /// Prereleases follow SemVer precedence. Invalid names sort lexically after
+    /// valid versions so stray cache directories remain visible and deterministic.
     pub async fn list_cached_versions(&self) -> Result<Vec<String>> {
         let cache_dir = &self.config.cache_dir;
         if !cache_dir.exists() {
@@ -243,7 +248,16 @@ impl BootAssetProvider {
                 }
             }
         }
-        versions.sort();
+        versions.sort_by(
+            |left, right| match (Version::parse(left), Version::parse(right)) {
+                (Ok(left_version), Ok(right_version)) => left_version
+                    .cmp_precedence(&right_version)
+                    .then_with(|| left.cmp(right)),
+                (Ok(_), Err(_)) => Ordering::Less,
+                (Err(_), Ok(_)) => Ordering::Greater,
+                (Err(_), Err(_)) => left.cmp(right),
+            },
+        );
         Ok(versions)
     }
 

--- a/app/arcbox-core/src/boot_assets/tests.rs
+++ b/app/arcbox-core/src/boot_assets/tests.rs
@@ -76,6 +76,51 @@ fn test_is_cached_requires_all_assets() {
     assert!(provider.is_cached());
 }
 
+#[tokio::test]
+async fn cached_versions_use_semver_order_before_invalid_names() {
+    let temp = tempfile::tempdir().unwrap();
+    for version in [
+        "invalid-z",
+        "0.6.13",
+        "1.0.0",
+        "1.0.0+z",
+        "0.5.13",
+        "1.0.0-alpha.10",
+        "1.0.0+a",
+        "invalid-a",
+        "0.6.2",
+        "1.0.0-alpha.2",
+        "0.5.5",
+    ] {
+        let version_dir = temp.path().join(version);
+        std::fs::create_dir(&version_dir).unwrap();
+        std::fs::write(version_dir.join("manifest.json"), b"{}").unwrap();
+    }
+
+    let provider = BootAssetProvider::with_config(BootAssetConfig {
+        cache_dir: temp.path().to_path_buf(),
+        ..Default::default()
+    })
+    .unwrap();
+
+    assert_eq!(
+        provider.list_cached_versions().await.unwrap(),
+        [
+            "0.5.5",
+            "0.5.13",
+            "0.6.2",
+            "0.6.13",
+            "1.0.0-alpha.2",
+            "1.0.0-alpha.10",
+            "1.0.0",
+            "1.0.0+a",
+            "1.0.0+z",
+            "invalid-a",
+            "invalid-z",
+        ]
+    );
+}
+
 #[test]
 fn only_development_config_accepts_a_locally_generated_manifest() {
     let temp = tempfile::tempdir().unwrap();

--- a/app/arcbox-core/src/error.rs
+++ b/app/arcbox-core/src/error.rs
@@ -40,6 +40,16 @@ pub enum CoreError {
         message: String,
     },
 
+    /// Guest-agent transport error.
+    #[error("{context}: {source}")]
+    Transport {
+        /// Transport operation that failed.
+        context: &'static str,
+        /// Original transport error.
+        #[source]
+        source: arcbox_transport::error::TransportError,
+    },
+
     /// Persistence deserialization error.
     #[error("persistence error: {0}")]
     Persistence(#[from] toml::de::Error),
@@ -117,5 +127,14 @@ impl CoreError {
 impl From<std::io::Error> for CoreError {
     fn from(err: std::io::Error) -> Self {
         Self::Common(CommonError::from(err))
+    }
+}
+
+impl From<arcbox_transport::error::TransportError> for CoreError {
+    fn from(source: arcbox_transport::error::TransportError) -> Self {
+        Self::Transport {
+            context: "guest-agent transport failed",
+            source,
+        }
     }
 }

--- a/app/arcbox-core/src/machine.rs
+++ b/app/arcbox-core/src/machine.rs
@@ -776,16 +776,22 @@ impl MachineManager {
     #[cfg(target_os = "macos")]
     pub fn connect_agent(&self, name: &str) -> Result<crate::agent_client::AgentClient> {
         use crate::agent_client::AgentClient;
-        let cid = self
-            .get_cid(name)
-            .ok_or_else(|| CoreError::invalid_state("CID not assigned"))?;
-        let backend = {
+        let (cid, vm_id) = {
             let machines = self.machines.read().map_err(|_| CoreError::LockPoisoned)?;
             let machine = machines
                 .get(name)
                 .ok_or_else(|| CoreError::not_found(name.to_string()))?;
-            self.vm_manager.backend(&machine.vm_id)?
+            if machine.state != MachineState::Running {
+                return Err(CoreError::invalid_state(format!(
+                    "machine '{name}' is not running"
+                )));
+            }
+            let cid = machine
+                .cid
+                .ok_or_else(|| CoreError::invalid_state("CID not assigned"))?;
+            (cid, machine.vm_id.clone())
         };
+        let backend = self.vm_manager.backend(&vm_id)?;
         let fd = self.connect_vsock_port(name, AGENT_PORT)?;
         // The transport must follow the backend, not the fd's socket domain:
         // both backends hand over unnamed AF_UNIX fds, but only the HV

--- a/app/arcbox-core/src/machine/tests.rs
+++ b/app/arcbox-core/src/machine/tests.rs
@@ -103,6 +103,42 @@ fn test_register_mock_machine_idempotent() {
     assert_eq!(machine.cid, Some(10));
 }
 
+#[tokio::test]
+async fn connect_agent_distinguishes_missing_and_stopped_machines() {
+    let temp_dir = tempdir().unwrap();
+    let machine_manager = test_machine_manager(temp_dir.path());
+
+    let missing = machine_manager
+        .connect_agent("missing")
+        .err()
+        .expect("missing machine must fail");
+    assert!(matches!(
+        &missing,
+        CoreError::Common(arcbox_error::CommonError::NotFound(_))
+    ));
+
+    machine_manager
+        .create(MachineConfig {
+            name: "stopped".to_string(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let stopped = machine_manager
+        .connect_agent("stopped")
+        .err()
+        .expect("stopped machine must fail");
+    assert!(matches!(
+        &stopped,
+        CoreError::Common(arcbox_error::CommonError::InvalidState(_))
+    ));
+    assert!(
+        stopped
+            .to_string()
+            .contains("machine 'stopped' is not running")
+    );
+}
+
 #[test]
 fn test_select_routable_ip_prefers_ipv4() {
     let ips = vec![

--- a/docs/boot-assets.md
+++ b/docs/boot-assets.md
@@ -56,3 +56,6 @@ https://boot.arcboxcdn.com/
 The daemon pins the boot asset version via `BOOT_ASSET_VERSION` in
 `app/arcbox-core/src/boot_assets.rs`. This can be overridden at runtime
 with the `ARCBOX_BOOT_ASSET_VERSION` environment variable.
+
+`abctl boot list` sorts cached versions by SemVer precedence, including
+prereleases; invalid version directory names appear afterward in lexical order.

--- a/guest/arcbox-agent/src/agent/exec_error.rs
+++ b/guest/arcbox-agent/src/agent/exec_error.rs
@@ -1,27 +1,98 @@
+use std::path::Path;
+
 use crate::rpc::ErrorResponse;
 
-pub(super) fn spawn_error(command: &str, error: std::io::Error) -> ErrorResponse {
-    if error.kind() == std::io::ErrorKind::NotFound {
+pub(super) fn spawn_error(
+    command: &str,
+    working_dir: &str,
+    path: Option<&str>,
+    error: std::io::Error,
+) -> ErrorResponse {
+    if error.kind() == std::io::ErrorKind::NotFound
+        && requested_executable_is_missing(command, working_dir, path)
+    {
         ErrorResponse::new(404, format!("command not found: '{command}': {error}"))
     } else {
         ErrorResponse::new(500, format!("failed to spawn command '{command}': {error}"))
     }
 }
 
+fn requested_executable_is_missing(command: &str, working_dir: &str, path: Option<&str>) -> bool {
+    let working_dir = (!working_dir.is_empty()).then(|| Path::new(working_dir));
+    if working_dir.is_some_and(|dir| !dir.is_dir()) {
+        return false;
+    }
+
+    let command_path = Path::new(command);
+    if command_path.is_absolute() || command.contains(std::path::MAIN_SEPARATOR) {
+        let resolved =
+            working_dir.map_or_else(|| command_path.to_path_buf(), |dir| dir.join(command_path));
+        return !resolved.is_file();
+    }
+
+    let Some(path) = path.map(Into::into).or_else(|| std::env::var_os("PATH")) else {
+        return false;
+    };
+    !std::env::split_paths(&path).any(|dir| {
+        let candidate = if dir.is_absolute() {
+            dir.join(command)
+        } else if let Some(working_dir) = working_dir {
+            working_dir.join(dir).join(command)
+        } else {
+            dir.join(command)
+        };
+        candidate.is_file()
+    })
+}
+
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::PermissionsExt as _;
+
     use super::*;
 
     #[test]
-    fn spawn_error_classifies_missing_commands() {
-        let missing = spawn_error(
-            "nope",
-            std::io::Error::new(std::io::ErrorKind::NotFound, "missing"),
-        );
+    fn spawn_error_classifies_only_a_missing_executable_as_not_found() {
+        let search_dir = tempfile::tempdir().unwrap();
+        let path = search_dir.path().to_str().unwrap();
+        let missing = spawn_failure("arcbox-command-that-does-not-exist", "", Some(path));
         assert_eq!(missing.code, 404);
-        assert!(missing.message.contains("nope"));
+        assert!(
+            missing
+                .message
+                .contains("arcbox-command-that-does-not-exist")
+        );
 
-        let other = spawn_error("nope", std::io::Error::other("boom"));
-        assert_eq!(other.code, 500);
+        let missing_working_dir = search_dir.path().join("missing-working-directory");
+        let command = std::env::current_exe().unwrap();
+        let cwd_error = spawn_failure(
+            command.to_str().unwrap(),
+            missing_working_dir.to_str().unwrap(),
+            None,
+        );
+        assert_eq!(cwd_error.code, 500);
+
+        let script = search_dir.path().join("missing-interpreter");
+        std::fs::write(&script, "#!/arcbox/no-such-interpreter\n").unwrap();
+        let mut permissions = std::fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions).unwrap();
+        let interpreter_error = spawn_failure(script.to_str().unwrap(), "", None);
+        assert_eq!(interpreter_error.code, 500);
+    }
+
+    fn spawn_failure(command: &str, working_dir: &str, path: Option<&str>) -> ErrorResponse {
+        let mut process = std::process::Command::new(command);
+        if !working_dir.is_empty() {
+            process.current_dir(working_dir);
+        }
+        if let Some(path) = path {
+            process.env("PATH", path);
+        }
+        let error = process
+            .spawn()
+            .expect_err("test command must fail to spawn");
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+        spawn_error(command, working_dir, path, error)
     }
 }

--- a/guest/arcbox-agent/src/agent/exec_error.rs
+++ b/guest/arcbox-agent/src/agent/exec_error.rs
@@ -1,0 +1,27 @@
+use crate::rpc::ErrorResponse;
+
+pub(super) fn spawn_error(command: &str, error: std::io::Error) -> ErrorResponse {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        ErrorResponse::new(404, format!("command not found: '{command}': {error}"))
+    } else {
+        ErrorResponse::new(500, format!("failed to spawn command '{command}': {error}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spawn_error_classifies_missing_commands() {
+        let missing = spawn_error(
+            "nope",
+            std::io::Error::new(std::io::ErrorKind::NotFound, "missing"),
+        );
+        assert_eq!(missing.code, 404);
+        assert!(missing.message.contains("nope"));
+
+        let other = spawn_error("nope", std::io::Error::other("boom"));
+        assert_eq!(other.code, 500);
+    }
+}

--- a/guest/arcbox-agent/src/agent/exec_error.rs
+++ b/guest/arcbox-agent/src/agent/exec_error.rs
@@ -64,9 +64,8 @@ mod tests {
         );
 
         let missing_working_dir = search_dir.path().join("missing-working-directory");
-        let command = std::env::current_exe().unwrap();
         let cwd_error = spawn_failure(
-            command.to_str().unwrap(),
+            "./arcbox-command-that-does-not-exist",
             missing_working_dir.to_str().unwrap(),
             None,
         );

--- a/guest/arcbox-agent/src/agent/linux/machine_exec.rs
+++ b/guest/arcbox-agent/src/agent/linux/machine_exec.rs
@@ -94,7 +94,12 @@ where
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            let err = spawn_error(&req.cmd[0], e);
+            let err = spawn_error(
+                &req.cmd[0],
+                &req.working_dir,
+                req.env.get("PATH").map(String::as_str),
+                e,
+            );
             write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
             return Ok(());
         }
@@ -251,7 +256,12 @@ where
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            let err = spawn_error(&req.cmd[0], e);
+            let err = spawn_error(
+                &req.cmd[0],
+                &req.working_dir,
+                req.env.get("PATH").map(String::as_str),
+                e,
+            );
             write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
             return Ok(());
         }

--- a/guest/arcbox-agent/src/agent/linux/machine_exec.rs
+++ b/guest/arcbox-agent/src/agent/linux/machine_exec.rs
@@ -21,6 +21,7 @@ use buffa::Message;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
 use tokio::process::Command;
 
+use super::super::exec_error::spawn_error;
 use crate::rpc::{ErrorResponse, MessageType, write_message};
 
 /// Handles a machine-level exec request on the current connection.
@@ -93,7 +94,7 @@ where
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            let err = ErrorResponse::new(500, format!("failed to spawn process: {e}"));
+            let err = spawn_error(&req.cmd[0], e);
             write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
             return Ok(());
         }
@@ -250,7 +251,7 @@ where
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            let err = ErrorResponse::new(500, format!("failed to spawn process: {e}"));
+            let err = spawn_error(&req.cmd[0], e);
             write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
             return Ok(());
         }

--- a/guest/arcbox-agent/src/agent/mod.rs
+++ b/guest/arcbox-agent/src/agent/mod.rs
@@ -9,6 +9,8 @@
 use anyhow::Result;
 
 pub mod ensure_runtime;
+#[cfg(any(target_os = "linux", test))]
+mod exec_error;
 
 #[cfg(target_os = "linux")]
 mod linux;


### PR DESCRIPTION
## Linear issues

- CORE-96
- CORE-97
- CORE-99
- CORE-100
- CORE-101

## Root cause and fix

- **CORE-96:** the CLI's top-level `anyhow` termination path exposed raw internal chains, the API collapsed typed core/transport failures into `Internal`, guest spawn failures all used one status, and an exec stream without a terminal status could report success. Preserve typed errors through core/API boundaries, classify resource and execution failures once, render actionable normal output with full `--debug` context, require the terminal exec frame, and document exit contracts.
- **CORE-97:** `abctl top` refreshed output without a tested terminal-input path. Live table mode now exposes `q` / Ctrl-C, exits successfully on either, and relies on the existing RAII raw-mode guard; non-interactive formats emit one snapshot.
- **CORE-99:** log/tracing output preserved escape bytes regardless of destination. ANSI is now retained only for interactive terminals and is stripped for redirected output or `NO_COLOR`.
- **CORE-100:** cached boot directories were ordered lexically. They now use SemVer precedence, deterministic prerelease/build ties, and lexical invalid-name fallback shared by human and JSON output.
- **CORE-101:** version output reported an unreliable `Rust: unknown` field and ambiguous component versions. Human output labels local/default/minimum compatibility roles; JSON exposes stable named component fields without daemon access.

## User impact

Errors identify the affected machine, sandbox, or command and provide a next action without losing debug detail. Interactive `top` is safely controllable, redirected output is automation-safe, boot versions sort correctly, and version output clearly describes each shipped component.

## Verification

- `devenv shell -- cargo fmt --all -- --check`
- `devenv shell -- cargo clippy --workspace --all-targets -- -D warnings`
- `devenv shell -- cargo test -p arcbox-api -p arcbox-cli -p arcbox-core -p arcbox-agent`
- `devenv shell -- cargo clippy -p arcbox-agent --target aarch64-unknown-linux-musl --all-targets`
- `devenv shell -- cargo build -p arcbox-agent --target aarch64-unknown-linux-musl --release`
- `git diff --check`
