### PR TITLE
fix(sdk): expose __version__ and bound connect()'s waits (CORE-85)

### DIFF
--- a/sdk/python/src/arcbox/__init__.py
+++ b/sdk/python/src/arcbox/__init__.py
@@ -7,6 +7,8 @@ wire code and is deliberately NOT exported. The error hierarchy lives
 in :mod:`arcbox.errors`.
 """
 
+from importlib.metadata import PackageNotFoundError, version
+
 from arcbox._async._client import AsyncConnectClient
 from arcbox._async.commands import AsyncCommandHandle, AsyncCommands, AsyncOutputStream
 from arcbox._async.files import AsyncFiles
@@ -27,6 +29,13 @@ from arcbox._types import (
     SandboxSummary,
     SignalName,
 )
+
+try:
+    __version__ = version("arcbox")
+except PackageNotFoundError:
+    # An uninstalled source tree carries no distribution metadata; a
+    # fixed dev sentinel beats parsing pyproject.toml on every import.
+    __version__ = "0.0.0.dev0"
 
 __all__ = [
     "MAX_FILE_BYTES",

--- a/sdk/python/src/arcbox/_async/_client.py
+++ b/sdk/python/src/arcbox/_async/_client.py
@@ -128,11 +128,20 @@ class AsyncConnectClient:
         message.ParseFromString(response.content)
         return message
 
-    def stream(self, path: str, request: Message, response_type: type[M]) -> AsyncServerStream[M]:
+    def stream(
+        self,
+        path: str,
+        request: Message,
+        response_type: type[M],
+        timeout: float | None = None,
+    ) -> AsyncServerStream[M]:
         """One server-streaming RPC. Entering the returned context sends
         the request (that is what registers a subscription server-side);
-        iterate it for messages."""
-        return AsyncServerStream(self._http, path, request, response_type)
+        iterate it for messages. Streams are exempt from the configured
+        ``request_timeout``; ``timeout``, when set, bounds the connect
+        phase and each read gap (used by ``connect``'s overall
+        deadline)."""
+        return AsyncServerStream(self._http, path, request, response_type, timeout)
 
     async def client_stream(
         self, path: str, requests: Iterable[Message], response_type: type[M]
@@ -182,17 +191,23 @@ class AsyncServerStream(Generic[M]):
         path: str,
         request: Message,
         response_type: type[M],
+        timeout: float | None = None,
     ) -> None:
         self._http = http
         self._path = path
         self._body = encode_envelope(0, request.SerializeToString())
         self._response_type = response_type
+        self._timeout = timeout
         self._cm: AbstractAsyncContextManager[httpx.Response] | None = None
         self._response: httpx.Response | None = None
 
     async def __aenter__(self) -> AsyncServerStream[M]:
         cm = self._http.stream(
-            "POST", self._path, content=self._body, headers=_STREAM_HEADERS, timeout=None
+            "POST",
+            self._path,
+            content=self._body,
+            headers=_STREAM_HEADERS,
+            timeout=None if self._timeout is None else httpx.Timeout(self._timeout),
         )
         response = await cm.__aenter__()
         if response.status_code != 200:

--- a/sdk/python/src/arcbox/_async/_client.py
+++ b/sdk/python/src/arcbox/_async/_client.py
@@ -202,6 +202,11 @@ class AsyncServerStream(Generic[M]):
         self._response: httpx.Response | None = None
 
     async def __aenter__(self) -> AsyncServerStream[M]:
