### PR TITLE
ci(sdk): gate the TypeScript and Python SDKs on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,8 +209,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # uv pinned to the same range as pyproject.toml's uv_build
+      # requirement and the publish gate (release-sdk-python.yml), so PR
+      # validation and release run the same toolchain.
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: '>=0.12.1,<0.13'
 
       - name: Install dependencies
         run: uv sync --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,3 +234,6 @@ jobs:
 
       - name: Run tests
         run: uv run pytest
+
+      - name: Build
+        run: uv build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,10 @@ jobs:
     # compare against the branch's previous state on origin.
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch base branch for comparison
         env:
@@ -35,7 +36,7 @@ jobs:
         run: git fetch origin "$BASE_REF:refs/remotes/origin/$BASE_REF" || true
 
       - name: Install buf
-        uses: bufbuild/buf-action@v1
+        uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3 # v1.5.0
         with:
           setup_only: true
 
@@ -53,10 +54,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        # The `toolchain` input selects the toolchain (not the action ref),
+        # so the SHA pin does not freeze the Rust version.
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
         with:
           toolchain: stable
 
@@ -64,7 +69,7 @@ jobs:
         run: brew install protobuf
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/bin/
@@ -122,22 +127,25 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Set up buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
           github_token: ${{ github.token }}
 
       # Self-bootstrapping: inert until the proto first lands on the base
       # branch, so it never blocks the PR that introduces it.
       - name: Check for breaking changes
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          base="${{ github.base_ref }}"
           module=fleet/arcbox-fleet-control-proto
-          git fetch --depth=1 origin "$base"
+          git fetch --depth=1 origin "$BASE_REF"
           if git cat-file -e "FETCH_HEAD:$module/buf.yaml" 2>/dev/null; then
             buf breaking "$module" --against ".git#ref=FETCH_HEAD,subdir=$module"
           else
-            echo "control-plane proto not yet on '$base'; breaking check inactive"
+            echo "control-plane proto not yet on '$BASE_REF'; breaking check inactive"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,3 +149,83 @@ jobs:
           else
             echo "control-plane proto not yet on '$BASE_REF'; breaking check inactive"
           fi
+
+  # The published SDKs live outside the cargo workspace, so the main `ci`
+  # job never touches them. These run the same gates as the release
+  # workflows (release-sdk-typescript.yml / release-sdk-python.yml), so a
+  # PR cannot land a change that would only fail at publish time. No path
+  # filter, matching this workflow's other jobs — both suites finish in
+  # about a minute.
+  sdk-typescript:
+    name: SDK TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: sdk/typescript
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  sdk-python:
+    name: SDK Python
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: sdk/python
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Lint
+        run: uv run ruff check .
+
+      - name: Check formatting
+        run: uv run ruff format --check .
+
+      - name: Typecheck
+        run: uv run pyright
+
+      - name: Check sync-tree lockstep
+        run: uv run python scripts/gen_sync.py --check
+
+      - name: Run tests
+        run: uv run pytest

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -138,9 +138,10 @@ ARCBOX_SDK_E2E=1 uv run pytest tests/test_e2e.py
   **maturin**/PyO3 extension crate in this repo's workspace; nothing in
   the current SDK needs it.
 
-TODO(CI): wire the gates above into `.github/workflows` as an
-`sdk-python` job (follow-up; workflow changes are intentionally not part
-of this branch).
+The development gates (ruff check + format, pyright, the
+`gen_sync.py --check` lockstep gate, pytest) run on every PR as the
+`sdk-python` job in `.github/workflows/ci.yml`, from a
+`uv sync --locked` environment.
 
 ## Releasing
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -79,9 +79,9 @@ opt-in:
 ARCBOX_SDK_E2E=1 npm test -- test/e2e.test.ts
 ```
 
-TODO(CI): wire `npm run lint`, `npm run format:check`, `npm test`, and
-`npm run typecheck` into `.github/workflows` as an `sdk-typescript` job
-(follow-up; workflow changes are intentionally not part of this branch).
+The gates above (lint, format check, tests, typecheck, build) run on
+every PR as the `sdk-typescript` job in `.github/workflows/ci.yml`, on
+Node 22 from a clean `npm ci`.
 
 ## Releasing
 


### PR DESCRIPTION
## Summary

The two published SDKs (`sdk/typescript`, `sdk/python`) had **zero CI coverage** — the main `ci` job only builds the cargo workspace, and both READMEs carried a `TODO(CI)`. This PR closes that gap and hardens `ci.yml` while touching it.

### `sdk-typescript` job (ubuntu, Node 22)
`npm ci` → `npm run lint` (eslint) → `npm run format:check` (biome) → `npm run typecheck` (`tsc --noEmit`) → `npm test` (vitest, 38 tests) → `npm run build` (bunchee). Mirrors the gate sequence `release-sdk-typescript.yml` runs at publish time, so a PR cannot land a change that only fails on release.

### `sdk-python` job (ubuntu, uv)
`uv sync --locked` → `ruff check` → `ruff format --check` → `pyright` (strict) → `scripts/gen_sync.py --check` (async→sync tree lockstep) → `pytest` (73 tests). `astral-sh/setup-uv` is pinned to the commit SHA of the current latest tag (v9.0.0).

Both jobs run unconditionally, matching this workflow's existing convention (no path filtering anywhere in `ci.yml`); each finishes in about a minute. All gates verified green locally on both SDKs before wiring.

### `ci.yml` hardening (first commit)
The gate for this change was actionlint + `zizmor --min-severity medium` clean on the edited workflow; ci.yml had 11 pre-existing findings, all fixed:
- every action pinned to a commit SHA (resolved from the same tags the workflow already tracked, so no version change);
- `persist-credentials: false` on every checkout (the later `git fetch`es are anonymous reads of this public repo);
- `github.base_ref` in `proto-compat` routed through `env` instead of spliced into the script body (template-injection), matching the pattern `proto-breaking` already used.

### READMEs
The `TODO(CI)` notes in both SDK READMEs are replaced with the wired-up reality (docs updated with behavior, per repo rule).

## Sandbox e2e (CORE-17)
Investigated as part of this change; **not feasible in hosted CI today** — findings and a concrete phased plan are recorded on [CORE-17](https://linear.app/arcbox/issue/CORE-17). Short version: the macOS route needs nested virt (VZ on M3+ bare metal; GH macOS runners are M1/M2-class VMs without Virtualization.framework support), and the Linux route needs the KVM System-VM boot path brought up first (nothing in CI even builds the daemon stack for Linux; the KVM backend never programs guest CPUID, so an x86_64 System VM cannot boot, let alone expose `/dev/kvm` for nested Firecracker). The in-process `sandbox_service_manager` job in `test-vm-linux.yml` remains the Firecracker-level gate meanwhile.

## Validation
- `actionlint` + `zizmor --min-severity medium` clean on `ci.yml` at both commits; `git diff --check` clean.
- All 11 SDK gate commands run green locally (TS: 38 passed / 1 skipped; Py: 73 passed / 2 skipped, pyright 0 errors).
- The new jobs run on this PR itself.