### PR TITLE
feat(sandbox): implement the filesystem verbs and process-plane queries (CORE-62)

### DIFF
--- a/app/arcbox-api/src/connect/filesystem.rs
+++ b/app/arcbox-api/src/connect/filesystem.rs
@@ -167,75 +167,183 @@ impl pb::SandboxFilesystemService for SandboxFilesystemServiceImpl {
         Response::ok(Empty::default())
     }
 
-    /// Contract-only stub (CORE-58 phase 1): the path verbs land with
-    /// CORE-62 (guest-agent implementation).
     async fn stat(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::StatFileRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::StatFileRequest>,
     ) -> ServiceResult<pb::FileStat> {
-        Err(ConnectError::unimplemented(
-            "stat is not implemented yet (CORE-62)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let runtime = self.runtime.ready()?;
+        let stat = sandbox_resume::with_auto_resume(
+            runtime,
+            &self.operations,
+            &ctx,
+            &machine,
+            &req.id,
+            || {
+                let req = req.clone();
+                async {
+                    let mut agent = runtime.get_agent(&machine)?;
+                    agent.sandbox_stat(req).await
+                }
+            },
+        )
+        .await?;
+        Response::ok(stat)
     }
 
-    /// Contract-only stub (CORE-58 phase 1): the path verbs land with
-    /// CORE-62 (guest-agent implementation).
     async fn list_dir(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::ListDirRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::ListDirRequest>,
     ) -> ServiceResult<pb::ListDirResponse> {
-        Err(ConnectError::unimplemented(
-            "list_dir is not implemented yet (CORE-62)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let runtime = self.runtime.ready()?;
+        let listing = sandbox_resume::with_auto_resume(
+            runtime,
+            &self.operations,
+            &ctx,
+            &machine,
+            &req.id,
+            || {
+                let req = req.clone();
+                async {
+                    let mut agent = runtime.get_agent(&machine)?;
+                    agent.sandbox_list_dir(req).await
+                }
+            },
+        )
+        .await?;
+        Response::ok(listing)
     }
 
-    /// Contract-only stub (CORE-58 phase 1): the path verbs land with
-    /// CORE-62 (guest-agent implementation).
     async fn make_dir(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::MakeDirRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::MakeDirRequest>,
     ) -> ServiceResult<Empty> {
-        Err(ConnectError::unimplemented(
-            "make_dir is not implemented yet (CORE-62)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let runtime = self.runtime.ready()?;
+        sandbox_resume::with_auto_resume(
+            runtime,
+            &self.operations,
+            &ctx,
+            &machine,
+            &req.id,
+            || {
+                let req = req.clone();
+                async {
+                    let mut agent = runtime.get_agent(&machine)?;
+                    agent.sandbox_make_dir(req).await
+                }
+            },
+        )
+        .await?;
+        Response::ok(Empty::default())
     }
 
-    /// Contract-only stub (CORE-58 phase 1): the path verbs land with
-    /// CORE-62 (guest-agent implementation).
     async fn remove(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::RemoveEntryRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::RemoveEntryRequest>,
     ) -> ServiceResult<Empty> {
-        Err(ConnectError::unimplemented(
-            "remove is not implemented yet (CORE-62)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let runtime = self.runtime.ready()?;
+        sandbox_resume::with_auto_resume(
+            runtime,
+            &self.operations,
+            &ctx,
+            &machine,
+            &req.id,
+            || {
+                let req = req.clone();
+                async {
+                    let mut agent = runtime.get_agent(&machine)?;
+                    agent.sandbox_remove_entry(req).await
+                }
+            },
+        )
+        .await?;
+        Response::ok(Empty::default())
     }
 
-    /// Contract-only stub (CORE-58 phase 1): the path verbs land with
-    /// CORE-62 (guest-agent implementation).
     async fn r#move(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::MoveEntryRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::MoveEntryRequest>,
     ) -> ServiceResult<Empty> {
-        Err(ConnectError::unimplemented(
-            "move is not implemented yet (CORE-62)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let runtime = self.runtime.ready()?;
+        sandbox_resume::with_auto_resume(
+            runtime,
+            &self.operations,
+            &ctx,
+            &machine,
+            &req.id,
+            || {
+                let req = req.clone();
+                async {
+                    let mut agent = runtime.get_agent(&machine)?;
+                    agent.sandbox_move_entry(req).await
+                }
+            },
+        )
+        .await?;
+        Response::ok(Empty::default())
     }
 
-    /// Contract-only stub (CORE-58 phase 1): the path verbs land with
-    /// CORE-62 (guest-agent implementation).
     async fn watch_dir(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::WatchDirRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::WatchDirRequest>,
     ) -> ServiceResult<ServiceStream<pb::WatchDirResponse>> {
-        Err(ConnectError::unimplemented(
-            "watch_dir is not implemented yet (CORE-62)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let runtime = self.runtime.ready()?;
+
+        // Optimistic first attempt, mirroring read_file: the guest confirms
+        // an established watch with an immediate keepalive frame, so peeking
+        // the first item is fast — a SANDBOX_PAUSED answer becomes one
+        // resume + one fresh watch instead of an in-stream error.
+        let agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
+        let mut rx = agent
+            .sandbox_watch_dir(req.clone())
+            .await
+            .map_err(ApiError::from)?;
+        let first = match rx.recv().await {
+            Some(Err(error)) if sandbox_resume::is_sandbox_paused(&error) => {
+                if sandbox_resume::auto_resume_opted_out(&ctx) {
+                    return Err(ConnectError::from(ApiError::from(error)));
+                }
+                sandbox_resume::resume(
+                    runtime,
+                    &self.operations,
+                    &machine,
+                    &req.id,
+                    sandbox_resume::REASON_AUTO_RESUME,
+                )
+                .await?;
+                let agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
+                rx = agent.sandbox_watch_dir(req).await.map_err(ApiError::from)?;
+                rx.recv().await
+            }
+            other => other,
+        };
+
+        let stream = tokio_stream::iter(first)
+            .chain(ReceiverStream::new(rx))
+            .map(|r| r.map_err(|e| ConnectError::from(ApiError::from(e))));
+        // The guest already interleaves its own keepalives; this adds the
+        // daemon-side ones the proto promises even if that hop stalls.
+        let stream = with_keepalive(stream, || pb::WatchDirResponse {
+            payload: pb::KeepAlive::default().into(),
+            ..Default::default()
+        });
+        Response::ok(Box::pin(stream))
     }
 }

--- a/app/arcbox-api/src/connect/process.rs
+++ b/app/arcbox-api/src/connect/process.rs
@@ -23,6 +23,23 @@ use super::{ConnectRuntimeExt as _, ContextExt as _, with_keepalive};
 /// documented on the proto field ("0 = daemon default of 30 s").
 const DEFAULT_WAIT_FOR_PORT_TIMEOUT_SECS: u32 = 30;
 
+/// Cap on the caller-supplied wait budget. Each wait occupies one of the
+/// vm-agent's bounded exec-channel connection slots for its whole duration,
+/// so an unbounded timeout would let a handful of requests pin those slots
+/// indefinitely and starve exec traffic to the sandbox.
+const MAX_WAIT_FOR_PORT_TIMEOUT_SECS: u32 = 600;
+
+/// Resolve the effective `WaitForPort` budget: 0 takes the daemon default,
+/// anything else is clamped to [`MAX_WAIT_FOR_PORT_TIMEOUT_SECS`] (the
+/// deadline error at the cap tells the caller when the daemon gave up).
+const fn resolve_wait_for_port_budget(requested: u32) -> u32 {
+    match requested {
+        0 => DEFAULT_WAIT_FOR_PORT_TIMEOUT_SECS,
+        t if t > MAX_WAIT_FOR_PORT_TIMEOUT_SECS => MAX_WAIT_FOR_PORT_TIMEOUT_SECS,
+        t => t,
+    }
+}
+
 /// Execution service implementation.
 ///
 /// Every call addresses one execution inside one sandbox and carries its
@@ -270,11 +287,9 @@ impl pb::SandboxProcessService for SandboxProcessServiceImpl {
     ) -> ServiceResult<Empty> {
         let machine = ctx.sandbox_machine_id()?;
         let mut req = request.to_owned_message();
-        if req.timeout_seconds == 0 {
-            // The proto documents 0 as "the daemon default of 30 s"; resolve
-            // it here so the guest always enforces an explicit budget.
-            req.timeout_seconds = DEFAULT_WAIT_FOR_PORT_TIMEOUT_SECS;
-        }
+        // Resolve the proto's "0 = daemon default" and cap the budget here,
+        // so the guest always enforces an explicit, bounded wait.
+        req.timeout_seconds = resolve_wait_for_port_budget(req.timeout_seconds);
         let runtime = self.runtime.ready()?;
         sandbox_resume::with_auto_resume(
             runtime,
@@ -292,5 +307,28 @@ impl pb::SandboxProcessService for SandboxProcessServiceImpl {
         )
         .await?;
         Response::ok(Empty::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wait_for_port_budget_defaults_and_caps() {
+        assert_eq!(
+            resolve_wait_for_port_budget(0),
+            DEFAULT_WAIT_FOR_PORT_TIMEOUT_SECS
+        );
+        assert_eq!(resolve_wait_for_port_budget(5), 5);
+        assert_eq!(
+            resolve_wait_for_port_budget(MAX_WAIT_FOR_PORT_TIMEOUT_SECS),
+            MAX_WAIT_FOR_PORT_TIMEOUT_SECS
+        );
+        // An adversarial u32::MAX cannot pin a guest exec slot for years.
+        assert_eq!(
+            resolve_wait_for_port_budget(u32::MAX),
+            MAX_WAIT_FOR_PORT_TIMEOUT_SECS
+        );
     }
 }

--- a/app/arcbox-api/src/connect/process.rs
+++ b/app/arcbox-api/src/connect/process.rs
@@ -19,6 +19,10 @@ use super::sandbox_locks::SandboxOperationLocks;
 use super::sandbox_resume;
 use super::{ConnectRuntimeExt as _, ContextExt as _, with_keepalive};
 
+/// Wait budget applied when `WaitForPortRequest.timeout_seconds` is 0, as
+/// documented on the proto field ("0 = daemon default of 30 s").
+const DEFAULT_WAIT_FOR_PORT_TIMEOUT_SECS: u32 = 30;
+
 /// Execution service implementation.
 ///
 /// Every call addresses one execution inside one sandbox and carries its
@@ -238,27 +242,55 @@ impl pb::SandboxProcessService for SandboxProcessServiceImpl {
         Response::ok(execution)
     }
 
-    /// Contract-only stub (CORE-58 phase 1): execution discovery lands
-    /// with CORE-58 phase 2 (guest-agent enumeration).
+    /// Serves from the guest's execution registry without waking the
+    /// sandbox: pausing already interrupted the running executions, so a
+    /// paused sandbox's history answers as-is at no resume cost.
     async fn list_executions(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::ListExecutionsRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::ListExecutionsRequest>,
     ) -> ServiceResult<pb::ListExecutionsResponse> {
-        Err(ConnectError::unimplemented(
-            "execution listing is not implemented yet (CORE-58 phase 2)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let mut agent = self
+            .runtime
+            .ready()?
+            .get_agent(&machine)
+            .map_err(ApiError::from)?;
+        let listing = agent
+            .sandbox_exec_list(request.to_owned_message())
+            .await
+            .map_err(ApiError::from)?;
+        Response::ok(listing)
     }
 
-    /// Contract-only stub (CORE-58 phase 1): the guest-agent listen-table
-    /// watch lands with CORE-58 phase 2.
     async fn wait_for_port(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::WaitForPortRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::WaitForPortRequest>,
     ) -> ServiceResult<Empty> {
-        Err(ConnectError::unimplemented(
-            "port readiness waits are not implemented yet (CORE-58 phase 2)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let mut req = request.to_owned_message();
+        if req.timeout_seconds == 0 {
+            // The proto documents 0 as "the daemon default of 30 s"; resolve
+            // it here so the guest always enforces an explicit budget.
+            req.timeout_seconds = DEFAULT_WAIT_FOR_PORT_TIMEOUT_SECS;
+        }
+        let runtime = self.runtime.ready()?;
+        sandbox_resume::with_auto_resume(
+            runtime,
+            &self.operations,
+            &ctx,
+            &machine,
+            &req.sandbox_id,
+            || {
+                let req = req.clone();
+                async {
+                    let mut agent = runtime.get_agent(&machine)?;
+                    agent.sandbox_wait_for_port(req).await
+                }
+            },
+        )
+        .await?;
+        Response::ok(Empty::default())
     }
 }

--- a/app/arcbox-api/src/error.rs
+++ b/app/arcbox-api/src/error.rs
@@ -66,6 +66,8 @@ impl From<ApiError> for connectrpc::ConnectError {
                     // Stdin offset gap: resync via GetStdinStatus.
                     416 => ErrorCode::OutOfRange,
                     503 => ErrorCode::Unavailable,
+                    // A bounded guest wait elapsed (e.g. WaitForPort).
+                    504 => ErrorCode::DeadlineExceeded,
                     _ => ErrorCode::Internal,
                 };
                 let mut error = Self::new(connect_code, message);
@@ -104,6 +106,30 @@ fn classify_agent_error(code: i32, message: &str) -> Option<connectrpc::ErrorDet
             "list sandboxes with `abctl sandbox list`",
             &[],
         )),
+        // VmmError::PathNotFound → "path not found: {path}" (the sandbox
+        // filesystem verbs, CORE-62).
+        404 if message.starts_with("path not found: ") => {
+            let path = message.strip_prefix("path not found: ").unwrap_or_default();
+            Some(error_info(
+                pb::ErrorCode::FileNotFound,
+                "check the path with `Stat` or `ListDir` on its parent directory",
+                &[("path", path)],
+            ))
+        }
+        // The guest agent's per-file write cap → "file exceeds the
+        // {limit}-byte write limit".
+        400 if message.contains("-byte write limit") => {
+            let limit = message
+                .split("exceeds the ")
+                .nth(1)
+                .and_then(|rest| rest.split("-byte").next())
+                .unwrap_or_default();
+            Some(error_info(
+                pb::ErrorCode::FileTooLarge,
+                "split the payload or ship it through the sandbox's own tooling",
+                &[("limit_bytes", limit)],
+            ))
+        }
         // Guest-side nested-virt probe failure (the daemon's own fail-fast
         // gate attaches this detail directly; this covers agent-originated
         // 412s, e.g. a stale capability view).
@@ -283,6 +309,47 @@ mod tests {
             ),
             Some(pb::ErrorCode::TemplateInvalid)
         );
+        // VmmError::PathNotFound (the filesystem verbs, CORE-62).
+        assert_eq!(
+            classified(404, "path not found: /work/missing.txt"),
+            Some(pb::ErrorCode::FileNotFound)
+        );
+        // The guest agent's per-file write cap.
+        assert_eq!(
+            classified(400, "file exceeds the 268435456-byte write limit"),
+            Some(pb::ErrorCode::FileTooLarge)
+        );
+    }
+
+    #[test]
+    fn file_not_found_context_carries_the_path() {
+        let detail =
+            classify_agent_error(404, "path not found: /work/missing.txt").expect("classified");
+        let info = decode_info(&detail);
+        assert_eq!(
+            info.context.get("path").map(String::as_str),
+            Some("/work/missing.txt")
+        );
+    }
+
+    #[test]
+    fn file_too_large_context_carries_the_limit() {
+        let detail = classify_agent_error(400, "file exceeds the 268435456-byte write limit")
+            .expect("classified");
+        let info = decode_info(&detail);
+        assert_eq!(
+            info.context.get("limit_bytes").map(String::as_str),
+            Some("268435456")
+        );
+    }
+
+    #[test]
+    fn deadline_wire_code_maps_to_deadline_exceeded() {
+        let error = connectrpc::ConnectError::from(ApiError::Core(arcbox_core::CoreError::Agent {
+            code: 504,
+            message: "no listener on port 8080 in sandbox 'box1' within 30s".into(),
+        }));
+        assert_eq!(error.code, connectrpc::ErrorCode::DeadlineExceeded);
     }
 
     #[test]

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -15,13 +15,14 @@ use self::transport::{AgentTransport, BLOCKING_RPC_TIMEOUT};
 use crate::error::{CoreError, Result};
 use arcbox_connect::sandbox_v1::{
     AttachExecutionRequest, CheckpointRequest, CheckpointResponse, CreateSandboxRequest,
-    CreateSandboxResponse, DeleteSnapshotRequest, Execution, ExecutionEvent, FileChunk,
-    GetStdinStatusRequest, InspectSandboxRequest, ListSandboxesRequest, ListSandboxesResponse,
-    ListSnapshotsRequest, ListSnapshotsResponse, PauseSandboxRequest, ReadFileRequest,
+    CreateSandboxResponse, DeleteSnapshotRequest, Execution, ExecutionEvent, FileChunk, FileStat,
+    GetStdinStatusRequest, InspectSandboxRequest, ListDirRequest, ListDirResponse,
+    ListSandboxesRequest, ListSandboxesResponse, ListSnapshotsRequest, ListSnapshotsResponse,
+    MakeDirRequest, MoveEntryRequest, PauseSandboxRequest, ReadFileRequest, RemoveEntryRequest,
     RemoveSandboxRequest, ResizeExecutionTtyRequest, RestoreRequest, RestoreResponse, SandboxEvent,
     SandboxEventsRequest, SandboxInfo, SetLifecycleRequest, SignalExecutionRequest,
-    StartExecutionRequest, StdinStatus, StopSandboxRequest, WaitExecutionRequest, WriteFileOpen,
-    WriteStdinRequest, execution_event,
+    StartExecutionRequest, StatFileRequest, StdinStatus, StopSandboxRequest, WaitExecutionRequest,
+    WatchDirRequest, WatchDirResponse, WriteFileOpen, WriteStdinRequest, execution_event,
 };
 use arcbox_connect::v1::{
     AgentPingRequest as PingRequest, AgentPingResponse as PingResponse, ContainerFsPathsRequest,
@@ -1385,6 +1386,154 @@ impl AgentClient {
             )));
         }
         Ok(())
+    }
+
+    /// Stats one path inside a sandbox (symlinks reported, not followed).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_stat(&mut self, req: StatFileRequest) -> Result<FileStat> {
+        let payload = req.encode_to_vec();
+        self.unary_rpc(
+            MessageType::SandboxFileStatRequest,
+            &payload,
+            MessageType::SandboxFileStatResponse,
+        )
+        .await
+    }
+
+    /// Lists a sandbox directory, non-recursively, with full per-entry
+    /// metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_list_dir(&mut self, req: ListDirRequest) -> Result<ListDirResponse> {
+        let payload = req.encode_to_vec();
+        self.unary_rpc(
+            MessageType::SandboxFileListDirRequest,
+            &payload,
+            MessageType::SandboxFileListDirResponse,
+        )
+        .await
+    }
+
+    /// Creates a directory inside a sandbox (`mkdir -p` semantics).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_make_dir(&mut self, req: MakeDirRequest) -> Result<()> {
+        let (resp_type, _) = self
+            .rpc_call(MessageType::SandboxFileMakeDirRequest, &req.encode_to_vec())
+            .await?;
+        Self::expect_ack_response_type(resp_type, MessageType::SandboxFileMakeDirResponse)
+    }
+
+    /// Removes a file, symlink, or directory inside a sandbox.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_remove_entry(&mut self, req: RemoveEntryRequest) -> Result<()> {
+        let (resp_type, _) = self
+            .rpc_call(MessageType::SandboxFileRemoveRequest, &req.encode_to_vec())
+            .await?;
+        Self::expect_ack_response_type(resp_type, MessageType::SandboxFileRemoveResponse)
+    }
+
+    /// Renames / moves an entry within a sandbox.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_move_entry(&mut self, req: MoveEntryRequest) -> Result<()> {
+        let (resp_type, _) = self
+            .rpc_call(MessageType::SandboxFileMoveRequest, &req.encode_to_vec())
+            .await?;
+        Self::expect_ack_response_type(resp_type, MessageType::SandboxFileMoveResponse)
+    }
+
+    /// Opens a directory watch stream inside a sandbox.
+    ///
+    /// The guest confirms establishment with an immediate keepalive frame
+    /// and interleaves further keepalives while idle; the channel closes
+    /// cleanly when the guest ends the stream (sandbox stop). Consumes the
+    /// client because the stream task requires exclusive transport access.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the initial send fails; in-stream failures
+    /// arrive as `Err` items on the channel.
+    pub async fn sandbox_watch_dir(
+        mut self,
+        req: WatchDirRequest,
+    ) -> Result<mpsc::Receiver<Result<WatchDirResponse>>> {
+        if !self.connected {
+            self.connect().await?;
+        }
+
+        let payload = req.encode_to_vec();
+        let buf = wire::build_message(MessageType::SandboxFileWatchRequest, "", &payload);
+        self.transport
+            .async_send(buf)
+            .await
+            .map_err(|e| CoreError::Machine(format!("failed to send watch-dir request: {e}")))?;
+
+        let (tx, rx) = mpsc::channel(STREAM_CHANNEL_CAPACITY);
+        tokio::spawn(async move {
+            loop {
+                let raw = match self.transport.async_recv().await {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(CoreError::Machine(format!("recv error: {e}"))))
+                            .await;
+                        break;
+                    }
+                };
+                let (resp_type, _, resp_payload) = match wire::parse_response(&raw) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        let _ = tx.send(Err(e)).await;
+                        break;
+                    }
+                };
+                if resp_type == MessageType::SandboxFileWatchEnd as u32 {
+                    break; // clean end: the sandbox stopped
+                }
+                if resp_type == MessageType::Error as u32 {
+                    let (code, message) = wire::parse_error_response(&resp_payload)
+                        .unwrap_or_else(|_| (500, "unknown error".to_string()));
+                    let _ = tx.send(Err(CoreError::Agent { code, message })).await;
+                    break;
+                }
+                if resp_type != MessageType::SandboxFileWatchEvent as u32 {
+                    let _ = tx
+                        .send(Err(CoreError::Machine(format!(
+                            "unexpected response type: 0x{resp_type:04x}"
+                        ))))
+                        .await;
+                    break;
+                }
+                match WatchDirResponse::decode_from_slice(&resp_payload) {
+                    Ok(frame) => {
+                        if tx.send(Ok(frame)).await.is_err() {
+                            break; // consumer gone: dropping self cancels the watch
+                        }
+                    }
+                    Err(e) => {
+                        let _ = tx
+                            .send(Err(CoreError::Machine(format!("decode error: {e}"))))
+                            .await;
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(rx)
     }
 
     /// Runs a command in the machine root (the agent's own mount namespace)

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -17,11 +17,12 @@ use arcbox_connect::sandbox_v1::{
     AttachExecutionRequest, CheckpointRequest, CheckpointResponse, CreateSandboxRequest,
     CreateSandboxResponse, DeleteSnapshotRequest, Execution, ExecutionEvent, FileChunk, FileStat,
     GetStdinStatusRequest, InspectSandboxRequest, ListDirRequest, ListDirResponse,
-    ListSandboxesRequest, ListSandboxesResponse, ListSnapshotsRequest, ListSnapshotsResponse,
-    MakeDirRequest, MoveEntryRequest, PauseSandboxRequest, ReadFileRequest, RemoveEntryRequest,
-    RemoveSandboxRequest, ResizeExecutionTtyRequest, RestoreRequest, RestoreResponse, SandboxEvent,
-    SandboxEventsRequest, SandboxInfo, SetLifecycleRequest, SignalExecutionRequest,
-    StartExecutionRequest, StatFileRequest, StdinStatus, StopSandboxRequest, WaitExecutionRequest,
+    ListExecutionsRequest, ListExecutionsResponse, ListSandboxesRequest, ListSandboxesResponse,
+    ListSnapshotsRequest, ListSnapshotsResponse, MakeDirRequest, MoveEntryRequest,
+    PauseSandboxRequest, ReadFileRequest, RemoveEntryRequest, RemoveSandboxRequest,
+    ResizeExecutionTtyRequest, RestoreRequest, RestoreResponse, SandboxEvent, SandboxEventsRequest,
+    SandboxInfo, SetLifecycleRequest, SignalExecutionRequest, StartExecutionRequest,
+    StatFileRequest, StdinStatus, StopSandboxRequest, WaitExecutionRequest, WaitForPortRequest,
     WatchDirRequest, WatchDirResponse, WriteFileOpen, WriteStdinRequest, execution_event,
 };
 use arcbox_connect::v1::{
@@ -1840,6 +1841,40 @@ impl AgentClient {
             MessageType::SandboxExecWaitResponse,
         )
         .await
+    }
+
+    /// Lists a sandbox's retained executions, running and exited.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_exec_list(
+        &mut self,
+        req: ListExecutionsRequest,
+    ) -> Result<ListExecutionsResponse> {
+        let payload = req.encode_to_vec();
+        self.unary_rpc(
+            MessageType::SandboxExecListRequest,
+            &payload,
+            MessageType::SandboxExecListResponse,
+        )
+        .await
+    }
+
+    /// Waits until something inside a sandbox listens on a TCP port.
+    ///
+    /// The guest enforces the wait budget from `req.timeout_seconds` (the
+    /// caller resolves the default) and answers 504 when it elapses; the
+    /// async transport applies no client-side deadline of its own.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the deadline elapses.
+    pub async fn sandbox_wait_for_port(&mut self, req: WaitForPortRequest) -> Result<()> {
+        let (resp_type, _) = self
+            .rpc_call(MessageType::SandboxWaitForPortRequest, &req.encode_to_vec())
+            .await?;
+        Self::expect_ack_response_type(resp_type, MessageType::SandboxWaitForPortResponse)
     }
 
     /// Attaches to an execution's output and returns a channel of

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -124,6 +124,31 @@ pub enum MessageType {
     /// One chunk of file content during a write stream (payload:
     /// `arcbox.sandbox.v1.FileChunk`; `done == true` on the last chunk).
     SandboxFileChunk = 0x0037,
+    /// Stat one path inside a sandbox (payload:
+    /// `arcbox.sandbox.v1.StatFileRequest`). Answered with
+    /// [`Self::SandboxFileStatResponse`].
+    SandboxFileStatRequest = 0x0038,
+    /// List a sandbox directory non-recursively (payload:
+    /// `arcbox.sandbox.v1.ListDirRequest`). Answered with
+    /// [`Self::SandboxFileListDirResponse`].
+    SandboxFileListDirRequest = 0x0039,
+    /// Create a directory with `mkdir -p` semantics (payload:
+    /// `arcbox.sandbox.v1.MakeDirRequest`). Answered with
+    /// [`Self::SandboxFileMakeDirResponse`].
+    SandboxFileMakeDirRequest = 0x003A,
+    /// Remove a file, symlink, or directory (payload:
+    /// `arcbox.sandbox.v1.RemoveEntryRequest`). Answered with
+    /// [`Self::SandboxFileRemoveResponse`].
+    SandboxFileRemoveRequest = 0x003B,
+    /// Rename / move an entry within a sandbox (payload:
+    /// `arcbox.sandbox.v1.MoveEntryRequest`). Answered with
+    /// [`Self::SandboxFileMoveResponse`].
+    SandboxFileMoveRequest = 0x003C,
+    /// Open a filesystem watch stream (payload:
+    /// `arcbox.sandbox.v1.WatchDirRequest`). The agent answers with a
+    /// stream of [`Self::SandboxFileWatchEvent`] frames, terminated by
+    /// [`Self::SandboxFileWatchEnd`] when the sandbox stops.
+    SandboxFileWatchRequest = 0x003D,
 
     // Sandbox snapshot request types (0x0040 - 0x0043).
     SandboxCheckpointRequest = 0x0040,
@@ -266,6 +291,26 @@ pub enum MessageType {
     SandboxFileData = 0x1038,
     /// Acknowledges a completed file-write stream (empty payload).
     SandboxFileWriteResponse = 0x1039,
+    /// Answers [`Self::SandboxFileStatRequest`] (payload:
+    /// `arcbox.sandbox.v1.FileStat`).
+    SandboxFileStatResponse = 0x103A,
+    /// Answers [`Self::SandboxFileListDirRequest`] (payload:
+    /// `arcbox.sandbox.v1.ListDirResponse`).
+    SandboxFileListDirResponse = 0x103B,
+    /// Acknowledges [`Self::SandboxFileMakeDirRequest`] (empty payload).
+    SandboxFileMakeDirResponse = 0x103C,
+    /// Acknowledges [`Self::SandboxFileRemoveRequest`] (empty payload).
+    SandboxFileRemoveResponse = 0x103D,
+    /// Acknowledges [`Self::SandboxFileMoveRequest`] (empty payload).
+    SandboxFileMoveResponse = 0x103E,
+    /// One frame of a directory-watch stream answering
+    /// [`Self::SandboxFileWatchRequest`] (payload:
+    /// `arcbox.sandbox.v1.WatchDirResponse` — an event or a keepalive).
+    SandboxFileWatchEvent = 0x103F,
+    /// Clean end of a directory-watch stream (empty payload): the sandbox
+    /// stopped, so no further events can come. Lives past the snapshot and
+    /// pause/resume blocks because 0x1040-0x1046 were already assigned.
+    SandboxFileWatchEnd = 0x1047,
 
     // Sandbox snapshot response types (0x1040 - 0x1043).
     SandboxCheckpointResponse = 0x1040,
@@ -342,6 +387,12 @@ impl MessageType {
             0x0035 => Some(Self::SandboxFileReadRequest),
             0x0036 => Some(Self::SandboxFileWriteRequest),
             0x0037 => Some(Self::SandboxFileChunk),
+            0x0038 => Some(Self::SandboxFileStatRequest),
+            0x0039 => Some(Self::SandboxFileListDirRequest),
+            0x003A => Some(Self::SandboxFileMakeDirRequest),
+            0x003B => Some(Self::SandboxFileRemoveRequest),
+            0x003C => Some(Self::SandboxFileMoveRequest),
+            0x003D => Some(Self::SandboxFileWatchRequest),
             // Sandbox snapshot requests.
             0x0040 => Some(Self::SandboxCheckpointRequest),
             0x0041 => Some(Self::SandboxRestoreRequest),
@@ -402,6 +453,13 @@ impl MessageType {
             0x1037 => Some(Self::SandboxEvent),
             0x1038 => Some(Self::SandboxFileData),
             0x1039 => Some(Self::SandboxFileWriteResponse),
+            0x103A => Some(Self::SandboxFileStatResponse),
+            0x103B => Some(Self::SandboxFileListDirResponse),
+            0x103C => Some(Self::SandboxFileMakeDirResponse),
+            0x103D => Some(Self::SandboxFileRemoveResponse),
+            0x103E => Some(Self::SandboxFileMoveResponse),
+            0x103F => Some(Self::SandboxFileWatchEvent),
+            0x1047 => Some(Self::SandboxFileWatchEnd),
             // Sandbox snapshot responses.
             0x1040 => Some(Self::SandboxCheckpointResponse),
             0x1041 => Some(Self::SandboxRestoreResponse),
@@ -435,6 +493,12 @@ impl MessageType {
                 | Self::SandboxEventsRequest
                 | Self::SandboxFileReadRequest
                 | Self::SandboxFileWriteRequest
+                | Self::SandboxFileStatRequest
+                | Self::SandboxFileListDirRequest
+                | Self::SandboxFileMakeDirRequest
+                | Self::SandboxFileRemoveRequest
+                | Self::SandboxFileMoveRequest
+                | Self::SandboxFileWatchRequest
                 | Self::SandboxPortForwardRequest
                 | Self::SandboxPortForwardRemoveRequest
                 | Self::SandboxCleanupPrepareRequest
@@ -563,9 +627,22 @@ mod tests {
             (0x0035, MessageType::SandboxFileReadRequest),
             (0x0036, MessageType::SandboxFileWriteRequest),
             (0x0037, MessageType::SandboxFileChunk),
+            (0x0038, MessageType::SandboxFileStatRequest),
+            (0x0039, MessageType::SandboxFileListDirRequest),
+            (0x003A, MessageType::SandboxFileMakeDirRequest),
+            (0x003B, MessageType::SandboxFileRemoveRequest),
+            (0x003C, MessageType::SandboxFileMoveRequest),
+            (0x003D, MessageType::SandboxFileWatchRequest),
             (0x1037, MessageType::SandboxEvent),
             (0x1038, MessageType::SandboxFileData),
             (0x1039, MessageType::SandboxFileWriteResponse),
+            (0x103A, MessageType::SandboxFileStatResponse),
+            (0x103B, MessageType::SandboxFileListDirResponse),
+            (0x103C, MessageType::SandboxFileMakeDirResponse),
+            (0x103D, MessageType::SandboxFileRemoveResponse),
+            (0x103E, MessageType::SandboxFileMoveResponse),
+            (0x103F, MessageType::SandboxFileWatchEvent),
+            (0x1047, MessageType::SandboxFileWatchEnd),
             // Sandbox executions (execution redesign, CORE-55/56).
             (0x0060, MessageType::SandboxExecStartRequest),
             (0x0061, MessageType::SandboxExecAttachRequest),
@@ -622,6 +699,12 @@ mod tests {
         assert!(MessageType::SandboxExecWaitRequest.is_sandbox_request());
         assert!(MessageType::SandboxFileReadRequest.is_sandbox_request());
         assert!(MessageType::SandboxFileWriteRequest.is_sandbox_request());
+        assert!(MessageType::SandboxFileStatRequest.is_sandbox_request());
+        assert!(MessageType::SandboxFileListDirRequest.is_sandbox_request());
+        assert!(MessageType::SandboxFileMakeDirRequest.is_sandbox_request());
+        assert!(MessageType::SandboxFileRemoveRequest.is_sandbox_request());
+        assert!(MessageType::SandboxFileMoveRequest.is_sandbox_request());
+        assert!(MessageType::SandboxFileWatchRequest.is_sandbox_request());
         assert!(MessageType::SandboxCheckpointRequest.is_sandbox_request());
         assert!(MessageType::SandboxPauseRequest.is_sandbox_request());
         assert!(MessageType::SandboxResumeRequest.is_sandbox_request());

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -204,6 +204,15 @@ pub enum MessageType {
     /// `arcbox.sandbox.v1.WaitExecutionRequest`). Answered with
     /// [`Self::SandboxExecWaitResponse`].
     SandboxExecWaitRequest = 0x0066,
+    /// List a sandbox's retained executions (payload:
+    /// `arcbox.sandbox.v1.ListExecutionsRequest`). Answered with
+    /// [`Self::SandboxExecListResponse`].
+    SandboxExecListRequest = 0x0067,
+    /// Wait for a TCP listener inside a sandbox (payload:
+    /// `arcbox.sandbox.v1.WaitForPortRequest`). Answered with
+    /// [`Self::SandboxWaitForPortResponse`]; an elapsed deadline is an
+    /// `Error` frame with code 504.
+    SandboxWaitForPortRequest = 0x0068,
 
     /// Starts a machine-level exec: runs a command in the machine root (the
     /// agent's own mount namespace), streamed back as
@@ -337,6 +346,12 @@ pub enum MessageType {
     /// Answers [`Self::SandboxExecWaitRequest`] (payload:
     /// `arcbox.sandbox.v1.Execution`).
     SandboxExecWaitResponse = 0x1066,
+    /// Answers [`Self::SandboxExecListRequest`] (payload:
+    /// `arcbox.sandbox.v1.ListExecutionsResponse`).
+    SandboxExecListResponse = 0x1067,
+    /// Acknowledges [`Self::SandboxWaitForPortRequest`] (empty payload):
+    /// the listener exists.
+    SandboxWaitForPortResponse = 0x1068,
 
     /// One machine exec output frame (payload: `arcbox.v1.MachineExecOutput`;
     /// `done == true` on the final frame carrying the exit code).
@@ -409,6 +424,8 @@ impl MessageType {
             0x0064 => Some(Self::SandboxExecSignalRequest),
             0x0065 => Some(Self::SandboxExecResizeRequest),
             0x0066 => Some(Self::SandboxExecWaitRequest),
+            0x0067 => Some(Self::SandboxExecListRequest),
+            0x0068 => Some(Self::SandboxWaitForPortRequest),
             // Machine-level exec.
             0x0050 => Some(Self::MachineExecRequest),
             0x0051 => Some(Self::MachineExecInput),
@@ -472,6 +489,8 @@ impl MessageType {
             0x1064 => Some(Self::SandboxExecSignalResponse),
             0x1065 => Some(Self::SandboxExecResizeResponse),
             0x1066 => Some(Self::SandboxExecWaitResponse),
+            0x1067 => Some(Self::SandboxExecListResponse),
+            0x1068 => Some(Self::SandboxWaitForPortResponse),
             0x1050 => Some(Self::MachineExecOutput),
             0x0000 => Some(Self::Empty),
             0xFFFF => Some(Self::Error),
@@ -518,6 +537,8 @@ impl MessageType {
                 | Self::SandboxExecSignalRequest
                 | Self::SandboxExecResizeRequest
                 | Self::SandboxExecWaitRequest
+                | Self::SandboxExecListRequest
+                | Self::SandboxWaitForPortRequest
         )
     }
 
@@ -651,12 +672,16 @@ mod tests {
             (0x0064, MessageType::SandboxExecSignalRequest),
             (0x0065, MessageType::SandboxExecResizeRequest),
             (0x0066, MessageType::SandboxExecWaitRequest),
+            (0x0067, MessageType::SandboxExecListRequest),
+            (0x0068, MessageType::SandboxWaitForPortRequest),
             (0x1060, MessageType::SandboxExecStartResponse),
             (0x1061, MessageType::SandboxExecEvent),
             (0x1062, MessageType::SandboxStdinStatus),
             (0x1064, MessageType::SandboxExecSignalResponse),
             (0x1065, MessageType::SandboxExecResizeResponse),
             (0x1066, MessageType::SandboxExecWaitResponse),
+            (0x1067, MessageType::SandboxExecListResponse),
+            (0x1068, MessageType::SandboxWaitForPortResponse),
             // Sandbox snapshots.
             (0x0040, MessageType::SandboxCheckpointRequest),
             (0x0041, MessageType::SandboxRestoreRequest),

--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -535,6 +535,34 @@ where
                 send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
             }
         },
+        MessageType::SandboxExecListRequest => match svc.list_executions(payload) {
+            Ok(resp) => {
+                write_message(
+                    stream,
+                    MessageType::SandboxExecListResponse,
+                    trace_id,
+                    &resp.encode_to_vec(),
+                )
+                .await?;
+            }
+            Err(e) => {
+                send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+            }
+        },
+        MessageType::SandboxWaitForPortRequest => match svc.wait_for_port(payload).await {
+            Ok(()) => {
+                write_message(
+                    stream,
+                    MessageType::SandboxWaitForPortResponse,
+                    trace_id,
+                    &[],
+                )
+                .await?;
+            }
+            Err(e) => {
+                send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+            }
+        },
         // -----------------------------------------------------------------
         // Streaming: Events
         // -----------------------------------------------------------------

--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -553,6 +553,73 @@ where
         MessageType::SandboxFileWriteRequest => {
             svc.handle_write_file(stream, trace_id, payload).await?;
         }
+        MessageType::SandboxFileStatRequest => match svc.stat_file(payload).await {
+            Ok(resp) => {
+                write_message(
+                    stream,
+                    MessageType::SandboxFileStatResponse,
+                    trace_id,
+                    &resp.encode_to_vec(),
+                )
+                .await?;
+            }
+            Err(e) => {
+                send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+            }
+        },
+        MessageType::SandboxFileListDirRequest => match svc.list_dir(payload).await {
+            Ok(resp) => {
+                write_message(
+                    stream,
+                    MessageType::SandboxFileListDirResponse,
+                    trace_id,
+                    &resp.encode_to_vec(),
+                )
+                .await?;
+            }
+            Err(e) => {
+                send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+            }
+        },
+        MessageType::SandboxFileMakeDirRequest => match svc.make_dir(payload).await {
+            Ok(()) => {
+                write_message(
+                    stream,
+                    MessageType::SandboxFileMakeDirResponse,
+                    trace_id,
+                    &[],
+                )
+                .await?;
+            }
+            Err(e) => {
+                send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+            }
+        },
+        MessageType::SandboxFileRemoveRequest => match svc.remove_entry(payload).await {
+            Ok(()) => {
+                write_message(
+                    stream,
+                    MessageType::SandboxFileRemoveResponse,
+                    trace_id,
+                    &[],
+                )
+                .await?;
+            }
+            Err(e) => {
+                send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+            }
+        },
+        MessageType::SandboxFileMoveRequest => match svc.move_entry(payload).await {
+            Ok(()) => {
+                write_message(stream, MessageType::SandboxFileMoveResponse, trace_id, &[]).await?;
+            }
+            Err(e) => {
+                send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+            }
+        },
+        MessageType::SandboxFileWatchRequest => {
+            svc.handle_watch_dir(stream, trace_id, payload).await?;
+        }
         // -----------------------------------------------------------------
         // Port forwarding
         // -----------------------------------------------------------------

--- a/guest/arcbox-agent/src/error.rs
+++ b/guest/arcbox-agent/src/error.rs
@@ -30,6 +30,10 @@ pub enum SandboxError {
     StdinGap(String),
     /// The host / guest lacks a prerequisite (e.g. nested virtualization).
     Unsupported(String),
+    /// A bounded wait elapsed before the awaited condition held (e.g. a
+    /// `WaitForPort` deadline). Carried as 504 so the daemon maps it onto
+    /// `DEADLINE_EXCEEDED` instead of a blanket `INTERNAL`.
+    Deadline(String),
     /// A retryable runtime condition, including an unconfirmed durable write.
     Unavailable(String),
     /// A runtime or business-logic error.
@@ -47,6 +51,7 @@ impl fmt::Display for SandboxError {
             | Self::SandboxPaused(msg)
             | Self::StdinGap(msg)
             | Self::Unsupported(msg)
+            | Self::Deadline(msg)
             | Self::Unavailable(msg)
             | Self::Internal(msg) => f.write_str(msg),
         }
@@ -71,6 +76,7 @@ impl SandboxError {
             Self::StdinGap(_) => 416,
             Self::SandboxPaused(_) => 423,
             Self::Unavailable(_) => 503,
+            Self::Deadline(_) => 504,
             Self::Internal(_) => 500,
         }
     }
@@ -92,6 +98,7 @@ impl From<arcbox_vm::VmmError> for SandboxError {
             }
             VmmError::Paused(_) => Self::SandboxPaused(e.to_string()),
             VmmError::StdinGap { .. } => Self::StdinGap(e.to_string()),
+            VmmError::DeadlineExceeded(_) => Self::Deadline(e.to_string()),
             VmmError::Unavailable(_) | VmmError::AckUnconfirmed { .. } => {
                 Self::Unavailable(e.to_string())
             }
@@ -159,6 +166,15 @@ mod tests {
     fn not_a_directory_maps_to_400() {
         let err = SandboxError::from(arcbox_vm::VmmError::NotADirectory("/a/file".into()));
         assert_eq!(err.status_code(), 400);
+    }
+
+    #[test]
+    fn deadline_maps_to_504_for_the_daemon_deadline_code() {
+        let err = SandboxError::from(arcbox_vm::VmmError::DeadlineExceeded(
+            "no listener on port 8080".into(),
+        ));
+        assert!(matches!(err, SandboxError::Deadline(_)));
+        assert_eq!(err.status_code(), 504);
     }
 
     #[test]

--- a/guest/arcbox-agent/src/error.rs
+++ b/guest/arcbox-agent/src/error.rs
@@ -80,17 +80,27 @@ impl From<arcbox_vm::VmmError> for SandboxError {
     fn from(e: arcbox_vm::VmmError) -> Self {
         use arcbox_vm::VmmError;
         match &e {
-            VmmError::NotFound(_) => Self::NotFound(e.to_string()),
+            // A missing sandbox path keeps its typed "path not found:"
+            // message: the daemon's classifier maps the 404 onto the
+            // FILE_NOT_FOUND registry code by that prefix.
+            VmmError::NotFound(_) | VmmError::PathNotFound(_) => Self::NotFound(e.to_string()),
             VmmError::AlreadyExists(_) => Self::AlreadyExists(e.to_string()),
-            VmmError::WrongState { .. } => Self::WrongState(e.to_string()),
+            // A non-empty directory is a precondition failure (412), like a
+            // wrong sandbox state: retrying without `recursive` never helps.
+            VmmError::WrongState { .. } | VmmError::DirectoryNotEmpty(_) => {
+                Self::WrongState(e.to_string())
+            }
             VmmError::Paused(_) => Self::SandboxPaused(e.to_string()),
             VmmError::StdinGap { .. } => Self::StdinGap(e.to_string()),
             VmmError::Unavailable(_) | VmmError::AckUnconfirmed { .. } => {
                 Self::Unavailable(e.to_string())
             }
-            // Invalid caller input (e.g. a rejected sandbox id) is a 400, not a
-            // 500 — otherwise a bad request surfaces as INTERNAL to the client.
-            VmmError::Config(_) => Self::InvalidArgument(e.to_string()),
+            // Invalid caller input (e.g. a rejected sandbox id, or a
+            // directory verb aimed at a non-directory) is a 400, not a
+            // 500 — otherwise a bad request surfaces as INTERNAL.
+            VmmError::Config(_) | VmmError::NotADirectory(_) => {
+                Self::InvalidArgument(e.to_string())
+            }
             _ => Self::Internal(e.to_string()),
         }
     }
@@ -128,6 +138,27 @@ mod tests {
         let err = SandboxError::from(arcbox_vm::VmmError::Paused("box".into()));
         assert!(matches!(err, SandboxError::SandboxPaused(_)));
         assert_eq!(err.status_code(), 423);
+    }
+
+    #[test]
+    fn path_not_found_maps_to_404_with_the_classifier_prefix() {
+        let err = SandboxError::from(arcbox_vm::VmmError::PathNotFound("/a/b".into()));
+        assert!(matches!(err, SandboxError::NotFound(_)));
+        assert_eq!(err.status_code(), 404);
+        // The daemon classifier keys on this exact prefix (FILE_NOT_FOUND).
+        assert_eq!(err.to_string(), "path not found: /a/b");
+    }
+
+    #[test]
+    fn directory_not_empty_maps_to_412() {
+        let err = SandboxError::from(arcbox_vm::VmmError::DirectoryNotEmpty("/full".into()));
+        assert_eq!(err.status_code(), 412);
+    }
+
+    #[test]
+    fn not_a_directory_maps_to_400() {
+        let err = SandboxError::from(arcbox_vm::VmmError::NotADirectory("/a/file".into()));
+        assert_eq!(err.status_code(), 400);
     }
 
     #[test]

--- a/guest/arcbox-agent/src/sandbox/convert.rs
+++ b/guest/arcbox-agent/src/sandbox/convert.rs
@@ -2,6 +2,7 @@
 //! plus the shared id-ordered pagination helper.
 
 use arcbox_connect::sandbox_v1;
+use arcbox_vm::file_io::proto as file_proto;
 use arcbox_vm::{
     CheckpointInfo, CheckpointSummary, ExecutionChannel, ExecutionSnapshot, ExitStatus, IdleAction,
     SandboxEvent as VmSandboxEvent, SandboxInfo, SandboxState, SandboxSummary, StdinState,
@@ -75,6 +76,53 @@ pub(super) fn execution_to_proto(snap: &ExecutionSnapshot) -> sandbox_v1::Execut
         stdout_len: snap.stdout_len,
         stderr_len: snap.stderr_len,
         stdin: stdin_to_proto(snap.stdin).into(),
+        ..Default::default()
+    }
+}
+
+/// Map a file-channel kind string onto the wire enum.
+fn file_kind_to_proto(kind: &str) -> sandbox_v1::FileKind {
+    match kind {
+        file_proto::KIND_FILE => sandbox_v1::FileKind::File,
+        file_proto::KIND_DIR => sandbox_v1::FileKind::Directory,
+        file_proto::KIND_SYMLINK => sandbox_v1::FileKind::Symlink,
+        file_proto::KIND_OTHER => sandbox_v1::FileKind::Other,
+        _ => sandbox_v1::FileKind::Unspecified,
+    }
+}
+
+pub(super) fn file_stat_to_proto(dto: &file_proto::FileStatDto) -> sandbox_v1::FileStat {
+    sandbox_v1::FileStat {
+        name: dto.name.clone(),
+        kind: file_kind_to_proto(&dto.kind).into(),
+        size: dto.size,
+        mode: dto.mode,
+        modified_at: Timestamp {
+            seconds: dto.mtime_secs,
+            // Sub-second nanos are < 1e9; i32 holds them.
+            nanos: i32::try_from(dto.mtime_nanos).unwrap_or(0),
+            ..Default::default()
+        }
+        .into(),
+        uid: dto.uid,
+        gid: dto.gid,
+        symlink_target: dto.symlink_target.clone(),
+        ..Default::default()
+    }
+}
+
+pub(super) fn fs_event_to_proto(dto: file_proto::FsEventDto) -> sandbox_v1::FsEvent {
+    let kind = match dto.kind.as_str() {
+        file_proto::EVENT_CREATED => sandbox_v1::FsEventKind::Created,
+        file_proto::EVENT_MODIFIED => sandbox_v1::FsEventKind::Modified,
+        file_proto::EVENT_REMOVED => sandbox_v1::FsEventKind::Removed,
+        file_proto::EVENT_RENAMED => sandbox_v1::FsEventKind::Renamed,
+        _ => sandbox_v1::FsEventKind::Unspecified,
+    };
+    sandbox_v1::FsEvent {
+        kind: kind.into(),
+        path: dto.path,
+        renamed_to: dto.renamed_to,
         ..Default::default()
     }
 }

--- a/guest/arcbox-agent/src/sandbox/execution.rs
+++ b/guest/arcbox-agent/src/sandbox/execution.rs
@@ -243,4 +243,40 @@ impl SandboxService {
             .map_err(SandboxError::from)?;
         Ok(convert::execution_to_proto(&snapshot))
     }
+
+    /// List a sandbox's retained executions, running and exited.
+    pub fn list_executions(
+        &self,
+        payload: &[u8],
+    ) -> Result<sandbox_v1::ListExecutionsResponse, SandboxError> {
+        let req = sandbox_v1::ListExecutionsRequest::decode_from_slice(payload)
+            .map_err(|e| SandboxError::Decode(e.to_string()))?;
+        let snapshots = self
+            .manager
+            .list_executions(&req.sandbox_id)
+            .map_err(SandboxError::from)?;
+        Ok(sandbox_v1::ListExecutionsResponse {
+            executions: snapshots.iter().map(convert::execution_to_proto).collect(),
+            ..Default::default()
+        })
+    }
+
+    /// Wait for a TCP listener inside the sandbox (the caller resolves the
+    /// timeout default; 0 checks once).
+    pub async fn wait_for_port(&self, payload: &[u8]) -> Result<(), SandboxError> {
+        let req = sandbox_v1::WaitForPortRequest::decode_from_slice(payload)
+            .map_err(|e| SandboxError::Decode(e.to_string()))?;
+        let port = u16::try_from(req.port)
+            .ok()
+            .filter(|p| *p != 0)
+            .ok_or_else(|| SandboxError::InvalidArgument(format!("invalid port {}", req.port)))?;
+        self.manager
+            .wait_sandbox_port(
+                &req.sandbox_id,
+                port,
+                Duration::from_secs(u64::from(req.timeout_seconds)),
+            )
+            .await
+            .map_err(SandboxError::from)
+    }
 }

--- a/guest/arcbox-agent/src/sandbox/files.rs
+++ b/guest/arcbox-agent/src/sandbox/files.rs
@@ -1,12 +1,19 @@
-//! Sandbox file I/O streaming handlers.
+//! Sandbox file I/O streaming handlers and path verbs (CORE-62).
+
+use std::time::Duration;
 
 use arcbox_connect::sandbox_v1;
 use buffa::Message;
 use tokio::io::{AsyncRead, AsyncWrite};
 
-use super::SandboxService;
+use super::{SandboxService, convert};
 use crate::error::SandboxError;
 use crate::rpc::{ErrorResponse, MessageType, read_message, write_message};
+
+/// How often an idle watch stream emits a keepalive frame. Below the
+/// daemon's own 15 s client-facing keepalive so the host↔guest hop never
+/// looks dead first.
+const WATCH_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 
 impl SandboxService {
     /// Stream a file out of a sandbox as `SandboxFileData` frames.
@@ -151,4 +158,184 @@ impl SandboxService {
         }
         Ok(())
     }
+
+    /// Stat one path inside a sandbox (symlinks reported, not followed).
+    pub async fn stat_file(&self, payload: &[u8]) -> Result<sandbox_v1::FileStat, SandboxError> {
+        let req = sandbox_v1::StatFileRequest::decode_from_slice(payload)
+            .map_err(|e| SandboxError::Decode(e.to_string()))?;
+        let dto = self
+            .manager
+            .stat_sandbox_path(&req.id, &req.path)
+            .await
+            .map_err(SandboxError::from)?;
+        Ok(convert::file_stat_to_proto(&dto))
+    }
+
+    /// List a directory inside a sandbox, non-recursively.
+    pub async fn list_dir(
+        &self,
+        payload: &[u8],
+    ) -> Result<sandbox_v1::ListDirResponse, SandboxError> {
+        let req = sandbox_v1::ListDirRequest::decode_from_slice(payload)
+            .map_err(|e| SandboxError::Decode(e.to_string()))?;
+        let entries = self
+            .manager
+            .list_sandbox_dir(&req.id, &req.path)
+            .await
+            .map_err(SandboxError::from)?;
+        Ok(sandbox_v1::ListDirResponse {
+            entries: entries.iter().map(convert::file_stat_to_proto).collect(),
+            ..Default::default()
+        })
+    }
+
+    /// Create a directory (with `mkdir -p` semantics) inside a sandbox.
+    pub async fn make_dir(&self, payload: &[u8]) -> Result<(), SandboxError> {
+        let req = sandbox_v1::MakeDirRequest::decode_from_slice(payload)
+            .map_err(|e| SandboxError::Decode(e.to_string()))?;
+        let mode = if req.mode == 0 { 0o755 } else { req.mode };
+        self.manager
+            .make_sandbox_dir(&req.id, &req.path, mode)
+            .await
+            .map_err(SandboxError::from)
+    }
+
+    /// Remove a file, symlink, or directory inside a sandbox.
+    pub async fn remove_entry(&self, payload: &[u8]) -> Result<(), SandboxError> {
+        let req = sandbox_v1::RemoveEntryRequest::decode_from_slice(payload)
+            .map_err(|e| SandboxError::Decode(e.to_string()))?;
+        self.manager
+            .remove_sandbox_path(&req.id, &req.path, req.recursive)
+            .await
+            .map_err(SandboxError::from)
+    }
+
+    /// Rename / move an entry within a sandbox.
+    pub async fn move_entry(&self, payload: &[u8]) -> Result<(), SandboxError> {
+        let req = sandbox_v1::MoveEntryRequest::decode_from_slice(payload)
+            .map_err(|e| SandboxError::Decode(e.to_string()))?;
+        self.manager
+            .move_sandbox_path(&req.id, &req.from_path, &req.to_path)
+            .await
+            .map_err(SandboxError::from)
+    }
+
+    /// Stream `SandboxFileWatchEvent` frames for a directory watch.
+    ///
+    /// An immediate keepalive frame confirms the watch is established (it
+    /// also lets the daemon's paused-sandbox first-frame peek return fast);
+    /// further keepalives are interleaved while idle. The stream ends with
+    /// `SandboxFileWatchEnd` when the sandbox stops (the vm-agent side of
+    /// the vsock channel closes), or an `Error` frame on setup and stream
+    /// failures. Host cancellation surfaces as a failed write here, which
+    /// drops the watch and closes the vm-agent connection.
+    pub async fn handle_watch_dir<S>(
+        &self,
+        stream: &mut S,
+        trace_id: &str,
+        payload: &[u8],
+    ) -> anyhow::Result<()>
+    where
+        S: AsyncWrite + Unpin,
+    {
+        let req = match sandbox_v1::WatchDirRequest::decode_from_slice(payload) {
+            Ok(r) => r,
+            Err(e) => {
+                let err = ErrorResponse::new(400, format!("decode error: {e}"));
+                write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+                return Ok(());
+            }
+        };
+
+        let mut watch = match self
+            .manager
+            .watch_sandbox_dir(&req.id, &req.path, req.recursive)
+            .await
+        {
+            Ok(watch) => watch,
+            Err(e) => {
+                let e = SandboxError::from(e);
+                let err = ErrorResponse::new(e.status_code(), e.to_string());
+                write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+                return Ok(());
+            }
+        };
+
+        // Relay events through a channel: `next_event` is not cancellation
+        // safe (a frame read spans several awaits), so it must not race a
+        // keepalive tick inside select!. Dropping the receiver stops the
+        // relay, which drops the watch and closes the vm-agent connection.
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(64);
+        tokio::spawn(async move {
+            loop {
+                match watch.next_event().await {
+                    Ok(Some(event)) => {
+                        if event_tx.send(Ok(Some(event))).await.is_err() {
+                            return;
+                        }
+                    }
+                    terminal => {
+                        let _ = event_tx.send(terminal).await;
+                        return;
+                    }
+                }
+            }
+        });
+
+        write_watch_keepalive(stream, trace_id).await?;
+        let mut keepalive = tokio::time::interval_at(
+            tokio::time::Instant::now() + WATCH_KEEPALIVE_INTERVAL,
+            WATCH_KEEPALIVE_INTERVAL,
+        );
+        loop {
+            tokio::select! {
+                event = event_rx.recv() => match event {
+                    Some(Ok(Some(event))) => {
+                        let frame = sandbox_v1::WatchDirResponse {
+                            payload: convert::fs_event_to_proto(event).into(),
+                            ..Default::default()
+                        };
+                        write_message(
+                            stream,
+                            MessageType::SandboxFileWatchEvent,
+                            trace_id,
+                            &frame.encode_to_vec(),
+                        )
+                        .await?;
+                    }
+                    // Clean EOF from the vm-agent: the sandbox stopped.
+                    Some(Ok(None)) | None => {
+                        write_message(stream, MessageType::SandboxFileWatchEnd, trace_id, &[])
+                            .await?;
+                        return Ok(());
+                    }
+                    Some(Err(e)) => {
+                        let e = SandboxError::from(e);
+                        let err = ErrorResponse::new(e.status_code(), e.to_string());
+                        write_message(stream, MessageType::Error, trace_id, &err.encode()).await?;
+                        return Ok(());
+                    }
+                },
+                _ = keepalive.tick() => write_watch_keepalive(stream, trace_id).await?,
+            }
+        }
+    }
+}
+
+/// One `SandboxFileWatchEvent` frame carrying a keepalive payload.
+async fn write_watch_keepalive<S>(stream: &mut S, trace_id: &str) -> anyhow::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let frame = sandbox_v1::WatchDirResponse {
+        payload: sandbox_v1::KeepAlive::default().into(),
+        ..Default::default()
+    };
+    write_message(
+        stream,
+        MessageType::SandboxFileWatchEvent,
+        trace_id,
+        &frame.encode_to_vec(),
+    )
+    .await
 }

--- a/guest/arcbox-agent/src/sandbox/files.rs
+++ b/guest/arcbox-agent/src/sandbox/files.rs
@@ -268,16 +268,25 @@ impl SandboxService {
         let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(64);
         tokio::spawn(async move {
             loop {
-                match watch.next_event().await {
-                    Ok(Some(event)) => {
-                        if event_tx.send(Ok(Some(event))).await.is_err() {
+                tokio::select! {
+                    event = watch.next_event() => match event {
+                        Ok(Some(event)) => {
+                            if event_tx.send(Ok(Some(event))).await.is_err() {
+                                return;
+                            }
+                        }
+                        terminal => {
+                            let _ = event_tx.send(terminal).await;
                             return;
                         }
-                    }
-                    terminal => {
-                        let _ = event_tx.send(terminal).await;
-                        return;
-                    }
+                    },
+                    // The handler dropped the receiver (host cancelled): stop
+                    // relaying even while no event ever arrives, so the watch
+                    // and its vm-agent connection are released immediately
+                    // rather than on the next filesystem event. Cutting
+                    // `next_event` mid-frame is fine — the connection is being
+                    // torn down either way.
+                    () = event_tx.closed() => return,
                 }
             }
         });

--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -22,13 +22,15 @@ use arcbox_grpc::sandbox_v1::sandbox_service_client::SandboxServiceClient;
 use arcbox_grpc::sandbox_v1::sandbox_snapshot_service_client::SandboxSnapshotServiceClient;
 use arcbox_protocol::sandbox_v1::{
     AttachExecutionRequest, CheckpointRequest, CreateSandboxRequest, Execution, ExecutionEvent,
-    FileChunk, GetCapabilitiesRequest, GetStdinStatusRequest, IdleAction, InspectSandboxRequest,
-    ListSandboxesRequest, PauseSandboxRequest, ReadFileRequest, RemoveSandboxRequest,
-    ResourceLimits, RestoreRequest, ResumeSandboxRequest, SandboxEventKind, SandboxEventsRequest,
-    SandboxState, SetLifecycleRequest, Signal, SignalExecutionRequest, StartExecutionRequest,
-    StdioChannel, StopSandboxRequest, WaitExecutionRequest, WatchEventsResponse, WriteFileOpen,
-    WriteFileRequest, WriteStdinRequest, execution_event, exit_status, watch_events_response,
-    write_file_request,
+    ExecutionState, FileChunk, FileKind, FsEventKind, GetCapabilitiesRequest,
+    GetStdinStatusRequest, IdleAction, InspectSandboxRequest, ListDirRequest,
+    ListExecutionsRequest, ListSandboxesRequest, MakeDirRequest, MoveEntryRequest,
+    PauseSandboxRequest, ReadFileRequest, RemoveEntryRequest, RemoveSandboxRequest, ResourceLimits,
+    RestoreRequest, ResumeSandboxRequest, SandboxEventKind, SandboxEventsRequest, SandboxState,
+    SetLifecycleRequest, Signal, SignalExecutionRequest, StartExecutionRequest, StatFileRequest,
+    StdioChannel, StopSandboxRequest, WaitExecutionRequest, WaitForPortRequest, WatchDirRequest,
+    WatchEventsResponse, WriteFileOpen, WriteFileRequest, WriteStdinRequest, execution_event,
+    exit_status, watch_dir_response, watch_events_response, write_file_request,
 };
 use tonic::transport::Channel;
 use tracing::{info, warn};
@@ -392,6 +394,19 @@ async fn drive_sandboxes(
     }
     metrics.record("sandbox_file_io", file_started.elapsed().as_secs_f64());
     info!("file round-trip verified");
+
+    // -- CORE-62: filesystem verbs + WatchDir ------------------------------
+    let verbs_started = Instant::now();
+    file_verbs_scenario(&mut files).await?;
+    metrics.record("sandbox_file_verbs", verbs_started.elapsed().as_secs_f64());
+
+    // -- CORE-58 phase 2: ListExecutions + WaitForPort ---------------------
+    let process_started = Instant::now();
+    process_plane_scenario(&mut sandboxes, &mut processes).await?;
+    metrics.record(
+        "sandbox_process_plane",
+        process_started.elapsed().as_secs_f64(),
+    );
 
     // -- Pause / transparent auto-resume / explicit Resume (CORE-21) -------
     let pause_started = Instant::now();
@@ -1426,6 +1441,298 @@ async fn run_and_collect(
         Some(exit_status::Status::Code(0)) => Ok(stdout),
         other => bail!("command {cmd:?} exit status {other:?}: {stdout:?}"),
     }
+}
+
+/// CORE-62 acceptance: the filesystem verbs round-trip against a live
+/// sandbox — mkdir -p semantics, symlink-free stat metadata, a full
+/// listing, rename, the non-empty-remove guard — and a recursive WatchDir
+/// opened before the mutations reports them as events (with keepalives
+/// interleaved) until the client cancels it.
+async fn file_verbs_scenario(files: &mut SandboxFilesystemServiceClient<Channel>) -> Result<()> {
+    let make_dir = MakeDirRequest {
+        id: "smoke1".into(),
+        path: "/tmp/verbs/nested".into(),
+        mode: 0,
+    };
+    files
+        .make_dir(with_machine(make_dir.clone()))
+        .await
+        .context("MakeDir failed")?;
+    // `mkdir -p` semantics: an existing directory succeeds.
+    files
+        .make_dir(with_machine(make_dir))
+        .await
+        .context("MakeDir on an existing directory failed")?;
+
+    let stat = files
+        .stat(with_machine(StatFileRequest {
+            id: "smoke1".into(),
+            path: "/tmp/verbs/nested".into(),
+        }))
+        .await
+        .context("Stat directory failed")?
+        .into_inner();
+    if stat.kind() != FileKind::Directory {
+        bail!("expected a directory, got {:?}", stat.kind());
+    }
+
+    // Open the watch BEFORE mutating, so the mutations below are events.
+    let mut watch = files
+        .watch_dir(with_machine(WatchDirRequest {
+            id: "smoke1".into(),
+            path: "/tmp/verbs".into(),
+            recursive: true,
+        }))
+        .await
+        .context("WatchDir failed")?
+        .into_inner();
+
+    let payload = b"file-verbs payload".to_vec();
+    write_file(files, "smoke1", "/tmp/verbs/nested/a.bin", &payload).await?;
+
+    let stat = files
+        .stat(with_machine(StatFileRequest {
+            id: "smoke1".into(),
+            path: "/tmp/verbs/nested/a.bin".into(),
+        }))
+        .await
+        .context("Stat file failed")?
+        .into_inner();
+    if stat.kind() != FileKind::File || stat.size != payload.len() as u64 {
+        bail!("unexpected file stat: {stat:?}");
+    }
+    if stat.mode != 0o644 {
+        bail!("expected default 0644 mode, got {:o}", stat.mode);
+    }
+    if stat.name != "a.bin" {
+        bail!("expected base name a.bin, got {:?}", stat.name);
+    }
+
+    let listing = files
+        .list_dir(with_machine(ListDirRequest {
+            id: "smoke1".into(),
+            path: "/tmp/verbs/nested".into(),
+        }))
+        .await
+        .context("ListDir failed")?
+        .into_inner();
+    let names: Vec<&str> = listing.entries.iter().map(|e| e.name.as_str()).collect();
+    if names != ["a.bin"] {
+        bail!("unexpected listing: {names:?}");
+    }
+
+    files
+        .r#move(with_machine(MoveEntryRequest {
+            id: "smoke1".into(),
+            from_path: "/tmp/verbs/nested/a.bin".into(),
+            to_path: "/tmp/verbs/nested/b.bin".into(),
+        }))
+        .await
+        .context("Move failed")?;
+
+    // The old path is gone — and carries the FILE_NOT_FOUND classification's
+    // transport code (NOT_FOUND).
+    let err = files
+        .stat(with_machine(StatFileRequest {
+            id: "smoke1".into(),
+            path: "/tmp/verbs/nested/a.bin".into(),
+        }))
+        .await
+        .err()
+        .context("Stat of the moved-away path unexpectedly succeeded")?;
+    if err.code() != tonic::Code::NotFound {
+        bail!("expected NOT_FOUND for the old path, got {err:?}");
+    }
+    let back = read_file(files, "smoke1", "/tmp/verbs/nested/b.bin").await?;
+    if back != payload {
+        bail!("moved file content mismatch");
+    }
+
+    // The watch saw the mutations: drain until both the file's creation and
+    // the rename appear (keepalives and intermediate events are skipped).
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let (mut saw_created, mut saw_renamed, mut saw_keepalive) = (false, false, false);
+    while !(saw_created && saw_renamed) {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .context("WatchDir events did not arrive within 30s")?;
+        let frame = tokio::time::timeout(remaining, watch.message())
+            .await
+            .context("WatchDir stream stalled")?
+            .context("WatchDir stream error")?
+            .context("WatchDir stream ended before the expected events")?;
+        match frame.payload {
+            Some(watch_dir_response::Payload::Event(event)) => {
+                info!(kind = ?event.kind(), path = %event.path, renamed_to = %event.renamed_to,
+                      "watch event");
+                if event.path == "/tmp/verbs/nested/a.bin"
+                    && matches!(event.kind(), FsEventKind::Created | FsEventKind::Modified)
+                {
+                    saw_created = true;
+                }
+                if event.kind() == FsEventKind::Renamed
+                    && event.path == "/tmp/verbs/nested/a.bin"
+                    && event.renamed_to == "/tmp/verbs/nested/b.bin"
+                {
+                    saw_renamed = true;
+                }
+            }
+            Some(watch_dir_response::Payload::KeepAlive(_)) => saw_keepalive = true,
+            None => {}
+        }
+    }
+    if !saw_keepalive {
+        bail!("WatchDir never interleaved a keepalive frame");
+    }
+    // Client-side cancellation: dropping the stream tears the watch down.
+    drop(watch);
+
+    // A non-empty directory refuses a non-recursive remove...
+    let err = files
+        .remove(with_machine(RemoveEntryRequest {
+            id: "smoke1".into(),
+            path: "/tmp/verbs".into(),
+            recursive: false,
+        }))
+        .await
+        .err()
+        .context("non-recursive Remove of a non-empty directory succeeded")?;
+    if err.code() != tonic::Code::FailedPrecondition {
+        bail!("expected FAILED_PRECONDITION, got {err:?}");
+    }
+    // ...and a recursive one takes the tree out.
+    files
+        .remove(with_machine(RemoveEntryRequest {
+            id: "smoke1".into(),
+            path: "/tmp/verbs".into(),
+            recursive: true,
+        }))
+        .await
+        .context("recursive Remove failed")?;
+    let err = files
+        .stat(with_machine(StatFileRequest {
+            id: "smoke1".into(),
+            path: "/tmp/verbs".into(),
+        }))
+        .await
+        .err()
+        .context("Stat of the removed tree unexpectedly succeeded")?;
+    if err.code() != tonic::Code::NotFound {
+        bail!("expected NOT_FOUND after the recursive remove, got {err:?}");
+    }
+
+    info!("filesystem verbs + WatchDir verified");
+    Ok(())
+}
+
+/// CORE-58 phase 2 acceptance: WaitForPort fails fast with
+/// DEADLINE_EXCEEDED while nothing listens, flips once a workload binds
+/// the port (the guest watches its own listen table — no client polling),
+/// and ListExecutions rediscovers the listener both while it runs and
+/// after it exits.
+async fn process_plane_scenario(
+    sandboxes: &mut SandboxServiceClient<Channel>,
+    processes: &mut SandboxProcessServiceClient<Channel>,
+) -> Result<()> {
+    const PORT: u32 = 23456;
+
+    // The listener below needs busybox `nc`; fail with a clear message if
+    // the rootfs busybox was built without it.
+    let nc_probe = run_and_collect(processes, "smoke1", &["/bin/sh", "-c", "command -v nc"]).await;
+    if nc_probe.is_err() {
+        bail!("the sandbox rootfs busybox has no `nc` applet; the WaitForPort phase needs one");
+    }
+    wait_ready(sandboxes, "smoke1").await?;
+
+    // No listener: a 1 s budget elapses as DEADLINE_EXCEEDED.
+    let err = processes
+        .wait_for_port(with_machine(WaitForPortRequest {
+            sandbox_id: "smoke1".into(),
+            port: PORT,
+            timeout_seconds: 1,
+        }))
+        .await
+        .err()
+        .context("WaitForPort succeeded with nothing listening")?;
+    if err.code() != tonic::Code::DeadlineExceeded {
+        bail!("expected DEADLINE_EXCEEDED, got {err:?}");
+    }
+
+    // Start a listener, then wait for the port to come up.
+    let listener = start_execution(
+        processes,
+        "smoke1",
+        "port-listener",
+        &["/bin/sh", "-c", "exec nc -l -p 23456 >/dev/null"],
+        false,
+    )
+    .await?;
+    processes
+        .wait_for_port(with_machine(WaitForPortRequest {
+            sandbox_id: "smoke1".into(),
+            port: PORT,
+            timeout_seconds: 30,
+        }))
+        .await
+        .context("WaitForPort did not observe the listener")?;
+
+    // ListExecutions rediscovers the running listener by id.
+    let listing = processes
+        .list_executions(with_machine(ListExecutionsRequest {
+            sandbox_id: "smoke1".into(),
+        }))
+        .await
+        .context("ListExecutions failed")?
+        .into_inner();
+    let found = listing
+        .executions
+        .iter()
+        .find(|e| e.id == listener.id)
+        .context("listener missing from ListExecutions")?;
+    if found.state() != ExecutionState::Running {
+        bail!("expected the listener RUNNING, got {:?}", found.state());
+    }
+
+    // Tear the listener down and confirm the exited record stays listed.
+    processes
+        .signal_execution(with_machine(SignalExecutionRequest {
+            sandbox_id: "smoke1".into(),
+            execution_id: listener.id.clone(),
+            signal: Signal::Sigkill.into(),
+        }))
+        .await
+        .context("SignalExecution failed")?;
+    let done = processes
+        .wait_execution(with_machine(WaitExecutionRequest {
+            sandbox_id: "smoke1".into(),
+            execution_id: listener.id.clone(),
+            timeout_seconds: 30,
+        }))
+        .await
+        .context("WaitExecution failed")?
+        .into_inner();
+    if done.state() != ExecutionState::Exited {
+        bail!("listener did not exit after SIGKILL: {done:?}");
+    }
+    let listing = processes
+        .list_executions(with_machine(ListExecutionsRequest {
+            sandbox_id: "smoke1".into(),
+        }))
+        .await
+        .context("ListExecutions (after exit) failed")?
+        .into_inner();
+    let found = listing
+        .executions
+        .iter()
+        .find(|e| e.id == listener.id)
+        .context("exited listener missing from ListExecutions")?;
+    if found.state() != ExecutionState::Exited {
+        bail!("expected the listener EXITED, got {:?}", found.state());
+    }
+
+    wait_ready(sandboxes, "smoke1").await?;
+    info!("ListExecutions + WaitForPort verified");
+    Ok(())
 }
 
 async fn write_file(

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -413,8 +413,14 @@ mod agent {
     // File I/O channel (vsock:53) — imported from the shared proto module.
     use arcbox_vm::boot_proto::{KernelIpParam, NetReconfigCommand};
     use arcbox_vm::file_io::proto::{
-        FILE_ACK, FILE_DATA, FILE_DONE, FILE_ERR, FILE_PORT, FILE_READ_REQ, FILE_WRITE_REQ,
-        MAX_FILE_SIZE,
+        ERR_NOT_A_DIRECTORY, ERR_NOT_EMPTY, ERR_NOT_FOUND, FILE_ACK, FILE_DATA, FILE_DONE,
+        FILE_ERR, FILE_EVENT, FILE_LIST, FILE_LIST_REQ, FILE_MKDIR_REQ, FILE_MOVE_REQ, FILE_PORT,
+        FILE_READ_REQ, FILE_REMOVE_REQ, FILE_STAT, FILE_STAT_REQ, FILE_WATCH_REQ, FILE_WRITE_REQ,
+        FileStatDto, KIND_DIR, KIND_FILE, KIND_OTHER, KIND_SYMLINK, ListDirReq, MAX_FILE_SIZE,
+        MakeDirReq, MoveReq, RemoveReq, StatReq, WatchReq,
+    };
+    use arcbox_vm::file_watch::{
+        IN_CREATE, IN_MOVED_TO, WATCH_MASK, map_events, parse_event_buffer,
     };
     // Readiness dial-out port — shared with the host-side boot gate.
     use arcbox_vm::vsock::READY_PORT;
@@ -808,6 +814,12 @@ mod agent {
         match msg_type {
             FILE_WRITE_REQ => handle_file_write(conn, &payload),
             FILE_READ_REQ => handle_file_read(conn, &payload),
+            FILE_STAT_REQ => handle_file_stat(conn, &payload),
+            FILE_LIST_REQ => handle_file_list(conn, &payload),
+            FILE_MKDIR_REQ => handle_file_mkdir(conn, &payload),
+            FILE_REMOVE_REQ => handle_file_remove(conn, &payload),
+            FILE_MOVE_REQ => handle_file_move(conn, &payload),
+            FILE_WATCH_REQ => handle_file_watch(conn, &payload),
             other => eprintln!("agent: file: unexpected frame type 0x{other:02x}"),
         }
     }
@@ -926,6 +938,318 @@ mod agent {
             }
         }
         let _ = write_frame(&mut conn, FILE_DONE, &[]);
+    }
+
+    /// Decode a JSON request payload, answering `FILE_ERR` on parse failure.
+    fn parse_file_req<T: serde::de::DeserializeOwned>(
+        conn: &mut VsockStream,
+        payload: &[u8],
+    ) -> Option<T> {
+        match serde_json::from_slice(payload) {
+            Ok(req) => Some(req),
+            Err(e) => {
+                let _ = write_frame(conn, FILE_ERR, format!("parse request: {e}").as_bytes());
+                None
+            }
+        }
+    }
+
+    /// Format a path-verb failure with the machine-readable errno prefix the
+    /// host maps onto typed errors (`arcbox_vm::file_io::decode_file_err`).
+    fn path_err_payload(op: &str, path: &str, e: &std::io::Error) -> String {
+        match e.raw_os_error() {
+            Some(libc::ENOENT) => format!("{ERR_NOT_FOUND}{path}"),
+            Some(libc::ENOTDIR) => format!("{ERR_NOT_A_DIRECTORY}{path}"),
+            Some(libc::ENOTEMPTY) => format!("{ERR_NOT_EMPTY}{path}"),
+            _ => format!("{op} '{path}': {e}"),
+        }
+    }
+
+    /// Stat one path without following symlinks (the wire contract reports
+    /// symlinks as symlinks, `mode` as the low 12 bits of `st_mode`).
+    fn stat_dto(path: &std::path::Path) -> std::io::Result<FileStatDto> {
+        use std::os::unix::fs::MetadataExt as _;
+        let md = std::fs::symlink_metadata(path)?;
+        let ft = md.file_type();
+        let (kind, symlink_target) = if ft.is_symlink() {
+            let target = std::fs::read_link(path)
+                .map(|t| t.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            (KIND_SYMLINK, target)
+        } else if ft.is_dir() {
+            (KIND_DIR, String::new())
+        } else if ft.is_file() {
+            (KIND_FILE, String::new())
+        } else {
+            (KIND_OTHER, String::new())
+        };
+        Ok(FileStatDto {
+            name: path.file_name().map_or_else(
+                || path.to_string_lossy().into_owned(),
+                |n| n.to_string_lossy().into_owned(),
+            ),
+            kind: kind.to_owned(),
+            size: if ft.is_file() { md.len() } else { 0 },
+            mode: md.mode() & 0o7777,
+            mtime_secs: md.mtime(),
+            mtime_nanos: u32::try_from(md.mtime_nsec()).unwrap_or(0),
+            uid: md.uid(),
+            gid: md.gid(),
+            symlink_target,
+        })
+    }
+
+    fn handle_file_stat(mut conn: VsockStream, header_payload: &[u8]) {
+        let Some(req) = parse_file_req::<StatReq>(&mut conn, header_payload) else {
+            return;
+        };
+        match stat_dto(std::path::Path::new(&req.path))
+            .map_err(|e| path_err_payload("stat", &req.path, &e))
+            .and_then(|dto| serde_json::to_vec(&dto).map_err(|e| format!("encode stat: {e}")))
+        {
+            Ok(body) => {
+                let _ = write_frame(&mut conn, FILE_STAT, &body);
+            }
+            Err(msg) => {
+                let _ = write_frame(&mut conn, FILE_ERR, msg.as_bytes());
+            }
+        }
+    }
+
+    fn handle_file_list(mut conn: VsockStream, header_payload: &[u8]) {
+        let Some(req) = parse_file_req::<ListDirReq>(&mut conn, header_payload) else {
+            return;
+        };
+        let listing = || -> std::io::Result<Vec<FileStatDto>> {
+            let mut entries = Vec::new();
+            for entry in std::fs::read_dir(&req.path)? {
+                let entry = entry?;
+                // An entry deleted between readdir and stat is not an error
+                // for the listing — skip it.
+                if let Ok(dto) = stat_dto(&entry.path()) {
+                    entries.push(dto);
+                }
+            }
+            entries.sort_by(|a, b| a.name.cmp(&b.name));
+            Ok(entries)
+        };
+        match listing()
+            .map_err(|e| path_err_payload("list", &req.path, &e))
+            .and_then(|list| serde_json::to_vec(&list).map_err(|e| format!("encode listing: {e}")))
+        {
+            Ok(body) => {
+                let _ = write_frame(&mut conn, FILE_LIST, &body);
+            }
+            Err(msg) => {
+                let _ = write_frame(&mut conn, FILE_ERR, msg.as_bytes());
+            }
+        }
+    }
+
+    fn handle_file_mkdir(mut conn: VsockStream, header_payload: &[u8]) {
+        use std::os::unix::fs::DirBuilderExt as _;
+        let Some(req) = parse_file_req::<MakeDirReq>(&mut conn, header_payload) else {
+            return;
+        };
+        // Recursive create is idempotent: an existing directory succeeds.
+        match std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(req.mode)
+            .create(&req.path)
+        {
+            Ok(()) => {
+                let _ = write_frame(&mut conn, FILE_ACK, &[]);
+            }
+            Err(e) => {
+                let msg = path_err_payload("mkdir", &req.path, &e);
+                let _ = write_frame(&mut conn, FILE_ERR, msg.as_bytes());
+            }
+        }
+    }
+
+    fn handle_file_remove(mut conn: VsockStream, header_payload: &[u8]) {
+        let Some(req) = parse_file_req::<RemoveReq>(&mut conn, header_payload) else {
+            return;
+        };
+        let path = std::path::Path::new(&req.path);
+        // Symlink-aware: a symlink to a directory is removed as a link,
+        // never followed into.
+        let result = std::fs::symlink_metadata(path).and_then(|md| {
+            if md.file_type().is_dir() {
+                if req.recursive {
+                    std::fs::remove_dir_all(path)
+                } else {
+                    std::fs::remove_dir(path)
+                }
+            } else {
+                std::fs::remove_file(path)
+            }
+        });
+        match result {
+            Ok(()) => {
+                let _ = write_frame(&mut conn, FILE_ACK, &[]);
+            }
+            Err(e) => {
+                let msg = path_err_payload("remove", &req.path, &e);
+                let _ = write_frame(&mut conn, FILE_ERR, msg.as_bytes());
+            }
+        }
+    }
+
+    fn handle_file_move(mut conn: VsockStream, header_payload: &[u8]) {
+        let Some(req) = parse_file_req::<MoveReq>(&mut conn, header_payload) else {
+            return;
+        };
+        match std::fs::rename(&req.from, &req.to) {
+            Ok(()) => {
+                let _ = write_frame(&mut conn, FILE_ACK, &[]);
+            }
+            Err(e) => {
+                let msg = path_err_payload("rename", &req.from, &e);
+                let _ = write_frame(&mut conn, FILE_ERR, msg.as_bytes());
+            }
+        }
+    }
+
+    /// Add an inotify watch on `dir` (and its subtree when `recursive`).
+    /// Per-child errors during the walk are ignored — entries can vanish
+    /// while walking — but the root watch itself must succeed.
+    fn add_watch_tree(
+        ifd: RawFd,
+        dir: &std::path::Path,
+        recursive: bool,
+        watches: &mut HashMap<i32, String>,
+    ) -> std::io::Result<()> {
+        use std::os::unix::ffi::OsStrExt as _;
+        let c_path = std::ffi::CString::new(dir.as_os_str().as_bytes()).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "path contains NUL")
+        })?;
+        // SAFETY: ifd is a live inotify fd; c_path is a valid NUL-terminated
+        // string outliving the call.
+        let wd = unsafe { libc::inotify_add_watch(ifd, c_path.as_ptr(), WATCH_MASK) };
+        if wd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        watches.insert(wd, dir.to_string_lossy().into_owned());
+        if recursive && let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                if entry.file_type().is_ok_and(|t| t.is_dir()) {
+                    let _ = add_watch_tree(ifd, &entry.path(), true, watches);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Stream inotify events for a directory until either side closes the
+    /// connection: the host closing it is the cancellation signal; sandbox
+    /// teardown kills this process, closing it from this side (the host
+    /// reads that EOF as the clean end of the watch).
+    fn handle_file_watch(mut conn: VsockStream, header_payload: &[u8]) {
+        let Some(req) = parse_file_req::<WatchReq>(&mut conn, header_payload) else {
+            return;
+        };
+
+        // SAFETY: plain inotify_init1 call; result checked below.
+        let ifd = unsafe { libc::inotify_init1(libc::IN_CLOEXEC) };
+        if ifd < 0 {
+            let e = std::io::Error::last_os_error();
+            let _ = write_frame(&mut conn, FILE_ERR, format!("inotify_init: {e}").as_bytes());
+            return;
+        }
+        struct InotifyFd(RawFd);
+        impl Drop for InotifyFd {
+            fn drop(&mut self) {
+                // SAFETY: the fd is owned by this guard and closed once.
+                unsafe { libc::close(self.0) };
+            }
+        }
+        let _ifd_guard = InotifyFd(ifd);
+
+        let mut watches: HashMap<i32, String> = HashMap::new();
+        if let Err(e) = add_watch_tree(
+            ifd,
+            std::path::Path::new(&req.path),
+            req.recursive,
+            &mut watches,
+        ) {
+            let msg = path_err_payload("watch", &req.path, &e);
+            let _ = write_frame(&mut conn, FILE_ERR, msg.as_bytes());
+            return;
+        }
+        if write_frame(&mut conn, FILE_ACK, &[]).is_err() {
+            return;
+        }
+
+        let mut buf = [0u8; 16384];
+        loop {
+            let mut fds = [
+                libc::pollfd {
+                    fd: ifd,
+                    events: libc::POLLIN,
+                    revents: 0,
+                },
+                libc::pollfd {
+                    fd: conn.fd,
+                    events: libc::POLLIN,
+                    revents: 0,
+                },
+            ];
+            // SAFETY: fds points at two initialized pollfd entries.
+            let n = unsafe { libc::poll(fds.as_mut_ptr(), 2, -1) };
+            if n < 0 {
+                if std::io::Error::last_os_error().kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return;
+            }
+            // Any readiness on the host connection means it closed — the
+            // host never sends further frames on a watch connection.
+            if fds[1].revents != 0 {
+                return;
+            }
+            if fds[0].revents == 0 {
+                continue;
+            }
+            // SAFETY: buf is a valid writable buffer; ifd is a live inotify fd.
+            let len =
+                unsafe { libc::read(ifd, buf.as_mut_ptr().cast::<libc::c_void>(), buf.len()) };
+            if len <= 0 {
+                return;
+            }
+            let raw = parse_event_buffer(&buf[..len as usize]);
+            // Recursive watches follow directories created or moved into the
+            // tree. Best-effort: events inside a new directory that fire
+            // before its watch lands are unobserved (the inotify recursion
+            // gap).
+            if req.recursive {
+                for event in &raw {
+                    if event.is_dir()
+                        && event.mask & (IN_CREATE | IN_MOVED_TO) != 0
+                        && let Some(dir) = watches.get(&event.wd)
+                    {
+                        let child = std::path::Path::new(dir).join(&event.name);
+                        let _ = add_watch_tree(ifd, &child, true, &mut watches);
+                    }
+                }
+            }
+            let events = map_events(&raw, |wd| watches.get(&wd).cloned());
+            // Prune after mapping: a removal event still needs its wd→path
+            // resolution for the batch it arrived in.
+            for event in &raw {
+                if event.mask & arcbox_vm::file_watch::IN_IGNORED != 0 {
+                    watches.remove(&event.wd);
+                }
+            }
+            for event in events {
+                let Ok(body) = serde_json::to_vec(&event) else {
+                    continue;
+                };
+                if write_frame(&mut conn, FILE_EVENT, &body).is_err() {
+                    return; // host went away mid-write
+                }
+            }
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -420,7 +420,8 @@ mod agent {
         MakeDirReq, MoveReq, RemoveReq, StatReq, WatchReq,
     };
     use arcbox_vm::file_watch::{
-        IN_CREATE, IN_MOVED_TO, WATCH_MASK, map_events, parse_event_buffer,
+        IN_CREATE, IN_MOVED_TO, WATCH_MASK, has_overflow, map_events, parse_event_buffer,
+        trailing_unpaired_move_from,
     };
     // Readiness dial-out port — shared with the host-side boot gate.
     use arcbox_vm::vsock::{MSG_WAIT_PORT, READY_PORT};
@@ -1178,6 +1179,22 @@ mod agent {
         Ok(())
     }
 
+    /// How long a batch ending in an unpaired `IN_MOVED_FROM` waits for the
+    /// matching `IN_MOVED_TO` before mapping the batch as-is.
+    const RENAME_PAIR_GRACE_MS: libc::c_int = 5;
+
+    /// True when `fd` becomes readable within `timeout_ms`.
+    fn poll_readable(fd: RawFd, timeout_ms: libc::c_int) -> bool {
+        let mut fds = [libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        }];
+        // SAFETY: fds points at one initialized pollfd entry.
+        let n = unsafe { libc::poll(fds.as_mut_ptr(), 1, timeout_ms) };
+        n > 0 && fds[0].revents & libc::POLLIN != 0
+    }
+
     /// Stream inotify events for a directory until either side closes the
     /// connection: the host closing it is the cancellation signal; sandbox
     /// teardown kills this process, closing it from this side (the host
@@ -1254,7 +1271,33 @@ mod agent {
             if len <= 0 {
                 return;
             }
-            let raw = parse_event_buffer(&buf[..len as usize]);
+            let mut raw = parse_event_buffer(&buf[..len as usize]);
+            // A rename's FROM/TO halves usually share one read; when FROM is
+            // the batch's last event its TO may still be in flight (or the
+            // buffer split the pair), so give the queue one bounded chance
+            // to complete the pair before mapping. A still-unpaired half
+            // degrades to removed/created, which is also what a move across
+            // the watch boundary legitimately looks like.
+            if trailing_unpaired_move_from(&raw) && poll_readable(ifd, RENAME_PAIR_GRACE_MS) {
+                // SAFETY: buf is a valid writable buffer; ifd is a live
+                // inotify fd (the earlier batch is already parsed and owned).
+                let more =
+                    unsafe { libc::read(ifd, buf.as_mut_ptr().cast::<libc::c_void>(), buf.len()) };
+                if more > 0 {
+                    raw.extend(parse_event_buffer(&buf[..more as usize]));
+                }
+            }
+            // The kernel dropped an unknown number of events: the consumer's
+            // view can no longer be kept consistent, so fail the stream
+            // rather than silently streaming a wrong one.
+            if has_overflow(&raw) {
+                let _ = write_frame(
+                    &mut conn,
+                    FILE_ERR,
+                    b"watch overflowed: the kernel dropped events; re-list and re-watch",
+                );
+                return;
+            }
             // Recursive watches follow directories created or moved into the
             // tree. Best-effort: events inside a new directory that fire
             // before its watch lands are unobserved (the inotify recursion

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -420,8 +420,8 @@ mod agent {
         MakeDirReq, MoveReq, RemoveReq, StatReq, WatchReq,
     };
     use arcbox_vm::file_watch::{
-        IN_CREATE, IN_MOVED_TO, WATCH_MASK, has_overflow, map_events, parse_event_buffer,
-        trailing_unpaired_move_from,
+        IN_CREATE, IN_MOVED_TO, WATCH_MASK, has_overflow, has_unpaired_move_from, map_events,
+        parse_event_buffer,
     };
     // Readiness dial-out port — shared with the host-side boot gate.
     use arcbox_vm::vsock::{MSG_WAIT_PORT, READY_PORT};
@@ -1272,13 +1272,14 @@ mod agent {
                 return;
             }
             let mut raw = parse_event_buffer(&buf[..len as usize]);
-            // A rename's FROM/TO halves usually share one read; when FROM is
-            // the batch's last event its TO may still be in flight (or the
-            // buffer split the pair), so give the queue one bounded chance
-            // to complete the pair before mapping. A still-unpaired half
+            // A rename's FROM/TO halves usually share one read; when the
+            // batch carries an unpaired FROM (its TO still in flight, or
+            // split off by the buffer, possibly with concurrent events
+            // interleaved after it), give the queue one bounded chance to
+            // complete the pair before mapping. A still-unpaired half
             // degrades to removed/created, which is also what a move across
             // the watch boundary legitimately looks like.
-            if trailing_unpaired_move_from(&raw) && poll_readable(ifd, RENAME_PAIR_GRACE_MS) {
+            if has_unpaired_move_from(&raw) && poll_readable(ifd, RENAME_PAIR_GRACE_MS) {
                 // SAFETY: buf is a valid writable buffer; ifd is a live
                 // inotify fd (the earlier batch is already parsed and owned).
                 let more =

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -423,7 +423,7 @@ mod agent {
         IN_CREATE, IN_MOVED_TO, WATCH_MASK, map_events, parse_event_buffer,
     };
     // Readiness dial-out port — shared with the host-side boot gate.
-    use arcbox_vm::vsock::READY_PORT;
+    use arcbox_vm::vsock::{MSG_WAIT_PORT, READY_PORT};
 
     const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
 
@@ -566,6 +566,7 @@ mod agent {
         match msg_type {
             MSG_CLOCK_SYNC => handle_clock_sync(conn, &payload),
             MSG_NET_RECONFIG => handle_net_reconfig(conn, &payload),
+            MSG_WAIT_PORT => handle_wait_port(conn, &payload),
             MSG_START => {
                 let start: StartCommand = match serde_json::from_slice(&payload) {
                     Ok(s) => s,
@@ -584,6 +585,42 @@ mod agent {
                 eprintln!("agent: unexpected frame type 0x{other:02x} on exec port");
             }
         }
+    }
+
+    /// Watch the guest's own TCP listen table until `req.port` has a
+    /// listener or the deadline elapses. Answers `MSG_EXIT` with 0
+    /// (listening) or 1 (deadline). Reading `/proc/net/tcp{,6}` in-process
+    /// keeps the wait free of connect probes that would perturb the
+    /// workload with spurious accepted connections.
+    fn handle_wait_port(mut conn: VsockStream, payload: &[u8]) {
+        const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+
+        let req: arcbox_vm::vsock::WaitPortReq = match serde_json::from_slice(payload) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("agent: parse WaitPortReq: {e}");
+                let _ = write_frame(&mut conn, MSG_EXIT, &(-1i32).to_le_bytes());
+                return;
+            }
+        };
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(req.timeout_ms);
+        let code = loop {
+            let listening = [
+                std::fs::read_to_string("/proc/net/tcp").unwrap_or_default(),
+                std::fs::read_to_string("/proc/net/tcp6").unwrap_or_default(),
+            ]
+            .iter()
+            .any(|table| arcbox_vm::listen_table::any_listener_on_port(table, req.port));
+            if listening {
+                break 0i32;
+            }
+            if std::time::Instant::now() >= deadline {
+                break 1i32;
+            }
+            thread::sleep(POLL_INTERVAL);
+        };
+        let _ = write_frame(&mut conn, MSG_EXIT, &code.to_le_bytes());
     }
 
     fn handle_clock_sync(mut conn: VsockStream, payload: &[u8]) {

--- a/virt/arcbox-vm/src/error.rs
+++ b/virt/arcbox-vm/src/error.rs
@@ -61,6 +61,21 @@ pub enum VmmError {
     #[error("vsock error: {0}")]
     Vsock(String),
 
+    /// A path inside a sandbox does not exist. The message shape is a
+    /// contract: the daemon's error classifier keys on the "path not
+    /// found:" prefix to attach the `FILE_NOT_FOUND` registry code.
+    #[error("path not found: {0}")]
+    PathNotFound(String),
+
+    /// A directory operation addressed a non-directory path.
+    #[error("not a directory: {0}")]
+    NotADirectory(String),
+
+    /// Refused to remove a non-empty directory without `recursive`
+    /// (`FAILED_PRECONDITION` per the filesystem contract).
+    #[error("directory not empty: {0}")]
+    DirectoryNotEmpty(String),
+
     /// A retryable operation whose durable result could not be confirmed.
     #[error("service unavailable: {0}")]
     Unavailable(String),

--- a/virt/arcbox-vm/src/error.rs
+++ b/virt/arcbox-vm/src/error.rs
@@ -76,6 +76,11 @@ pub enum VmmError {
     #[error("directory not empty: {0}")]
     DirectoryNotEmpty(String),
 
+    /// A bounded wait elapsed before the awaited condition held
+    /// (`DEADLINE_EXCEEDED` on the daemon surface).
+    #[error("deadline exceeded: {0}")]
+    DeadlineExceeded(String),
+
     /// A retryable operation whose durable result could not be confirmed.
     #[error("service unavailable: {0}")]
     Unavailable(String),

--- a/virt/arcbox-vm/src/file_io.rs
+++ b/virt/arcbox-vm/src/file_io.rs
@@ -5,14 +5,35 @@
 //! Frame format is identical to the exec channel: `[u8 type][u32 LE len][payload]`.
 //! One vsock connection per operation; vm-agent closes after sending the final frame.
 //!
-//! | Hex  | Name             | Direction      | Payload                          |
-//! |------|------------------|----------------|----------------------------------|
-//! | 0x20 | `FILE_WRITE_REQ` | Host → Agent   | JSON `{"path": str, "mode": u32}`|
-//! | 0x21 | `FILE_DATA`      | bidirectional  | raw bytes (one chunk)            |
-//! | 0x22 | `FILE_DONE`      | bidirectional  | empty — end of data stream       |
-//! | 0x23 | `FILE_READ_REQ`  | Host → Agent   | JSON `{"path": str}`             |
-//! | 0x30 | `FILE_ACK`       | Agent → Host   | empty — write succeeded          |
-//! | 0x31 | `FILE_ERR`       | Agent → Host   | UTF-8 error message              |
+//! | Hex  | Name              | Direction      | Payload                          |
+//! |------|-------------------|----------------|----------------------------------|
+//! | 0x20 | `FILE_WRITE_REQ`  | Host → Agent   | JSON `{"path": str, "mode": u32}`|
+//! | 0x21 | `FILE_DATA`       | bidirectional  | raw bytes (one chunk)            |
+//! | 0x22 | `FILE_DONE`       | bidirectional  | empty — end of data stream       |
+//! | 0x23 | `FILE_READ_REQ`   | Host → Agent   | JSON `{"path": str}`             |
+//! | 0x24 | `FILE_STAT_REQ`   | Host → Agent   | JSON [`proto::StatReq`]          |
+//! | 0x25 | `FILE_LIST_REQ`   | Host → Agent   | JSON [`proto::ListDirReq`]       |
+//! | 0x26 | `FILE_MKDIR_REQ`  | Host → Agent   | JSON [`proto::MakeDirReq`]       |
+//! | 0x27 | `FILE_REMOVE_REQ` | Host → Agent   | JSON [`proto::RemoveReq`]        |
+//! | 0x28 | `FILE_MOVE_REQ`   | Host → Agent   | JSON [`proto::MoveReq`]          |
+//! | 0x29 | `FILE_WATCH_REQ`  | Host → Agent   | JSON [`proto::WatchReq`]         |
+//! | 0x30 | `FILE_ACK`        | Agent → Host   | empty — operation succeeded      |
+//! | 0x31 | `FILE_ERR`        | Agent → Host   | UTF-8 error message              |
+//! | 0x32 | `FILE_STAT`       | Agent → Host   | JSON [`proto::FileStatDto`]      |
+//! | 0x33 | `FILE_LIST`       | Agent → Host   | JSON `[FileStatDto, ...]`        |
+//! | 0x34 | `FILE_EVENT`      | Agent → Host   | JSON [`proto::FsEventDto`]       |
+//!
+//! ## Path-verb flows (CORE-62)
+//!
+//! Stat/List answer one data frame; MakeDir/Remove/Move answer `FILE_ACK`.
+//! Watch answers `FILE_ACK` once the inotify watch is established, then
+//! streams `FILE_EVENT` frames until either side closes the connection —
+//! the host closing it is the cancellation signal, the agent side closing
+//! it (sandbox stop) is the clean end of the stream.
+//!
+//! `FILE_ERR` payloads for the path verbs carry a machine-readable errno
+//! prefix (`ERR_NOT_FOUND` and friends) so the host maps them onto typed
+//! [`VmmError`] variants instead of a blanket vsock error.
 //!
 //! ## Write flow
 //! ```text
@@ -35,6 +56,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use serde::Serialize;
+use tokio::io::AsyncReadExt as _;
+use tokio::net::UnixStream;
 
 use crate::error::{Result, VmmError};
 use crate::vsock::{MAX_FRAME_SIZE, connect_to_port, read_frame, write_frame};
@@ -46,6 +69,8 @@ const FILE_IO_TIMEOUT: Duration = Duration::from_mins(1);
 /// guest vm-agent binary.  The vm-agent should import these from
 /// `arcbox_vm::file_io::proto` instead of duplicating numeric values.
 pub mod proto {
+    use serde::{Deserialize, Serialize};
+
     /// Guest-side vsock port for file I/O.
     pub const FILE_PORT: u32 = 53;
 
@@ -54,16 +79,118 @@ pub mod proto {
     pub const FILE_DATA: u8 = 0x21;
     pub const FILE_DONE: u8 = 0x22;
     pub const FILE_READ_REQ: u8 = 0x23;
+    pub const FILE_STAT_REQ: u8 = 0x24;
+    pub const FILE_LIST_REQ: u8 = 0x25;
+    pub const FILE_MKDIR_REQ: u8 = 0x26;
+    pub const FILE_REMOVE_REQ: u8 = 0x27;
+    pub const FILE_MOVE_REQ: u8 = 0x28;
+    pub const FILE_WATCH_REQ: u8 = 0x29;
     pub const FILE_ACK: u8 = 0x30;
     pub const FILE_ERR: u8 = 0x31;
+    pub const FILE_STAT: u8 = 0x32;
+    pub const FILE_LIST: u8 = 0x33;
+    pub const FILE_EVENT: u8 = 0x34;
 
     /// Maximum total file size for file I/O operations (256 MiB).
     pub const MAX_FILE_SIZE: usize = 256 * 1024 * 1024;
+
+    // Machine-readable errno prefixes on `FILE_ERR` payloads for the path
+    // verbs. The remainder of the payload is the affected path; the host
+    // maps each prefix onto a typed `VmmError` (see `decode_file_err`).
+    pub const ERR_NOT_FOUND: &str = "ENOENT: ";
+    pub const ERR_NOT_A_DIRECTORY: &str = "ENOTDIR: ";
+    pub const ERR_NOT_EMPTY: &str = "ENOTEMPTY: ";
+
+    // `FileStatDto.kind` vocabulary.
+    pub const KIND_FILE: &str = "file";
+    pub const KIND_DIR: &str = "dir";
+    pub const KIND_SYMLINK: &str = "symlink";
+    pub const KIND_OTHER: &str = "other";
+
+    // `FsEventDto.kind` vocabulary.
+    pub const EVENT_CREATED: &str = "created";
+    pub const EVENT_MODIFIED: &str = "modified";
+    pub const EVENT_REMOVED: &str = "removed";
+    pub const EVENT_RENAMED: &str = "renamed";
+
+    /// `FILE_STAT_REQ` payload.
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct StatReq {
+        pub path: String,
+    }
+
+    /// `FILE_LIST_REQ` payload.
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct ListDirReq {
+        pub path: String,
+    }
+
+    /// `FILE_MKDIR_REQ` payload. `mode` carries the Unix permission bits
+    /// for created directories (already defaulted by the caller).
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct MakeDirReq {
+        pub path: String,
+        pub mode: u32,
+    }
+
+    /// `FILE_REMOVE_REQ` payload.
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct RemoveReq {
+        pub path: String,
+        pub recursive: bool,
+    }
+
+    /// `FILE_MOVE_REQ` payload.
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct MoveReq {
+        pub from: String,
+        pub to: String,
+    }
+
+    /// `FILE_WATCH_REQ` payload.
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct WatchReq {
+        pub path: String,
+        pub recursive: bool,
+    }
+
+    /// Metadata of one filesystem entry (`FILE_STAT` / `FILE_LIST` payload).
+    ///
+    /// Mirrors `arcbox.sandbox.v1.FileStat`: symlinks are reported, never
+    /// followed; `mode` is the low 12 bits of `st_mode`; `size` is 0 for
+    /// non-regular files.
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct FileStatDto {
+        pub name: String,
+        pub kind: String,
+        pub size: u64,
+        pub mode: u32,
+        pub mtime_secs: i64,
+        pub mtime_nanos: u32,
+        pub uid: u32,
+        pub gid: u32,
+        #[serde(default)]
+        pub symlink_target: String,
+    }
+
+    /// One filesystem event (`FILE_EVENT` payload). Mirrors
+    /// `arcbox.sandbox.v1.FsEvent`: `path` is the old path for renames,
+    /// with `renamed_to` set only then.
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct FsEventDto {
+        pub kind: String,
+        pub path: String,
+        #[serde(default)]
+        pub renamed_to: String,
+    }
 }
 
 pub use proto::FILE_PORT;
 use proto::{
-    FILE_ACK, FILE_DATA, FILE_DONE, FILE_ERR, FILE_READ_REQ, FILE_WRITE_REQ, MAX_FILE_SIZE,
+    FILE_ACK, FILE_DATA, FILE_DONE, FILE_ERR, FILE_EVENT, FILE_LIST, FILE_LIST_REQ, FILE_MKDIR_REQ,
+    FILE_MOVE_REQ, FILE_READ_REQ, FILE_REMOVE_REQ, FILE_STAT, FILE_STAT_REQ, FILE_WATCH_REQ,
+    FILE_WRITE_REQ, FileStatDto, FsEventDto, ListDirReq, MAX_FILE_SIZE, MakeDirReq, MoveReq,
+    RemoveReq, StatReq, WatchReq,
 };
 
 #[derive(Serialize)]
@@ -177,6 +304,192 @@ async fn read_file_inner(uds_path: &Path, path: &str) -> Result<Vec<u8>> {
             }
         }
     }
+}
+
+/// Map a `FILE_ERR` payload onto a typed error.
+///
+/// Path-verb errors carry the errno prefixes from [`proto`]; anything else
+/// (including all errors from old vm-agents) stays a vsock error.
+fn decode_file_err(payload: &[u8]) -> VmmError {
+    let text = String::from_utf8_lossy(payload).into_owned();
+    if let Some(path) = text.strip_prefix(proto::ERR_NOT_FOUND) {
+        VmmError::PathNotFound(path.to_owned())
+    } else if let Some(path) = text.strip_prefix(proto::ERR_NOT_A_DIRECTORY) {
+        VmmError::NotADirectory(path.to_owned())
+    } else if let Some(path) = text.strip_prefix(proto::ERR_NOT_EMPTY) {
+        VmmError::DirectoryNotEmpty(path.to_owned())
+    } else {
+        VmmError::Vsock(text)
+    }
+}
+
+/// One request frame, one response frame. Returns the response payload when
+/// the type matches `ok_type`; decodes `FILE_ERR` into a typed error.
+async fn unary_file_op(
+    uds_path: &Path,
+    req_type: u8,
+    req: &(impl Serialize + Sync),
+    ok_type: u8,
+) -> Result<Vec<u8>> {
+    let payload =
+        serde_json::to_vec(req).map_err(|e| VmmError::Vsock(format!("serialize request: {e}")))?;
+    let op = async {
+        let mut stream = connect_to_port(uds_path, FILE_PORT).await?;
+        write_frame(&mut stream, req_type, &payload)
+            .await
+            .map_err(|e| VmmError::Vsock(format!("write request 0x{req_type:02x}: {e}")))?;
+        let (resp_type, resp) = read_frame(&mut stream)
+            .await
+            .map_err(|e| VmmError::Vsock(format!("read response: {e}")))?;
+        match resp_type {
+            t if t == ok_type => Ok(resp),
+            FILE_ERR => Err(decode_file_err(&resp)),
+            other => Err(VmmError::Vsock(format!(
+                "unexpected response type 0x{other:02x}"
+            ))),
+        }
+    };
+    tokio::time::timeout(FILE_IO_TIMEOUT, op)
+        .await
+        .map_err(|_| VmmError::Vsock("file operation timed out".into()))?
+}
+
+fn parse_json<T: serde::de::DeserializeOwned>(payload: &[u8]) -> Result<T> {
+    serde_json::from_slice(payload)
+        .map_err(|e| VmmError::Vsock(format!("malformed agent response: {e}")))
+}
+
+/// Stat one path inside the sandbox (symlinks reported, not followed).
+pub async fn stat_file(uds_path: &Path, path: &str) -> Result<FileStatDto> {
+    let req = StatReq {
+        path: path.to_owned(),
+    };
+    let payload = unary_file_op(uds_path, FILE_STAT_REQ, &req, FILE_STAT).await?;
+    parse_json(&payload)
+}
+
+/// List a directory inside the sandbox, non-recursively, entries sorted by
+/// name with full metadata.
+pub async fn list_dir(uds_path: &Path, path: &str) -> Result<Vec<FileStatDto>> {
+    let req = ListDirReq {
+        path: path.to_owned(),
+    };
+    let payload = unary_file_op(uds_path, FILE_LIST_REQ, &req, FILE_LIST).await?;
+    parse_json(&payload)
+}
+
+/// Create a directory (and missing parents) inside the sandbox. Succeeds
+/// when the directory already exists. `mode` must already be defaulted.
+pub async fn make_dir(uds_path: &Path, path: &str, mode: u32) -> Result<()> {
+    let req = MakeDirReq {
+        path: path.to_owned(),
+        mode,
+    };
+    unary_file_op(uds_path, FILE_MKDIR_REQ, &req, FILE_ACK).await?;
+    Ok(())
+}
+
+/// Remove a file, symlink, or directory inside the sandbox. A non-empty
+/// directory requires `recursive` and fails with
+/// [`VmmError::DirectoryNotEmpty`] otherwise.
+pub async fn remove_entry(uds_path: &Path, path: &str, recursive: bool) -> Result<()> {
+    let req = RemoveReq {
+        path: path.to_owned(),
+        recursive,
+    };
+    unary_file_op(uds_path, FILE_REMOVE_REQ, &req, FILE_ACK).await?;
+    Ok(())
+}
+
+/// Rename / move an entry within the sandbox.
+pub async fn move_entry(uds_path: &Path, from: &str, to: &str) -> Result<()> {
+    let req = MoveReq {
+        from: from.to_owned(),
+        to: to.to_owned(),
+    };
+    unary_file_op(uds_path, FILE_MOVE_REQ, &req, FILE_ACK).await?;
+    Ok(())
+}
+
+/// A live directory watch over the sandbox's vsock file channel.
+///
+/// The connection streams `FILE_EVENT` frames until either side closes it.
+/// Dropping this closes the connection, which is the cancellation signal
+/// the vm-agent tears its inotify watch down on.
+#[derive(Debug)]
+pub struct DirWatch {
+    stream: UnixStream,
+}
+
+impl DirWatch {
+    /// Next filesystem event. `Ok(None)` is the clean end of the stream —
+    /// the vm-agent side closed the connection (sandbox stopped).
+    pub async fn next_event(&mut self) -> Result<Option<FsEventDto>> {
+        // Read the frame-type byte manually: a clean EOF is only clean at a
+        // frame boundary, which `read_frame`'s `read_exact` cannot express.
+        let mut ty = [0u8; 1];
+        let n = self
+            .stream
+            .read(&mut ty)
+            .await
+            .map_err(|e| VmmError::Vsock(format!("watch read: {e}")))?;
+        if n == 0 {
+            return Ok(None);
+        }
+        let len = self
+            .stream
+            .read_u32_le()
+            .await
+            .map_err(|e| VmmError::Vsock(format!("watch read: {e}")))? as usize;
+        if len > MAX_FRAME_SIZE {
+            return Err(VmmError::Vsock(format!("watch frame too large: {len}")));
+        }
+        let mut payload = vec![0u8; len];
+        if len > 0 {
+            self.stream
+                .read_exact(&mut payload)
+                .await
+                .map_err(|e| VmmError::Vsock(format!("watch read: {e}")))?;
+        }
+        match ty[0] {
+            FILE_EVENT => Ok(Some(parse_json(&payload)?)),
+            FILE_ERR => Err(decode_file_err(&payload)),
+            other => Err(VmmError::Vsock(format!(
+                "unexpected watch frame type 0x{other:02x}"
+            ))),
+        }
+    }
+}
+
+/// Open a directory watch inside the sandbox. The setup handshake (connect,
+/// request, `FILE_ACK`) is bounded by [`FILE_IO_TIMEOUT`]; the returned
+/// stream itself is long-lived and unbounded.
+pub async fn watch_dir(uds_path: &Path, path: &str, recursive: bool) -> Result<DirWatch> {
+    let req = WatchReq {
+        path: path.to_owned(),
+        recursive,
+    };
+    let payload = serde_json::to_vec(&req)
+        .map_err(|e| VmmError::Vsock(format!("serialize WatchReq: {e}")))?;
+    let setup = async {
+        let mut stream = connect_to_port(uds_path, FILE_PORT).await?;
+        write_frame(&mut stream, FILE_WATCH_REQ, &payload)
+            .await
+            .map_err(|e| VmmError::Vsock(format!("write FILE_WATCH_REQ: {e}")))?;
+        let (resp_type, resp) = read_frame(&mut stream)
+            .await
+            .map_err(|e| VmmError::Vsock(format!("read watch ack: {e}")))?;
+        match resp_type {
+            FILE_ACK => Ok(DirWatch { stream }),
+            FILE_ERR => Err(decode_file_err(&resp)),
+            other => Err(VmmError::Vsock(format!(
+                "unexpected watch ack type 0x{other:02x}"
+            ))),
+        }
+    };
+    tokio::time::timeout(FILE_IO_TIMEOUT, setup)
+        .await
+        .map_err(|_| VmmError::Vsock("watch setup timed out".into()))?
 }
 
 #[cfg(test)]
@@ -362,5 +675,140 @@ mod tests {
         assert_eq!(std::str::from_utf8(&payload).unwrap(), "no such file");
 
         agent_handle.await.unwrap();
+    }
+
+    #[test]
+    fn file_err_prefixes_decode_to_typed_errors() {
+        assert!(matches!(
+            decode_file_err(b"ENOENT: /a/b"),
+            VmmError::PathNotFound(p) if p == "/a/b"
+        ));
+        assert!(matches!(
+            decode_file_err(b"ENOTDIR: /a/file"),
+            VmmError::NotADirectory(p) if p == "/a/file"
+        ));
+        assert!(matches!(
+            decode_file_err(b"ENOTEMPTY: /a/dir"),
+            VmmError::DirectoryNotEmpty(p) if p == "/a/dir"
+        ));
+        // Old-agent / free-form errors stay vsock errors.
+        assert!(matches!(
+            decode_file_err(b"read file: boom"),
+            VmmError::Vsock(m) if m == "read file: boom"
+        ));
+    }
+
+    /// Bind a mock Firecracker vsock UDS: accept one connection, answer the
+    /// `CONNECT {port}` handshake, then hand the stream to `script`.
+    async fn mock_vsock_server<F, Fut>(script: F) -> (tempfile::TempDir, std::path::PathBuf)
+    where
+        F: FnOnce(UnixStream) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send,
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("v.sock");
+        let listener = tokio::net::UnixListener::bind(&path).unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            // Consume "CONNECT {port}\n".
+            let mut byte = [0u8; 1];
+            loop {
+                stream.read_exact(&mut byte).await.unwrap();
+                if byte[0] == b'\n' {
+                    break;
+                }
+            }
+            use tokio::io::AsyncWriteExt as _;
+            stream.write_all(b"OK 53\n").await.unwrap();
+            script(stream).await;
+        });
+        (dir, path)
+    }
+
+    #[tokio::test]
+    async fn stat_file_round_trips_the_dto() {
+        let dto = FileStatDto {
+            name: "b".into(),
+            kind: proto::KIND_FILE.into(),
+            size: 42,
+            mode: 0o644,
+            mtime_secs: 1_700_000_000,
+            mtime_nanos: 5,
+            uid: 0,
+            gid: 0,
+            symlink_target: String::new(),
+        };
+        let expected = dto.clone();
+        let (_dir, path) = mock_vsock_server(move |mut stream| async move {
+            let (ty, payload) = async_read_frame(&mut stream).await.unwrap();
+            assert_eq!(ty, FILE_STAT_REQ);
+            let req: StatReq = serde_json::from_slice(&payload).unwrap();
+            assert_eq!(req.path, "/a/b");
+            let body = serde_json::to_vec(&dto).unwrap();
+            async_write_frame(&mut stream, FILE_STAT, &body)
+                .await
+                .unwrap();
+        })
+        .await;
+
+        let got = stat_file(&path, "/a/b").await.unwrap();
+        assert_eq!(got, expected);
+    }
+
+    #[tokio::test]
+    async fn remove_entry_surfaces_directory_not_empty() {
+        let (_dir, path) = mock_vsock_server(|mut stream| async move {
+            let (ty, _) = async_read_frame(&mut stream).await.unwrap();
+            assert_eq!(ty, FILE_REMOVE_REQ);
+            async_write_frame(&mut stream, FILE_ERR, b"ENOTEMPTY: /full")
+                .await
+                .unwrap();
+        })
+        .await;
+
+        let err = remove_entry(&path, "/full", false).await.unwrap_err();
+        assert!(matches!(err, VmmError::DirectoryNotEmpty(p) if p == "/full"));
+    }
+
+    #[tokio::test]
+    async fn watch_dir_streams_events_until_clean_eof() {
+        let (_dir, path) = mock_vsock_server(|mut stream| async move {
+            let (ty, payload) = async_read_frame(&mut stream).await.unwrap();
+            assert_eq!(ty, FILE_WATCH_REQ);
+            let req: WatchReq = serde_json::from_slice(&payload).unwrap();
+            assert!(req.recursive);
+            async_write_frame(&mut stream, FILE_ACK, &[]).await.unwrap();
+            let event = FsEventDto {
+                kind: proto::EVENT_CREATED.into(),
+                path: "/w/new".into(),
+                renamed_to: String::new(),
+            };
+            let body = serde_json::to_vec(&event).unwrap();
+            async_write_frame(&mut stream, FILE_EVENT, &body)
+                .await
+                .unwrap();
+            // Dropping the stream is the clean end (sandbox stopped).
+        })
+        .await;
+
+        let mut watch = watch_dir(&path, "/w", true).await.unwrap();
+        let event = watch.next_event().await.unwrap().unwrap();
+        assert_eq!(event.kind, proto::EVENT_CREATED);
+        assert_eq!(event.path, "/w/new");
+        assert!(watch.next_event().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn watch_dir_setup_error_is_typed() {
+        let (_dir, path) = mock_vsock_server(|mut stream| async move {
+            let _ = async_read_frame(&mut stream).await.unwrap();
+            async_write_frame(&mut stream, FILE_ERR, b"ENOENT: /missing")
+                .await
+                .unwrap();
+        })
+        .await;
+
+        let err = watch_dir(&path, "/missing", false).await.unwrap_err();
+        assert!(matches!(err, VmmError::PathNotFound(p) if p == "/missing"));
     }
 }

--- a/virt/arcbox-vm/src/file_watch.rs
+++ b/virt/arcbox-vm/src/file_watch.rs
@@ -166,6 +166,34 @@ pub fn map_events(
     out.into_iter().flatten().collect()
 }
 
+/// True when the batch ends in a rename's unmatched FROM half.
+///
+/// The final event is an `IN_MOVED_FROM` whose matching `IN_MOVED_TO` is
+/// absent from the batch — the TO half may still be in flight, so the
+/// reader should give the queue one bounded chance to complete the pair
+/// before mapping (an unpaired half degrades to `removed`/`created`, which
+/// then stands for a move across the watch boundary or a genuinely split
+/// pair).
+#[must_use]
+pub fn trailing_unpaired_move_from(batch: &[RawWatchEvent]) -> bool {
+    let Some(last) = batch.last() else {
+        return false;
+    };
+    last.mask & IN_MOVED_FROM != 0
+        && !batch
+            .iter()
+            .any(|event| event.mask & IN_MOVED_TO != 0 && event.cookie == last.cookie)
+}
+
+/// True when the kernel reported a queue overflow in this batch.
+///
+/// An unknown number of events was dropped, so the consumer's view can no
+/// longer be kept consistent and the watch must fail rather than stream on.
+#[must_use]
+pub fn has_overflow(batch: &[RawWatchEvent]) -> bool {
+    batch.iter().any(|event| event.mask & IN_Q_OVERFLOW != 0)
+}
+
 /// Join a watched directory and an event's relative name (empty name means
 /// the directory itself, e.g. `IN_DELETE_SELF`).
 fn join_path(dir: &str, name: &str) -> String {
@@ -291,6 +319,35 @@ mod tests {
             (99, IN_CREATE, 0, "orphan"),
         ]));
         assert!(map_events(&batch, root_only).is_empty());
+    }
+
+    #[test]
+    fn trailing_unpaired_move_from_flags_only_the_open_pair() {
+        // FROM with no TO at the end of the batch: the pair may be split.
+        let open = parse_event_buffer(&encode(&[(1, IN_MOVED_FROM, 7, "old")]));
+        assert!(trailing_unpaired_move_from(&open));
+        // A paired batch is complete.
+        let paired = parse_event_buffer(&encode(&[
+            (1, IN_MOVED_FROM, 7, "old"),
+            (1, IN_MOVED_TO, 7, "new"),
+        ]));
+        assert!(!trailing_unpaired_move_from(&paired));
+        // A trailing non-move event closes the window too.
+        let closed = parse_event_buffer(&encode(&[
+            (1, IN_MOVED_FROM, 7, "old"),
+            (1, IN_CREATE, 0, "other"),
+        ]));
+        assert!(!trailing_unpaired_move_from(&closed));
+        assert!(!trailing_unpaired_move_from(&[]));
+    }
+
+    #[test]
+    fn overflow_is_detected() {
+        let batch = parse_event_buffer(&encode(&[(-1, IN_Q_OVERFLOW, 0, "")]));
+        assert!(has_overflow(&batch));
+        assert!(!has_overflow(&parse_event_buffer(&encode(&[(
+            1, IN_CREATE, 0, "f"
+        )]))));
     }
 
     #[test]

--- a/virt/arcbox-vm/src/file_watch.rs
+++ b/virt/arcbox-vm/src/file_watch.rs
@@ -166,23 +166,23 @@ pub fn map_events(
     out.into_iter().flatten().collect()
 }
 
-/// True when the batch ends in a rename's unmatched FROM half.
+/// True when the batch carries a rename's unmatched FROM half.
 ///
-/// The final event is an `IN_MOVED_FROM` whose matching `IN_MOVED_TO` is
-/// absent from the batch — the TO half may still be in flight, so the
-/// reader should give the queue one bounded chance to complete the pair
-/// before mapping (an unpaired half degrades to `removed`/`created`, which
-/// then stands for a move across the watch boundary or a genuinely split
-/// pair).
+/// Any `IN_MOVED_FROM` whose matching `IN_MOVED_TO` is absent from the
+/// batch (events from concurrent operations can interleave between the two
+/// halves, so the FROM need not be last): the TO half may still be in
+/// flight, and the reader should give the queue one bounded chance to
+/// complete the pair before mapping. A still-unpaired half degrades to
+/// `removed`/`created`, which then stands for a move across the watch
+/// boundary or a genuinely split pair.
 #[must_use]
-pub fn trailing_unpaired_move_from(batch: &[RawWatchEvent]) -> bool {
-    let Some(last) = batch.last() else {
-        return false;
-    };
-    last.mask & IN_MOVED_FROM != 0
-        && !batch
-            .iter()
-            .any(|event| event.mask & IN_MOVED_TO != 0 && event.cookie == last.cookie)
+pub fn has_unpaired_move_from(batch: &[RawWatchEvent]) -> bool {
+    batch.iter().any(|from| {
+        from.mask & IN_MOVED_FROM != 0
+            && !batch
+                .iter()
+                .any(|to| to.mask & IN_MOVED_TO != 0 && to.cookie == from.cookie)
+    })
 }
 
 /// True when the kernel reported a queue overflow in this batch.
@@ -322,23 +322,24 @@ mod tests {
     }
 
     #[test]
-    fn trailing_unpaired_move_from_flags_only_the_open_pair() {
+    fn unpaired_move_from_is_flagged_at_any_position() {
         // FROM with no TO at the end of the batch: the pair may be split.
         let open = parse_event_buffer(&encode(&[(1, IN_MOVED_FROM, 7, "old")]));
-        assert!(trailing_unpaired_move_from(&open));
+        assert!(has_unpaired_move_from(&open));
         // A paired batch is complete.
         let paired = parse_event_buffer(&encode(&[
             (1, IN_MOVED_FROM, 7, "old"),
             (1, IN_MOVED_TO, 7, "new"),
         ]));
-        assert!(!trailing_unpaired_move_from(&paired));
-        // A trailing non-move event closes the window too.
-        let closed = parse_event_buffer(&encode(&[
+        assert!(!has_unpaired_move_from(&paired));
+        // Events from concurrent operations can interleave between the
+        // halves, so a non-trailing unpaired FROM still opens the window.
+        let interleaved = parse_event_buffer(&encode(&[
             (1, IN_MOVED_FROM, 7, "old"),
             (1, IN_CREATE, 0, "other"),
         ]));
-        assert!(!trailing_unpaired_move_from(&closed));
-        assert!(!trailing_unpaired_move_from(&[]));
+        assert!(has_unpaired_move_from(&interleaved));
+        assert!(!has_unpaired_move_from(&[]));
     }
 
     #[test]

--- a/virt/arcbox-vm/src/file_watch.rs
+++ b/virt/arcbox-vm/src/file_watch.rs
@@ -1,0 +1,303 @@
+//! Inotify event-buffer parsing and mapping to sandbox filesystem events.
+//!
+//! The vm-agent's directory watch (`FILE_WATCH_REQ`, see [`crate::file_io`])
+//! reads raw `inotify(7)` event buffers inside the guest. Everything that
+//! does not need a syscall lives here so it compiles and is unit-tested on
+//! every host platform: the fixed 16-byte event header layout, the mask
+//! constants, and the cookie-based rename pairing that turns kernel
+//! `IN_MOVED_FROM`/`IN_MOVED_TO` pairs into single `renamed` events.
+
+use crate::file_io::proto::{
+    EVENT_CREATED, EVENT_MODIFIED, EVENT_REMOVED, EVENT_RENAMED, FsEventDto,
+};
+
+// `inotify(7)` mask bits (stable kernel ABI; mirrored here so this module
+// needs no libc and stays testable off-Linux).
+pub const IN_MODIFY: u32 = 0x0000_0002;
+pub const IN_ATTRIB: u32 = 0x0000_0004;
+pub const IN_MOVED_FROM: u32 = 0x0000_0040;
+pub const IN_MOVED_TO: u32 = 0x0000_0080;
+pub const IN_CREATE: u32 = 0x0000_0100;
+pub const IN_DELETE: u32 = 0x0000_0200;
+pub const IN_DELETE_SELF: u32 = 0x0000_0400;
+pub const IN_Q_OVERFLOW: u32 = 0x0000_4000;
+pub const IN_IGNORED: u32 = 0x0000_8000;
+pub const IN_ISDIR: u32 = 0x4000_0000;
+
+/// The mask a directory watch subscribes with. `IN_CLOSE_WRITE` is left out
+/// deliberately: `IN_MODIFY` already reports content changes, and reporting
+/// both would emit two `modified` events per write.
+pub const WATCH_MASK: u32 =
+    IN_MODIFY | IN_ATTRIB | IN_MOVED_FROM | IN_MOVED_TO | IN_CREATE | IN_DELETE | IN_DELETE_SELF;
+
+/// One decoded `struct inotify_event`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawWatchEvent {
+    /// Watch descriptor the event fired on (`-1` for queue overflow).
+    pub wd: i32,
+    /// Event mask bits.
+    pub mask: u32,
+    /// Kernel cookie pairing `IN_MOVED_FROM` with `IN_MOVED_TO`.
+    pub cookie: u32,
+    /// Entry name relative to the watched directory (empty for events on
+    /// the watched directory itself, e.g. `IN_DELETE_SELF`).
+    pub name: String,
+}
+
+impl RawWatchEvent {
+    /// True when the event names a directory (`IN_ISDIR`).
+    #[must_use]
+    pub const fn is_dir(&self) -> bool {
+        self.mask & IN_ISDIR != 0
+    }
+}
+
+/// Decode a raw `read(2)` buffer from an inotify fd.
+///
+/// Layout per event: `i32 wd, u32 mask, u32 cookie, u32 len`, then `len`
+/// bytes of NUL-padded name. A truncated trailing record (which the kernel
+/// never produces, but arbitrary short reads must not panic) ends the parse.
+#[must_use]
+pub fn parse_event_buffer(buf: &[u8]) -> Vec<RawWatchEvent> {
+    const HEADER: usize = 16;
+    let mut events = Vec::new();
+    let mut off = 0usize;
+    while buf.len() - off >= HEADER {
+        let wd = i32::from_ne_bytes(buf[off..off + 4].try_into().unwrap());
+        let mask = u32::from_ne_bytes(buf[off + 4..off + 8].try_into().unwrap());
+        let cookie = u32::from_ne_bytes(buf[off + 8..off + 12].try_into().unwrap());
+        let len = u32::from_ne_bytes(buf[off + 12..off + 16].try_into().unwrap()) as usize;
+        let Some(end) = off.checked_add(HEADER).and_then(|s| s.checked_add(len)) else {
+            break;
+        };
+        if end > buf.len() {
+            break;
+        }
+        let name_bytes = &buf[off + HEADER..end];
+        let name_end = name_bytes
+            .iter()
+            .position(|b| *b == 0)
+            .unwrap_or(name_bytes.len());
+        events.push(RawWatchEvent {
+            wd,
+            mask,
+            cookie,
+            name: String::from_utf8_lossy(&name_bytes[..name_end]).into_owned(),
+        });
+        off = end;
+    }
+    events
+}
+
+/// Map one batch of raw events onto wire events.
+///
+/// `path_of` resolves a watch descriptor to the absolute directory path it
+/// watches (`None` for descriptors already forgotten, whose events are
+/// dropped). Rename pairing is per-batch: an `IN_MOVED_FROM` whose cookie is
+/// matched by an `IN_MOVED_TO` in the same batch becomes one `renamed`
+/// event; an unmatched half degrades to `removed` / `created`, which is
+/// exactly what a move across the watch boundary is from the watcher's view.
+pub fn map_events(
+    batch: &[RawWatchEvent],
+    mut path_of: impl FnMut(i32) -> Option<String>,
+) -> Vec<FsEventDto> {
+    // Pending unmatched IN_MOVED_FROM halves: (cookie, absolute path,
+    // emitted `removed` slot index).
+    let mut pending_from: Vec<(u32, String, usize)> = Vec::new();
+    let mut out: Vec<Option<FsEventDto>> = Vec::new();
+
+    for event in batch {
+        if event.mask & (IN_Q_OVERFLOW | IN_IGNORED) != 0 {
+            continue;
+        }
+        let Some(dir) = path_of(event.wd) else {
+            continue;
+        };
+        let path = join_path(&dir, &event.name);
+
+        if event.mask & IN_MOVED_FROM != 0 {
+            // Tentatively a removal; upgraded to `renamed` if the TO half
+            // arrives later in this batch.
+            pending_from.push((event.cookie, path.clone(), out.len()));
+            out.push(Some(FsEventDto {
+                kind: EVENT_REMOVED.to_owned(),
+                path,
+                renamed_to: String::new(),
+            }));
+        } else if event.mask & IN_MOVED_TO != 0 {
+            if let Some(idx) = pending_from
+                .iter()
+                .position(|(cookie, _, _)| *cookie == event.cookie)
+            {
+                let (_, from_path, slot) = pending_from.swap_remove(idx);
+                out[slot] = Some(FsEventDto {
+                    kind: EVENT_RENAMED.to_owned(),
+                    path: from_path,
+                    renamed_to: path,
+                });
+            } else {
+                out.push(Some(FsEventDto {
+                    kind: EVENT_CREATED.to_owned(),
+                    path,
+                    renamed_to: String::new(),
+                }));
+            }
+        } else if event.mask & IN_CREATE != 0 {
+            out.push(Some(FsEventDto {
+                kind: EVENT_CREATED.to_owned(),
+                path,
+                renamed_to: String::new(),
+            }));
+        } else if event.mask & (IN_DELETE | IN_DELETE_SELF) != 0 {
+            out.push(Some(FsEventDto {
+                kind: EVENT_REMOVED.to_owned(),
+                path,
+                renamed_to: String::new(),
+            }));
+        } else if event.mask & (IN_MODIFY | IN_ATTRIB) != 0 {
+            out.push(Some(FsEventDto {
+                kind: EVENT_MODIFIED.to_owned(),
+                path,
+                renamed_to: String::new(),
+            }));
+        }
+    }
+
+    out.into_iter().flatten().collect()
+}
+
+/// Join a watched directory and an event's relative name (empty name means
+/// the directory itself, e.g. `IN_DELETE_SELF`).
+fn join_path(dir: &str, name: &str) -> String {
+    if name.is_empty() {
+        dir.to_owned()
+    } else if dir.ends_with('/') {
+        format!("{dir}{name}")
+    } else {
+        format!("{dir}/{name}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encode(events: &[(i32, u32, u32, &str)]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for (wd, mask, cookie, name) in events {
+            // NUL-pad to a 4-byte boundary like the kernel does.
+            let mut name_bytes = name.as_bytes().to_vec();
+            if !name_bytes.is_empty() {
+                name_bytes.push(0);
+                while name_bytes.len() % 4 != 0 {
+                    name_bytes.push(0);
+                }
+            }
+            buf.extend_from_slice(&wd.to_ne_bytes());
+            buf.extend_from_slice(&mask.to_ne_bytes());
+            buf.extend_from_slice(&cookie.to_ne_bytes());
+            buf.extend_from_slice(&(name_bytes.len() as u32).to_ne_bytes());
+            buf.extend_from_slice(&name_bytes);
+        }
+        buf
+    }
+
+    fn root_only(wd: i32) -> Option<String> {
+        (wd == 1).then(|| "/watch".to_owned())
+    }
+
+    #[test]
+    fn parses_events_and_strips_nul_padding() {
+        let buf = encode(&[(1, IN_CREATE, 0, "a.txt"), (1, IN_DELETE_SELF, 0, "")]);
+        let events = parse_event_buffer(&buf);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].name, "a.txt");
+        assert_eq!(events[0].mask, IN_CREATE);
+        assert_eq!(events[1].name, "");
+    }
+
+    #[test]
+    fn truncated_buffer_does_not_panic() {
+        let buf = encode(&[(1, IN_CREATE, 0, "a.txt")]);
+        for cut in 0..buf.len() {
+            // Every prefix parses to zero or one event, never a panic.
+            assert!(parse_event_buffer(&buf[..cut]).len() <= 1);
+        }
+        // A header whose len field overruns the buffer is dropped.
+        let mut bogus = encode(&[(1, IN_CREATE, 0, "")]);
+        bogus[12..16].copy_from_slice(&u32::MAX.to_ne_bytes());
+        assert!(parse_event_buffer(&bogus).is_empty());
+    }
+
+    #[test]
+    fn rename_pairs_by_cookie_into_one_event() {
+        let batch = parse_event_buffer(&encode(&[
+            (1, IN_MOVED_FROM, 7, "old"),
+            (1, IN_MOVED_TO, 7, "new"),
+        ]));
+        let events = map_events(&batch, root_only);
+        assert_eq!(
+            events,
+            vec![FsEventDto {
+                kind: EVENT_RENAMED.to_owned(),
+                path: "/watch/old".to_owned(),
+                renamed_to: "/watch/new".to_owned(),
+            }]
+        );
+    }
+
+    #[test]
+    fn unpaired_move_halves_degrade_to_removed_and_created() {
+        let batch = parse_event_buffer(&encode(&[
+            (1, IN_MOVED_FROM, 7, "gone"),
+            (1, IN_MOVED_TO, 9, "arrived"),
+        ]));
+        let events = map_events(&batch, root_only);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].kind, EVENT_REMOVED);
+        assert_eq!(events[0].path, "/watch/gone");
+        assert_eq!(events[1].kind, EVENT_CREATED);
+        assert_eq!(events[1].path, "/watch/arrived");
+    }
+
+    #[test]
+    fn modify_attrib_delete_and_self_delete_map() {
+        let batch = parse_event_buffer(&encode(&[
+            (1, IN_MODIFY, 0, "f"),
+            (1, IN_ATTRIB, 0, "f"),
+            (1, IN_DELETE, 0, "f"),
+            (1, IN_DELETE_SELF, 0, ""),
+        ]));
+        let kinds: Vec<_> = map_events(&batch, root_only)
+            .into_iter()
+            .map(|e| (e.kind, e.path))
+            .collect();
+        assert_eq!(
+            kinds,
+            vec![
+                (EVENT_MODIFIED.to_owned(), "/watch/f".to_owned()),
+                (EVENT_MODIFIED.to_owned(), "/watch/f".to_owned()),
+                (EVENT_REMOVED.to_owned(), "/watch/f".to_owned()),
+                (EVENT_REMOVED.to_owned(), "/watch".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn overflow_ignored_and_unknown_wd_events_are_dropped() {
+        let batch = parse_event_buffer(&encode(&[
+            (-1, IN_Q_OVERFLOW, 0, ""),
+            (1, IN_IGNORED, 0, ""),
+            (99, IN_CREATE, 0, "orphan"),
+        ]));
+        assert!(map_events(&batch, root_only).is_empty());
+    }
+
+    #[test]
+    fn dir_flag_is_exposed_for_recursive_watch_maintenance() {
+        let batch = parse_event_buffer(&encode(&[(1, IN_CREATE | IN_ISDIR, 0, "sub")]));
+        assert!(batch[0].is_dir());
+        let events = map_events(&batch, root_only);
+        assert_eq!(events[0].kind, EVENT_CREATED);
+    }
+}

--- a/virt/arcbox-vm/src/lib.rs
+++ b/virt/arcbox-vm/src/lib.rs
@@ -33,6 +33,7 @@ pub mod boot_proto;
 pub mod config;
 pub mod error;
 pub mod file_io;
+pub mod file_watch;
 pub mod network;
 pub mod sandbox;
 pub mod snapshot;

--- a/virt/arcbox-vm/src/lib.rs
+++ b/virt/arcbox-vm/src/lib.rs
@@ -34,6 +34,7 @@ pub mod config;
 pub mod error;
 pub mod file_io;
 pub mod file_watch;
+pub mod listen_table;
 pub mod network;
 pub mod sandbox;
 pub mod snapshot;
@@ -62,7 +63,7 @@ pub use sandbox::{
     ExecutionChannel, ExecutionOutput, ExecutionSnapshot, ExecutionSpec, StdinState,
 };
 pub use snapshot::{SnapshotCatalog, SnapshotInfo};
-pub use vsock::{ExecInputMsg, ExitStatus, OutputChunk, StartCommand};
+pub use vsock::{ExecInputMsg, ExitStatus, OutputChunk, PortWait, StartCommand};
 
 // Re-export VmState for system_svc compatibility (internal use only).
 pub use instance::VmState;

--- a/virt/arcbox-vm/src/listen_table.rs
+++ b/virt/arcbox-vm/src/listen_table.rs
@@ -1,0 +1,72 @@
+//! `/proc/net/tcp{,6}` listen-table parsing.
+//!
+//! The vm-agent answers `WaitForPort` by watching the guest kernel's own
+//! listen table — never a connect probe, which would perturb the workload
+//! with spurious accepted connections. The text parsing lives here so it
+//! is unit-tested on every host platform.
+
+/// TCP state code for `LISTEN` in `/proc/net/tcp` (see `include/net/tcp_states.h`).
+const TCP_LISTEN: u32 = 0x0A;
+
+/// True when any socket in `table` — the text of `/proc/net/tcp` or
+/// `/proc/net/tcp6` — is LISTENing on local port `port`, whatever the
+/// bound address.
+#[must_use]
+pub fn any_listener_on_port(table: &str, port: u16) -> bool {
+    // Header line first; each row is
+    // `sl local_address rem_address st ...` with addresses as HEXIP:HEXPORT.
+    table.lines().skip(1).any(|line| {
+        let mut fields = line.split_whitespace();
+        let local = fields.nth(1);
+        let state = fields.nth(1);
+        let listening = state
+            .and_then(|st| u32::from_str_radix(st, 16).ok())
+            .is_some_and(|st| st == TCP_LISTEN);
+        listening
+            && local
+                .and_then(|addr| addr.rsplit(':').next())
+                .and_then(|p| u16::from_str_radix(p, 16).ok())
+                == Some(port)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TCP: &str = "\
+  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0
+   1: 0100007F:0035 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12346 1 0000000000000000 100 0 0 10 0
+   2: 0A00020F:D2F0 8EFB2CCE:01BB 01 00000000:00000000 00:00000000 00000000     0        0 12347 1 0000000000000000 20 4 30 10 -1
+";
+
+    const TCP6: &str = "\
+  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000000000000000000000000000:5BA0 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 22345 1 0000000000000000 100 0 0 10 0
+";
+
+    #[test]
+    fn finds_a_listener_on_any_address() {
+        assert!(any_listener_on_port(TCP, 0x1F90)); // 8080 on 0.0.0.0
+        assert!(any_listener_on_port(TCP, 53)); // 0x0035 on 127.0.0.1
+        assert!(any_listener_on_port(TCP6, 0x5BA0)); // v6 wildcard
+    }
+
+    #[test]
+    fn established_sockets_do_not_count() {
+        // Port 0xD2F0 exists only as an ESTABLISHED (st 01) socket.
+        assert!(!any_listener_on_port(TCP, 0xD2F0));
+    }
+
+    #[test]
+    fn absent_port_is_not_listening() {
+        assert!(!any_listener_on_port(TCP, 12345));
+        assert!(!any_listener_on_port("", 80));
+    }
+
+    #[test]
+    fn malformed_rows_are_ignored() {
+        assert!(!any_listener_on_port("garbage\nmore : garbage\n:::\n", 80));
+    }
+}

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -35,6 +35,7 @@ mod boot;
 mod checkpoint;
 mod cleanup;
 mod execution;
+mod files;
 mod lifecycle;
 mod pause;
 mod persistence;

--- a/virt/arcbox-vm/src/sandbox/execution.rs
+++ b/virt/arcbox-vm/src/sandbox/execution.rs
@@ -531,6 +531,19 @@ impl ExecutionRegistry {
             })
     }
 
+    /// Snapshots of every retained execution of one sandbox — running and
+    /// exited, until the retention GC drops them.
+    fn list(&self, sandbox_id: &str) -> Vec<ExecutionSnapshot> {
+        self.inner
+            .lock()
+            .unwrap()
+            .live
+            .iter()
+            .filter(|((sid, _), _)| sid == sandbox_id)
+            .map(|(_, exec)| exec.snapshot())
+            .collect()
+    }
+
     /// Remove `exec`'s entry if it is still the registered generation.
     fn remove_generation(&self, exec: &Arc<Execution>) {
         let key = (exec.sandbox_id.clone(), exec.id.clone());
@@ -828,6 +841,44 @@ impl SandboxManager {
             .get(sandbox_id, execution_id)?
             .wait(timeout)
             .await)
+    }
+
+    /// List a sandbox's retained executions, running and exited, ordered by
+    /// start time (then id, for a stable order under equal timestamps).
+    ///
+    /// The sandbox must exist; an unknown id is `NotFound` rather than an
+    /// empty list, so a caller can tell "no executions" from a typo.
+    pub fn list_executions(&self, sandbox_id: &SandboxId) -> Result<Vec<ExecutionSnapshot>> {
+        self.get_instance(sandbox_id)?;
+        let mut snapshots = self.executions.list(sandbox_id);
+        snapshots.sort_by(|a, b| {
+            a.started_at
+                .cmp(&b.started_at)
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        Ok(snapshots)
+    }
+
+    /// Wait until something inside an alive sandbox listens on TCP `port`,
+    /// or fail with [`VmmError::DeadlineExceeded`] once `timeout` elapses.
+    ///
+    /// The vm-agent watches the guest's own listen table in-process — no
+    /// connect probes that would perturb the workload with spurious
+    /// accepted connections.
+    pub async fn wait_sandbox_port(
+        &self,
+        id: &SandboxId,
+        port: u16,
+        timeout: Duration,
+    ) -> Result<()> {
+        let uds = self.require_alive_vsock(id)?;
+        match vsock::wait_for_port(&uds, port, timeout).await? {
+            crate::vsock::PortWait::Listening => Ok(()),
+            crate::vsock::PortWait::Deadline => Err(VmmError::DeadlineExceeded(format!(
+                "no listener on port {port} in sandbox '{id}' within {}s",
+                timeout.as_secs()
+            ))),
+        }
     }
 }
 

--- a/virt/arcbox-vm/src/sandbox/files.rs
+++ b/virt/arcbox-vm/src/sandbox/files.rs
@@ -1,0 +1,81 @@
+//! Sandbox file operations over the vsock file channel (CORE-62).
+//!
+//! Thin manager façade over [`crate::file_io`]: each verb verifies the
+//! sandbox is alive (Ready or Running — file I/O works alongside a running
+//! workload) and forwards to the vm-agent. Paused states surface as
+//! [`VmmError::Paused`] so the daemon's transparent auto-resume applies.
+
+use super::*;
+use crate::file_io::{self, DirWatch, proto::FileStatDto};
+
+impl SandboxManager {
+    /// Read a file from inside an alive sandbox over the vsock file channel.
+    pub async fn read_sandbox_file(&self, id: &SandboxId, path: &str) -> Result<Vec<u8>> {
+        let uds = self.require_alive_vsock(id)?;
+        file_io::read_file(&uds, path).await
+    }
+
+    /// Write a file into an alive sandbox over the vsock file channel.
+    pub async fn write_sandbox_file(
+        &self,
+        id: &SandboxId,
+        path: &str,
+        mode: u32,
+        data: &[u8],
+    ) -> Result<()> {
+        let uds = self.require_alive_vsock(id)?;
+        file_io::write_file(&uds, path, mode, data).await
+    }
+
+    /// Stat one path inside an alive sandbox (symlinks reported, not
+    /// followed).
+    pub async fn stat_sandbox_path(&self, id: &SandboxId, path: &str) -> Result<FileStatDto> {
+        let uds = self.require_alive_vsock(id)?;
+        file_io::stat_file(&uds, path).await
+    }
+
+    /// List a directory inside an alive sandbox, non-recursively, with full
+    /// per-entry metadata.
+    pub async fn list_sandbox_dir(&self, id: &SandboxId, path: &str) -> Result<Vec<FileStatDto>> {
+        let uds = self.require_alive_vsock(id)?;
+        file_io::list_dir(&uds, path).await
+    }
+
+    /// Create a directory (and missing parents) inside an alive sandbox.
+    /// Succeeds when the directory already exists. `mode` must already be
+    /// defaulted by the caller.
+    pub async fn make_sandbox_dir(&self, id: &SandboxId, path: &str, mode: u32) -> Result<()> {
+        let uds = self.require_alive_vsock(id)?;
+        file_io::make_dir(&uds, path, mode).await
+    }
+
+    /// Remove a file, symlink, or directory inside an alive sandbox. A
+    /// non-empty directory requires `recursive`.
+    pub async fn remove_sandbox_path(
+        &self,
+        id: &SandboxId,
+        path: &str,
+        recursive: bool,
+    ) -> Result<()> {
+        let uds = self.require_alive_vsock(id)?;
+        file_io::remove_entry(&uds, path, recursive).await
+    }
+
+    /// Rename / move an entry within an alive sandbox.
+    pub async fn move_sandbox_path(&self, id: &SandboxId, from: &str, to: &str) -> Result<()> {
+        let uds = self.require_alive_vsock(id)?;
+        file_io::move_entry(&uds, from, to).await
+    }
+
+    /// Open a directory watch inside an alive sandbox. The returned stream
+    /// ends cleanly when the sandbox stops; dropping it cancels the watch.
+    pub async fn watch_sandbox_dir(
+        &self,
+        id: &SandboxId,
+        path: &str,
+        recursive: bool,
+    ) -> Result<DirWatch> {
+        let uds = self.require_alive_vsock(id)?;
+        file_io::watch_dir(&uds, path, recursive).await
+    }
+}

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -734,24 +734,6 @@ impl SandboxManager {
             .clone()
             .ok_or_else(|| VmmError::Vsock(format!("sandbox {id} has no vsock configured")))
     }
-
-    /// Read a file from inside an alive sandbox over the vsock file channel.
-    pub async fn read_sandbox_file(&self, id: &SandboxId, path: &str) -> Result<Vec<u8>> {
-        let uds = self.require_alive_vsock(id)?;
-        crate::file_io::read_file(&uds, path).await
-    }
-
-    /// Write a file into an alive sandbox over the vsock file channel.
-    pub async fn write_sandbox_file(
-        &self,
-        id: &SandboxId,
-        path: &str,
-        mode: u32,
-        data: &[u8],
-    ) -> Result<()> {
-        let uds = self.require_alive_vsock(id)?;
-        crate::file_io::write_file(&uds, path, mode, data).await
-    }
 }
 
 /// Files a listed checkpoint occupies on disk, for storage accounting.

--- a/virt/arcbox-vm/src/vsock.rs
+++ b/virt/arcbox-vm/src/vsock.rs
@@ -73,6 +73,10 @@ pub(crate) const MSG_NET_RECONFIG: u8 = 0x06;
 /// Payload: `[i32 LE signal]` (4 bytes). Old vm-agents ignore unknown frame
 /// types, so sending this to a pre-signal agent is a silent no-op.
 const MSG_SIGNAL: u8 = 0x07;
+/// Wait until the guest's TCP listen table has a listener on a port.
+/// Payload: JSON [`WaitPortReq`]; answered with `MSG_EXIT` carrying `0`
+/// (listening) or `1` (deadline elapsed).
+pub const MSG_WAIT_PORT: u8 = 0x08;
 
 // Frame type constants — Agent → Host (exec channel).
 const MSG_STDOUT: u8 = 0x10;
@@ -162,6 +166,24 @@ pub struct StartCommand {
     pub tty_width: u16,
     pub tty_height: u16,
     pub timeout_seconds: u32,
+}
+
+/// `MSG_WAIT_PORT` payload, shared with the vm-agent binary.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaitPortReq {
+    /// TCP port a workload is expected to listen on.
+    pub port: u16,
+    /// Give up after this long (0 = check once and answer immediately).
+    pub timeout_ms: u64,
+}
+
+/// Outcome of a guest listen-table wait.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PortWait {
+    /// A listener on the port exists.
+    Listening,
+    /// The deadline elapsed with no listener.
+    Deadline,
 }
 
 // =============================================================================
@@ -668,6 +690,63 @@ async fn net_reconfig_on_stream<S: tokio::io::AsyncReadExt + tokio::io::AsyncWri
         );
     }
     Ok(())
+}
+
+/// Wait until the guest's TCP listen table has a listener on `port`.
+///
+/// Sends [`MSG_WAIT_PORT`] to the exec channel; the vm-agent watches
+/// `/proc/net/tcp{,6}` in-process (never a connect probe) and answers when
+/// the listener appears or `timeout` elapses. The host-side read deadline
+/// adds slack on top of the guest's own budget so a live guest always
+/// answers first.
+pub async fn wait_for_port(uds_path: &Path, port: u16, timeout: Duration) -> Result<PortWait> {
+    let mut stream = connect_to_agent(uds_path).await?;
+    wait_for_port_on_stream(&mut stream, port, timeout).await
+}
+
+/// Send a wait-port frame and decode the agent's verdict.
+///
+/// Extracted from [`wait_for_port`] so the wire protocol can be tested with
+/// `tokio::io::duplex` without needing a real vsock connection.
+async fn wait_for_port_on_stream<S: tokio::io::AsyncReadExt + tokio::io::AsyncWriteExt + Unpin>(
+    stream: &mut S,
+    port: u16,
+    timeout: Duration,
+) -> Result<PortWait> {
+    let req = WaitPortReq {
+        port,
+        timeout_ms: u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX),
+    };
+    let payload = serde_json::to_vec(&req)
+        .map_err(|e| VmmError::Vsock(format!("encode WaitPortReq: {e}")))?;
+    write_frame(stream, MSG_WAIT_PORT, &payload)
+        .await
+        .map_err(|e| VmmError::Vsock(format!("write MSG_WAIT_PORT: {e}")))?;
+
+    let read_deadline = timeout + Duration::from_secs(5);
+    let (msg_type, payload) = tokio::time::timeout(read_deadline, read_frame(stream))
+        .await
+        .map_err(|_| VmmError::Vsock("wait for port: timed out waiting for response".into()))?
+        .map_err(|e| VmmError::Vsock(format!("read wait-port response: {e}")))?;
+
+    if msg_type != MSG_EXIT {
+        return Err(VmmError::Vsock(format!(
+            "wait for port: unexpected response type 0x{msg_type:02x}"
+        )));
+    }
+    if payload.len() < 4 {
+        return Err(VmmError::Vsock(format!(
+            "wait for port: payload too short ({} bytes, expected 4)",
+            payload.len()
+        )));
+    }
+    match i32::from_le_bytes(payload[..4].try_into().unwrap()) {
+        0 => Ok(PortWait::Listening),
+        1 => Ok(PortWait::Deadline),
+        code => Err(VmmError::Vsock(format!(
+            "wait for port: agent returned exit code {code}"
+        ))),
+    }
 }
 
 /// Guest-side timing breakdown a net-reconfig `MSG_EXIT` reply may carry:


### PR DESCRIPTION
## Summary

Implements the remaining ungated sandbox functionality behind the contract that has been on master since #543 (CORE-62 + the process-plane queries): the six `SandboxFilesystemService` stubs and the two `SandboxProcessService` stubs become live end-to-end paths, vm-agent → guest agent → daemon.

**Filesystem verbs (CORE-62)**
- The sandbox vsock file channel (port 53) gains `FILE_STAT/LIST/MKDIR/REMOVE/MOVE/WATCH` frames; the vm-agent serves them with `std::fs` (symlink-aware stat, `mkdir -p` semantics, the non-empty-remove guard) and an inotify-backed `WatchDir` stream driven by `poll(2)` on the inotify fd + the connection fd, so a host cancel tears the watch down deterministically.
- Rename pairing (`IN_MOVED_FROM`/`IN_MOVED_TO` by cookie), event-buffer parsing, and `/proc/net/tcp{,6}` parsing live in new pure modules (`arcbox_vm::file_watch`, `arcbox_vm::listen_table`) so they are unit-tested off-Linux.
- New `MessageType`s `0x0038–0x003D` / `0x103A–0x103F` + `0x1047` (`SandboxFileWatchEnd`, the clean end-of-watch frame the guest emits when the sandbox stops). Purely additive — no `AGENT_PROTOCOL_VERSION` bump.
- Daemon handlers route through the shared CORE-21 auto-resume; `WatchDir` mirrors `ReadFile`'s optimistic first-frame peek (the guest confirms an established watch with an immediate keepalive, so the peek is fast) and interleaves keepalives per the proto contract.

**Process plane (CORE-58 phase 2)**
- `ListExecutions` enumerates the guest's execution registry (running + retained exited records) without waking a paused sandbox.
- `WaitForPort` rides a new `MSG_WAIT_PORT` exec-channel frame; the vm-agent watches the guest's own listen table in-process — no connect probes that would perturb the workload. Deadline expiry travels as wire code 504 → `DEADLINE_EXCEEDED` (new `VmmError::DeadlineExceeded` / `SandboxError::Deadline`). The daemon resolves the documented 30 s default.

**Error registry (#565 follow-up)**
- The deferred `FILE_NOT_FOUND` classification lands: `path not found: {path}` → `ERROR_CODE_FILE_NOT_FOUND` with the path in context. `FILE_TOO_LARGE` is classified from the write-cap message with the limit in context; wire 504 maps to `DeadlineExceeded`.

**Left untouched**: the five `TemplateService` stubs (Build/Publish/Get/List/Delete) — all gated on the CORE-21 template catalog and the CORE-5/CORE-16 build pipeline.

## Validation

- Unit tests in every touched crate (protocol mocks over the vsock handshake, inotify buffer/rename-pairing, listen-table parsing, error-classifier pins).
- `cargo clippy --workspace --exclude arcbox-agent --all-targets -- -D warnings`, workspace check, `cargo fmt --all --check`, musl checks for `arcbox-agent` and the `arcbox-vm` bins — all clean.
- Live sandbox e2e (VZ, real hardware) green end-to-end with two new phases: `sandbox_file_verbs` (mkdir/stat/list/move/remove round-trip; recursive WatchDir reports Created/Modified + the paired Renamed event, keepalives observed, client-side cancel) and `sandbox_process_plane` (WaitForPort deadline → success against a busybox `nc` listener; ListExecutions rediscovery running and exited).
- `sdk_ts` and `sdk_py` e2e regressions green.