+        # A per-phase cap, not wall-clock: httpx grants connect/read/
+        # write/pool this much each, so it bounds silence (a wedged
+        # peer), while a stream that keeps sending frames stays open —
+        # callers enforcing an overall deadline re-check their budget on
+        # every frame.
         cm = self._http.stream(
             "POST",
             self._path,

--- a/sdk/python/src/arcbox/_async/sandbox.py
+++ b/sdk/python/src/arcbox/_async/sandbox.py
@@ -28,6 +28,7 @@ from arcbox._types import (
 )
 from arcbox.errors import (
     ArcBoxError,
+    InvalidArgumentError,
     NotFoundError,
     RequestTimeoutError,
     SandboxStateError,
@@ -214,14 +215,26 @@ class AsyncArcBox:
 
         ``timeout`` bounds the WHOLE call — the settle poll, a resume,
         and the readiness wait share one deadline (default 60s;
-        ``None`` disables it). On expiry :class:`TimeoutError` is raised
-        and the sandbox is left as it was."""
+        ``None`` or ``math.inf`` disables it). On expiry
+        :class:`TimeoutError` is raised and the sandbox is left as it
+        was."""
         with wrap_errors("sandbox.connect"):
+            # Validate at the boundary: NaN and non-positive values
+            # would otherwise corrupt or silently pre-expire the budget
+            # arithmetic below.
+            if timeout is not None and not timeout > 0:
+                raise InvalidArgumentError(
+                    "connect timeout must be a positive number of seconds "
+                    "(None disables the bound)",
+                    context={"timeout": str(timeout)},
+                )
             # One deadline over every wait below — the settle poll,
             # resume, and the readiness wait; bounding only one of them
             # would be arbitrary while the neighbouring waits stayed
             # unbounded.
-            deadline = None if timeout is None else time.monotonic() + timeout
+            deadline = (
+                None if timeout is None or math.isinf(timeout) else time.monotonic() + timeout
+            )
             try:
                 return await self._connect(sandbox_id, deadline)
             except (RequestTimeoutError, httpx.TimeoutException) as exc:
@@ -489,8 +502,10 @@ class AsyncSandbox:
         timeout: float | None = _CONNECT_TIMEOUT_SECONDS,
         connection: Connection | None = None,
     ) -> AsyncSandbox:
-        """Attach to an existing sandbox by id. Client ownership works as
-        in :meth:`create`."""
+        """Attach to an existing sandbox by id. ``timeout`` bounds the
+        whole call as in :meth:`AsyncArcBox.connect` (default 60s;
+        ``None`` disables it; expiry raises :class:`TimeoutError`).
+        Client ownership works as in :meth:`create`."""
         box = AsyncArcBox(connection)
         try:
             sandbox = await box.connect(sandbox_id, timeout=timeout)

--- a/sdk/python/src/arcbox/_async/sandbox.py
+++ b/sdk/python/src/arcbox/_async/sandbox.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 import asyncio
 import math
+import time
 import uuid
 from contextlib import suppress
 from typing import TYPE_CHECKING
 
+import httpx
 from google.protobuf import empty_pb2
 
 from arcbox._boundary import wrap_errors
@@ -24,7 +26,13 @@ from arcbox._types import (
     sandbox_state_to_proto,
     sandbox_summary_from_proto,
 )
-from arcbox.errors import ArcBoxError, NotFoundError, SandboxStateError
+from arcbox.errors import (
+    ArcBoxError,
+    NotFoundError,
+    RequestTimeoutError,
+    SandboxStateError,
+    TimeoutError,
+)
 
 from ._client import AsyncConnectClient
 from .commands import AsyncCommands
@@ -61,9 +69,33 @@ _GONE_EVENTS = (
 #: should become an event wait.
 _PAUSE_SETTLE_POLL_SECONDS = 0.5
 
+#: Default overall deadline for ``connect`` in seconds — generous
+#: because a checkpoint restore or cold boot legitimately takes a
+#: while. ``timeout=None`` disables the bound.
+_CONNECT_TIMEOUT_SECONDS = 60.0
+
 
 def _seconds_to_wire(seconds: float | None) -> int:
     return 0 if seconds is None else math.ceil(seconds)
+
+
+def _connect_deadline_error(sandbox_id: str) -> TimeoutError:
+    return TimeoutError(
+        f"connect(timeout) elapsed before sandbox {sandbox_id} was ready",
+        suggestion="increase the connect timeout argument",
+        context={"id": sandbox_id},
+    )
+
+
+def _budget(deadline: float | None, sandbox_id: str) -> float | None:
+    """Seconds left before ``deadline`` (``None`` = unbounded), raising
+    the connect timeout once it has passed."""
+    if deadline is None:
+        return None
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise _connect_deadline_error(sandbox_id)
+    return remaining
 
 
 class AsyncArcBox:
@@ -171,46 +203,75 @@ class AsyncArcBox:
                     )
                 raise
 
-    async def connect(self, sandbox_id: str) -> AsyncSandbox:
+    async def connect(
+        self, sandbox_id: str, *, timeout: float | None = _CONNECT_TIMEOUT_SECONDS
+    ) -> AsyncSandbox:
         """Attach to an existing sandbox. A PAUSED sandbox is resumed
         (resume completes once it is READY again); a PAUSING one settles
         to PAUSED first, then resumes; a STARTING one is waited for. A
         terminal state is a typed error carrying the observed state.
-        Connecting never touches the sandbox's lifecycle deadlines."""
+        Connecting never touches the sandbox's lifecycle deadlines.
+
+        ``timeout`` bounds the WHOLE call — the settle poll, a resume,
+        and the readiness wait share one deadline (default 60s;
+        ``None`` disables it). On expiry :class:`TimeoutError` is raised
+        and the sandbox is left as it was."""
         with wrap_errors("sandbox.connect"):
-            info = await self._inspect(sandbox_id)
-            # A pausing sandbox's next stop is PAUSED — never READY — so
-            # waiting on readiness events would park forever. Poll the
-            # checkpoint out, then route on whatever state it settled in.
-            while info.state == sandbox_pb2.SANDBOX_STATE_PAUSING:
-                await asyncio.sleep(_PAUSE_SETTLE_POLL_SECONDS)
-                info = await self._inspect(sandbox_id)
-            if info.state in _READY_STATES:
-                return AsyncSandbox(self._client, sandbox_id)
-            if info.state == sandbox_pb2.SANDBOX_STATE_PAUSED:
-                # Deliberately no per-request deadline: restoring a
-                # checkpoint takes as long as it takes, and the RPC
-                # returns once READY.
-                await self._client.unary(
-                    _SANDBOX + "Resume",
-                    sandbox_pb2.ResumeSandboxRequest(id=sandbox_id),
-                    empty_pb2.Empty,
-                    timeout=None,
-                )
-                return AsyncSandbox(self._client, sandbox_id)
-            if info.state == sandbox_pb2.SANDBOX_STATE_STARTING:
-                async with self._client.stream(
-                    _SANDBOX + "Events",
-                    sandbox_pb2.SandboxEventsRequest(sandbox_id=sandbox_id),
-                    sandbox_pb2.WatchEventsResponse,
-                ) as events:
-                    await self._wait_ready(sandbox_id, events)
-                return AsyncSandbox(self._client, sandbox_id)
-            state = sandbox_state_from_proto(info.state)
-            raise SandboxStateError(
-                f"sandbox {sandbox_id} is {state} and cannot be connected to",
-                context={"id": sandbox_id, "state": state, "error": info.error},
+            # One deadline over every wait below — the settle poll,
+            # resume, and the readiness wait; bounding only one of them
+            # would be arbitrary while the neighbouring waits stayed
+            # unbounded.
+            deadline = None if timeout is None else time.monotonic() + timeout
+            try:
+                return await self._connect(sandbox_id, deadline)
+            except (RequestTimeoutError, httpx.TimeoutException) as exc:
+                # A per-RPC expiry observed after the overall deadline
+                # passed is the connect budget surfacing, not the
+                # per-request knob.
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise _connect_deadline_error(sandbox_id) from exc
+                raise
+
+    async def _connect(self, sandbox_id: str, deadline: float | None) -> AsyncSandbox:
+        info = await self._inspect(sandbox_id, deadline=deadline)
+        # A pausing sandbox's next stop is PAUSED — never READY — so
+        # waiting on readiness events would park forever. Poll the
+        # checkpoint out, then route on whatever state it settled in.
+        while info.state == sandbox_pb2.SANDBOX_STATE_PAUSING:
+            remaining = _budget(deadline, sandbox_id)
+            await asyncio.sleep(
+                _PAUSE_SETTLE_POLL_SECONDS
+                if remaining is None
+                else min(_PAUSE_SETTLE_POLL_SECONDS, remaining)
             )
+            info = await self._inspect(sandbox_id, deadline=deadline)
+        if info.state in _READY_STATES:
+            return AsyncSandbox(self._client, sandbox_id)
+        if info.state == sandbox_pb2.SANDBOX_STATE_PAUSED:
+            # No per-request deadline of its own: restoring a checkpoint
+            # takes as long as it takes, and the RPC returns once READY —
+            # the overall connect deadline is the only bound.
+            await self._client.unary(
+                _SANDBOX + "Resume",
+                sandbox_pb2.ResumeSandboxRequest(id=sandbox_id),
+                empty_pb2.Empty,
+                timeout=_budget(deadline, sandbox_id),
+            )
+            return AsyncSandbox(self._client, sandbox_id)
+        if info.state == sandbox_pb2.SANDBOX_STATE_STARTING:
+            async with self._client.stream(
+                _SANDBOX + "Events",
+                sandbox_pb2.SandboxEventsRequest(sandbox_id=sandbox_id),
+                sandbox_pb2.WatchEventsResponse,
+                timeout=_budget(deadline, sandbox_id),
+            ) as events:
+                await self._wait_ready(sandbox_id, events, deadline=deadline)
+            return AsyncSandbox(self._client, sandbox_id)
+        state = sandbox_state_from_proto(info.state)
+        raise SandboxStateError(
+            f"sandbox {sandbox_id} is {state} and cannot be connected to",
+            context={"id": sandbox_id, "state": state, "error": info.error},
+        )
 
     async def list(
         self,
@@ -241,11 +302,21 @@ class AsyncArcBox:
                 if page_token == "":
                     return
 
-    async def _inspect(self, sandbox_id: str) -> sandbox_pb2.SandboxInfo:
+    async def _inspect(
+        self, sandbox_id: str, deadline: float | None = None
+    ) -> sandbox_pb2.SandboxInfo:
+        """Inspect, with the configured per-RPC deadline capped by the
+        remaining connect budget when one is running."""
+        remaining = _budget(deadline, sandbox_id)
+        request = sandbox_pb2.InspectSandboxRequest(id=sandbox_id)
+        if remaining is None:
+            return await self._client.unary(_SANDBOX + "Inspect", request, sandbox_pb2.SandboxInfo)
+        base = self._client.request_timeout
         return await self._client.unary(
             _SANDBOX + "Inspect",
-            sandbox_pb2.InspectSandboxRequest(id=sandbox_id),
+            request,
             sandbox_pb2.SandboxInfo,
+            timeout=remaining if base is None else min(base, remaining),
         )
 
     async def _create(
@@ -294,6 +365,7 @@ class AsyncArcBox:
         self,
         sandbox_id: str,
         events: AsyncServerStream[sandbox_pb2.WatchEventsResponse],
+        deadline: float | None = None,
     ) -> None:
         """Consume lifecycle events until READY/RUNNING, or fail on a
         terminal transition. The subscription was armed before Create, so
@@ -316,10 +388,14 @@ class AsyncArcBox:
                 )
             return False
 
