### PR TITLE
feat(sandbox): template catalog store with GC pins (CORE-107)

### DIFF
--- a/docs/data-directories.md
+++ b/docs/data-directories.md
@@ -262,6 +262,7 @@ Tags defined in `common/arcbox-constants/src/virtiofs.rs`.
 | `/var/lib/arcbox/sandbox/sandbox-records` | Durable Sandbox lifecycle records | agent |
 | `/var/lib/arcbox/sandbox/snapshots` | Sandbox checkpoint catalog and data | agent |
 | `/var/lib/arcbox/sandbox/cow` | Sandbox dm-snapshot CoW files | agent |
+| `/var/lib/arcbox/sandbox/template-catalog` | Template catalog metadata, one JSON per template name (artifacts live in the rootfs cache / snapshot catalog) | agent |
 | `/var/lib/arcbox/sandbox/rootfs.ext4` | Default sandbox rootfs (busybox + vm-agent, auto-built) | agent |
 | `/var/lib/arcbox/sandbox/rootfs-<layer>-<agent>.ext4` | Converted image rootfs cache, keyed on the source layer and the injected `vm-agent`; superseded entries are swept on the next conversion unless a snapshot still needs them as its dm-snapshot origin | agent |
 | `/var/lib/arcbox/jailer` | Firecracker jailer chroots | agent |

