### PR TITLE
fix(sandbox): classify file read/write errors on the file channel

### DIFF
--- a/.github/workflows/test-vm-linux.yml
+++ b/.github/workflows/test-vm-linux.yml
@@ -65,7 +65,9 @@ jobs:
         run: cargo clippy -p arcbox-vm -- -D warnings
 
       - name: Unit tests
-        run: cargo test --lib -p arcbox-vm
+        # --bins covers the vm-agent guest handlers, whose tests are
+        # target_os = "linux" and never run under the macOS workspace job.
+        run: cargo test --lib --bins -p arcbox-vm
 
   # ---------------------------------------------------------------------------
   # Job 2: integration tests — requires root (TAP interface creation)

--- a/virt/arcbox-vm/src/bin/vm-agent.rs
+++ b/virt/arcbox-vm/src/bin/vm-agent.rs
@@ -923,7 +923,8 @@ mod agent {
         if let Some(parent) = path.parent()
             && let Err(e) = std::fs::create_dir_all(parent)
         {
-            let _ = write_frame(&mut conn, FILE_ERR, format!("create dirs: {e}").as_bytes());
+            let msg = path_err_payload("create dirs", &req.path, &e);
+            let _ = write_frame(&mut conn, FILE_ERR, msg.as_bytes());
             return;
         }
 
@@ -944,7 +945,8 @@ mod agent {
                 let _ = write_frame(&mut conn, FILE_ACK, &[]);
             }
             Err(e) => {
-                let _ = write_frame(&mut conn, FILE_ERR, format!("write file: {e}").as_bytes());
+                let msg = path_err_payload("write", &req.path, &e);
+                let _ = write_frame(&mut conn, FILE_ERR, msg.as_bytes());
             }
         }
     }
@@ -965,7 +967,8 @@ mod agent {
         let data = match std::fs::read(&req.path) {
             Ok(d) => d,
             Err(e) => {
-                let _ = write_frame(&mut conn, FILE_ERR, format!("read file: {e}").as_bytes());
+                let msg = path_err_payload("read", &req.path, &e);
+                let _ = write_frame(&mut conn, FILE_ERR, msg.as_bytes());
                 return;
             }
         };
@@ -992,7 +995,7 @@ mod agent {
         }
     }
 