-        info = await self._inspect(sandbox_id)
+        info = await self._inspect(sandbox_id, deadline=deadline)
         if check(info.state, info.error):
             return
         async for frame in events:
+            # The stream's read timeout only bounds silence; frames may
+            # keep arriving (keepalives) without ever tripping it, so the
+            # overall budget is re-checked on every frame.
+            _budget(deadline, sandbox_id)
             payload = frame.WhichOneof("payload")
             if payload == "event":
                 event = frame.event
@@ -337,7 +413,7 @@ class AsyncArcBox:
                         context={"id": sandbox_id, "state": "stopped"},
                     )
             elif payload == "keep_alive":
-                fresh = await self._inspect(sandbox_id)
+                fresh = await self._inspect(sandbox_id, deadline=deadline)
                 if check(fresh.state, fresh.error):
                     return
         raise ArcBoxError(
@@ -407,13 +483,17 @@ class AsyncSandbox:
 
     @classmethod
     async def connect(
-        cls, sandbox_id: str, *, connection: Connection | None = None
+        cls,
+        sandbox_id: str,
+        *,
+        timeout: float | None = _CONNECT_TIMEOUT_SECONDS,
+        connection: Connection | None = None,
     ) -> AsyncSandbox:
         """Attach to an existing sandbox by id. Client ownership works as
         in :meth:`create`."""
         box = AsyncArcBox(connection)
         try:
-            sandbox = await box.connect(sandbox_id)
+            sandbox = await box.connect(sandbox_id, timeout=timeout)
         except BaseException:
             await box.aclose()
             raise

--- a/sdk/python/src/arcbox/_async/sandbox.py
+++ b/sdk/python/src/arcbox/_async/sandbox.py
@@ -54,8 +54,11 @@ _GONE_EVENTS = (
     sandbox_pb2.SANDBOX_EVENT_KIND_REMOVED,
 )
 
-#: How often ``connect`` re-inspects a PAUSING sandbox. No lifecycle
-#: event marks the PAUSING→PAUSED edge, so it is polled out.
+#: How often ``connect`` re-inspects a PAUSING sandbox.
+#: ``SANDBOX_EVENT_KIND_PAUSED`` names this edge in the proto, but the
+#: daemon does not emit it yet (Pause/Resume are CORE-21 stubs), so the
+#: checkpoint is polled out instead. Once it is emitted, this poll
+#: should become an event wait.
 _PAUSE_SETTLE_POLL_SECONDS = 0.5
 
 

--- a/sdk/python/src/arcbox/_sync/_client.py
+++ b/sdk/python/src/arcbox/_sync/_client.py
@@ -201,6 +201,11 @@ class ServerStream(Generic[M]):
         self._response: httpx.Response | None = None
 
     def __enter__(self) -> ServerStream[M]:
+        # A per-phase cap, not wall-clock: httpx grants connect/read/
+        # write/pool this much each, so it bounds silence (a wedged
+        # peer), while a stream that keeps sending frames stays open —
+        # callers enforcing an overall deadline re-check their budget on
+        # every frame.
         cm = self._http.stream(
             "POST",
             self._path,

--- a/sdk/python/src/arcbox/_sync/_client.py
+++ b/sdk/python/src/arcbox/_sync/_client.py
@@ -129,11 +129,20 @@ class ConnectClient:
         message.ParseFromString(response.content)
         return message
 
-    def stream(self, path: str, request: Message, response_type: type[M]) -> ServerStream[M]:
+    def stream(
+        self,
+        path: str,
+        request: Message,
+        response_type: type[M],
+        timeout: float | None = None,
+    ) -> ServerStream[M]:
         """One server-streaming RPC. Entering the returned context sends
         the request (that is what registers a subscription server-side);
-        iterate it for messages."""
-        return ServerStream(self._http, path, request, response_type)
+        iterate it for messages. Streams are exempt from the configured
+        ``request_timeout``; ``timeout``, when set, bounds the connect
+        phase and each read gap (used by ``connect``'s overall
+        deadline)."""
+        return ServerStream(self._http, path, request, response_type, timeout)
 
     def client_stream(self, path: str, requests: Iterable[Message], response_type: type[M]) -> M:
         """One client-streaming RPC with the full request sequence known
@@ -181,17 +190,23 @@ class ServerStream(Generic[M]):
         path: str,
         request: Message,
         response_type: type[M],
+        timeout: float | None = None,
     ) -> None:
         self._http = http
         self._path = path
         self._body = encode_envelope(0, request.SerializeToString())
         self._response_type = response_type
+        self._timeout = timeout
         self._cm: AbstractContextManager[httpx.Response] | None = None
         self._response: httpx.Response | None = None
 
     def __enter__(self) -> ServerStream[M]:
         cm = self._http.stream(
-            "POST", self._path, content=self._body, headers=_STREAM_HEADERS, timeout=None
+            "POST",
+            self._path,
+            content=self._body,
+            headers=_STREAM_HEADERS,
+            timeout=None if self._timeout is None else httpx.Timeout(self._timeout),
         )
         response = cm.__enter__()
         if response.status_code != 200:

--- a/sdk/python/src/arcbox/_sync/sandbox.py
+++ b/sdk/python/src/arcbox/_sync/sandbox.py
@@ -28,6 +28,7 @@ from arcbox._types import (
 )
 from arcbox.errors import (
     ArcBoxError,
+    InvalidArgumentError,
     NotFoundError,
     RequestTimeoutError,
     SandboxStateError,
@@ -214,14 +215,26 @@ class ArcBox:
 
         ``timeout`` bounds the WHOLE call — the settle poll, a resume,
         and the readiness wait share one deadline (default 60s;
-        ``None`` disables it). On expiry :class:`TimeoutError` is raised
-        and the sandbox is left as it was."""
+        ``None`` or ``math.inf`` disables it). On expiry
+        :class:`TimeoutError` is raised and the sandbox is left as it
+        was."""
         with wrap_errors("sandbox.connect"):
+            # Validate at the boundary: NaN and non-positive values
+            # would otherwise corrupt or silently pre-expire the budget
+            # arithmetic below.
+            if timeout is not None and not timeout > 0:
+                raise InvalidArgumentError(
+                    "connect timeout must be a positive number of seconds "
+                    "(None disables the bound)",
+                    context={"timeout": str(timeout)},
+                )
             # One deadline over every wait below — the settle poll,
             # resume, and the readiness wait; bounding only one of them
             # would be arbitrary while the neighbouring waits stayed
             # unbounded.
-            deadline = None if timeout is None else time.monotonic() + timeout
+            deadline = (
+                None if timeout is None or math.isinf(timeout) else time.monotonic() + timeout
+            )
             try:
                 return self._connect(sandbox_id, deadline)
             except (RequestTimeoutError, httpx.TimeoutException) as exc:
@@ -487,8 +500,10 @@ class Sandbox:
         timeout: float | None = _CONNECT_TIMEOUT_SECONDS,
         connection: Connection | None = None,
     ) -> Sandbox:
-        """Attach to an existing sandbox by id. Client ownership works as
-        in :meth:`create`."""
+        """Attach to an existing sandbox by id. ``timeout`` bounds the
+        whole call as in :meth:`AsyncArcBox.connect` (default 60s;
+        ``None`` disables it; expiry raises :class:`TimeoutError`).
+        Client ownership works as in :meth:`create`."""
         box = ArcBox(connection)
         try:
             sandbox = box.connect(sandbox_id, timeout=timeout)

--- a/sdk/python/src/arcbox/_sync/sandbox.py
+++ b/sdk/python/src/arcbox/_sync/sandbox.py
@@ -13,6 +13,7 @@ import uuid
 from contextlib import suppress
 from typing import TYPE_CHECKING
 
+import httpx
 from google.protobuf import empty_pb2
 
 from arcbox._boundary import wrap_errors
@@ -25,7 +26,13 @@ from arcbox._types import (
     sandbox_state_to_proto,
     sandbox_summary_from_proto,
 )
-from arcbox.errors import ArcBoxError, NotFoundError, SandboxStateError
+from arcbox.errors import (
+    ArcBoxError,
+    NotFoundError,
+    RequestTimeoutError,
+    SandboxStateError,
+    TimeoutError,
+)
 
 from ._client import ConnectClient
 from .commands import Commands
@@ -62,9 +69,33 @@ _GONE_EVENTS = (
 #: should become an event wait.
 _PAUSE_SETTLE_POLL_SECONDS = 0.5
 
+#: Default overall deadline for ``connect`` in seconds — generous
+#: because a checkpoint restore or cold boot legitimately takes a
+#: while. ``timeout=None`` disables the bound.
+_CONNECT_TIMEOUT_SECONDS = 60.0
+
 
 def _seconds_to_wire(seconds: float | None) -> int:
     return 0 if seconds is None else math.ceil(seconds)
+
+
+def _connect_deadline_error(sandbox_id: str) -> TimeoutError:
+    return TimeoutError(
+        f"connect(timeout) elapsed before sandbox {sandbox_id} was ready",
+        suggestion="increase the connect timeout argument",
+        context={"id": sandbox_id},
+    )
+
+
+def _budget(deadline: float | None, sandbox_id: str) -> float | None:
+    """Seconds left before ``deadline`` (``None`` = unbounded), raising
+    the connect timeout once it has passed."""
+    if deadline is None:
+        return None
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise _connect_deadline_error(sandbox_id)
+    return remaining
 
 
 class ArcBox:
@@ -172,46 +203,75 @@ class ArcBox:
                     )
                 raise
 
-    def connect(self, sandbox_id: str) -> Sandbox:
+    def connect(
+        self, sandbox_id: str, *, timeout: float | None = _CONNECT_TIMEOUT_SECONDS
+    ) -> Sandbox:
         """Attach to an existing sandbox. A PAUSED sandbox is resumed
         (resume completes once it is READY again); a PAUSING one settles
         to PAUSED first, then resumes; a STARTING one is waited for. A
         terminal state is a typed error carrying the observed state.
-        Connecting never touches the sandbox's lifecycle deadlines."""
+        Connecting never touches the sandbox's lifecycle deadlines.
+
+        ``timeout`` bounds the WHOLE call — the settle poll, a resume,
+        and the readiness wait share one deadline (default 60s;
+        ``None`` disables it). On expiry :class:`TimeoutError` is raised
+        and the sandbox is left as it was."""
         with wrap_errors("sandbox.connect"):
-            info = self._inspect(sandbox_id)
-            # A pausing sandbox's next stop is PAUSED — never READY — so
-            # waiting on readiness events would park forever. Poll the
-            # checkpoint out, then route on whatever state it settled in.
-            while info.state == sandbox_pb2.SANDBOX_STATE_PAUSING:
-                time.sleep(_PAUSE_SETTLE_POLL_SECONDS)
-                info = self._inspect(sandbox_id)
-            if info.state in _READY_STATES:
-                return Sandbox(self._client, sandbox_id)
-            if info.state == sandbox_pb2.SANDBOX_STATE_PAUSED:
-                # Deliberately no per-request deadline: restoring a
-                # checkpoint takes as long as it takes, and the RPC
-                # returns once READY.
-                self._client.unary(
-                    _SANDBOX + "Resume",
-                    sandbox_pb2.ResumeSandboxRequest(id=sandbox_id),
-                    empty_pb2.Empty,
-                    timeout=None,
-                )
-                return Sandbox(self._client, sandbox_id)
-            if info.state == sandbox_pb2.SANDBOX_STATE_STARTING:
-                with self._client.stream(
-                    _SANDBOX + "Events",
-                    sandbox_pb2.SandboxEventsRequest(sandbox_id=sandbox_id),
-                    sandbox_pb2.WatchEventsResponse,
-                ) as events:
-                    self._wait_ready(sandbox_id, events)
-                return Sandbox(self._client, sandbox_id)
-            state = sandbox_state_from_proto(info.state)
-            raise SandboxStateError(
-                f"sandbox {sandbox_id} is {state} and cannot be connected to",
-                context={"id": sandbox_id, "state": state, "error": info.error},
+            # One deadline over every wait below — the settle poll,
+            # resume, and the readiness wait; bounding only one of them
+            # would be arbitrary while the neighbouring waits stayed
+            # unbounded.
+            deadline = None if timeout is None else time.monotonic() + timeout
+            try:
+                return self._connect(sandbox_id, deadline)
+            except (RequestTimeoutError, httpx.TimeoutException) as exc:
+                # A per-RPC expiry observed after the overall deadline
+                # passed is the connect budget surfacing, not the
+                # per-request knob.
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise _connect_deadline_error(sandbox_id) from exc
+                raise
+
+    def _connect(self, sandbox_id: str, deadline: float | None) -> Sandbox:
+        info = self._inspect(sandbox_id, deadline=deadline)
+        # A pausing sandbox's next stop is PAUSED — never READY — so
+        # waiting on readiness events would park forever. Poll the
+        # checkpoint out, then route on whatever state it settled in.
+        while info.state == sandbox_pb2.SANDBOX_STATE_PAUSING:
+            remaining = _budget(deadline, sandbox_id)
+            time.sleep(
+                _PAUSE_SETTLE_POLL_SECONDS
+                if remaining is None
+                else min(_PAUSE_SETTLE_POLL_SECONDS, remaining)
             )
+            info = self._inspect(sandbox_id, deadline=deadline)
+        if info.state in _READY_STATES:
+            return Sandbox(self._client, sandbox_id)
+        if info.state == sandbox_pb2.SANDBOX_STATE_PAUSED:
+            # No per-request deadline of its own: restoring a checkpoint
+            # takes as long as it takes, and the RPC returns once READY —
+            # the overall connect deadline is the only bound.
+            self._client.unary(
+                _SANDBOX + "Resume",
+                sandbox_pb2.ResumeSandboxRequest(id=sandbox_id),
+                empty_pb2.Empty,
+                timeout=_budget(deadline, sandbox_id),
+            )
+            return Sandbox(self._client, sandbox_id)
+        if info.state == sandbox_pb2.SANDBOX_STATE_STARTING:
+            with self._client.stream(
+                _SANDBOX + "Events",
+                sandbox_pb2.SandboxEventsRequest(sandbox_id=sandbox_id),
+                sandbox_pb2.WatchEventsResponse,
+                timeout=_budget(deadline, sandbox_id),
+            ) as events:
+                self._wait_ready(sandbox_id, events, deadline=deadline)
+            return Sandbox(self._client, sandbox_id)
+        state = sandbox_state_from_proto(info.state)
+        raise SandboxStateError(
+            f"sandbox {sandbox_id} is {state} and cannot be connected to",
+            context={"id": sandbox_id, "state": state, "error": info.error},
+        )
 
     def list(
         self,
@@ -242,11 +302,19 @@ class ArcBox:
                 if page_token == "":
                     return
 
-    def _inspect(self, sandbox_id: str) -> sandbox_pb2.SandboxInfo:
+    def _inspect(self, sandbox_id: str, deadline: float | None = None) -> sandbox_pb2.SandboxInfo:
+        """Inspect, with the configured per-RPC deadline capped by the
+        remaining connect budget when one is running."""
+        remaining = _budget(deadline, sandbox_id)
+        request = sandbox_pb2.InspectSandboxRequest(id=sandbox_id)
+        if remaining is None:
+            return self._client.unary(_SANDBOX + "Inspect", request, sandbox_pb2.SandboxInfo)
+        base = self._client.request_timeout
         return self._client.unary(
             _SANDBOX + "Inspect",
-            sandbox_pb2.InspectSandboxRequest(id=sandbox_id),
+            request,
             sandbox_pb2.SandboxInfo,
+            timeout=remaining if base is None else min(base, remaining),
         )
 
     def _create(
@@ -295,6 +363,7 @@ class ArcBox:
         self,
         sandbox_id: str,
         events: ServerStream[sandbox_pb2.WatchEventsResponse],
+        deadline: float | None = None,
     ) -> None:
         """Consume lifecycle events until READY/RUNNING, or fail on a
         terminal transition. The subscription was armed before Create, so
@@ -317,10 +386,14 @@ class ArcBox:
                 )
             return False
 