--- a/guest/arcbox-agent/src/error.rs
+++ b/guest/arcbox-agent/src/error.rs
@@ -89,13 +89,19 @@ impl From<arcbox_vm::VmmError> for SandboxError {
             // A missing sandbox path keeps its typed "path not found:"
             // message: the daemon's classifier maps the 404 onto the
             // FILE_NOT_FOUND registry code by that prefix.
-            VmmError::NotFound(_) | VmmError::PathNotFound(_) => Self::NotFound(e.to_string()),
-            VmmError::AlreadyExists(_) => Self::AlreadyExists(e.to_string()),
+            // A missing template keeps its typed "template not found:"
+            // message for the same reason (TEMPLATE_NOT_FOUND, CORE-107).
+            VmmError::NotFound(_) | VmmError::PathNotFound(_) | VmmError::TemplateNotFound(_) => {
+                Self::NotFound(e.to_string())
+            }
+            VmmError::AlreadyExists(_) | VmmError::TemplateVersionExists(_) => {
+                Self::AlreadyExists(e.to_string())
+            }
             // A non-empty directory is a precondition failure (412), like a
             // wrong sandbox state: retrying without `recursive` never helps.
-            VmmError::WrongState { .. } | VmmError::DirectoryNotEmpty(_) => {
-                Self::WrongState(e.to_string())
-            }
+            VmmError::WrongState { .. }
+            | VmmError::DirectoryNotEmpty(_)
+            | VmmError::FailedPrecondition(_) => Self::WrongState(e.to_string()),
             VmmError::Paused(_) => Self::SandboxPaused(e.to_string()),
             VmmError::StdinGap { .. } => Self::StdinGap(e.to_string()),
             VmmError::DeadlineExceeded(_) => Self::Deadline(e.to_string()),
@@ -154,6 +160,21 @@ mod tests {
         assert_eq!(err.status_code(), 404);
         // The daemon classifier keys on this exact prefix (FILE_NOT_FOUND).
         assert_eq!(err.to_string(), "path not found: /a/b");
+    }
+
+    #[test]
+    fn template_errors_keep_their_classifier_prefixes_and_codes() {
+        let err = SandboxError::from(arcbox_vm::VmmError::TemplateNotFound("code:9.9".into()));
+        assert!(matches!(err, SandboxError::NotFound(_)));
+        assert_eq!(err.status_code(), 404);
+        // The daemon classifier keys on this exact prefix (TEMPLATE_NOT_FOUND).
+        assert_eq!(err.to_string(), "template not found: code:9.9");
+
+        let err = SandboxError::from(arcbox_vm::VmmError::TemplateVersionExists("x".into()));
+        assert_eq!(err.status_code(), 409);
+
+        let err = SandboxError::from(arcbox_vm::VmmError::FailedPrecondition("no draft".into()));
+        assert_eq!(err.status_code(), 412);
     }
 
     #[test]

--- a/virt/arcbox-vm/src/error.rs
+++ b/virt/arcbox-vm/src/error.rs
@@ -76,6 +76,22 @@ pub enum VmmError {
     #[error("directory not empty: {0}")]
     DirectoryNotEmpty(String),
 
+    /// A catalog template reference did not resolve. The message shape is a
+    /// contract: the daemon's classifier keys on the "template not found:"
+    /// prefix to attach the `TEMPLATE_NOT_FOUND` registry code (CORE-107).
+    #[error("template not found: {0}")]
+    TemplateNotFound(String),
+
+    /// Publishing would repoint an existing immutable template version at
+    /// different content (409 on the daemon surface).
+    #[error("template version already exists: {0}")]
+    TemplateVersionExists(String),
+
+    /// A required precondition does not hold and retrying the same request
+    /// never helps (`FAILED_PRECONDITION` on the daemon surface).
+    #[error("failed precondition: {0}")]
+    FailedPrecondition(String),
+
     /// A bounded wait elapsed before the awaited condition held
     /// (`DEADLINE_EXCEEDED` on the daemon surface).
     #[error("deadline exceeded: {0}")]

--- a/virt/arcbox-vm/src/lib.rs
+++ b/virt/arcbox-vm/src/lib.rs
@@ -41,6 +41,7 @@ pub mod snapshot;
 pub mod snapshot_cow;
 pub mod spawn;
 pub mod store;
+pub mod template_catalog;
 pub mod user_spec;
 pub mod vsock;
 

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -29,6 +29,7 @@ use crate::network::{NetworkAllocation, NetworkManager};
 use crate::snapshot::{SnapshotCatalog, SnapshotDraft};
 use crate::snapshot_cow::{CowHandle, CowManager};
 use crate::spawn::{spawn_direct, spawn_jailer};
+use crate::template_catalog::TemplateCatalog;
 use crate::vsock::{self, ExecInputMsg, ExitStatus, OutputChunk, StartCommand};
 
 mod boot;
@@ -41,10 +42,13 @@ mod pause;
 mod persistence;
 mod pool;
 mod reconcile;
+mod templates;
 mod timers;
 mod types;
 mod warm;
 mod workload;
+
+pub(crate) use persistence::atomic_write;
 
 pub use execution::{
     ExecutionChannel, ExecutionOutput, ExecutionSnapshot, ExecutionSpec, StdinState,
@@ -68,6 +72,8 @@ pub struct SandboxManager {
     records: Arc<persistence::SandboxRecordStore>,
     network: Arc<NetworkManager>,
     snapshots: Arc<SnapshotCatalog>,
+    /// Template catalog (CORE-107); see `templates.rs` for the manager surface.
+    templates: Arc<TemplateCatalog>,
     config: Arc<VmmConfig>,
     events_tx: broadcast::Sender<SandboxEvent>,
     cow_manager: Arc<CowManager>,
@@ -102,6 +108,7 @@ impl SandboxManager {
             config.firecracker.sandbox_datapath,
         )?);
         let snapshots = Arc::new(SnapshotCatalog::new(&config.firecracker.data_dir));
+        let templates = Arc::new(TemplateCatalog::new(&config.firecracker.data_dir));
         let (events_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
         let cow_manager = Arc::new(CowManager::new(&config.firecracker.data_dir)?);
 
@@ -184,6 +191,7 @@ impl SandboxManager {
             records,
             network,
             snapshots,
+            templates,
             config,
             events_tx,
             cow_manager,

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -238,12 +238,19 @@ pub(super) async fn checkpoint_impl(
 }
 
 impl SandboxManager {
-    /// Rootfs images that existing snapshots need to stay restorable.
+    /// Rootfs images that existing snapshots or catalog templates need to
+    /// stay restorable/bootable.
     ///
     /// Exposed so whoever owns the converted-rootfs cache can pin them; see
-    /// [`SnapshotCatalog::referenced_rootfs_paths`].
+    /// [`SnapshotCatalog::referenced_rootfs_paths`] and
+    /// [`TemplateCatalog::rootfs_paths`](crate::template_catalog::TemplateCatalog::rootfs_paths).
+    /// The union matters: a non-prewarmed template pins no snapshot, so
+    /// without the catalog half a vm-agent update plus a create for the same
+    /// docker layer would sweep the template's ext4 as superseded.
     pub fn pinned_rootfs_paths(&self) -> Result<std::collections::BTreeSet<PathBuf>> {
-        self.snapshots.referenced_rootfs_paths()
+        let mut pinned = self.snapshots.referenced_rootfs_paths()?;
+        pinned.extend(self.templates.rootfs_paths()?);
+        Ok(pinned)
     }
 
     /// Checkpoint a `Ready` sandbox into the snapshot catalog.

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -1076,9 +1076,12 @@ impl SandboxManager {
     ///
     /// Internal pause checkpoints are refused — deleting one would strand
     /// its paused sandbox; they die with the sandbox via `Remove`.
-    /// Template-owned snapshots (CORE-107) are likewise refused: the
-    /// catalog still references them, so they are reclaimed only through
-    /// template deletion.
+    /// Template-owned snapshots (CORE-107) are refused while the catalog
+    /// still references them — they are reclaimed through template deletion.
+    /// A labeled snapshot no record references (orphaned by a failed
+    /// post-commit cleanup) is deliberately deletable: this is the operator's
+    /// only recovery path, since `list_checkpoints` hides it and
+    /// `delete_template` answers `TemplateNotFound`.
     pub async fn delete_checkpoint(&self, snapshot_id: &str) -> Result<()> {
         let meta = self.snapshots.find_by_id(snapshot_id)?;
         if meta.name.as_deref() == Some(super::pause::PAUSE_SNAPSHOT_NAME) {
@@ -1088,7 +1091,11 @@ impl SandboxManager {
                 actual: "the internal pause checkpoint of a paused sandbox".into(),
             });
         }
-        if let Some(owner) = meta.labels.get(crate::template_catalog::TEMPLATE_LABEL) {
+        // Fail closed on a catalog scan error: never delete what an
+        // unreadable catalog might still reference.
+        if let Some(owner) = meta.labels.get(crate::template_catalog::TEMPLATE_LABEL)
+            && self.templates.references_snapshot(snapshot_id)?
+        {
             return Err(VmmError::FailedPrecondition(format!(
                 "snapshot {snapshot_id} is owned by template {owner}; delete the template instead"
             )));

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -1042,6 +1042,8 @@ impl SandboxManager {
     ///
     /// Internal pause checkpoints are hidden: they are lifecycle state, not
     /// user-owned snapshots, and deleting one would strand a paused sandbox.
+    /// Template-owned snapshots (CORE-107) are hidden for the same reason —
+    /// they surface via `TemplateService.Get/List`, not as user checkpoints.
     pub fn list_checkpoints(&self, sandbox_id: Option<&str>) -> Result<Vec<CheckpointSummary>> {
         let infos = match sandbox_id {
             Some(sid) => self.snapshots.list(sid)?,
@@ -1050,6 +1052,10 @@ impl SandboxManager {
         Ok(infos
             .into_iter()
             .filter(|s| s.name.as_deref() != Some(super::pause::PAUSE_SNAPSHOT_NAME))
+            .filter(|s| {
+                !s.labels
+                    .contains_key(crate::template_catalog::TEMPLATE_LABEL)
+            })
             .map(|s| CheckpointSummary {
                 id: s.id,
                 sandbox_id: s.vm_id,
@@ -1070,6 +1076,9 @@ impl SandboxManager {
     ///
     /// Internal pause checkpoints are refused — deleting one would strand
     /// its paused sandbox; they die with the sandbox via `Remove`.
+    /// Template-owned snapshots (CORE-107) are likewise refused: the
+    /// catalog still references them, so they are reclaimed only through
+    /// template deletion.
     pub async fn delete_checkpoint(&self, snapshot_id: &str) -> Result<()> {
         let meta = self.snapshots.find_by_id(snapshot_id)?;
         if meta.name.as_deref() == Some(super::pause::PAUSE_SNAPSHOT_NAME) {
@@ -1078,6 +1087,11 @@ impl SandboxManager {
                 expected: "a user checkpoint".into(),
                 actual: "the internal pause checkpoint of a paused sandbox".into(),
             });
+        }
+        if let Some(owner) = meta.labels.get(crate::template_catalog::TEMPLATE_LABEL) {
+            return Err(VmmError::FailedPrecondition(format!(
+                "snapshot {snapshot_id} is owned by template {owner}; delete the template instead"
+            )));
         }
         self.drain_pool(Some(snapshot_id)).await;
         self.snapshots.delete_by_id(snapshot_id)

--- a/virt/arcbox-vm/src/sandbox/persistence.rs
+++ b/virt/arcbox-vm/src/sandbox/persistence.rs
@@ -77,7 +77,13 @@ fn atomic_write_inner(
 }
 
 /// Atomically persists a non-lifecycle file.
-pub(super) fn atomic_write(destination: &Path, bytes: &[u8]) -> Result<()> {
+///
+/// Re-exported at the `sandbox` module root for the template catalog.
+#[allow(
+    clippy::redundant_pub_crate,
+    reason = "re-exported outside the sandbox module; a pub(super) item cannot be re-exported wider (E0364)"
+)]
+pub(crate) fn atomic_write(destination: &Path, bytes: &[u8]) -> Result<()> {
     match atomic_write_inner(destination, bytes) {
         Ok(()) => Ok(()),
         Err(AtomicWriteError::NotCommitted(error)) => Err(error.into()),

--- a/virt/arcbox-vm/src/sandbox/templates.rs
+++ b/virt/arcbox-vm/src/sandbox/templates.rs
@@ -69,7 +69,10 @@ impl SandboxManager {
     /// `TemplateNotFound`. Leftovers are orphaned but recoverable: they carry
     /// no `arcbox.warm_key` (warm LRU ignores them), and once no record
     /// references them the checkpoint deletion guard steps aside, so
-    /// `DeleteSnapshot` by id reclaims the disk.
+    /// `DeleteSnapshot` by id reclaims the disk — provided the catalog still
+    /// parses. An unreadable record makes that guard fail closed (an
+    /// unreadable catalog must never authorise a delete), so recovery then
+    /// starts with removing the bad record.
     async fn delete_released_snapshots(&self, released: &ReleasedArtifacts) {
         for snapshot_id in &released.snapshot_ids {
             self.drain_pool(Some(snapshot_id)).await;

--- a/virt/arcbox-vm/src/sandbox/templates.rs
+++ b/virt/arcbox-vm/src/sandbox/templates.rs
@@ -1,0 +1,80 @@
+//! Template-catalog surface on [`SandboxManager`] (CORE-107).
+//!
+//! Thin delegation to [`TemplateCatalog`] plus the artifact side effects the
+//! catalog itself never performs: deleting warm snapshots a mutation
+//! released. Build orchestration (rootfs conversion, prewarm) lives in the
+//! guest agent and lands its results here via [`register_template_draft`].
+//!
+//! [`register_template_draft`]: SandboxManager::register_template_draft
+
+use tracing::{info, warn};
+
+use super::SandboxManager;
+use crate::error::Result;
+use crate::template_catalog::{ReleasedArtifacts, ResolvedTemplate, TemplateEntry};
+
+impl SandboxManager {
+    /// Resolve a `name[:version]` catalog reference.
+    pub fn get_template(&self, reference: &str) -> Result<ResolvedTemplate> {
+        self.templates.resolve(reference)
+    }
+
+    /// Every catalog row: `(name, entry)` — published versions in publish
+    /// order, then the draft, grouped by name.
+    pub fn list_templates(&self) -> Result<Vec<(String, TemplateEntry)>> {
+        self.templates.list()
+    }
+
+    /// Install a built entry as `name`'s draft, deleting any warm snapshot
+    /// the displaced previous draft owned exclusively.
+    pub fn register_template_draft(
+        &self,
+        name: &str,
+        entry: TemplateEntry,
+    ) -> Result<TemplateEntry> {
+        let outcome = self.templates.put_draft(name, entry)?;
+        self.delete_released_snapshots(&outcome.released);
+        info!(template = name, digest = %outcome.entry.digest, "template draft registered");
+        Ok(outcome.entry)
+    }
+
+    /// Freeze `name`'s draft as immutable `version`.
+    pub fn publish_template(&self, name: &str, version: &str) -> Result<TemplateEntry> {
+        self.templates.publish(name, version)
+    }
+
+    /// Delete a template version (`name:version`) or a whole template
+    /// (`name`), including warm snapshots no remaining entry references.
+    /// Rootfs images are reclaimed separately by the rootfs-cache sweep once
+    /// [`Self::pinned_rootfs_paths`] stops reporting them.
+    pub fn delete_template(&self, reference: &str) -> Result<()> {
+        self.check_reconcile()?;
+        let released = self.templates.delete(reference)?;
+        self.delete_released_snapshots(&released);
+        info!(template = reference, "template deleted");
+        Ok(())
+    }
+
+    /// Best-effort deletion of snapshots a catalog mutation released. The
+    /// catalog entry is already gone, so a failed snapshot delete must not
+    /// fail the mutation — it would strand the caller with a half-deleted
+    /// template it can only retry into `TemplateNotFound`. Leftovers are
+    /// orphaned but inert (they carry no `arcbox.warm_key`, so the warm LRU
+    /// ignores them) and warrant a warning, not an error.
+    fn delete_released_snapshots(&self, released: &ReleasedArtifacts) {
+        for snapshot_id in &released.snapshot_ids {
+            match self.snapshots.delete_by_id(snapshot_id) {
+                Ok(()) => {}
+                // `find_by_id` reports a missing snapshot as
+                // `VmmError::Snapshot("… not found")` — benign here: a retried
+                // mutation already deleted it.
+                Err(crate::error::VmmError::Snapshot(msg)) if msg.ends_with("not found") => {}
+                Err(error) => warn!(
+                    snapshot_id,
+                    %error,
+                    "failed to delete a template-owned snapshot; artifact is orphaned"
+                ),
+            }
+        }
+    }
+}

--- a/virt/arcbox-vm/src/sandbox/templates.rs
+++ b/virt/arcbox-vm/src/sandbox/templates.rs
@@ -66,9 +66,10 @@ impl SandboxManager {
     /// would otherwise outlive it). The catalog entry is already gone, so a
     /// failed snapshot delete must not fail the mutation — it would strand
     /// the caller with a half-deleted template it can only retry into
-    /// `TemplateNotFound`. Leftovers are orphaned but inert (they carry no
-    /// `arcbox.warm_key`, so the warm LRU ignores them) and warrant a
-    /// warning, not an error.
+    /// `TemplateNotFound`. Leftovers are orphaned but recoverable: they carry
+    /// no `arcbox.warm_key` (warm LRU ignores them), and once no record
+    /// references them the checkpoint deletion guard steps aside, so
+    /// `DeleteSnapshot` by id reclaims the disk.
     async fn delete_released_snapshots(&self, released: &ReleasedArtifacts) {
         for snapshot_id in &released.snapshot_ids {
             self.drain_pool(Some(snapshot_id)).await;
@@ -143,11 +144,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn template_snapshots_are_hidden_and_delete_refused_on_the_checkpoint_surface() {
+    async fn template_snapshots_are_hidden_and_delete_refused_while_referenced() {
         let dir = tempfile::tempdir().unwrap();
         let m = manager(dir.path()).await;
         let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
         let snapshot_id = publish_template_snapshot(&catalog, "code");
+        m.register_template_draft("code", entry_with_warm(&snapshot_id))
+            .await
+            .unwrap();
 
         let listed = m.list_checkpoints(None).unwrap();
         assert!(
@@ -164,6 +168,19 @@ mod tests {
             catalog.find_by_id(&snapshot_id).is_ok(),
             "guard must not delete"
         );
+    }
+
+    #[tokio::test]
+    async fn an_orphaned_template_snapshot_is_reclaimable_by_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = manager(dir.path()).await;
+        let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
+        // Labeled, but no catalog record references it — the failure-mode
+        // orphan. DeleteSnapshot by id is the recovery path and must work.
+        let snapshot_id = publish_template_snapshot(&catalog, "ghost");
+
+        m.delete_checkpoint(&snapshot_id).await.unwrap();
+        assert!(catalog.find_by_id(&snapshot_id).is_err());
     }
 
     #[tokio::test]

--- a/virt/arcbox-vm/src/sandbox/templates.rs
+++ b/virt/arcbox-vm/src/sandbox/templates.rs
@@ -1,9 +1,10 @@
 //! Template-catalog surface on [`SandboxManager`] (CORE-107).
 //!
-//! Thin delegation to [`TemplateCatalog`] plus the artifact side effects the
-//! catalog itself never performs: deleting warm snapshots a mutation
-//! released. Build orchestration (rootfs conversion, prewarm) lives in the
-//! guest agent and lands its results here via [`register_template_draft`].
+//! Thin delegation to [`TemplateCatalog`](crate::template_catalog::TemplateCatalog)
+//! plus the artifact side effects the catalog itself never performs: draining
+//! pre-warmed restore slots and deleting warm snapshots a mutation released.
+//! Build orchestration (rootfs conversion, prewarm) lives in the guest agent
+//! and lands its results here via [`register_template_draft`].
 //!
 //! [`register_template_draft`]: SandboxManager::register_template_draft
 
@@ -25,44 +26,52 @@ impl SandboxManager {
         self.templates.list()
     }
 
-    /// Install a built entry as `name`'s draft, deleting any warm snapshot
+    /// Install a built entry as `name`'s draft, reclaiming any warm snapshot
     /// the displaced previous draft owned exclusively.
-    pub fn register_template_draft(
+    pub async fn register_template_draft(
         &self,
         name: &str,
         entry: TemplateEntry,
     ) -> Result<TemplateEntry> {
         let outcome = self.templates.put_draft(name, entry)?;
-        self.delete_released_snapshots(&outcome.released);
+        self.delete_released_snapshots(&outcome.released).await;
         info!(template = name, digest = %outcome.entry.digest, "template draft registered");
         Ok(outcome.entry)
     }
 
-    /// Freeze `name`'s draft as immutable `version`.
-    pub fn publish_template(&self, name: &str, version: &str) -> Result<TemplateEntry> {
-        self.templates.publish(name, version)
+    /// Freeze `name`'s draft as immutable `version`, reclaiming the draft's
+    /// exclusively-owned artifacts when an idempotent re-publish collapses a
+    /// same-digest rebuild.
+    pub async fn publish_template(&self, name: &str, version: &str) -> Result<TemplateEntry> {
+        let outcome = self.templates.publish(name, version)?;
+        self.delete_released_snapshots(&outcome.released).await;
+        Ok(outcome.entry)
     }
 
     /// Delete a template version (`name:version`) or a whole template
     /// (`name`), including warm snapshots no remaining entry references.
     /// Rootfs images are reclaimed separately by the rootfs-cache sweep once
     /// [`Self::pinned_rootfs_paths`] stops reporting them.
-    pub fn delete_template(&self, reference: &str) -> Result<()> {
+    pub async fn delete_template(&self, reference: &str) -> Result<()> {
         self.check_reconcile()?;
         let released = self.templates.delete(reference)?;
-        self.delete_released_snapshots(&released);
+        self.delete_released_snapshots(&released).await;
         info!(template = reference, "template deleted");
         Ok(())
     }
 
-    /// Best-effort deletion of snapshots a catalog mutation released. The
-    /// catalog entry is already gone, so a failed snapshot delete must not
-    /// fail the mutation — it would strand the caller with a half-deleted
-    /// template it can only retry into `TemplateNotFound`. Leftovers are
-    /// orphaned but inert (they carry no `arcbox.warm_key`, so the warm LRU
-    /// ignores them) and warrant a warning, not an error.
-    fn delete_released_snapshots(&self, released: &ReleasedArtifacts) {
+    /// Best-effort deletion of snapshots a catalog mutation released,
+    /// draining any pre-warmed restore slots staged from each first
+    /// (mirroring `delete_checkpoint` — a slot restored from the snapshot
+    /// would otherwise outlive it). The catalog entry is already gone, so a
+    /// failed snapshot delete must not fail the mutation — it would strand
+    /// the caller with a half-deleted template it can only retry into
+    /// `TemplateNotFound`. Leftovers are orphaned but inert (they carry no
+    /// `arcbox.warm_key`, so the warm LRU ignores them) and warrant a
+    /// warning, not an error.
+    async fn delete_released_snapshots(&self, released: &ReleasedArtifacts) {
         for snapshot_id in &released.snapshot_ids {
+            self.drain_pool(Some(snapshot_id)).await;
             match self.snapshots.delete_by_id(snapshot_id) {
                 Ok(()) => {}
                 // `find_by_id` reports a missing snapshot as
@@ -76,5 +85,102 @@ impl SandboxManager {
                 ),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::Path;
+
+    use crate::config::VmmConfig;
+    use crate::sandbox::SandboxManager;
+    use crate::snapshot::{SnapshotCatalog, SnapshotDraft};
+    use crate::template_catalog::{
+        TEMPLATE_LABEL, TemplateDefaultsSpec, TemplateEntry, WarmArtifact,
+    };
+
+    async fn manager(data_dir: &Path) -> SandboxManager {
+        let mut config = VmmConfig::default();
+        config.firecracker.data_dir = data_dir.to_string_lossy().into_owned();
+        let manager = SandboxManager::new(config).unwrap();
+        manager.await_reconcile().await.unwrap();
+        manager
+    }
+
+    fn publish_template_snapshot(catalog: &SnapshotCatalog, template: &str) -> String {
+        let pending = catalog.begin(&format!("template-{template}")).unwrap();
+        std::fs::write(pending.dir().join("vmstate"), b"vmstate").unwrap();
+        pending
+            .commit(SnapshotDraft {
+                name: None,
+                labels: HashMap::from([(TEMPLATE_LABEL.to_owned(), template.to_owned())]),
+                snapshot_type: crate::config::SnapshotType::Full,
+                parent_id: None,
+                kernel_path: None,
+                rootfs_path: Some("/cache/rootfs-tpl.ext4".into()),
+                net_invariant: true,
+            })
+            .unwrap()
+            .id
+    }
+
+    fn entry_with_warm(snapshot_id: &str) -> TemplateEntry {
+        TemplateEntry {
+            version: String::new(),
+            digest: "sha256:d1".into(),
+            rootfs_path: "/cache/rootfs-tpl.ext4".into(),
+            warm: Some(WarmArtifact {
+                snapshot_id: snapshot_id.to_owned(),
+                vcpus: 2,
+                memory_mib: 512,
+            }),
+            defaults: TemplateDefaultsSpec::default(),
+            labels: HashMap::new(),
+            created_at: chrono::Utc::now(),
+            size_bytes: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn template_snapshots_are_hidden_and_delete_refused_on_the_checkpoint_surface() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = manager(dir.path()).await;
+        let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
+        let snapshot_id = publish_template_snapshot(&catalog, "code");
+
+        let listed = m.list_checkpoints(None).unwrap();
+        assert!(
+            listed.iter().all(|s| s.id != snapshot_id),
+            "template snapshot leaked into the user checkpoint list"
+        );
+
+        let err = m.delete_checkpoint(&snapshot_id).await.unwrap_err();
+        assert!(
+            err.to_string().contains("owned by template"),
+            "unexpected refusal message: {err}"
+        );
+        assert!(
+            catalog.find_by_id(&snapshot_id).is_ok(),
+            "guard must not delete"
+        );
+    }
+
+    #[tokio::test]
+    async fn deleting_a_template_deletes_its_owned_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = manager(dir.path()).await;
+        let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
+        let snapshot_id = publish_template_snapshot(&catalog, "code");
+        m.register_template_draft("code", entry_with_warm(&snapshot_id))
+            .await
+            .unwrap();
+
+        m.delete_template("code").await.unwrap();
+        assert!(
+            catalog.find_by_id(&snapshot_id).is_err(),
+            "snapshot must be reclaimed"
+        );
+        assert!(m.get_template("code").is_err());
     }
 }

--- a/virt/arcbox-vm/src/sandbox/warm.rs
+++ b/virt/arcbox-vm/src/sandbox/warm.rs
@@ -129,12 +129,18 @@ pub(super) fn warm_eligible(
         && spec.ssh_public_key.is_none()
 }
 
-/// Reject caller-supplied labels that would collide with the reserved
-/// warm-cache label.
+/// Reject caller-supplied labels that would collide with a reserved label:
+/// the warm-cache key or the template-catalog ownership marker (CORE-107).
 pub(super) fn reject_reserved_labels(labels: &HashMap<String, String>) -> Result<()> {
     if labels.contains_key(WARM_KEY_LABEL) {
         return Err(VmmError::Config(format!(
             "snapshot label {WARM_KEY_LABEL} is reserved for the warm-create cache"
+        )));
+    }
+    if labels.contains_key(crate::template_catalog::TEMPLATE_LABEL) {
+        return Err(VmmError::Config(format!(
+            "snapshot label {} is reserved for the template catalog",
+            crate::template_catalog::TEMPLATE_LABEL
         )));
     }
     Ok(())
@@ -578,6 +584,13 @@ mod tests {
         labels.insert("env".to_owned(), "prod".to_owned());
         assert!(reject_reserved_labels(&labels).is_ok());
         labels.insert(WARM_KEY_LABEL.to_owned(), "deadbeef".to_owned());
+        assert!(reject_reserved_labels(&labels).is_err());
+
+        let mut labels = HashMap::new();
+        labels.insert(
+            crate::template_catalog::TEMPLATE_LABEL.to_owned(),
+            "code".to_owned(),
+        );
         assert!(reject_reserved_labels(&labels).is_err());
     }
 

--- a/virt/arcbox-vm/src/template_catalog.rs
+++ b/virt/arcbox-vm/src/template_catalog.rs
@@ -1,0 +1,706 @@
+//! On-disk template catalog (CORE-107).
+//!
+//! A template is a named, versioned sandbox base: a built rootfs plus a
+//! default-config bundle, optionally paired with a pre-warmed boot-to-ready
+//! snapshot (`template.proto`). The catalog persists metadata only — one
+//! atomically-replaced JSON file per template name under
+//! `{data_dir}/template-catalog/` — while the artifacts live elsewhere and
+//! are referenced, never copied: rootfs images in the converted-rootfs cache
+//! (pinned through [`TemplateCatalog::rootfs_paths`]) and warm snapshots in
+//! the [`SnapshotCatalog`](crate::snapshot::SnapshotCatalog) under the
+//! [`TEMPLATE_LABEL`] reserved label.
+//!
+//! Versioning model: `Build` installs the mutable draft slot; `Publish`
+//! freezes the draft as an immutable version (newest published wins bare-name
+//! resolution). Version strings are caller-chosen and opaque — "newest" means
+//! publish order, never a semver comparison.
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, VmmError};
+use crate::sandbox::atomic_write;
+
+/// Directory under the vmm data dir holding one JSON file per template name.
+const CATALOG_DIR: &str = "template-catalog";
+
+/// Maximum length of a template name or version string.
+const MAX_COMPONENT_LEN: usize = 64;
+
+/// Reserved snapshot label marking a snapshot as owned by a catalog template.
+///
+/// The value is the owning template name. The checkpoint surface keeps user
+/// checkpoints from squatting on it and template artifacts out of user-facing
+/// snapshot lists; deleting such a snapshot goes through template deletion.
+pub const TEMPLATE_LABEL: &str = "arcbox.template";
+
+/// Readiness probe recorded in template defaults.
+///
+/// The native mirror of `ReadyProbe` (`template.proto`): how to decide a
+/// sandbox created from the template is ready for use. Enforcement gates the
+/// READY transition; expiry marks the sandbox FAILED.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReadyProbeSpec {
+    /// Ready when something inside the sandbox listens on this TCP port.
+    Port {
+        port: u16,
+        /// Seconds before giving up (0 = daemon default).
+        timeout_seconds: u32,
+    },
+    /// Ready when this command, run inside the sandbox, exits 0.
+    Command {
+        cmd: Vec<String>,
+        /// Seconds before giving up (0 = daemon default).
+        timeout_seconds: u32,
+    },
+}
+
+/// Default configuration a template applies to sandboxes created from it.
+///
+/// The native mirror of `TemplateDefaults` (`template.proto`). Zero `vcpus` /
+/// `memory_mib` mean "no template default" (the daemon default applies); the
+/// per-create override rules live on `CreateSandboxRequest`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TemplateDefaultsSpec {
+    #[serde(default)]
+    pub vcpus: u32,
+    #[serde(default)]
+    pub memory_mib: u64,
+    #[serde(default)]
+    pub cmd: Vec<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// Advisory: ports the workload is expected to listen on, so clients can
+    /// expose them without knowing the workload. Never acted on at create.
+    #[serde(default)]
+    pub exposed_ports: Vec<u32>,
+    #[serde(default)]
+    pub ready_probe: Option<ReadyProbeSpec>,
+}
+
+/// A pre-warmed boot-to-ready snapshot plus the geometry it requires.
+///
+/// A memory snapshot restores only onto identical vcpus/memory, so geometry
+/// is part of the artifact — create gates template-restore on an exact match
+/// and cold-boots otherwise.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WarmArtifact {
+    /// Snapshot id in the snapshot catalog (carries [`TEMPLATE_LABEL`]).
+    pub snapshot_id: String,
+    pub vcpus: u32,
+    pub memory_mib: u64,
+}
+
+/// One built template version, or the unpublished draft.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TemplateEntry {
+    /// Published version string; empty in the draft slot.
+    #[serde(default)]
+    pub version: String,
+    /// Content digest pinning this entry's artifacts (`sha256:<hex>`),
+    /// computed at build time over source identity + rootfs fingerprint +
+    /// warm snapshot + defaults + labels.
+    pub digest: String,
+    /// Guest-absolute path of the built rootfs image in the rootfs cache.
+    pub rootfs_path: String,
+    /// Pre-warmed snapshot, when the template carries one.
+    #[serde(default)]
+    pub warm: Option<WarmArtifact>,
+    #[serde(default)]
+    pub defaults: TemplateDefaultsSpec,
+    /// Arbitrary key-value metadata (filterable in List).
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+    /// When this entry was built (draft) or its content built (versions keep
+    /// the build time, not the publish time).
+    pub created_at: DateTime<Utc>,
+    /// On-disk footprint of the artifacts (rootfs + warm snapshot).
+    #[serde(default)]
+    pub size_bytes: u64,
+}
+
+/// Durable record for one template name: the current draft plus every
+/// published version in publish order (newest last).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TemplateRecord {
+    name: String,
+    #[serde(default)]
+    draft: Option<TemplateEntry>,
+    #[serde(default)]
+    versions: Vec<TemplateEntry>,
+}
+
+impl TemplateRecord {
+    fn entries(&self) -> impl Iterator<Item = &TemplateEntry> {
+        self.versions.iter().chain(self.draft.as_ref())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.draft.is_none() && self.versions.is_empty()
+    }
+}
+
+/// A `name[:version]` reference resolved against the catalog.
+#[derive(Debug, Clone)]
+pub struct ResolvedTemplate {
+    /// Template name (no version suffix).
+    pub name: String,
+    /// The resolved entry: the exact version, or — for a bare name — the
+    /// newest published version, falling back to the draft when nothing is
+    /// published.
+    pub entry: TemplateEntry,
+}
+
+impl ResolvedTemplate {
+    /// Canonical pinned reference: `name:version@digest` (`name:@digest` for
+    /// drafts). Substituted into `CreateSandboxRequest.template` before the
+    /// idempotent create key is computed, so a retried create after a Publish
+    /// diverges instead of silently replaying the old content.
+    #[must_use]
+    pub fn canonical_ref(&self) -> String {
+        format!("{}:{}@{}", self.name, self.entry.version, self.entry.digest)
+    }
+}
+
+/// Result of installing a draft: the stored entry plus any artifacts the
+/// displaced previous draft owned exclusively.
+#[derive(Debug)]
+pub struct PutDraftOutcome {
+    /// The entry as stored (version forced empty).
+    pub entry: TemplateEntry,
+    pub released: ReleasedArtifacts,
+}
+
+/// Snapshot ids released by a catalog mutation.
+///
+/// Owned by removed entries and referenced by no remaining entry anywhere in
+/// the catalog. The caller (`SandboxManager`) deletes them from the snapshot
+/// catalog — the catalog itself never touches artifacts.
+#[derive(Debug, Default)]
+pub struct ReleasedArtifacts {
+    pub snapshot_ids: Vec<String>,
+}
+
+/// The on-disk template catalog: one atomically-replaced JSON per name.
+pub struct TemplateCatalog {
+    root: PathBuf,
+    /// Serializes read-modify-write cycles within this process. Cross-process
+    /// safety is not a goal: one agent owns the data dir.
+    lock: Mutex<()>,
+}
+
+impl TemplateCatalog {
+    /// Create a catalog rooted under `data_dir`. The directory is created
+    /// lazily on first write; a missing directory reads as an empty catalog.
+    #[must_use]
+    pub fn new(data_dir: &str) -> Self {
+        Self {
+            root: Path::new(data_dir).join(CATALOG_DIR),
+            lock: Mutex::new(()),
+        }
+    }
+
+    /// Install `entry` as the draft for `name`, displacing any previous
+    /// draft. The stored entry's `version` is forced empty.
+    pub fn put_draft(&self, name: &str, mut entry: TemplateEntry) -> Result<PutDraftOutcome> {
+        validate_template_name(name)?;
+        let _guard = self.lock.lock().unwrap();
+        let mut record = self.read_record(name)?.unwrap_or_else(|| TemplateRecord {
+            name: name.to_string(),
+            draft: None,
+            versions: Vec::new(),
+        });
+        entry.version = String::new();
+        let displaced = record.draft.replace(entry.clone());
+        self.write_record(&record)?;
+        let released = self.released_by(displaced.as_slice())?;
+        Ok(PutDraftOutcome { entry, released })
+    }
+
+    /// Freeze the current draft as immutable `version`.
+    ///
+    /// Idempotent against retries: re-publishing an existing version succeeds
+    /// when there is no draft (the earlier attempt committed) or when the
+    /// draft's digest matches the published content; a digest clash is
+    /// [`VmmError::TemplateVersionExists`].
+    pub fn publish(&self, name: &str, version: &str) -> Result<TemplateEntry> {
+        validate_template_name(name)?;
+        validate_template_version(version)?;
+        let _guard = self.lock.lock().unwrap();
+        let mut record = self
+            .read_record(name)?
+            .ok_or_else(|| VmmError::TemplateNotFound(name.to_string()))?;
+        if let Some(existing) = record.versions.iter().find(|e| e.version == version) {
+            let existing = existing.clone();
+            return match record.draft.as_ref() {
+                None => Ok(existing),
+                Some(draft) if draft.digest == existing.digest => {
+                    record.draft = None;
+                    self.write_record(&record)?;
+                    Ok(existing)
+                }
+                Some(_) => Err(VmmError::TemplateVersionExists(format!(
+                    "{name}:{version} is already published with different content"
+                ))),
+            };
+        }
+        let mut entry = record.draft.take().ok_or_else(|| {
+            VmmError::FailedPrecondition(format!(
+                "template {name} has no draft to publish; run Build first"
+            ))
+        })?;
+        entry.version = version.to_string();
+        record.versions.push(entry.clone());
+        self.write_record(&record)?;
+        Ok(entry)
+    }
+
+    /// Resolve a `name` or `name:version` reference.
+    pub fn resolve(&self, reference: &str) -> Result<ResolvedTemplate> {
+        let (name, version) = parse_reference(reference)?;
+        let record = self
+            .read_record(name)?
+            .ok_or_else(|| VmmError::TemplateNotFound(reference.to_string()))?;
+        let entry = match version {
+            Some(v) => record.versions.iter().find(|e| e.version == v).cloned(),
+            None => record
+                .versions
+                .last()
+                .cloned()
+                .or_else(|| record.draft.clone()),
+        }
+        .ok_or_else(|| VmmError::TemplateNotFound(reference.to_string()))?;
+        Ok(ResolvedTemplate {
+            name: record.name,
+            entry,
+        })
+    }
+
+    /// Every catalog row: per name (lexical order), published versions in
+    /// publish order, then the draft.
+    pub fn list(&self) -> Result<Vec<(String, TemplateEntry)>> {
+        let mut rows = Vec::new();
+        for record in self.read_all()? {
+            for entry in record.entries() {
+                rows.push((record.name.clone(), entry.clone()));
+            }
+        }
+        Ok(rows)
+    }
+
+    /// Delete a template version (`name:version`) or a whole template with
+    /// all its versions and its draft (`name`).
+    pub fn delete(&self, reference: &str) -> Result<ReleasedArtifacts> {
+        let (name, version) = parse_reference(reference)?;
+        let _guard = self.lock.lock().unwrap();
+        let mut record = self
+            .read_record(name)?
+            .ok_or_else(|| VmmError::TemplateNotFound(reference.to_string()))?;
+        let removed: Vec<TemplateEntry> = match version {
+            None => {
+                let mut entries: Vec<_> = record.versions.drain(..).collect();
+                entries.extend(record.draft.take());
+                self.remove_record(name)?;
+                entries
+            }
+            Some(v) => {
+                let index = record
+                    .versions
+                    .iter()
+                    .position(|e| e.version == v)
+                    .ok_or_else(|| VmmError::TemplateNotFound(reference.to_string()))?;
+                let entry = record.versions.remove(index);
+                self.write_record(&record)?;
+                vec![entry]
+            }
+        };
+        self.released_by(&removed)
+    }
+
+    /// Rootfs images that catalog entries need to stay bootable — a pin
+    /// source for the converted-rootfs cache sweep, alongside
+    /// [`SnapshotCatalog::referenced_rootfs_paths`](crate::snapshot::SnapshotCatalog::referenced_rootfs_paths).
+    pub fn rootfs_paths(&self) -> Result<BTreeSet<PathBuf>> {
+        let mut pinned = BTreeSet::new();
+        for record in self.read_all()? {
+            for entry in record.entries() {
+                if !entry.rootfs_path.is_empty() {
+                    pinned.insert(PathBuf::from(&entry.rootfs_path));
+                }
+            }
+        }
+        Ok(pinned)
+    }
+
+    /// Snapshot ids among `removed` that no remaining catalog entry
+    /// references. Warm snapshots are created per build and never shared, but
+    /// the sweep is reference-counted anyway so a future sharing scheme can't
+    /// silently turn deletion into corruption.
+    fn released_by(&self, removed: &[TemplateEntry]) -> Result<ReleasedArtifacts> {
+        let candidates: Vec<String> = removed
+            .iter()
+            .filter_map(|e| e.warm.as_ref().map(|w| w.snapshot_id.clone()))
+            .collect();
+        if candidates.is_empty() {
+            return Ok(ReleasedArtifacts::default());
+        }
+        let live: HashSet<String> = self
+            .read_all()?
+            .iter()
+            .flat_map(TemplateRecord::entries)
+            .filter_map(|e| e.warm.as_ref().map(|w| w.snapshot_id.clone()))
+            .collect();
+        Ok(ReleasedArtifacts {
+            snapshot_ids: candidates
+                .into_iter()
+                .filter(|id| !live.contains(id))
+                .collect(),
+        })
+    }
+
+    fn record_path(&self, name: &str) -> PathBuf {
+        self.root.join(format!("{name}.json"))
+    }
+
+    fn read_record(&self, name: &str) -> Result<Option<TemplateRecord>> {
+        match std::fs::read_to_string(self.record_path(name)) {
+            Ok(json) => Ok(Some(serde_json::from_str(&json)?)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(VmmError::Io(e)),
+        }
+    }
+
+    /// Read every record. Strict by design: a corrupt record is real
+    /// corruption, and treating it as absent would unpin rootfs images the
+    /// cache sweep must not reclaim.
+    fn read_all(&self) -> Result<Vec<TemplateRecord>> {
+        if !self.root.exists() {
+            return Ok(Vec::new());
+        }
+        let mut records = Vec::new();
+        for dirent in std::fs::read_dir(&self.root).map_err(VmmError::Io)? {
+            let path = dirent.map_err(VmmError::Io)?.path();
+            if !path.is_file() || path.extension().is_none_or(|ext| ext != "json") {
+                continue;
+            }
+            let json = std::fs::read_to_string(&path).map_err(VmmError::Io)?;
+            records.push(serde_json::from_str(&json)?);
+        }
+        records.sort_by(|a: &TemplateRecord, b: &TemplateRecord| a.name.cmp(&b.name));
+        Ok(records)
+    }
+
+    fn write_record(&self, record: &TemplateRecord) -> Result<()> {
+        if record.is_empty() {
+            return self.remove_record(&record.name);
+        }
+        std::fs::create_dir_all(&self.root).map_err(VmmError::Io)?;
+        std::fs::set_permissions(&self.root, {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::Permissions::from_mode(0o700)
+        })
+        .map_err(VmmError::Io)?;
+        let bytes = serde_json::to_vec_pretty(record)?;
+        atomic_write(&self.record_path(&record.name), &bytes)
+    }
+
+    fn remove_record(&self, name: &str) -> Result<()> {
+        match std::fs::remove_file(self.record_path(name)) {
+            Ok(()) => std::fs::File::open(&self.root)
+                .and_then(|dir| dir.sync_all())
+                .map_err(VmmError::Io),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(VmmError::Io(e)),
+        }
+    }
+}
+
+/// Validate a template name.
+///
+/// Names become file names, snapshot `vm_id` components, and reference
+/// prefixes, so they share the sandbox-id charset; `:` is additionally
+/// impossible, keeping the `name[:version]` grammar unambiguous.
+pub fn validate_template_name(name: &str) -> Result<()> {
+    validate_component("template name", name, false)
+}
+
+/// Validate a template version string (`[A-Za-z0-9._-]`, e.g. "1.2.0").
+pub fn validate_template_version(version: &str) -> Result<()> {
+    validate_component("template version", version, true)
+}
+
+fn validate_component(kind: &str, value: &str, allow_dot: bool) -> Result<()> {
+    if value.is_empty() {
+        return Err(VmmError::Config(format!("{kind} must not be empty")));
+    }
+    if value.len() > MAX_COMPONENT_LEN {
+        return Err(VmmError::Config(format!(
+            "{kind} must be at most {MAX_COMPONENT_LEN} characters"
+        )));
+    }
+    let valid = value
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || (allow_dot && b == b'.'));
+    if !valid {
+        let extra = if allow_dot { ", '.'" } else { "" };
+        return Err(VmmError::Config(format!(
+            "invalid {kind} {value:?}: only ASCII letters, digits, '-', '_'{extra} are allowed"
+        )));
+    }
+    Ok(())
+}
+
+/// Split a `name[:version]` reference and validate both components.
+fn parse_reference(reference: &str) -> Result<(&str, Option<&str>)> {
+    match reference.split_once(':') {
+        None => {
+            validate_template_name(reference)?;
+            Ok((reference, None))
+        }
+        Some((name, version)) => {
+            validate_template_name(name)?;
+            validate_template_version(version)?;
+            Ok((name, Some(version)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(digest: &str, rootfs: &str) -> TemplateEntry {
+        TemplateEntry {
+            version: String::new(),
+            digest: digest.to_string(),
+            rootfs_path: rootfs.to_string(),
+            warm: None,
+            defaults: TemplateDefaultsSpec::default(),
+            labels: HashMap::new(),
+            created_at: Utc::now(),
+            size_bytes: 0,
+        }
+    }
+
+    fn warm_entry(digest: &str, snapshot_id: &str) -> TemplateEntry {
+        let mut e = entry(digest, "/cache/rootfs-a.ext4");
+        e.warm = Some(WarmArtifact {
+            snapshot_id: snapshot_id.to_string(),
+            vcpus: 2,
+            memory_mib: 512,
+        });
+        e
+    }
+
+    fn catalog() -> (tempfile::TempDir, TemplateCatalog) {
+        let dir = tempfile::tempdir().unwrap();
+        let catalog = TemplateCatalog::new(dir.path().to_str().unwrap());
+        (dir, catalog)
+    }
+
+    #[test]
+    fn bare_name_resolves_draft_until_publish_then_newest_version() {
+        let (_dir, c) = catalog();
+        c.put_draft("code", entry("sha256:d1", "/cache/r1.ext4"))
+            .unwrap();
+        assert_eq!(c.resolve("code").unwrap().entry.digest, "sha256:d1");
+
+        c.publish("code", "1.0").unwrap();
+        c.put_draft("code", entry("sha256:d2", "/cache/r2.ext4"))
+            .unwrap();
+        // Published wins over the newer draft on a bare name.
+        let resolved = c.resolve("code").unwrap();
+        assert_eq!(resolved.entry.version, "1.0");
+        assert_eq!(resolved.entry.digest, "sha256:d1");
+
+        c.publish("code", "2.0").unwrap();
+        assert_eq!(c.resolve("code").unwrap().entry.version, "2.0");
+        assert_eq!(c.resolve("code:1.0").unwrap().entry.digest, "sha256:d1");
+    }
+
+    #[test]
+    fn canonical_ref_pins_name_version_and_digest() {
+        let (_dir, c) = catalog();
+        c.put_draft("code", entry("sha256:d1", "/r.ext4")).unwrap();
+        assert_eq!(
+            c.resolve("code").unwrap().canonical_ref(),
+            "code:@sha256:d1"
+        );
+        c.publish("code", "1.0").unwrap();
+        assert_eq!(
+            c.resolve("code").unwrap().canonical_ref(),
+            "code:1.0@sha256:d1"
+        );
+    }
+
+    #[test]
+    fn missing_references_fail_with_the_classifier_prefix() {
+        let (_dir, c) = catalog();
+        let err = c.resolve("ghost").unwrap_err();
+        assert!(err.to_string().starts_with("template not found:"), "{err}");
+        c.put_draft("code", entry("sha256:d1", "/r.ext4")).unwrap();
+        assert!(matches!(
+            c.resolve("code:9.9").unwrap_err(),
+            VmmError::TemplateNotFound(_)
+        ));
+    }
+
+    #[test]
+    fn publish_is_idempotent_for_retries_but_rejects_content_clash() {
+        let (_dir, c) = catalog();
+        c.put_draft("code", entry("sha256:d1", "/r.ext4")).unwrap();
+        c.publish("code", "1.0").unwrap();
+        // Retry after commit (no draft left): succeeds, returns the version.
+        assert_eq!(c.publish("code", "1.0").unwrap().digest, "sha256:d1");
+        // Identical rebuild then re-publish: idempotent, draft consumed.
+        c.put_draft("code", entry("sha256:d1", "/r.ext4")).unwrap();
+        c.publish("code", "1.0").unwrap();
+        assert_eq!(c.resolve("code").unwrap().entry.version, "1.0");
+        // Different content under a taken version: refused.
+        c.put_draft("code", entry("sha256:d2", "/r.ext4")).unwrap();
+        assert!(matches!(
+            c.publish("code", "1.0").unwrap_err(),
+            VmmError::TemplateVersionExists(_)
+        ));
+        // The clashing draft survives for publishing under a new version.
+        assert_eq!(c.publish("code", "1.1").unwrap().digest, "sha256:d2");
+    }
+
+    #[test]
+    fn publish_without_a_draft_is_a_precondition_failure() {
+        let (_dir, c) = catalog();
+        c.put_draft("code", entry("sha256:d1", "/r.ext4")).unwrap();
+        c.publish("code", "1.0").unwrap();
+        assert!(matches!(
+            c.publish("code", "2.0").unwrap_err(),
+            VmmError::FailedPrecondition(_)
+        ));
+        assert!(matches!(
+            c.publish("ghost", "1.0").unwrap_err(),
+            VmmError::TemplateNotFound(_)
+        ));
+    }
+
+    #[test]
+    fn delete_version_and_whole_template_release_unreferenced_snapshots() {
+        let (_dir, c) = catalog();
+        c.put_draft("code", warm_entry("sha256:d1", "snap-1"))
+            .unwrap();
+        c.publish("code", "1.0").unwrap();
+        c.put_draft("code", warm_entry("sha256:d2", "snap-2"))
+            .unwrap();
+
+        let released = c.delete("code:1.0").unwrap();
+        assert_eq!(released.snapshot_ids, vec!["snap-1".to_string()]);
+        // Draft survives a version delete.
+        assert_eq!(c.resolve("code").unwrap().entry.digest, "sha256:d2");
+
+        let released = c.delete("code").unwrap();
+        assert_eq!(released.snapshot_ids, vec!["snap-2".to_string()]);
+        assert!(matches!(
+            c.resolve("code").unwrap_err(),
+            VmmError::TemplateNotFound(_)
+        ));
+        assert!(matches!(
+            c.delete("code").unwrap_err(),
+            VmmError::TemplateNotFound(_)
+        ));
+    }
+
+    #[test]
+    fn a_still_referenced_snapshot_is_not_released() {
+        let (_dir, c) = catalog();
+        // Defensive cross-reference: two entries sharing one snapshot id.
+        c.put_draft("a", warm_entry("sha256:d1", "shared")).unwrap();
+        c.publish("a", "1.0").unwrap();
+        c.put_draft("b", warm_entry("sha256:d2", "shared")).unwrap();
+
+        assert!(c.delete("a").unwrap().snapshot_ids.is_empty());
+        assert_eq!(
+            c.delete("b").unwrap().snapshot_ids,
+            vec!["shared".to_string()]
+        );
+    }
+
+    #[test]
+    fn displacing_a_draft_releases_its_exclusive_snapshot() {
+        let (_dir, c) = catalog();
+        c.put_draft("code", warm_entry("sha256:d1", "snap-old"))
+            .unwrap();
+        let outcome = c
+            .put_draft("code", warm_entry("sha256:d2", "snap-new"))
+            .unwrap();
+        assert_eq!(outcome.released.snapshot_ids, vec!["snap-old".to_string()]);
+        assert_eq!(outcome.entry.version, "");
+    }
+
+    #[test]
+    fn list_orders_by_name_then_publish_order_with_draft_last() {
+        let (_dir, c) = catalog();
+        c.put_draft("b", entry("sha256:b1", "/rb.ext4")).unwrap();
+        c.put_draft("a", entry("sha256:a1", "/ra.ext4")).unwrap();
+        c.publish("a", "1.0").unwrap();
+        c.put_draft("a", entry("sha256:a2", "/ra2.ext4")).unwrap();
+
+        let rows = c.list().unwrap();
+        let keys: Vec<String> = rows
+            .iter()
+            .map(|(name, e)| format!("{name}:{}", e.version))
+            .collect();
+        assert_eq!(keys, vec!["a:1.0", "a:", "b:"]);
+    }
+
+    #[test]
+    fn rootfs_paths_pin_every_entry_including_drafts() {
+        let (_dir, c) = catalog();
+        c.put_draft("a", entry("sha256:a1", "/cache/ra.ext4"))
+            .unwrap();
+        c.publish("a", "1.0").unwrap();
+        c.put_draft("a", entry("sha256:a2", "/cache/ra2.ext4"))
+            .unwrap();
+        c.put_draft("b", entry("sha256:b1", "/cache/rb.ext4"))
+            .unwrap();
+
+        let pinned = c.rootfs_paths().unwrap();
+        for path in ["/cache/ra.ext4", "/cache/ra2.ext4", "/cache/rb.ext4"] {
+            assert!(pinned.contains(Path::new(path)), "missing {path}");
+        }
+    }
+
+    #[test]
+    fn records_survive_a_catalog_reload() {
+        let (dir, c) = catalog();
+        c.put_draft("code", warm_entry("sha256:d1", "snap-1"))
+            .unwrap();
+        c.publish("code", "1.0").unwrap();
+
+        let reloaded = TemplateCatalog::new(dir.path().to_str().unwrap());
+        let resolved = reloaded.resolve("code:1.0").unwrap();
+        assert_eq!(resolved.entry.digest, "sha256:d1");
+        assert_eq!(resolved.entry.warm.as_ref().unwrap().snapshot_id, "snap-1");
+    }
+
+    #[test]
+    fn names_and_versions_reject_traversal_and_grammar_collisions() {
+        let (_dir, c) = catalog();
+        for bad in ["", "../etc", "a/b", "a b", ":1.0", "名字", &"x".repeat(65)] {
+            assert!(
+                matches!(c.resolve(bad), Err(VmmError::Config(_))),
+                "accepted {bad:?}"
+            );
+        }
+        // Versions allow dots; '@' stays reserved for canonical refs.
+        assert!(matches!(
+            c.resolve("code:1.0@sha256"),
+            Err(VmmError::Config(_))
+        ));
+        assert!(matches!(
+            c.put_draft("docker:img", entry("d", "/r")).unwrap_err(),
+            VmmError::Config(_)
+        ));
+    }
+}

--- a/virt/arcbox-vm/src/template_catalog.rs
+++ b/virt/arcbox-vm/src/template_catalog.rs
@@ -350,6 +350,23 @@ impl TemplateCatalog {
         Ok(self.released_after_commit(&removed))
     }
 
+    /// True when any catalog entry references `snapshot_id` as its warm
+    /// artifact. The checkpoint surface's deletion guard keys on this so an
+    /// orphaned template-labeled snapshot (record gone after a failed
+    /// post-commit cleanup) stays reclaimable via `DeleteSnapshot`.
+    pub fn references_snapshot(&self, snapshot_id: &str) -> Result<bool> {
+        let _guard = self.lock.lock().unwrap();
+        Ok(self
+            .read_all()?
+            .iter()
+            .flat_map(TemplateRecord::entries)
+            .any(|e| {
+                e.warm
+                    .as_ref()
+                    .is_some_and(|w| w.snapshot_id == snapshot_id)
+            }))
+    }
+
     /// Rootfs images that catalog entries need to stay bootable — a pin
     /// source for the converted-rootfs cache sweep, alongside
     /// [`SnapshotCatalog::referenced_rootfs_paths`](crate::snapshot::SnapshotCatalog::referenced_rootfs_paths).

--- a/virt/arcbox-vm/src/template_catalog.rs
+++ b/virt/arcbox-vm/src/template_catalog.rs
@@ -389,13 +389,22 @@ impl TemplateCatalog {
     /// already durable, so a failed catalog-wide scan (an unrelated corrupt
     /// record) must not turn into an error the caller would read as "nothing
     /// happened". Releasing nothing is the safe direction — a logged orphan,
-    /// never a deleted snapshot something still references.
+    /// never a deleted snapshot something still references. The warning names
+    /// every candidate id: `list_checkpoints` hides template-labeled
+    /// snapshots, so this log line is how an operator discovers what to
+    /// reclaim with `DeleteSnapshot` once the catalog reads cleanly.
     fn released_after_commit(&self, removed: &[TemplateEntry]) -> ReleasedArtifacts {
         self.released_by(removed).unwrap_or_else(|error| {
+            let candidates: Vec<&str> = removed
+                .iter()
+                .filter_map(|e| e.warm.as_ref().map(|w| w.snapshot_id.as_str()))
+                .collect();
             warn!(
                 %error,
+                snapshot_ids = candidates.join(","),
                 "template catalog scan failed after a committed mutation; \
-                 skipping artifact release (warm snapshots may be orphaned)"
+                 skipping artifact release (listed warm snapshots may be \
+                 orphaned; reclaim via DeleteSnapshot once the catalog parses)"
             );
             ReleasedArtifacts::default()
         })

--- a/virt/arcbox-vm/src/template_catalog.rs
+++ b/virt/arcbox-vm/src/template_catalog.rs
@@ -21,6 +21,7 @@ use std::sync::Mutex;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::error::{Result, VmmError};
 use crate::sandbox::atomic_write;
@@ -175,6 +176,18 @@ pub struct PutDraftOutcome {
     pub released: ReleasedArtifacts,
 }
 
+/// Result of publishing: the frozen version plus any released artifacts.
+///
+/// An idempotent re-publish can collapse a rebuilt same-digest draft whose
+/// warm snapshot the published version never shared; that snapshot comes
+/// back here for the caller to reclaim.
+#[derive(Debug)]
+pub struct PublishOutcome {
+    /// The published entry.
+    pub entry: TemplateEntry,
+    pub released: ReleasedArtifacts,
+}
+
 /// Snapshot ids released by a catalog mutation.
 ///
 /// Owned by removed entries and referenced by no remaining entry anywhere in
@@ -217,7 +230,7 @@ impl TemplateCatalog {
         entry.version = String::new();
         let displaced = record.draft.replace(entry.clone());
         self.write_record(&record)?;
-        let released = self.released_by(displaced.as_slice())?;
+        let released = self.released_after_commit(displaced.as_slice());
         Ok(PutDraftOutcome { entry, released })
     }
 
@@ -225,9 +238,11 @@ impl TemplateCatalog {
     ///
     /// Idempotent against retries: re-publishing an existing version succeeds
     /// when there is no draft (the earlier attempt committed) or when the
-    /// draft's digest matches the published content; a digest clash is
-    /// [`VmmError::TemplateVersionExists`].
-    pub fn publish(&self, name: &str, version: &str) -> Result<TemplateEntry> {
+    /// draft's digest matches the published content — releasing that draft's
+    /// exclusively-owned artifacts; a digest clash is
+    /// [`VmmError::TemplateVersionExists`] (the divergent draft survives for
+    /// publishing under a new version, and a later `put_draft` releases it).
+    pub fn publish(&self, name: &str, version: &str) -> Result<PublishOutcome> {
         validate_template_name(name)?;
         validate_template_version(version)?;
         let _guard = self.lock.lock().unwrap();
@@ -237,11 +252,21 @@ impl TemplateCatalog {
         if let Some(existing) = record.versions.iter().find(|e| e.version == version) {
             let existing = existing.clone();
             return match record.draft.as_ref() {
-                None => Ok(existing),
+                None => Ok(PublishOutcome {
+                    entry: existing,
+                    released: ReleasedArtifacts::default(),
+                }),
                 Some(draft) if draft.digest == existing.digest => {
-                    record.draft = None;
+                    let displaced = record.draft.take();
                     self.write_record(&record)?;
-                    Ok(existing)
+                    // Refcount after the write so the scan observes the
+                    // record without the draft, or the snapshot still looks
+                    // referenced and is never released.
+                    let released = self.released_after_commit(displaced.as_slice());
+                    Ok(PublishOutcome {
+                        entry: existing,
+                        released,
+                    })
                 }
                 Some(_) => Err(VmmError::TemplateVersionExists(format!(
                     "{name}:{version} is already published with different content"
@@ -256,7 +281,10 @@ impl TemplateCatalog {
         entry.version = version.to_string();
         record.versions.push(entry.clone());
         self.write_record(&record)?;
-        Ok(entry)
+        Ok(PublishOutcome {
+            entry,
+            released: ReleasedArtifacts::default(),
+        })
     }
 
     /// Resolve a `name` or `name:version` reference.
@@ -283,6 +311,7 @@ impl TemplateCatalog {
     /// Every catalog row: per name (lexical order), published versions in
     /// publish order, then the draft.
     pub fn list(&self) -> Result<Vec<(String, TemplateEntry)>> {
+        let _guard = self.lock.lock().unwrap();
         let mut rows = Vec::new();
         for record in self.read_all()? {
             for entry in record.entries() {
@@ -318,13 +347,16 @@ impl TemplateCatalog {
                 vec![entry]
             }
         };
-        self.released_by(&removed)
+        Ok(self.released_after_commit(&removed))
     }
 
     /// Rootfs images that catalog entries need to stay bootable — a pin
     /// source for the converted-rootfs cache sweep, alongside
     /// [`SnapshotCatalog::referenced_rootfs_paths`](crate::snapshot::SnapshotCatalog::referenced_rootfs_paths).
     pub fn rootfs_paths(&self) -> Result<BTreeSet<PathBuf>> {
+        // Held so a listing cannot straddle a mutation and momentarily miss
+        // a path the cache sweep must keep pinned.
+        let _guard = self.lock.lock().unwrap();
         let mut pinned = BTreeSet::new();
         for record in self.read_all()? {
             for entry in record.entries() {
@@ -334,6 +366,22 @@ impl TemplateCatalog {
             }
         }
         Ok(pinned)
+    }
+
+    /// [`Self::released_by`] for the post-commit position: the mutation is
+    /// already durable, so a failed catalog-wide scan (an unrelated corrupt
+    /// record) must not turn into an error the caller would read as "nothing
+    /// happened". Releasing nothing is the safe direction — a logged orphan,
+    /// never a deleted snapshot something still references.
+    fn released_after_commit(&self, removed: &[TemplateEntry]) -> ReleasedArtifacts {
+        self.released_by(removed).unwrap_or_else(|error| {
+            warn!(
+                %error,
+                "template catalog scan failed after a committed mutation; \
+                 skipping artifact release (warm snapshots may be orphaned)"
+            );
+            ReleasedArtifacts::default()
+        })
     }
 
     /// Snapshot ids among `removed` that no remaining catalog entry
@@ -555,7 +603,7 @@ mod tests {
         c.put_draft("code", entry("sha256:d1", "/r.ext4")).unwrap();
         c.publish("code", "1.0").unwrap();
         // Retry after commit (no draft left): succeeds, returns the version.
-        assert_eq!(c.publish("code", "1.0").unwrap().digest, "sha256:d1");
+        assert_eq!(c.publish("code", "1.0").unwrap().entry.digest, "sha256:d1");
         // Identical rebuild then re-publish: idempotent, draft consumed.
         c.put_draft("code", entry("sha256:d1", "/r.ext4")).unwrap();
         c.publish("code", "1.0").unwrap();
@@ -567,7 +615,42 @@ mod tests {
             VmmError::TemplateVersionExists(_)
         ));
         // The clashing draft survives for publishing under a new version.
-        assert_eq!(c.publish("code", "1.1").unwrap().digest, "sha256:d2");
+        assert_eq!(c.publish("code", "1.1").unwrap().entry.digest, "sha256:d2");
+    }
+
+    #[test]
+    fn collapsing_a_same_digest_draft_releases_its_fresh_snapshot() {
+        let (_dir, c) = catalog();
+        c.put_draft("code", warm_entry("sha256:d1", "snap-a"))
+            .unwrap();
+        c.publish("code", "1.0").unwrap();
+        // A rebuild can produce identical content with a freshly allocated
+        // warm snapshot; the idempotent re-publish must not leak it.
+        c.put_draft("code", warm_entry("sha256:d1", "snap-b"))
+            .unwrap();
+        let outcome = c.publish("code", "1.0").unwrap();
+        assert_eq!(outcome.entry.warm.as_ref().unwrap().snapshot_id, "snap-a");
+        assert_eq!(outcome.released.snapshot_ids, vec!["snap-b".to_string()]);
+    }
+
+    #[test]
+    fn a_corrupt_sibling_record_does_not_fail_a_committed_mutation() {
+        let (dir, c) = catalog();
+        c.put_draft("code", warm_entry("sha256:d1", "snap-1"))
+            .unwrap();
+        std::fs::write(
+            dir.path().join("template-catalog").join("broken.json"),
+            b"not json",
+        )
+        .unwrap();
+        // The delete commits and reports success; the scan failure only
+        // suppresses artifact release (logged orphan, safe direction).
+        let released = c.delete("code").unwrap();
+        assert!(released.snapshot_ids.is_empty());
+        assert!(matches!(
+            c.resolve("code").unwrap_err(),
+            VmmError::TemplateNotFound(_)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Part 1 of the template-catalog campaign ([CORE-107](https://linear.app/arcbox/issue/CORE-107)) — the on-disk store, no user-visible surface yet.

## What

- **`virt/arcbox-vm/src/template_catalog.rs`** — one atomically-replaced JSON per template name under `{data_dir}/template-catalog/`. Draft/publish versioning: `Build` installs the mutable draft, `Publish` freezes it as an immutable version; bare-name resolution prefers the newest published version and falls back to the draft (matches `template.proto`). `Publish` is retry-idempotent (no-draft retry and same-digest rebuild succeed; a digest clash is refused). Deletion and draft displacement report exclusively-owned warm-snapshot ids (reference-counted across the whole catalog) for the manager to reclaim — the catalog itself never touches artifacts.
- **`virt/arcbox-vm/src/sandbox/templates.rs`** — the `SandboxManager` surface: `get/list/register-draft/publish/delete`, deleting released snapshots best-effort (a failed artifact delete must not strand a half-deleted template).
- **GC pin union** — `pinned_rootfs_paths` now unions snapshot-referenced and template-referenced rootfs paths. Without this, a vm-agent update plus a create for the same docker layer would sweep a non-prewarmed template's ext4 as superseded.
- **Typed errors** — `TemplateNotFound` (404, classifier prefix `template not found:`), `TemplateVersionExists` (409), `FailedPrecondition` (412), mapped on the agent wire with tests pinning the prefixes.

## Why one JSON per name

Snapshot-catalog precedent (`meta.json` + atomic replace) without the directory dance: template records are small metadata; artifacts stay in the rootfs cache / snapshot catalog and are referenced by path/id.

## Validation

- `cargo test -p arcbox-vm --lib` — 216 passed (12 new catalog tests: resolution precedence, publish idempotency matrix, delete refcounts, reload, validation grammar).
- `cargo clippy --workspace --exclude arcbox-agent -- -D warnings` clean; musl-target agent clippy clean on changed lines; `cargo fmt --check` clean.

Next up (separate PRs): vsock wire plumbing + daemon forwarders, then the Build sources.