-    /// Format a path-verb failure with the machine-readable errno prefix the
+    /// Format a file-op failure with the machine-readable errno prefix the
     /// host maps onto typed errors (`arcbox_vm::file_io::decode_file_err`).
     fn path_err_payload(op: &str, path: &str, e: &std::io::Error) -> String {
         match e.raw_os_error() {
@@ -1062,10 +1065,14 @@ mod agent {
             let mut entries = Vec::new();
             for entry in std::fs::read_dir(&req.path)? {
                 let entry = entry?;
-                // An entry deleted between readdir and stat is not an error
-                // for the listing — skip it.
-                if let Ok(dto) = stat_dto(&entry.path()) {
-                    entries.push(dto);
+                match stat_dto(&entry.path()) {
+                    Ok(dto) => entries.push(dto),
+                    // An entry deleted between readdir and stat is not an
+                    // error for the listing — skip it. Anything else
+                    // (EACCES, I/O) fails the listing rather than silently
+                    // truncating it.
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => return Err(e),
                 }
             }
             entries.sort_by(|a, b| a.name.cmp(&b.name));
@@ -1090,9 +1097,11 @@ mod agent {
             return;
         };
         // Recursive create is idempotent: an existing directory succeeds.
+        // `0` means "agent default", mirroring the write handler's `0o644`.
+        let mode = if req.mode == 0 { 0o755 } else { req.mode };
         match std::fs::DirBuilder::new()
             .recursive(true)
-            .mode(req.mode)
+            .mode(mode)
             .create(&req.path)
         {
             Ok(()) => {
@@ -2247,6 +2256,89 @@ mod agent {
             let killed = exit_payload(WaitOutcome::Signaled(9));
             assert_eq!(i32::from_le_bytes(killed[..4].try_into().unwrap()), 137);
             assert_eq!(i32::from_le_bytes(killed[4..].try_into().unwrap()), 9);
+        }
+
+        /// Wrap one end of a socketpair as the handler's connection; drive
+        /// frames from the returned test end.
+        fn conn_pair() -> (VsockStream, std::os::unix::net::UnixStream) {
+            use std::os::fd::IntoRawFd as _;
+            let (theirs, ours) = std::os::unix::net::UnixStream::pair().unwrap();
+            // SAFETY: into_raw_fd transfers ownership of an open socket fd;
+            // VsockStream closes it on drop.
+            let conn = unsafe { VsockStream::from_raw_fd(theirs.into_raw_fd()) };
+            (conn, ours)
+        }
+
+        fn path_req(path: &std::path::Path) -> Vec<u8> {
+            serde_json::to_vec(&serde_json::json!({ "path": path })).unwrap()
+        }
+
+        #[test]
+        fn read_of_missing_path_is_classified() {
+            let (conn, mut host) = conn_pair();
+            handle_file_read(conn, br#"{"path":"/definitely/missing"}"#);
+            let (ty, payload) = read_frame(&mut host).unwrap();
+            assert_eq!(ty, FILE_ERR);
+            assert_eq!(
+                std::str::from_utf8(&payload).unwrap(),
+                "ENOENT: /definitely/missing"
+            );
+        }
+
+        #[test]
+        fn read_of_a_directory_reports_the_fallback_message() {
+            let dir = tempfile::tempdir().unwrap();
+            let (conn, mut host) = conn_pair();
+            handle_file_read(conn, &path_req(dir.path()));
+            let (ty, payload) = read_frame(&mut host).unwrap();
+            assert_eq!(ty, FILE_ERR);
+            let msg = std::str::from_utf8(&payload).unwrap();
+            assert!(msg.starts_with("read '"), "unexpected payload: {msg}");
+        }
+
+        #[test]
+        fn mkdir_mode_zero_defaults_to_the_agent_default() {
+            use std::os::unix::fs::MetadataExt as _;
+            let dir = tempfile::tempdir().unwrap();
+            let target = dir.path().join("made");
+            let req = serde_json::to_vec(&MakeDirReq {
+                path: target.to_str().unwrap().to_owned(),
+                mode: 0,
+            })
+            .unwrap();
+            let (conn, mut host) = conn_pair();
+            handle_file_mkdir(conn, &req);
+            let (ty, _) = read_frame(&mut host).unwrap();
+            assert_eq!(ty, FILE_ACK);
+            // The exact bits depend on the process umask; the bug this pins
+            // down produced a mode-0000 directory.
+            let mode = std::fs::metadata(&target).unwrap().mode() & 0o7777;
+            assert_eq!(mode & 0o700, 0o700, "mode 0 must fall back, got {mode:o}");
+        }
+
+        #[test]
+        fn list_fails_rather_than_truncates_on_unreadable_entry() {
+            // Root bypasses DAC, so the permission denial cannot be staged.
+            // SAFETY: geteuid has no preconditions.
+            if unsafe { libc::geteuid() } == 0 {
+                return;
+            }
+            use std::os::unix::fs::PermissionsExt as _;
+            let dir = tempfile::tempdir().unwrap();
+            let root = dir.path().join("root");
+            std::fs::create_dir(&root).unwrap();
+            std::fs::write(root.join("a.txt"), b"x").unwrap();
+            // r-- : the entry names still list, but per-entry stat is denied.
+            std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o400)).unwrap();
+
+            let (conn, mut host) = conn_pair();
+            handle_file_list(conn, &path_req(&root));
+            let (ty, payload) = read_frame(&mut host).unwrap();
+            // Restore access so the tempdir can be removed.
+            std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o700)).unwrap();
+            assert_eq!(ty, FILE_ERR);
+            let msg = std::str::from_utf8(&payload).unwrap();
+            assert!(msg.starts_with("list '"), "unexpected payload: {msg}");
         }
     }
 }

--- a/virt/arcbox-vm/src/file_io.rs
+++ b/virt/arcbox-vm/src/file_io.rs
@@ -31,8 +31,9 @@
 //! the host closing it is the cancellation signal, the agent side closing
 //! it (sandbox stop) is the clean end of the stream.
 //!
-//! `FILE_ERR` payloads for the path verbs carry a machine-readable errno
-//! prefix (`ERR_NOT_FOUND` and friends) so the host maps them onto typed
+//! `FILE_ERR` payloads carry a machine-readable errno prefix
+//! (`ERR_NOT_FOUND` and friends) on every verb — the path verbs and the
+//! read/write flows alike — so the host maps them onto typed
 //! [`VmmError`] variants instead of a blanket vsock error.
 //!
 //! ## Write flow
@@ -126,7 +127,7 @@ pub mod proto {
     }
 
     /// `FILE_MKDIR_REQ` payload. `mode` carries the Unix permission bits
-    /// for created directories (already defaulted by the caller).
+    /// for created directories; `0` defaults to `0o755` on the agent side.
     #[derive(Debug, Serialize, Deserialize)]
     pub struct MakeDirReq {
         pub path: String,
@@ -251,9 +252,7 @@ async fn write_file_inner(uds_path: &Path, path: &str, mode: u32, data: &[u8]) -
 
     match resp_type {
         FILE_ACK => Ok(()),
-        FILE_ERR => Err(VmmError::Vsock(
-            String::from_utf8_lossy(&payload).into_owned(),
-        )),
+        FILE_ERR => Err(decode_file_err(&payload)),
         other => Err(VmmError::Vsock(format!(
             "file write: unexpected response type 0x{other:02x}"
         ))),
@@ -292,11 +291,7 @@ async fn read_file_inner(uds_path: &Path, path: &str) -> Result<Vec<u8>> {
                 }
             }
             FILE_DONE => return Ok(buf),
-            FILE_ERR => {
-                return Err(VmmError::Vsock(
-                    String::from_utf8_lossy(&payload).into_owned(),
-                ));
-            }
+            FILE_ERR => return Err(decode_file_err(&payload)),
             other => {
                 return Err(VmmError::Vsock(format!(
                     "file read: unexpected frame type 0x{other:02x}"
@@ -308,8 +303,9 @@ async fn read_file_inner(uds_path: &Path, path: &str) -> Result<Vec<u8>> {
 
 /// Map a `FILE_ERR` payload onto a typed error.
 ///
-/// Path-verb errors carry the errno prefixes from [`proto`]; anything else
-/// (including all errors from old vm-agents) stays a vsock error.
+/// Every verb — path verbs and read/write alike — carries the errno
+/// prefixes from [`proto`]; anything else (including all errors from old
+/// vm-agents) stays a vsock error.
 fn decode_file_err(payload: &[u8]) -> VmmError {
     let text = String::from_utf8_lossy(payload).into_owned();
     if let Some(path) = text.strip_prefix(proto::ERR_NOT_FOUND) {
@@ -379,7 +375,8 @@ pub async fn list_dir(uds_path: &Path, path: &str) -> Result<Vec<FileStatDto>> {
 }
 
 /// Create a directory (and missing parents) inside the sandbox. Succeeds
-/// when the directory already exists. `mode` must already be defaulted.
+/// when the directory already exists. `mode` is the Unix permission bits;
+/// `0` defaults to `0o755` on the agent side.
 pub async fn make_dir(uds_path: &Path, path: &str, mode: u32) -> Result<()> {
     let req = MakeDirReq {
         path: path.to_owned(),
@@ -768,6 +765,43 @@ mod tests {
 
         let err = remove_entry(&path, "/full", false).await.unwrap_err();
         assert!(matches!(err, VmmError::DirectoryNotEmpty(p) if p == "/full"));
+    }
+
+    #[tokio::test]
+    async fn read_file_error_is_classified() {
+        let (_dir, path) = mock_vsock_server(|mut stream| async move {
+            let _ = async_read_frame(&mut stream).await.unwrap();
+            async_write_frame(&mut stream, FILE_ERR, b"ENOENT: /missing")
+                .await
+                .unwrap();
+        })
+        .await;
+
+        let err = read_file(&path, "/missing").await.unwrap_err();
+        assert!(matches!(err, VmmError::PathNotFound(p) if p == "/missing"));
+    }
+
+    #[tokio::test]
+    async fn write_file_error_is_classified() {
+        let (_dir, path) = mock_vsock_server(|mut stream| async move {
+            // Consume WRITE_REQ, then the data frames until DONE.
+            let _ = async_read_frame(&mut stream).await.unwrap();
+            loop {
+                let (ty, _) = async_read_frame(&mut stream).await.unwrap();
+                if ty == FILE_DONE {
+                    break;
+                }
+            }
+            async_write_frame(&mut stream, FILE_ERR, b"ENOTDIR: /plain.txt/sub")
+                .await
+                .unwrap();
+        })
+        .await;
+
+        let err = write_file(&path, "/plain.txt/sub", 0, b"x")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, VmmError::NotADirectory(p) if p == "/plain.txt/sub"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Linear

- Follow-up to [CORE-62](https://linear.app/arcbox/issue/CORE-62) (filesystem verbs, #582)

## Root cause and user impact

The path verbs (Stat/ListDir/MakeDir/Remove/Move) ship a machine-readable errno-prefix contract on `FILE_ERR` payloads, but the read/write flows predate it and bypassed it on both sides: the guest emitted bare `format!` messages and the host mapped every `FILE_ERR` to `VmmError::Vsock`. Net effect: `ReadFile` on a missing path surfaced as **500 INTERNAL** instead of 404, and the daemon error registry's `FILE_NOT_FOUND` classifier was unreachable from the read/write verbs — exactly the verbs an SDK `files.exists()` / read-before-write pattern hits first.

## Changes

- Guest `handle_file_read` / `handle_file_write` route failures through `path_err_payload` (same contract as the path verbs); host `read_file_inner` / `write_file_inner` decode through `decode_file_err`. Old agents' free-form messages still degrade to `VmmError::Vsock` by construction.
- File-channel `mkdir` defaults `mode: 0` to `0o755` in the guest handler (mirrors the write handler's `0o644`), so a mode-0 caller can no longer create an unusable directory regardless of which layer forgot to default.
- `list_dir` propagates per-entry stat failures other than `NotFound` instead of silently truncating the listing (racing deletes stay skipped).

## Tests

- Guest: 4 new tests drive the real handlers over a socketpair (`read` ENOENT classification, read-fallback message shape, mkdir mode-0 default, list EACCES propagation).
- Host: 2 new mock-vsock-server tests pin the `decode_file_err` wiring for the read and write flows.
- CI: the Linux unit job now runs `cargo test --lib --bins -p arcbox-vm` — the vm-agent guest tests are `target_os = "linux"` and were previously executed by no job (macOS workspace job compiles them out).

## Validation

- `cargo test -p arcbox-vm --lib` — 204 passed (13 file_io).
- `cargo clippy -p arcbox-vm --lib --bins -- -D warnings` clean on both the host and `aarch64-unknown-linux-musl` targets; `cargo check --all-targets` clean for the musl target (compiles the guest tests).