-        info = self._inspect(sandbox_id)
+        info = self._inspect(sandbox_id, deadline=deadline)
         if check(info.state, info.error):
             return
         for frame in events:
+            # The stream's read timeout only bounds silence; frames may
+            # keep arriving (keepalives) without ever tripping it, so the
+            # overall budget is re-checked on every frame.
+            _budget(deadline, sandbox_id)
             payload = frame.WhichOneof("payload")
             if payload == "event":
                 event = frame.event
@@ -338,7 +411,7 @@ class ArcBox:
                         context={"id": sandbox_id, "state": "stopped"},
                     )
             elif payload == "keep_alive":
-                fresh = self._inspect(sandbox_id)
+                fresh = self._inspect(sandbox_id, deadline=deadline)
                 if check(fresh.state, fresh.error):
                     return
         raise ArcBoxError(
@@ -407,12 +480,18 @@ class Sandbox:
         return sandbox
 
     @classmethod
-    def connect(cls, sandbox_id: str, *, connection: Connection | None = None) -> Sandbox:
+    def connect(
+        cls,
+        sandbox_id: str,
+        *,
+        timeout: float | None = _CONNECT_TIMEOUT_SECONDS,
+        connection: Connection | None = None,
+    ) -> Sandbox:
         """Attach to an existing sandbox by id. Client ownership works as
         in :meth:`create`."""
         box = ArcBox(connection)
         try:
-            sandbox = box.connect(sandbox_id)
+            sandbox = box.connect(sandbox_id, timeout=timeout)
         except BaseException:
             box.close()
             raise

--- a/sdk/python/src/arcbox/_sync/sandbox.py
+++ b/sdk/python/src/arcbox/_sync/sandbox.py
@@ -55,8 +55,11 @@ _GONE_EVENTS = (
     sandbox_pb2.SANDBOX_EVENT_KIND_REMOVED,
 )
 
-#: How often ``connect`` re-inspects a PAUSING sandbox. No lifecycle
-#: event marks the PAUSING→PAUSED edge, so it is polled out.
+#: How often ``connect`` re-inspects a PAUSING sandbox.
+#: ``SANDBOX_EVENT_KIND_PAUSED`` names this edge in the proto, but the
+#: daemon does not emit it yet (Pause/Resume are CORE-21 stubs), so the
+#: checkpoint is polled out instead. Once it is emitted, this poll
+#: should become an event wait.
 _PAUSE_SETTLE_POLL_SECONDS = 0.5
 
 

--- a/sdk/python/tests/test_connect.py
+++ b/sdk/python/tests/test_connect.py
@@ -14,6 +14,7 @@ from google.protobuf import empty_pb2
 from arcbox import ArcBox, Connection
 from arcbox._envelope import FLAG_END_STREAM, encode_envelope
 from arcbox._gen import sandbox_pb2
+from arcbox.errors import InvalidArgumentError
 from arcbox.errors import TimeoutError as ArcBoxTimeoutError
 
 
@@ -90,6 +91,13 @@ def test_connect_settles_a_pausing_sandbox_then_resumes() -> None:
     assert daemon.inspects == 2
     assert daemon.event_streams == 0
     assert daemon.resumes == 1
+
+
+def test_connect_rejects_a_non_positive_timeout_before_any_rpc() -> None:
+    daemon = MockLifecycle([sandbox_pb2.SANDBOX_STATE_READY])
+    with pytest.raises(InvalidArgumentError):
+        connect_against(daemon).connect("sb-1", timeout=-1)
+    assert daemon.inspects == 0
 
 
 def test_connect_bounds_a_never_settling_pausing_sandbox() -> None:

--- a/sdk/python/tests/test_connect.py
+++ b/sdk/python/tests/test_connect.py
@@ -11,26 +11,52 @@ import httpx
 from google.protobuf import empty_pb2
 
 from arcbox import ArcBox, Connection
+from arcbox._envelope import FLAG_END_STREAM, encode_envelope
 from arcbox._gen import sandbox_pb2
 
 
+def _events_body() -> bytes:
+    """What the daemon serves a pausing sandbox: a keepalive and no
+    state change, because READY is not where it is headed. The real
+    stream never ends; ending it here makes a connect that wrongly
+    waits on readiness fail fast, and say why, instead of hanging."""
+    keepalive = sandbox_pb2.WatchEventsResponse(keep_alive=sandbox_pb2.KeepAlive())
+    return encode_envelope(0, keepalive.SerializeToString()) + encode_envelope(
+        FLAG_END_STREAM, b"{}"
+    )
+
+
 class MockLifecycle:
-    """Serves Inspect from a state script and records Resume calls."""
+    """Serves Inspect from a state script, counting every call it answers."""
 
     def __init__(self, states: list[sandbox_pb2.SandboxState]) -> None:
         #: Consumed one per Inspect; the last entry repeats.
         self.states = states
         self.resumes = 0
+        #: The settle poll is witnessed by this count: ``resume``
+        #: rewrites ``states`` unconditionally, so the post-state is
+        #: ``[READY]`` whether or not a second Inspect ever ran.
+        self.inspects = 0
+        #: Readiness subscriptions opened. A PAUSING connect must open none.
+        self.event_streams = 0
 
     def __call__(self, request: httpx.Request) -> httpx.Response:
         path = request.url.path
         if path.endswith("/Inspect"):
+            self.inspects += 1
             state = self.states.pop(0) if len(self.states) > 1 else self.states[0]
             body = sandbox_pb2.SandboxInfo(id="sb-1", state=state).SerializeToString()
         elif path.endswith("/Resume"):
             self.resumes += 1
             self.states = [sandbox_pb2.SANDBOX_STATE_READY]
             body = empty_pb2.Empty().SerializeToString()
+        elif path.endswith("/Events"):
+            self.event_streams += 1
+            return httpx.Response(
+                200,
+                content=_events_body(),
+                headers={"content-type": "application/connect+proto"},
+            )
         else:
             return httpx.Response(404, content=b"unhandled: " + path.encode())
         return httpx.Response(200, content=body, headers={"content-type": "application/proto"})
@@ -45,6 +71,9 @@ def test_connect_resumes_a_paused_sandbox() -> None:
     daemon = MockLifecycle([sandbox_pb2.SANDBOX_STATE_PAUSED])
     sandbox = connect_against(daemon).connect("sb-1")
     assert sandbox.id == "sb-1"
+    # The negative that gives the PAUSING count below its meaning: an
+    # already-settled state routes off the first Inspect.
+    assert daemon.inspects == 1
     assert daemon.resumes == 1
 
 
@@ -52,7 +81,10 @@ def test_connect_settles_a_pausing_sandbox_then_resumes() -> None:
     daemon = MockLifecycle([sandbox_pb2.SANDBOX_STATE_PAUSING, sandbox_pb2.SANDBOX_STATE_PAUSED])
     sandbox = connect_against(daemon).connect("sb-1")
     assert sandbox.id == "sb-1"
-    # The checkpoint was polled out (a second Inspect ran) and exactly
-    # one Resume followed — not a readiness-event wait that never ends.
-    assert daemon.states == [sandbox_pb2.SANDBOX_STATE_READY]
+    # The checkpoint was polled out — a second Inspect ran — and exactly
+    # one Resume followed. No readiness subscription was ever opened:
+    # that is the regression, since READY is not where a pausing sandbox
+    # is headed.
+    assert daemon.inspects == 2
+    assert daemon.event_streams == 0
     assert daemon.resumes == 1

--- a/sdk/python/tests/test_connect.py
+++ b/sdk/python/tests/test_connect.py
@@ -8,11 +8,13 @@ out and then resume, not wait on readiness events that cannot arrive.
 from __future__ import annotations
 
 import httpx
+import pytest
 from google.protobuf import empty_pb2
 
 from arcbox import ArcBox, Connection
 from arcbox._envelope import FLAG_END_STREAM, encode_envelope
 from arcbox._gen import sandbox_pb2
+from arcbox.errors import TimeoutError as ArcBoxTimeoutError
 
 
 def _events_body() -> bytes:
@@ -88,3 +90,14 @@ def test_connect_settles_a_pausing_sandbox_then_resumes() -> None:
     assert daemon.inspects == 2
     assert daemon.event_streams == 0
     assert daemon.resumes == 1
+
+
+def test_connect_bounds_a_never_settling_pausing_sandbox() -> None:
+    # A daemon that keeps reporting PAUSING (wedged checkpoint) used to
+    # spin the settle poll forever; the overall deadline is the escape.
+    daemon = MockLifecycle([sandbox_pb2.SANDBOX_STATE_PAUSING])
+    with pytest.raises(ArcBoxTimeoutError, match=r"connect\(timeout\) elapsed") as excinfo:
+        connect_against(daemon).connect("sb-1", timeout=0.05)
+    assert excinfo.value.operation == "sandbox.connect"
+    assert daemon.event_streams == 0
+    assert daemon.resumes == 0

--- a/sdk/python/tests/test_version.py
+++ b/sdk/python/tests/test_version.py
@@ -1,0 +1,31 @@
+"""``arcbox.__version__`` resolution."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+
+import pytest
+
+import arcbox
+
+
+def test_version_is_exposed() -> None:
+    # The install-smoke regression: the published package printed "n/a".
+    assert arcbox.__version__
+    assert arcbox.__version__ != "0.0.0.dev0"
+
+
+def test_version_falls_back_when_no_distribution_is_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing(name: str) -> str:
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    try:
+        with monkeypatch.context() as patch:
+            patch.setattr(importlib.metadata, "version", missing)
+            assert importlib.reload(arcbox).__version__ == "0.0.0.dev0"
+    finally:
+        # Re-resolve against the real metadata for later tests.
+        importlib.reload(arcbox)

--- a/sdk/typescript/src/sandbox.ts
+++ b/sdk/typescript/src/sandbox.ts
@@ -8,6 +8,7 @@ import { Commands } from "./commands";
 import type { ConnectionOptions } from "./connection";
 import {
   ArcBoxError,
+  InvalidArgumentError,
   NotFoundError,
   SandboxStateError,
   TimeoutError,
@@ -72,7 +73,8 @@ export interface ConnectSandboxOptions {
    * readiness wait all share it (default 60_000 — generous because a
    * checkpoint restore or cold boot legitimately takes a while). On
    * expiry a {@link TimeoutError} is thrown and the sandbox is left as
-   * it was. `Number.POSITIVE_INFINITY` disables the bound.
+   * it was. Fractional values round up; the valid range is 1..2^31 - 1,
+   * and `Number.POSITIVE_INFINITY` disables the bound.
    */
   timeoutMs?: number;
   /** Connection override for this entry point. */
@@ -101,6 +103,9 @@ const PAUSE_SETTLE_POLL_MS = 500;
 
 /** Default overall deadline for {@link ArcBox.connect} — see {@link ConnectSandboxOptions.timeoutMs}. */
 const CONNECT_TIMEOUT_MS = 60000;
+
+/** Node clamps timer delays past 2^31 - 1 to 1ms; reject rather than mislead. */
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 
 /** Merge the connect deadline signal into a call's options, when one is set. */
 function withSignal(
@@ -213,7 +218,26 @@ export class ArcBox {
     id: string,
     opts: ConnectSandboxOptions = {},
   ): Promise<Sandbox> {
-    const timeoutMs = opts.timeoutMs ?? CONNECT_TIMEOUT_MS;
+    // Fractional milliseconds round up; the rest of the range is
+    // validated here so a bad knob surfaces as the SDK's typed error:
+    // AbortSignal.timeout() throws a raw RangeError on non-integers and
+    // negatives, NaN and NEGATIVE_INFINITY would silently disable the
+    // bound, and Node clamps timer delays past 2^31 - 1 to 1ms.
+    const timeoutMs = Math.ceil(opts.timeoutMs ?? CONNECT_TIMEOUT_MS);
+    if (
+      Number.isNaN(timeoutMs) ||
+      timeoutMs <= 0 ||
+      (Number.isFinite(timeoutMs) && timeoutMs > MAX_TIMEOUT_MS)
+    ) {
+      throw new InvalidArgumentError(
+        "connect timeoutMs must be a positive number of milliseconds at " +
+          "most 2**31 - 1 (Number.POSITIVE_INFINITY disables the bound)",
+        {
+          context: { timeoutMs: String(opts.timeoutMs) },
+          operation: "sandbox.connect",
+        },
+      );
+    }
     const timeoutLabel = String(timeoutMs);
     // One deadline over every wait below — the settle poll, resume, and
     // the readiness wait; bounding only one of them would be arbitrary

--- a/sdk/typescript/src/sandbox.ts
+++ b/sdk/typescript/src/sandbox.ts
@@ -1,7 +1,8 @@
-import type { Client } from "@connectrpc/connect";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import type { CallOptions, Client } from "@connectrpc/connect";
 import { createClient } from "@connectrpc/connect";
 import { noop } from "foxts/noop";
-import { wait } from "foxts/wait";
 
 import { Commands } from "./commands";
 import type { ConnectionOptions } from "./connection";
@@ -9,6 +10,7 @@ import {
   ArcBoxError,
   NotFoundError,
   SandboxStateError,
+  TimeoutError,
   toArcBoxError,
 } from "./errors";
 import { Files } from "./files";
@@ -64,6 +66,16 @@ export interface CreateSandboxOptions {
 
 /** Options for {@link Sandbox.connect}. */
 export interface ConnectSandboxOptions {
+  /**
+   * Overall deadline in milliseconds for the whole connect() call: the
+   * PAUSING settle poll, a checkpoint resume, and the STARTING
+   * readiness wait all share it (default 60_000 — generous because a
+   * checkpoint restore or cold boot legitimately takes a while). On
+   * expiry a {@link TimeoutError} is thrown and the sandbox is left as
+   * it was. `Number.POSITIVE_INFINITY` disables the bound.
+   */
+  timeoutMs?: number;
+  /** Connection override for this entry point. */
   connection?: ConnectionOptions;
 }
 
@@ -86,6 +98,17 @@ type SandboxClient = Client<typeof SandboxService>;
  * should become an event wait.
  */
 const PAUSE_SETTLE_POLL_MS = 500;
+
+/** Default overall deadline for {@link ArcBox.connect} — see {@link ConnectSandboxOptions.timeoutMs}. */
+const CONNECT_TIMEOUT_MS = 60000;
+
+/** Merge the connect deadline signal into a call's options, when one is set. */
+function withSignal(
+  options: CallOptions,
+  signal: AbortSignal | undefined,
+): CallOptions {
+  return { ...options, ...(signal !== undefined && { signal }) };
+}
 
 /**
  * Client entry point. Holds one resolved connection; every handle it
@@ -181,39 +204,66 @@ export class ArcBox {
    * first, then resumes; a STARTING one is waited for. A terminal state
    * is a typed error carrying the observed state. Connecting never
    * touches the sandbox's lifecycle deadlines.
+   *
+   * `timeoutMs` bounds the WHOLE call — the settle poll, a resume, and
+   * the readiness wait share one deadline (default 60s). On expiry a
+   * {@link TimeoutError} is thrown and the sandbox is left as it was.
    */
-  async connect(id: string): Promise<Sandbox> {
+  async connect(
+    id: string,
+    opts: ConnectSandboxOptions = {},
+  ): Promise<Sandbox> {
+    const timeoutMs = opts.timeoutMs ?? CONNECT_TIMEOUT_MS;
+    const timeoutLabel = String(timeoutMs);
+    // One deadline over every wait below — the settle poll, resume, and
+    // the readiness wait; bounding only one of them would be arbitrary
+    // while the neighbouring waits stayed unbounded.
+    const deadline = Number.isFinite(timeoutMs)
+      ? AbortSignal.timeout(timeoutMs)
+      : undefined;
     try {
-      let info = await this.#client.inspect({ id }, unaryOptions(this.#ctx));
+      let info = await this.#client.inspect(
+        { id },
+        withSignal(unaryOptions(this.#ctx), deadline),
+      );
       // A pausing sandbox's next stop is PAUSED — never READY — so
       // waiting on readiness events would park forever. Poll the
       // checkpoint out, then route on whatever state it settled in.
       while (info.state === SandboxStateProto.PAUSING) {
         // eslint-disable-next-line no-await-in-loop -- sequential by design: each re-inspect waits out the poll interval
-        await wait(PAUSE_SETTLE_POLL_MS);
+        await sleep(PAUSE_SETTLE_POLL_MS, undefined, { signal: deadline });
         // eslint-disable-next-line no-await-in-loop -- sequential by design: the settled state decides the route
-        info = await this.#client.inspect({ id }, unaryOptions(this.#ctx));
+        info = await this.#client.inspect(
+          { id },
+          withSignal(unaryOptions(this.#ctx), deadline),
+        );
       }
       switch (info.state) {
         case SandboxStateProto.READY:
         case SandboxStateProto.RUNNING:
           return new Sandbox(this.#ctx, id);
         case SandboxStateProto.PAUSED:
-          // Deliberately no per-request deadline: restoring a checkpoint
-          // takes as long as it takes, and the RPC returns once READY.
-          await this.#client.resume({ id });
+          // No per-request deadline of its own: restoring a checkpoint
+          // takes as long as it takes, and the RPC returns once READY —
+          // the overall connect deadline is the only bound.
+          await this.#client.resume({ id }, withSignal({}, deadline));
           return new Sandbox(this.#ctx, id);
         case SandboxStateProto.STARTING: {
           const abort = new AbortController();
           try {
             const stream = this.#client.events(
               { sandboxId: id },
-              { signal: abort.signal },
+              {
+                signal:
+                  deadline === undefined
+                    ? abort.signal
+                    : AbortSignal.any([abort.signal, deadline]),
+              },
             );
             const events = stream[Symbol.asyncIterator]();
             const first = events.next();
             first.catch(noop);
-            await this.#waitReady(id, events, first);
+            await this.#waitReady(id, events, first, deadline);
           } finally {
             abort.abort();
           }
@@ -232,6 +282,22 @@ export class ArcBox {
           );
       }
     } catch (error) {
+      // A failure observed after the deadline fired is the deadline
+      // surfacing (an aborted RPC, wait, or event read) — unless the
+      // SDK already typed it, in which case the state error stands.
+      if (deadline?.aborted === true && !(error instanceof ArcBoxError)) {
+        throw toArcBoxError(
+          new TimeoutError(
+            `connect(timeoutMs) elapsed before sandbox ${id} was ready`,
+            {
+              suggestion: "increase the connect timeoutMs option",
+              context: { id, timeoutMs: timeoutLabel },
+              cause: error,
+            },
+          ),
+          "sandbox.connect",
+        );
+      }
       throw toArcBoxError(error, "sandbox.connect");
     }
   }
@@ -270,6 +336,7 @@ export class ArcBox {
     id: string,
     events: AsyncIterator<WatchEventsResponse>,
     firstEvent: Promise<IteratorResult<WatchEventsResponse>>,
+    deadline?: AbortSignal,
   ): Promise<void> {
     const check = (state: SandboxStateProto, error: string): boolean => {
       switch (state) {
@@ -297,7 +364,7 @@ export class ArcBox {
     };
     const inspected = await this.#client.inspect(
       { id },
-      unaryOptions(this.#ctx),
+      withSignal(unaryOptions(this.#ctx), deadline),
     );
     if (check(inspected.state, inspected.error)) {
       return;
@@ -349,7 +416,7 @@ export class ArcBox {
         // eslint-disable-next-line no-await-in-loop -- sequential by design: the re-inspect must resolve before reading further events
         const info = await this.#client.inspect(
           { id },
-          unaryOptions(this.#ctx),
+          withSignal(unaryOptions(this.#ctx), deadline),
         );
         if (check(info.state, info.error)) {
           return;
@@ -398,7 +465,7 @@ export class Sandbox {
     id: string,
     opts: ConnectSandboxOptions = {},
   ): Promise<Sandbox> {
-    return new ArcBox(opts.connection).connect(id);
+    return new ArcBox(opts.connection).connect(id, opts);
   }
 
   /** List sandboxes (auto-paginating). */

--- a/sdk/typescript/test/connect.test.ts
+++ b/sdk/typescript/test/connect.test.ts
@@ -12,7 +12,7 @@ import { createRouterTransport } from "@connectrpc/connect";
 import { noop } from "foxts/noop";
 import { describe, expect, it } from "vitest";
 
-import { TimeoutError } from "../src/errors.js";
+import { InvalidArgumentError, TimeoutError } from "../src/errors.js";
 import {
   KeepAliveSchema,
   SandboxInfoSchema,
@@ -115,6 +115,15 @@ describe("ArcBox.connect lifecycle routing", () => {
     await expect(attempt).rejects.toThrow("connect(timeoutMs) elapsed");
     expect(daemon.eventStreams).toBe(0);
     expect(daemon.resumes).toBe(0);
+  });
+
+  it("rejects an out-of-range timeoutMs before any RPC", async () => {
+    // AbortSignal.timeout would throw a raw RangeError (or Node would
+    // clamp a huge delay to 1ms); the boundary check types the failure.
+    const daemon = new MockLifecycle([SandboxStateProto.READY]);
+    const attempt = connectAgainst(daemon).connect("sb-1", { timeoutMs: -5 });
+    await expect(attempt).rejects.toBeInstanceOf(InvalidArgumentError);
+    expect(daemon.inspects).toBe(0);
   });
 
   it("bounds a hung checkpoint resume with the same deadline", async () => {

--- a/sdk/typescript/test/connect.test.ts
+++ b/sdk/typescript/test/connect.test.ts
@@ -9,8 +9,10 @@ import { create } from "@bufbuild/protobuf";
 import { EmptySchema } from "@bufbuild/protobuf/wkt";
 import type { Transport } from "@connectrpc/connect";
 import { createRouterTransport } from "@connectrpc/connect";
+import { noop } from "foxts/noop";
 import { describe, expect, it } from "vitest";
 
+import { TimeoutError } from "../src/errors.js";
 import {
   KeepAliveSchema,
   SandboxInfoSchema,
@@ -23,6 +25,8 @@ import { ArcBox } from "../src/sandbox.js";
 /** Serves Inspect from a state script, counting every call it answers. */
 class MockLifecycle {
   resumes = 0;
+  /** When set, Resume parks forever — a wedged checkpoint restore. */
+  hangResume = false;
   /**
    * The settle poll is witnessed by this count: `resume` rewrites
    * `states` unconditionally, so the post-state is `[READY]` whether or
@@ -48,6 +52,9 @@ class MockLifecycle {
         },
         resume: () => {
           this.resumes += 1;
+          if (this.hangResume) {
+            return new Promise<never>(noop);
+          }
           this.states = [SandboxStateProto.READY];
           return create(EmptySchema);
         },
@@ -96,6 +103,27 @@ describe("ArcBox.connect lifecycle routing", () => {
     // sandbox is headed.
     expect(daemon.inspects).toBe(2);
     expect(daemon.eventStreams).toBe(0);
+    expect(daemon.resumes).toBe(1);
+  });
+
+  it("bounds a never-settling PAUSING sandbox with timeoutMs", async () => {
+    // A daemon that keeps reporting PAUSING (wedged checkpoint) used to
+    // spin the settle poll forever; the overall deadline is the escape.
+    const daemon = new MockLifecycle([SandboxStateProto.PAUSING]);
+    const attempt = connectAgainst(daemon).connect("sb-1", { timeoutMs: 25 });
+    await expect(attempt).rejects.toBeInstanceOf(TimeoutError);
+    await expect(attempt).rejects.toThrow("connect(timeoutMs) elapsed");
+    expect(daemon.eventStreams).toBe(0);
+    expect(daemon.resumes).toBe(0);
+  });
+
+  it("bounds a hung checkpoint resume with the same deadline", async () => {
+    // Resume deliberately carries no per-request deadline; the overall
+    // connect deadline must still cut a wedged restore loose.
+    const daemon = new MockLifecycle([SandboxStateProto.PAUSED]);
+    daemon.hangResume = true;
+    const attempt = connectAgainst(daemon).connect("sb-1", { timeoutMs: 25 });
+    await expect(attempt).rejects.toBeInstanceOf(TimeoutError);
     expect(daemon.resumes).toBe(1);
   });
 });


### PR DESCRIPTION
Two small fixes to the published SDKs (npm `@arcbox/sandbox` 0.1.1, PyPI `arcbox` 0.1.1).

## Python `__version__`

The published wheel exposed no version attribute (the install smoke printed n/a). `arcbox.__version__` now resolves from the installed distribution metadata, falling back to a fixed `0.0.0.dev0` sentinel for an uninstalled source tree (documented at the site; a fixed sentinel beats parsing pyproject.toml on every import). Regression tests cover both branches.

## CORE-85 — one overall deadline over connect()

`connect()` could wait indefinitely in three places: the PAUSING settle poll, the Resume RPC (deliberately carrying no per-request deadline), and the STARTING readiness wait. Per the issue, the fix is one deadline over the whole call — bounding only the settle poll would be arbitrary while the neighbouring waits stayed unbounded.

**Deadline model** (default 60s, generous because a checkpoint restore or cold boot legitimately takes a while):
- **TypeScript**: `ConnectSandboxOptions.timeoutMs` (default `60000`, `Infinity` disables) drives one `AbortSignal.timeout` threaded through every inspect, the settle sleep, Resume, and the Events stream. Expiry throws the existing `TimeoutError` naming the knob (`connect(timeoutMs) elapsed …` / `increase the connect timeoutMs option`). No `AbortSignal` option is added: the surrounding public API (RunOptions, CreateSandboxOptions) has no such convention.
- **Python**: `connect(id, timeout=60.0)` (`None` disables), async tree edited and `_sync` regenerated. Since the sync tree is a mechanical unasync mirror, the deadline is a monotonic-clock budget rather than asyncio machinery: the settle sleep is clamped to the remainder, each Inspect caps its per-RPC deadline by it, Resume and the Events stream receive the remainder, and the readiness loop re-checks it on every frame (keepalives never trip a read timeout). A per-RPC expiry observed past the overall deadline is re-mapped to the connect `TimeoutError` so the error names the right knob; a genuine `Connection.request_timeout` expiry before it still names its own.

**Test corrections ported to the Python twin** (from arcbox#550): the PAUSING test asserted the mock's post-state, which `resume` rewrites unconditionally — it passed identically on the already-PAUSED baseline. The mock now counts Inspect calls (1 settled, 2 polled-out) and readiness subscriptions (must stay 0), and serves `Events` as the daemon does for a pausing sandbox so a reverted fix fails naming the regression. The stale `_PAUSE_SETTLE_POLL_SECONDS` comment is corrected: `SANDBOX_EVENT_KIND_PAUSED` does exist in the proto; the daemon just does not emit it yet (CORE-21 stubs).

## Validation

All gates exit 0 —
- TS: `npm run lint`, `npm run format:check`, `npm test` (42 tests), `npx tsc --noEmit`, `npm run build`
- Python: `uv sync`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright` (strict), `uv run pytest` (76 passed), `uv run python scripts/gen_sync.py --check`

Closes CORE-85.