### PR TITLE
perf(net): batched frame I/O with sendmsg_x/recvmsg_x (ABX-313)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6497,6 +6497,7 @@ dependencies = [
  "arcbox-fakeip",
  "arcbox-packet",
  "arcbox-proxy",
+ "arcbox-xnu-net",
  "crossbeam-channel",
  "libc",
  "socket2 0.6.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,7 @@ dependencies = [
  "arcbox-proxy",
  "arcbox-route",
  "arcbox-vmnet",
+ "arcbox-xnu-net",
  "bytes",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,7 @@ arcbox-error = { version = "0.6.3", path = "common/arcbox-error" } # x-release-p
 arcbox-route = { version = "0.6.3", path = "common/arcbox-route" } # x-release-please-version
 arcbox-packet = { version = "0.6.3", path = "common/arcbox-packet" } # x-release-please-version
 arcbox-datapath = { version = "0.6.3", path = "common/arcbox-datapath" } # x-release-please-version
+arcbox-xnu-net = { version = "0.6.3", path = "common/arcbox-xnu-net" } # x-release-please-version
 arcbox-conntrack = { version = "0.6.3", path = "common/arcbox-conntrack" } # x-release-please-version
 arcbox-fakeip = { version = "0.6.3", path = "common/arcbox-fakeip" } # x-release-please-version
 arcbox-proxy = { version = "0.6.3", path = "common/arcbox-proxy" } # x-release-please-version

--- a/common/AGENTS.md
+++ b/common/AGENTS.md
@@ -124,17 +124,39 @@ distribution".
 
 ## arcbox-xnu-net — macOS batch DGRAM kernel landmines
 
+It carries both halves of the datapath's guest socketpair I/O (ABX-313):
+`GuestTx::flush` (`virt/arcbox-net/src/darwin/datapath_loop/guest_tx.rs`)
+sends, `FdFrameSource::drain` (`common/splicetcp/src/frame_source.rs`)
+receives. A semantics change here lands on both directions at once.
+
 - `msghdr_x` must be **fully zeroed before every `recvmsg_x`** — older XNU
   kernels validate all fields, not just the ones we set (`src/ffi.rs`,
   `src/batch.rs` re-zeros per call). `recvmsg_x`/`sendmsg_x` are private-but-
   stable XNU symbols from `libsystem_kernel.dylib`.
 - `MAX_BATCH = 256` matches the **default** `kern.ipc.maxrecvmsgx` /
-  `maxsendmsgx`. These sysctls are tunable down; calling with `cnt > max`
-  returns **EINVAL** (a hard failure, not a short batch). Clamp per-call len if
-  targeting hardened hosts.
+  `maxsendmsgx`. These sysctls are tunable down and `cnt > max` returns
+  **EINVAL** (a hard failure, not a short batch), so the crate reads both once
+  per process and clamps every call itself
+  (`BatchDgram::{send,recv}_capacity`). Callers no longer clamp — but a caller
+  that pre-sizes buffers off `MAX_BATCH` will over-allocate on such a host.
+- **An oversized datagram is truncated *silently* on recv.** XNU leaves
+  `msg_flags` zeroed instead of raising `MSG_TRUNC` (measured macOS 26.4;
+  `oversized_datagram_is_truncated_without_a_flag` pins it) and the discarded
+  tail is not left queued. Slots are sized before the syscall and cannot grow,
+  so every buffer must be at least the largest datagram the peer can send —
+  this is why `MAX_FRAME_SIZE` stays 65535 in `frame_source.rs`.
+- **A send that overruns the peer is a partial send, not an error.**
+  `sendmsg_x` returns the accepted count and carries **no errno** once it
+  accepted anything, so the caller must requeue `bufs[n..]` and learn *why* it
+  blocked from a follow-up call. `GuestTx::flush` depends on this: it needs
+  `EAGAIN` vs `ENOBUFS` for its blocked-state machine, so it hands the first
+  refusal to a single `write(2)`. Regression:
+  `partial_send_reports_accepted_count`.
 - The fd must be `O_NONBLOCK`; `recv_batch` returns `WouldBlock` when idle and
   readiness reactors rely on that to clear readiness. A blocking fd wedges the
-  reactor.
+  reactor. A reactor must also drain **to** `WouldBlock` rather than stop at
+  the first short batch — it clears readiness afterwards, so a datagram that
+  arrived mid-drain would wait for an unrelated wakeup.
 
 ## arcbox-fakeip / arcbox-proxy — proxy awareness
 
@@ -157,7 +179,19 @@ distribution".
   subnet (default `192.168.64.0/24`).
 - **Batch recv fails with EINVAL on some hosts** → check `sysctl
   kern.ipc.maxrecvmsgx kern.ipc.maxsendmsgx`; a lowered cap below the per-call
-  `cnt` is EINVAL. Confirm the fd is `O_NONBLOCK`.
+  `cnt` is EINVAL. `BatchDgram` clamps to these itself, so an EINVAL here means
+  the clamp was bypassed (a hand-rolled `recvmsg_x` call). Confirm the fd is
+  `O_NONBLOCK`.
+- **Guest-bound frames stop flowing while `guest-tx delivery counters` shows
+  `queue_len` stuck non-zero** → the datapath queues on `send` and only writes
+  on `flush`, so a missing `GuestTx::flush` in a new event-loop path strands
+  everything it queued. `rg -n "guest_tx.flush" virt/arcbox-net/src/darwin` —
+  the tail flush must also precede the `has_backlog` fast-path gate, or the
+  gate reads "produced this iteration" as backpressure and starves the poll.
+- **`tx_frames / tx_syscalls` sits at ~1 in the same log line** → batching is
+  not engaging: either every flush sees a single queued frame (an event-loop
+  path flushing too eagerly) or `sendmsg_x` is failing and every frame falls
+  through to the single-write classifier.
 - **Malformed DNS response for a client** → diff the flag/count bytes in the
   builder; confirm ANCOUNT/NSCOUNT/ARCOUNT are zeroed on the negative paths.
 - **Sporadic memory corruption near the datapath** → look for a second

--- a/common/arcbox-xnu-net/src/batch.rs
+++ b/common/arcbox-xnu-net/src/batch.rs
@@ -154,6 +154,49 @@ impl BatchDgram {
         Ok(&self.entries[..n])
     }
 
+    /// Receives into `buf` treated as back-to-back slots of `slot_len` bytes.
+    ///
+    /// Equivalent to [`recv_batch`](Self::recv_batch) over
+    /// `buf.chunks_mut(slot_len)`, but without materializing that
+    /// `&mut [&mut [u8]]` — a reactor loop reading fixed-size frames would
+    /// otherwise allocate one such slice per syscall. Datagram `i` lands at
+    /// `buf[i * slot_len..][..entries[i].len]`, and the same sizing rule as
+    /// `recv_batch` applies: an oversized datagram is truncated silently.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slot_len` is zero.
+    ///
+    /// # Errors
+    ///
+    /// Returns `io::Error` for syscall failures, including `WouldBlock`.
+    pub fn recv_batch_chunked(
+        &mut self,
+        fd: RawFd,
+        buf: &mut [u8],
+        slot_len: usize,
+    ) -> io::Result<&[RxEntry]> {
+        assert!(slot_len > 0, "slot_len must be non-zero");
+        let count = (buf.len() / slot_len).min(Self::recv_capacity());
+        if count == 0 {
+            return Ok(&[]);
+        }
+
+        for (i, slot) in buf.chunks_mut(slot_len).take(count).enumerate() {
+            self.iovecs[i] = libc::iovec {
+                iov_base: slot.as_mut_ptr().cast(),
+                iov_len: slot_len,
+            };
+        }
+        self.setup_hdrs_recv(count);
+
+        let n = self.platform_recv(fd, count)?;
+
+        self.collect_recv(n);
+
+        Ok(&self.entries[..n])
+    }
+
     /// Returns the first `count` [`RxEntry`] slots from the last
     /// [`recv_batch`](Self::recv_batch) call.
     ///
@@ -606,6 +649,36 @@ mod tests {
             .recv_batch(b.as_raw_fd(), &mut bufs)
             .expect_err("the truncated tail must not remain queued");
         assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+    }
+
+    /// The chunked form must place datagram `i` at slot `i` and report the
+    /// same lengths as the slice form.
+    #[test]
+    fn recv_batch_chunked_slots_datagrams_in_order() {
+        let (a, b) = socketpair();
+
+        let sizes = [1usize, 700, 64, 1024];
+        for (i, &size) in sizes.iter().enumerate() {
+            write_datagram(a.as_raw_fd(), &vec![i as u8; size]);
+        }
+
+        const SLOT: usize = 2048;
+        let mut buf = vec![0u8; SLOT * 8];
+        let mut batch = BatchDgram::new();
+
+        let entries = batch
+            .recv_batch_chunked(b.as_raw_fd(), &mut buf, SLOT)
+            .unwrap();
+        let lens: Vec<usize> = entries.iter().map(|e| e.len).collect();
+        assert_eq!(lens, sizes);
+
+        for (i, &size) in sizes.iter().enumerate() {
+            let slot = &buf[i * SLOT..][..size];
+            assert!(
+                slot.iter().all(|&byte| byte == i as u8),
+                "datagram {i} landed in the wrong slot"
+            );
+        }
     }
 
     #[test]

--- a/common/arcbox-xnu-net/src/batch.rs
+++ b/common/arcbox-xnu-net/src/batch.rs
@@ -13,9 +13,32 @@ use std::os::fd::RawFd;
 /// kernel cap on `recvmmsg`/`sendmmsg`, but this constant is shared for
 /// uniform buffer pre-allocation.
 ///
-/// If you target hosts that may carry non-default sysctls, clamp your
-/// per-call `bufs.len()` to a value you know is safe.
+/// [`BatchDgram`] reads the live sysctls once per process and clamps every
+/// call for you ([`BatchDgram::send_capacity`] /
+/// [`BatchDgram::recv_capacity`]); this constant stays the upper bound on
+/// pre-allocation and on what a caller may usefully pass.
 pub const MAX_BATCH: usize = 256;
+
+/// The live per-call caps, read once per process.
+///
+/// Returned as `(send, recv)`, each already clamped to [`MAX_BATCH`]. On
+/// Linux there is no kernel cap, so both are [`MAX_BATCH`].
+fn kernel_caps() -> (usize, usize) {
+    static CAPS: std::sync::OnceLock<(usize, usize)> = std::sync::OnceLock::new();
+    *CAPS.get_or_init(|| {
+        #[cfg(target_os = "macos")]
+        {
+            (
+                crate::ffi::darwin::sysctl_batch_cap(c"kern.ipc.maxsendmsgx"),
+                crate::ffi::darwin::sysctl_batch_cap(c"kern.ipc.maxrecvmsgx"),
+            )
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            (MAX_BATCH, MAX_BATCH)
+        }
+    })
+}
 
 /// Result of a single datagram within a batch receive.
 #[derive(Debug, Clone, Copy)]
@@ -45,7 +68,7 @@ pub struct BatchDgram {
 // SAFETY: BatchDgram contains raw pointers in its iovec/msghdr arrays, which
 // is why the auto-impl of `Send` is denied. Those pointers are only valid
 // for the duration of a single recv_batch/send_batch call — they alias the
-// caller-supplied buffer slices, get filled in by `setup_recv`/`setup_send`,
+// caller-supplied buffer slices, get filled in by `setup_recv`/`send_batch_iter`,
 // and are passed to the kernel by the immediately-following syscall under
 // `&mut self`. Between calls they are stale and never dereferenced by Rust.
 // Moving the struct across threads therefore moves no live aliases. We
@@ -80,7 +103,22 @@ impl BatchDgram {
         }
     }
 
-    /// Receives up to `bufs.len()` datagrams (capped at [`MAX_BATCH`]) from `fd`.
+    /// The largest batch [`send_batch`](Self::send_batch) will issue on this
+    /// host: [`MAX_BATCH`] clamped to the live `kern.ipc.maxsendmsgx`.
+    #[must_use]
+    pub fn send_capacity() -> usize {
+        kernel_caps().0
+    }
+
+    /// The largest batch [`recv_batch`](Self::recv_batch) will issue on this
+    /// host: [`MAX_BATCH`] clamped to the live `kern.ipc.maxrecvmsgx`.
+    #[must_use]
+    pub fn recv_capacity() -> usize {
+        kernel_caps().1
+    }
+
+    /// Receives up to `bufs.len()` datagrams (capped at
+    /// [`recv_capacity`](Self::recv_capacity)) from `fd`.
     ///
     /// On success returns a slice of [`RxEntry`] whose length equals the
     /// number of datagrams received; `entries[i].len` is the byte length
@@ -94,7 +132,7 @@ impl BatchDgram {
     ///
     /// Returns `io::Error` for syscall failures, including `WouldBlock`.
     pub fn recv_batch(&mut self, fd: RawFd, bufs: &mut [&mut [u8]]) -> io::Result<&[RxEntry]> {
-        let count = bufs.len().min(MAX_BATCH);
+        let count = bufs.len().min(Self::recv_capacity());
         if count == 0 {
             return Ok(&[]);
         }
@@ -121,7 +159,8 @@ impl BatchDgram {
         &self.entries[..count]
     }
 
-    /// Sends up to `bufs.len()` datagrams (capped at [`MAX_BATCH`]) on `fd`.
+    /// Sends up to `bufs.len()` datagrams (capped at
+    /// [`send_capacity`](Self::send_capacity)) on `fd`.
     ///
     /// Returns the number of datagrams actually sent. `EINTR` is retried
     /// internally. Returns `Err(WouldBlock)` when the FD's send buffer is
@@ -132,12 +171,37 @@ impl BatchDgram {
     ///
     /// Returns `io::Error` for syscall failures, including `WouldBlock`.
     pub fn send_batch(&mut self, fd: RawFd, bufs: &[&[u8]]) -> io::Result<usize> {
-        let count = bufs.len().min(MAX_BATCH);
+        self.send_batch_iter(fd, bufs.iter().copied())
+    }
+
+    /// Sends up to [`send_capacity`](Self::send_capacity) datagrams yielded
+    /// by `bufs` on `fd`.
+    ///
+    /// The iterator form lets a caller feed a non-contiguous container (a
+    /// `VecDeque` of queued frames, say) straight into the pre-allocated
+    /// iovec array without materializing a `&[&[u8]]` slice first.
+    /// Otherwise identical to [`send_batch`](Self::send_batch).
+    ///
+    /// # Errors
+    ///
+    /// Returns `io::Error` for syscall failures, including `WouldBlock`.
+    pub fn send_batch_iter<'a, I>(&mut self, fd: RawFd, bufs: I) -> io::Result<usize>
+    where
+        I: IntoIterator<Item = &'a [u8]>,
+    {
+        let mut count = 0;
+        for buf in bufs.into_iter().take(Self::send_capacity()) {
+            self.iovecs[count] = libc::iovec {
+                iov_base: buf.as_ptr().cast_mut().cast(),
+                iov_len: buf.len(),
+            };
+            count += 1;
+        }
         if count == 0 {
             return Ok(0);
         }
 
-        self.setup_send(bufs, count);
+        self.setup_hdrs_send(count);
 
         self.platform_send(fd, count)
     }
@@ -152,16 +216,6 @@ impl BatchDgram {
             };
         }
         self.setup_hdrs_recv(count);
-    }
-
-    fn setup_send(&mut self, bufs: &[&[u8]], count: usize) {
-        for (i, buf) in bufs.iter().enumerate().take(count) {
-            self.iovecs[i] = libc::iovec {
-                iov_base: buf.as_ptr().cast_mut().cast(),
-                iov_len: buf.len(),
-            };
-        }
-        self.setup_hdrs_send(count);
     }
 
     // ── macOS implementation ───────────────────────────────────────────
@@ -546,27 +600,56 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
     }
 
+    /// The per-call caps come from the live sysctls, so a host that tuned
+    /// `kern.ipc.max{send,recv}msgx` down gets a shorter batch instead of the
+    /// `EINVAL` an unclamped `cnt` would earn.
+    #[test]
+    fn capacities_are_within_the_kernel_caps() {
+        for (cap, name) in [
+            (BatchDgram::send_capacity(), "kern.ipc.maxsendmsgx"),
+            (BatchDgram::recv_capacity(), "kern.ipc.maxrecvmsgx"),
+        ] {
+            assert!(
+                (1..=MAX_BATCH).contains(&cap),
+                "{name} capacity {cap} outside 1..={MAX_BATCH}"
+            );
+            #[cfg(target_os = "macos")]
+            assert!(cap <= read_sysctl(name), "{name} capacity {cap} exceeds it");
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn read_sysctl(name: &str) -> usize {
+        let out = std::process::Command::new("/usr/sbin/sysctl")
+            .arg("-n")
+            .arg(name)
+            .output()
+            .expect("sysctl");
+        String::from_utf8_lossy(&out.stdout).trim().parse().unwrap()
+    }
+
     #[test]
     fn test_max_batch_cap() {
-        // With more queued datagrams than `MAX_BATCH` and a longer `bufs`
-        // slice, a single `recv_batch` should return exactly `MAX_BATCH`
-        // entries — not the full `bufs.len()` and not less.
+        // With more queued datagrams than one call can take and a longer
+        // `bufs` slice, a single `recv_batch` should return exactly
+        // `recv_capacity()` entries — not the full `bufs.len()`, not less.
         let (a, b) = socketpair();
 
+        let cap = BatchDgram::recv_capacity();
         let extra = 10;
-        for _ in 0..MAX_BATCH + extra {
+        for _ in 0..cap + extra {
             write_datagram(a.as_raw_fd(), &[0xAA; 8]);
         }
 
-        let mut buffers: Vec<Vec<u8>> = (0..MAX_BATCH + extra * 2).map(|_| vec![0u8; 64]).collect();
+        let mut buffers: Vec<Vec<u8>> = (0..cap + extra * 2).map(|_| vec![0u8; 64]).collect();
         let mut bufs: Vec<&mut [u8]> = buffers.iter_mut().map(|b| b.as_mut_slice()).collect();
 
         let mut batch = BatchDgram::new();
         let entries = batch.recv_batch(b.as_raw_fd(), &mut bufs).unwrap();
         assert_eq!(
             entries.len(),
-            MAX_BATCH,
-            "first call must return exactly MAX_BATCH ({MAX_BATCH}) entries"
+            cap,
+            "first call must return exactly recv_capacity ({cap}) entries"
         );
         for entry in entries {
             assert_eq!(entry.len, 8);
@@ -610,6 +693,66 @@ mod tests {
         let send_bufs: Vec<&[u8]> = vec![];
         let sent = batch.send_batch(b.as_raw_fd(), &send_bufs).unwrap();
         assert_eq!(sent, 0);
+    }
+
+    /// `send_batch_iter` accepts a non-contiguous source (the shape the
+    /// datapath's pending-frame `VecDeque` has) and preserves send order.
+    #[test]
+    fn send_batch_iter_sends_from_a_non_contiguous_queue() {
+        let (a, b) = socketpair();
+
+        let mut queue: std::collections::VecDeque<Vec<u8>> = (0..8u8)
+            .map(|i| vec![i; 64])
+            .collect::<std::collections::VecDeque<_>>(
+        );
+        // Force a wrapped (two-slice) internal layout.
+        queue.rotate_left(3);
+
+        let mut batch = BatchDgram::new();
+        let sent = batch
+            .send_batch_iter(a.as_raw_fd(), queue.iter().map(Vec::as_slice))
+            .unwrap();
+        assert_eq!(sent, 8);
+
+        let mut buf = [0u8; 128];
+        for expected in &queue {
+            let n = read_datagram(b.as_raw_fd(), &mut buf);
+            assert_eq!(n, 64);
+            assert_eq!(buf[0], expected[0], "datagram order must be preserved");
+        }
+    }
+
+    /// A batch that overruns the peer's receive buffer is a **partial send**,
+    /// not a failure: the kernel reports how many datagrams it accepted and
+    /// leaves the rest untouched. Callers must requeue `bufs[n..]` and learn
+    /// the blocking errno from a follow-up call — the batch call itself
+    /// carries no errno once it has sent at least one datagram.
+    #[test]
+    fn partial_send_reports_accepted_count() {
+        let (a, b) = socketpair();
+        // Shrink both ends so a modest batch overruns the peer buffer.
+        set_buf_size(a.as_raw_fd(), libc::SO_SNDBUF, 8192);
+        set_buf_size(b.as_raw_fd(), libc::SO_RCVBUF, 8192);
+
+        let count = BatchDgram::send_capacity();
+        let payloads: Vec<Vec<u8>> = (0..count).map(|_| vec![0xEE; 2048]).collect();
+        let bufs: Vec<&[u8]> = payloads.iter().map(|p| p.as_slice()).collect();
+
+        let mut batch = BatchDgram::new();
+        let sent = batch.send_batch(a.as_raw_fd(), &bufs).unwrap();
+        assert!(
+            sent > 0 && sent < count,
+            "expected a partial send, got {sent}/{count}"
+        );
+
+        // The follow-up call is what surfaces the blocking errno.
+        let err = batch
+            .send_batch(a.as_raw_fd(), &bufs[sent..])
+            .expect_err("a full peer buffer must block the next batch");
+        assert!(
+            err.kind() == io::ErrorKind::WouldBlock || err.raw_os_error() == Some(libc::ENOBUFS),
+            "unexpected block errno: {err}"
+        );
     }
 
     #[test]

--- a/common/arcbox-xnu-net/src/batch.rs
+++ b/common/arcbox-xnu-net/src/batch.rs
@@ -128,6 +128,14 @@ impl BatchDgram {
     /// has no pending data — callers integrating with a readiness reactor
     /// rely on this to clear readiness.
     ///
+    /// **Size each buffer for the largest datagram the peer can send.** A
+    /// datagram that overruns its slot is truncated *silently*: XNU's
+    /// `recvmsg_x` leaves `msg_flags` zeroed rather than raising `MSG_TRUNC`
+    /// the way plain `recvmsg` would (measured on macOS 26.4), and the
+    /// iovecs are fixed before the syscall, so there is no way to notice
+    /// after the fact or to grow a slot mid-call. Regression:
+    /// `oversized_datagram_is_truncated_without_a_flag`.
+    ///
     /// # Errors
     ///
     /// Returns `io::Error` for syscall failures, including `WouldBlock`.
@@ -571,6 +579,33 @@ mod tests {
         for entry in entries.iter().take(3) {
             assert_eq!(entry.len, 50);
         }
+    }
+
+    /// XNU truncates an oversized datagram **without** setting `MSG_TRUNC`,
+    /// so a short `len` is the only trace and a full-slot `len` is
+    /// indistinguishable from a datagram that happened to fit. Callers must
+    /// size slots for the largest datagram the peer can send; this pins the
+    /// behaviour so a kernel that starts reporting it is noticed.
+    #[test]
+    fn oversized_datagram_is_truncated_without_a_flag() {
+        let (a, b) = socketpair();
+
+        write_datagram(a.as_raw_fd(), &[0x5A; 4096]);
+
+        let mut batch = BatchDgram::new();
+        let mut buf = vec![0u8; 1024];
+        let mut bufs: Vec<&mut [u8]> = vec![buf.as_mut_slice()];
+
+        let entries = batch.recv_batch(b.as_raw_fd(), &mut bufs).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].len, 1024, "only the slot's worth is delivered");
+
+        // The discarded 3072 bytes are gone — not left queued for a second
+        // call, which would at least be recoverable.
+        let err = batch
+            .recv_batch(b.as_raw_fd(), &mut bufs)
+            .expect_err("the truncated tail must not remain queued");
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
     }
 
     #[test]

--- a/common/arcbox-xnu-net/src/ffi.rs
+++ b/common/arcbox-xnu-net/src/ffi.rs
@@ -44,6 +44,35 @@ pub mod darwin {
         }
     }
 
+    /// Reads an integer `kern.ipc.max{send,recv}msgx` sysctl and clamps it to
+    /// [`MAX_BATCH`](crate::MAX_BATCH).
+    ///
+    /// Both sysctls default to 256 but are tunable **down**, and a batch call
+    /// with `cnt` above the live value fails outright with `EINVAL` instead of
+    /// degrading to a shorter batch — so the value has to be read, not assumed.
+    /// An unreadable or nonsensical sysctl falls back to 1, which is always
+    /// legal and reduces batching to the unbatched syscall rate.
+    pub fn sysctl_batch_cap(name: &std::ffi::CStr) -> usize {
+        let mut value: c_int = 0;
+        let mut len = std::mem::size_of::<c_int>();
+        // SAFETY: `name` is a valid NUL-terminated C string; `value`/`len` are
+        // a correctly sized out-parameter pair; the new-value pointer is null
+        // (read-only query).
+        let ret = unsafe {
+            libc::sysctlbyname(
+                name.as_ptr(),
+                (&raw mut value).cast(),
+                &raw mut len,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if ret != 0 || value <= 0 {
+            return 1;
+        }
+        (value as usize).min(crate::MAX_BATCH)
+    }
+
     // Symbols exported from libsystem_kernel.dylib. No syscall numbers needed.
     unsafe extern "C" {
         /// Receive up to `cnt` datagrams in a single syscall.

--- a/common/splicetcp/Cargo.toml
+++ b/common/splicetcp/Cargo.toml
@@ -14,6 +14,7 @@ arcbox-datapath = { workspace = true }
 arcbox-fakeip = { workspace = true }
 arcbox-packet = { workspace = true }
 arcbox-proxy = { workspace = true }
+arcbox-xnu-net.workspace = true
 crossbeam-channel = "0.5"
 libc = { workspace = true }
 socket2 = "0.6"

--- a/common/splicetcp/src/frame_source.rs
+++ b/common/splicetcp/src/frame_source.rs
@@ -9,8 +9,20 @@
 use std::io;
 use std::os::fd::RawFd;
 
+use arcbox_xnu_net::BatchDgram;
+
 /// Largest L2 frame we read from a source in a single `read`.
+///
+/// Also the batch-receive slot size: a datagram that overruns its slot is
+/// truncated silently (see [`BatchDgram::recv_batch_chunked`]), so this must
+/// stay at or above the largest datagram the peer can hand us.
 const MAX_FRAME_SIZE: usize = 65535;
+
+/// Frames one `recvmsg_x` collects. The backing buffer is
+/// `RX_BATCH * MAX_FRAME_SIZE` of zeroed — hence lazily faulted — address
+/// space, so the resident cost tracks the frames that actually arrive, not
+/// the reservation.
+const RX_BATCH: usize = 32;
 
 /// A source of inbound L2 Ethernet frames.
 ///
@@ -30,15 +42,20 @@ pub trait FrameSource {
     fn drain(&mut self, f: impl FnMut(&[u8]));
 }
 
-/// A [`FrameSource`] backed by a raw fd read with `libc::read`.
+/// A [`FrameSource`] backed by a raw `SOCK_DGRAM` fd read in batches.
 ///
-/// Suitable for any fd that delivers whole L2 frames per read — the VM's
-/// `SOCK_DGRAM` socketpair, or a `utun` once wrapped by the
-/// [`shim`](crate::shim). The fd must already be non-blocking; the datapath
-/// sets `O_NONBLOCK` before registering it for readiness.
+/// Suitable for a datagram fd that delivers whole L2 frames — the VM's
+/// `SOCK_DGRAM` socketpair. The fd must already be non-blocking; the
+/// datapath sets `O_NONBLOCK` before registering it for readiness.
+/// (A `utun` is L3 and has its own source,
+/// [`UtunFrameSource`](crate::utun::UtunFrameSource), wrapped for the
+/// classifier by the [`shim`](crate::shim).)
 pub struct FdFrameSource {
     fd: RawFd,
+    /// [`RX_BATCH`] back-to-back [`MAX_FRAME_SIZE`] slots.
     read_buf: Vec<u8>,
+    /// Pre-allocated `msghdr_x`/`iovec` arrays for the batched read.
+    batch: BatchDgram,
 }
 
 impl FdFrameSource {
@@ -49,7 +66,8 @@ impl FdFrameSource {
     pub fn new(fd: RawFd) -> Self {
         Self {
             fd,
-            read_buf: vec![0u8; MAX_FRAME_SIZE],
+            read_buf: vec![0u8; RX_BATCH * MAX_FRAME_SIZE],
+            batch: BatchDgram::new(),
         }
     }
 }
@@ -59,11 +77,34 @@ impl FrameSource for FdFrameSource {
         self.fd
     }
 
+    /// Collects up to [`RX_BATCH`] frames per syscall, and keeps going until
+    /// the fd would block.
+    ///
+    /// Draining to `WouldBlock` — rather than stopping on the first short
+    /// batch — is load-bearing: the caller clears read readiness afterwards,
+    /// so a frame that arrived mid-drain would otherwise sit unread until
+    /// the next unrelated wakeup.
     fn drain(&mut self, mut f: impl FnMut(&[u8])) {
+        let Self {
+            fd,
+            read_buf,
+            batch,
+        } = self;
         loop {
-            match fd_read(self.fd, &mut self.read_buf) {
-                Ok(n) if n > 0 => f(&self.read_buf[..n]),
-                Ok(_) => break,
+            match batch.recv_batch_chunked(*fd, read_buf, MAX_FRAME_SIZE) {
+                Ok(entries) => {
+                    if entries.is_empty() {
+                        break;
+                    }
+                    for (i, entry) in entries.iter().enumerate() {
+                        // A zero-length datagram carries no frame; skipping
+                        // it keeps the drain going, where a plain `read`
+                        // could not tell it from EOF.
+                        if entry.len > 0 {
+                            f(&read_buf[i * MAX_FRAME_SIZE..][..entry.len]);
+                        }
+                    }
+                }
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
                 Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
                 Err(e) => {
@@ -75,14 +116,111 @@ impl FrameSource for FdFrameSource {
     }
 }
 
-/// Reads from a file descriptor into `buf`, returning the number of bytes read.
-fn fd_read(fd: RawFd, buf: &mut [u8]) -> io::Result<usize> {
-    // SAFETY: reading into our own buffer from a valid fd.
-    let n = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
-    if n < 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        #[allow(clippy::cast_sign_loss)]
-        Ok(n as usize)
+#[cfg(test)]
+mod tests {
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+    use super::{FdFrameSource, FrameSource, MAX_FRAME_SIZE, RX_BATCH};
+
+    /// Non-blocking `AF_UNIX SOCK_DGRAM` pair with room for the test's frames.
+    fn socketpair() -> (OwnedFd, OwnedFd) {
+        let mut fds = [0i32; 2];
+        // SAFETY: `fds` is a valid 2-element array; AF_UNIX SOCK_DGRAM is
+        // universally supported.
+        let ret = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_DGRAM, 0, fds.as_mut_ptr()) };
+        assert_eq!(ret, 0, "socketpair failed");
+        for fd in fds {
+            let size: libc::c_int = 1024 * 1024;
+            for opt in [libc::SO_SNDBUF, libc::SO_RCVBUF] {
+                // SAFETY: setsockopt on a valid fd with a correctly sized payload.
+                unsafe {
+                    libc::setsockopt(
+                        fd,
+                        libc::SOL_SOCKET,
+                        opt,
+                        (&raw const size).cast(),
+                        std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+                    );
+                }
+            }
+            // SAFETY: fcntl on a valid fd.
+            unsafe {
+                let flags = libc::fcntl(fd, libc::F_GETFL);
+                libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+            }
+        }
+        // SAFETY: both fds are freshly created by socketpair and owned by us.
+        unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+    }
+
+    fn write_frame(fd: &OwnedFd, data: &[u8]) {
+        // SAFETY: writing our own buffer to a valid socketpair fd.
+        let n = unsafe { libc::write(fd.as_raw_fd(), data.as_ptr().cast(), data.len()) };
+        assert_eq!(n, data.len().cast_signed(), "short write");
+    }
+
+    /// Frame boundaries and ordering survive the batched read, including
+    /// across the batch edge — the drain must keep going past a full batch
+    /// or the caller's `clear_ready()` strands the remainder.
+    #[test]
+    fn drain_preserves_frame_boundaries_across_batches() {
+        let (host, guest) = socketpair();
+
+        let count = RX_BATCH + RX_BATCH / 2;
+        for i in 0..count {
+            write_frame(&guest, &vec![u8::try_from(i % 251).unwrap(); 100 + i]);
+        }
+
+        let mut source = FdFrameSource::new(host.as_raw_fd());
+        let mut seen: Vec<(usize, u8)> = Vec::new();
+        source.drain(|frame| seen.push((frame.len(), frame[0])));
+
+        assert_eq!(seen.len(), count, "every frame must be delivered");
+        for (i, &(len, tag)) in seen.iter().enumerate() {
+            assert_eq!(len, 100 + i, "frame {i} length");
+            assert_eq!(tag, u8::try_from(i % 251).unwrap(), "frame {i} order");
+        }
+    }
+
+    /// An empty source yields nothing and returns rather than spinning.
+    #[test]
+    fn drain_on_an_idle_fd_yields_nothing() {
+        let (host, _guest) = socketpair();
+
+        let mut source = FdFrameSource::new(host.as_raw_fd());
+        let mut count = 0;
+        source.drain(|_| count += 1);
+        assert_eq!(count, 0);
+    }
+
+    /// A zero-length datagram is skipped without ending the drain — a plain
+    /// `read` could not tell it from EOF.
+    #[test]
+    fn drain_skips_a_zero_length_datagram() {
+        let (host, guest) = socketpair();
+
+        write_frame(&guest, &[]);
+        write_frame(&guest, b"after the empty one");
+
+        let mut source = FdFrameSource::new(host.as_raw_fd());
+        let mut frames: Vec<Vec<u8>> = Vec::new();
+        source.drain(|frame| frames.push(frame.to_vec()));
+
+        assert_eq!(frames, vec![b"after the empty one".to_vec()]);
+    }
+
+    /// The largest frame the slot size admits round-trips intact.
+    #[test]
+    fn drain_delivers_a_max_size_frame() {
+        let (host, guest) = socketpair();
+
+        let frame: Vec<u8> = (0..MAX_FRAME_SIZE).map(|i| (i % 256) as u8).collect();
+        write_frame(&guest, &frame);
+
+        let mut source = FdFrameSource::new(host.as_raw_fd());
+        let mut got: Option<Vec<u8>> = None;
+        source.drain(|f| got = Some(f.to_vec()));
+
+        assert_eq!(got.as_deref(), Some(frame.as_slice()));
     }
 }

--- a/tests/e2e/src/boot_assets.rs
+++ b/tests/e2e/src/boot_assets.rs
@@ -408,7 +408,7 @@ pub fn stage_dev_boot_assets(root: &Path, data_dir: &Path, version: &str) -> Res
     // Seed the guest runtime binaries from an installed ArcBox so a bare test
     // daemon boots without reaching the CDN. Best-effort: prepare_binaries
     // downloads anything still missing.
-    stage_runtime_binaries(&data_dir.join("runtime/bin"));
+    stage_runtime_binaries(data_dir, version);
 
     // Then pre-seed runtime binaries staged in boot-assets/dev/runtime-bin
     // (put there by hand or by `boot-assets sync-binaries` in the sibling
@@ -444,17 +444,51 @@ pub fn stage_dev_boot_assets(root: &Path, data_dir: &Path, version: &str) -> Res
     Ok(())
 }
 
-/// Copies every guest runtime binary from the installed ArcBox's data dir into
-/// the test data dir, so the daemon's binary prepare finds them locally instead
-/// of downloading. Best-effort — anything still missing or version-mismatched
+/// Copies runtime binaries from the installed ArcBox's data dir into the test
+/// data dir, so the daemon's binary prepare finds them locally instead of
+/// downloading. Best-effort — anything still missing or version-mismatched
 /// falls back to the daemon's own download.
-fn stage_runtime_binaries(dest_dir: &Path) {
-    let src_dir = arcbox_constants::paths::ArcboxProfile::Production
+///
+/// **Two destinations, and they are not interchangeable.** Host tools
+/// (`docker`, `docker-compose`, …) live in the unversioned
+/// `<data_dir>/runtime/bin`, but the *guest* binaries (`dockerd`,
+/// `containerd`, `k3s`, `FEX`, …) are generation-scoped: `Runtime::init`
+/// prepares them into `<data_dir>/runtime/<boot version>/bin`. Seeding only
+/// the unversioned directory leaves the guest set entirely un-seeded, and
+/// every run re-downloads ~250 MB from the CDN — which silently turns each
+/// test's readiness budget into a bandwidth test.
+fn stage_runtime_binaries(data_dir: &Path, version: &str) {
+    let installed = arcbox_constants::paths::ArcboxProfile::Production
         .default_data_dir()
-        .join("runtime/bin");
-    let Ok(entries) = fs::read_dir(&src_dir) else {
+        .join("runtime");
+
+    stage_binary_dir(&installed.join("bin"), &data_dir.join("runtime/bin"));
+
+    // Prefer this generation's installed copy; fall back to the unversioned
+    // directory, which older installs used for guest binaries too. Either
+    // way the daemon checksum-verifies what it finds, so a stale file costs
+    // a re-download rather than a bad boot.
+    let versioned = installed.join(version).join("bin");
+    let guest_src = if versioned.is_dir() {
+        versioned
+    } else {
+        installed.join("bin")
+    };
+    stage_binary_dir(
+        &guest_src,
+        &data_dir.join("runtime").join(version).join("bin"),
+    );
+}
+
+/// Copies every regular file in `src_dir` into `dest_dir`, warning per file.
+fn stage_binary_dir(src_dir: &Path, dest_dir: &Path) {
+    let Ok(entries) = fs::read_dir(src_dir) else {
         return;
     };
+    if let Err(error) = fs::create_dir_all(dest_dir) {
+        warn!(dir = %dest_dir.display(), %error, "failed to create runtime binary dir");
+        return;
+    }
     for entry in entries.flatten() {
         let src = entry.path();
         if src.is_file() {

--- a/virt/arcbox-net/Cargo.toml
+++ b/virt/arcbox-net/Cargo.toml
@@ -37,6 +37,7 @@ hickory-proto = { version = "0.26.1", default-features = false, features = ["std
 
 [target.'cfg(target_os = "macos")'.dependencies]
 arcbox-vmnet = { workspace = true }
+arcbox-xnu-net.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/virt/arcbox-net/src/darwin/datapath_loop/guest_tx.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/guest_tx.rs
@@ -15,6 +15,17 @@
 //!   UDP, ICMP replies). The protocol above recovers from loss; bounded
 //!   queue overflow drops them.
 //!
+//! # Queue-then-flush
+//!
+//! [`GuestTx::send`] only enqueues; [`GuestTx::flush`] issues the syscalls.
+//! Everything queued within one event-loop iteration therefore leaves in a
+//! single batched `sendmsg_x` instead of one `write(2)` per frame — the
+//! iteration produces bursts (a fast-path poll returns every frame read
+//! from every host socket, a guest read burst produces one ACK per frame),
+//! and at 1500-byte frames a 10 Gbps link is ~833K frames/s, i.e. ~833K
+//! syscalls/s before batching (ABX-313). The event loop flushes on every
+//! iteration, so a frame never waits for a later wakeup.
+//!
 //! # macOS socketpair overflow semantics
 //!
 //! When the VZ side of the `SOCK_DGRAM` socketpair stops draining (guest RX
@@ -24,6 +35,11 @@
 //! back to writable in that state, so an ENOBUFS-blocked queue is drained by
 //! a short retry timer ([`NOBUFS_RETRY_DELAY`]) instead of
 //! `AsyncFd::writable()`; an `EAGAIN`-blocked queue uses write-readiness.
+//!
+//! `sendmsg_x` reports only how many datagrams it accepted, never an errno
+//! once it accepted at least one, so [`GuestTx::flush`] hands the first
+//! refusal to a single `write(2)` — that call carries the errno the
+//! blocked-state machine above needs.
 
 use std::collections::VecDeque;
 use std::io;
@@ -32,6 +48,7 @@ use std::os::fd::RawFd;
 use std::sync::Arc;
 use std::time::Duration;
 
+use arcbox_xnu_net::BatchDgram;
 use tokio::sync::mpsc;
 
 use crate::darwin::egress::HostEgress;
@@ -116,6 +133,10 @@ pub(super) struct GuestTxStats {
     pub queue_high_water: usize,
     /// Frames successfully written to the guest FD (or inject sink).
     pub tx_frames: u64,
+    /// Write syscalls issued to the guest FD (batched and single combined).
+    /// `tx_frames / tx_syscalls` is the realised batching factor — the
+    /// number ABX-313 exists to move.
+    pub tx_syscalls: u64,
 }
 
 /// Outcome of a single non-blocking write attempt.
@@ -134,8 +155,11 @@ pub(super) struct GuestTx {
     /// Inject-thread sink (HV backend). When set, frames bypass the
     /// socketpair entirely.
     frame_sink: Option<Arc<dyn FrameSink>>,
-    /// Frames awaiting socketpair capacity, in delivery order.
+    /// Frames awaiting delivery, in order. Emptied by [`GuestTx::flush`]
+    /// unless the guest FD refuses them.
     queue: VecDeque<FrameBuf>,
+    /// Pre-allocated `msghdr_x`/`iovec` arrays for the batched write.
+    batch: BatchDgram,
     /// Why the last write failed, if a backlog is pending.
     blocked: Option<WriteBlock>,
     /// Delivery counters.
@@ -149,14 +173,19 @@ impl GuestTx {
         Self {
             frame_sink,
             queue: VecDeque::new(),
+            batch: BatchDgram::new(),
             blocked: None,
             stats: GuestTxStats::default(),
         }
     }
 
-    /// True when frames are queued waiting for socketpair capacity. Bulk
+    /// True when frames the guest FD refused are still pending. Bulk
     /// producers (fast-path host-socket reads) must be gated on this so the
     /// backlog stays bounded and backpressure reaches the remote sender.
+    ///
+    /// Only meaningful **after** a [`flush`](Self::flush): between a
+    /// [`send`](Self::send) and the next flush the queue holds frames that
+    /// have not been offered to the FD yet, which is not backpressure.
     pub(super) fn has_backlog(&self) -> bool {
         !self.queue.is_empty()
     }
@@ -176,18 +205,18 @@ impl GuestTx {
         self.has_backlog()
     }
 
-    /// Sends one frame to the guest.
+    /// Queues one frame for the guest; [`flush`](Self::flush) delivers it.
     ///
-    /// Reliable frames always reach the guest FD eventually: they are
-    /// written directly when the queue is empty and queued otherwise. Lossy
-    /// frames follow the same path but are dropped (and counted) once
-    /// [`LOSSY_QUEUE_CAP`] frames are pending.
-    pub(super) fn send(&mut self, guest_fd: RawFd, frame: &[u8], class: DeliveryClass) {
+    /// Takes ownership so the frame moves into the queue (or into the inject
+    /// channel) without a copy. Reliable frames are never dropped here;
+    /// lossy frames are dropped (and counted) once [`LOSSY_QUEUE_CAP`]
+    /// frames are pending.
+    pub(super) fn send(&mut self, frame: Vec<u8>, class: DeliveryClass) {
         if let Some(sink) = &self.frame_sink {
             // Inject-thread path (HV): bounded channel, drop-on-full.
             // TODO(ABX-420): reliable frames need the lossless contract on
             // this path too; count failures so post-mortems can see them.
-            if sink.send(frame.to_vec()) {
+            if sink.send(frame) {
                 self.stats.tx_frames += 1;
             } else {
                 self.stats.sink_send_failures += 1;
@@ -196,30 +225,32 @@ impl GuestTx {
             return;
         }
 
-        if self.queue.is_empty() {
-            match self.try_write(guest_fd, frame) {
-                WriteOutcome::Consumed => {}
-                WriteOutcome::Blocked(block) => {
-                    self.blocked = Some(block);
-                    self.push(frame);
-                }
-            }
-            return;
-        }
-
-        // Backlog pending: append to preserve per-flow frame order.
         if class == DeliveryClass::Lossy && self.queue.len() >= LOSSY_QUEUE_CAP {
             self.stats.lossy_dropped += 1;
             tracing::debug!("Lossy queue cap ({LOSSY_QUEUE_CAP}) reached, dropping frame");
             return;
         }
-        self.push(frame);
+        self.queue.push_back(FrameBuf::from(frame));
+        self.stats.queue_high_water = self.stats.queue_high_water.max(self.queue.len());
     }
 
-    /// Drains the pending queue until it empties or the FD blocks again,
-    /// updating the blocked state accordingly.
-    pub(super) fn drain(&mut self, guest_fd: RawFd) {
+    /// Writes the pending queue to `guest_fd` until it empties or the FD
+    /// blocks, updating the blocked state accordingly.
+    ///
+    /// Two phases: batched `sendmsg_x` while more than one frame is pending,
+    /// then single `write(2)`s. The second phase both handles the tail and
+    /// is what classifies a refusal — see the module docs.
+    pub(super) fn flush(&mut self, guest_fd: RawFd) {
         self.blocked = None;
+
+        while self.queue.len() > 1 {
+            let sent = self.try_write_batch(guest_fd);
+            if sent == 0 {
+                break;
+            }
+            self.queue.drain(..sent);
+        }
+
         // Pop before writing (`try_write` needs `&mut self` for counters);
         // a blocked frame is pushed back to the front, preserving order.
         while let Some(frame) = self.queue.pop_front() {
@@ -234,8 +265,33 @@ impl GuestTx {
         }
     }
 
+    /// Offers the head of the queue to one `sendmsg_x`, returning how many
+    /// frames it accepted.
+    ///
+    /// `0` means the caller must fall back to a single write: a batch that
+    /// accepted nothing reports no usable errno (and one that accepted some
+    /// reports none at all), while the blocked-state machine needs to tell
+    /// `EAGAIN` from `ENOBUFS`.
+    fn try_write_batch(&mut self, guest_fd: RawFd) -> usize {
+        let Self {
+            queue,
+            batch,
+            stats,
+            ..
+        } = self;
+        stats.tx_syscalls += 1;
+        match batch.send_batch_iter(guest_fd, queue.iter().map(|frame| &**frame)) {
+            Ok(sent) => {
+                stats.tx_frames += sent as u64;
+                sent
+            }
+            Err(_) => 0,
+        }
+    }
+
     /// Attempts one non-blocking write of `frame` to `guest_fd`.
     fn try_write(&mut self, guest_fd: RawFd, frame: &[u8]) -> WriteOutcome {
+        self.stats.tx_syscalls += 1;
         match fd_write(guest_fd, frame) {
             Ok(n) if n >= frame.len() => {
                 self.stats.tx_frames += 1;
@@ -270,11 +326,6 @@ impl GuestTx {
         }
     }
 
-    fn push(&mut self, frame: &[u8]) {
-        self.queue.push_back(FrameBuf::from(frame.to_vec()));
-        self.stats.queue_high_water = self.stats.queue_high_water.max(self.queue.len());
-    }
-
     /// Logs a delivery-counter snapshot. Called from the maintenance tick;
     /// a backlog that persists across consecutive reports indicates a
     /// wedged drain, and `tx_frames` advancing while a connection is
@@ -287,6 +338,7 @@ impl GuestTx {
             queue_len = self.queue.len(),
             blocked = ?self.blocked,
             tx_frames = s.tx_frames,
+            tx_syscalls = s.tx_syscalls,
             rx_frames,
             enobufs = s.enobufs_events,
             would_block = s.would_block_events,
@@ -301,20 +353,16 @@ impl GuestTx {
     }
 }
 
-/// Non-blocking drain of the reply channel. Delivers pending proxy
-/// responses (DNS, UDP, ICMP) to the guest without blocking the event loop.
+/// Non-blocking drain of the reply channel. Queues pending proxy responses
+/// (DNS, UDP, ICMP) for the guest without blocking the event loop.
 ///
 /// Limits each call to `DRAIN_REPLY_BATCH` frames to avoid starving other
 /// `select!` branches.
-pub(super) fn drain_reply_rx(
-    reply_rx: &mut mpsc::Receiver<Vec<u8>>,
-    guest_tx: &mut GuestTx,
-    guest_fd: RawFd,
-) {
+pub(super) fn drain_reply_rx(reply_rx: &mut mpsc::Receiver<Vec<u8>>, guest_tx: &mut GuestTx) {
     for _ in 0..DRAIN_REPLY_BATCH {
         match reply_rx.try_recv() {
             Ok(reply_frame) => {
-                guest_tx.send(guest_fd, &reply_frame, DeliveryClass::Lossy);
+                guest_tx.send(reply_frame, DeliveryClass::Lossy);
             }
             Err(_) => break,
         }

--- a/virt/arcbox-net/src/darwin/datapath_loop/intercept.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/intercept.rs
@@ -1,5 +1,4 @@
 use std::net::{Ipv4Addr, SocketAddr};
-use std::os::fd::RawFd;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -20,7 +19,6 @@ use super::guest_tx::{DeliveryClass, GuestTx};
 pub(super) fn handle_intercepted_frame(
     intercepted: &crate::darwin::classifier::InterceptedFrame,
     guest_tx: &mut GuestTx,
-    guest_fd: RawFd,
     egress: &mut HostEgress,
     dhcp_server: &mut DhcpServer,
     dns_forwarder: &DnsForwarder,
@@ -38,7 +36,6 @@ pub(super) fn handle_intercepted_frame(
             handle_dhcp(
                 frame,
                 guest_tx,
-                guest_fd,
                 dhcp_server,
                 gateway_ip,
                 gateway_mac,
@@ -100,7 +97,6 @@ pub(super) fn process_inbound_cmd(
 fn handle_dhcp(
     frame: &[u8],
     guest_tx: &mut GuestTx,
-    guest_fd: RawFd,
     dhcp_server: &mut DhcpServer,
     gateway_ip: Ipv4Addr,
     gateway_mac: [u8; 6],
@@ -132,7 +128,7 @@ fn handle_dhcp(
             );
             for reply_frame in reply_frames {
                 tracing::info!("Sending DHCP reply frame: {} bytes", reply_frame.len());
-                guest_tx.send(guest_fd, &reply_frame, DeliveryClass::Lossy);
+                guest_tx.send(reply_frame, DeliveryClass::Lossy);
             }
         }
         Ok(None) => {

--- a/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/mod.rs
@@ -280,7 +280,7 @@ impl NetworkDatapath {
                 // receive buffer on a macOS AF_UNIX datagram socket.
                 writable = guest_async.writable(), if awaits_writable => {
                     let mut guard = writable?;
-                    guest_tx.drain(guest_raw_fd);
+                    guest_tx.flush(guest_raw_fd);
                     if guest_tx.awaits_writable() {
                         // Still blocked: clear readiness so the next poll
                         // waits for a fresh writability edge.
@@ -293,7 +293,7 @@ impl NetworkDatapath {
                 // EAGAIN, where a missed writability edge would otherwise
                 // wedge all guest-bound traffic permanently.
                 _ = nobufs_retry.tick(), if awaits_retry => {
-                    guest_tx.drain(guest_raw_fd);
+                    guest_tx.flush(guest_raw_fd);
                 }
 
                 // Guest → Host: read frames, classify, and dispatch.
@@ -325,7 +325,7 @@ impl NetworkDatapath {
                         tcp_bridge.try_fast_path_intercept(frame_data)
                     });
                     for ack in fast_acks {
-                        guest_tx.send(guest_raw_fd, &ack, DeliveryClass::Reliable);
+                        guest_tx.send(ack, DeliveryClass::Reliable);
                     }
 
                     // Handshake intercept: complete in-progress shim handshakes
@@ -336,12 +336,12 @@ impl NetworkDatapath {
                         tcp_bridge.try_complete_handshake(frame_data)
                     });
                     for reply in hs_replies {
-                        guest_tx.send(guest_raw_fd, &reply, DeliveryClass::Reliable);
+                        guest_tx.send(reply, DeliveryClass::Reliable);
                     }
 
                     // Flush ARP replies produced inline by the classifier.
                     for reply in device.take_arp_replies() {
-                        guest_tx.send(guest_raw_fd, &reply, DeliveryClass::Lossy);
+                        guest_tx.send(reply, DeliveryClass::Lossy);
                     }
 
                     // Discard any TCP frames left in the rx queue that didn't
@@ -355,7 +355,6 @@ impl NetworkDatapath {
                         handle_intercepted_frame(
                             intercepted_frame,
                             &mut guest_tx,
-                            guest_raw_fd,
                             &mut egress,
                             &mut dhcp_server,
                             &dns_forwarder,
@@ -377,7 +376,7 @@ impl NetworkDatapath {
                     let gmac = guest_mac.unwrap_or([0xFF; 6]);
                     for syn in &gated_syns {
                         if let Some(rst) = tcp_bridge.handle_outbound_syn(&syn.frame, gateway_mac, gmac) {
-                            guest_tx.send(guest_raw_fd, &rst, DeliveryClass::Reliable);
+                            guest_tx.send(rst, DeliveryClass::Reliable);
                         }
                     }
 
@@ -387,7 +386,7 @@ impl NetworkDatapath {
                 // Always poll — the bounded channel (256) provides natural backpressure
                 // to spawned tasks. Gating on backlog depth starved DNS replies.
                 Some(reply_frame) = reply_rx.recv() => {
-                    guest_tx.send(guest_raw_fd, &reply_frame, DeliveryClass::Lossy);
+                    guest_tx.send(reply_frame, DeliveryClass::Lossy);
                 }
 
                 // Inbound commands from InboundListenerManager.
@@ -453,7 +452,7 @@ impl NetworkDatapath {
             //    active-open (ActiveOpen), and retransmits under loss.
             let hs_frames = tcp_bridge.poll_handshakes();
             for frame in hs_frames {
-                guest_tx.send(guest_raw_fd, &frame, DeliveryClass::Reliable);
+                guest_tx.send(frame, DeliveryClass::Reliable);
             }
 
             // 1.5. Drain inbound listener commands so `cmd_rx.recv()` cannot be
@@ -467,7 +466,15 @@ impl NetworkDatapath {
                 guest_mac,
             );
 
-            // 2. Poll fast-path host streams for inbound data and inject
+            // 2. Flush everything queued so far (this iteration's ACKs,
+            //    handshake frames and intercept replies) in one batched
+            //    write. This must precede the gate below: `has_backlog` only
+            //    means backpressure once the frames have been offered to the
+            //    guest FD — before a flush it is merely "produced this
+            //    iteration", which would gate the poll on every pass.
+            guest_tx.flush(guest_raw_fd);
+
+            // 3. Poll fast-path host streams for inbound data and inject
             //    constructed frames directly to guest — but only when no
             //    backlog is pending. Skipping the poll leaves host-socket
             //    data in the host kernel's receive buffer, closing the
@@ -479,11 +486,15 @@ impl NetworkDatapath {
                 guest_tx.stats.gated_polls += 1;
             } else {
                 for frame in tcp_bridge.poll_fast_path() {
-                    guest_tx.send(guest_raw_fd, &frame, DeliveryClass::Reliable);
+                    guest_tx.send(frame, DeliveryClass::Reliable);
                 }
             }
 
-            drain_reply_rx(&mut reply_rx, &mut guest_tx, guest_raw_fd);
+            // 4. Second flush: the fast-path frames and proxy replies queued
+            //    since the flush above. Frames therefore never wait for a
+            //    later loop iteration to reach the guest.
+            drain_reply_rx(&mut reply_rx, &mut guest_tx);
+            guest_tx.flush(guest_raw_fd);
 
             // Yield to the tokio runtime so spawned tasks (e.g. host relay
             // read/write) get a chance to run on this worker thread. Without

--- a/virt/arcbox-net/src/darwin/datapath_loop/tests.rs
+++ b/virt/arcbox-net/src/darwin/datapath_loop/tests.rs
@@ -37,8 +37,9 @@ fn shrink_socket_buffers(fd: RawFd) {
 fn send_until_backlog(tx: &mut GuestTx, fd: RawFd, frame: &[u8]) -> usize {
     let mut sent = 0usize;
     for _ in 0..10_000 {
-        tx.send(fd, frame, DeliveryClass::Reliable);
+        tx.send(frame.to_vec(), DeliveryClass::Reliable);
         sent += 1;
+        tx.flush(fd);
         if tx.has_backlog() {
             return sent;
         }
@@ -101,22 +102,51 @@ fn test_fd_write_roundtrip() {
 }
 
 #[test]
-fn guest_tx_direct_write_when_unblocked() {
+fn guest_tx_flush_delivers_a_queued_frame() {
     let (a, b) = socketpair();
     set_nonblocking(a.as_raw_fd()).unwrap();
 
     let mut tx = GuestTx::new(None);
-    let frame_data = b"direct write frame";
-    tx.send(a.as_raw_fd(), frame_data, DeliveryClass::Reliable);
+    let frame_data = b"queued frame".to_vec();
+    tx.send(frame_data.clone(), DeliveryClass::Reliable);
+    assert_eq!(tx.stats.tx_syscalls, 0, "send must not touch the fd");
 
-    assert!(
-        !tx.has_backlog(),
-        "queue should be empty after direct write"
-    );
+    tx.flush(a.as_raw_fd());
+    assert!(!tx.has_backlog(), "queue should be empty after a flush");
 
     let mut buf = [0u8; 128];
     let n = fd_read(b.as_raw_fd(), &mut buf).unwrap();
     assert_eq!(&buf[..n], frame_data.as_slice());
+}
+
+/// The point of ABX-313: a burst produced within one event-loop iteration
+/// costs one syscall, not one per frame — and still arrives in order.
+#[test]
+fn guest_tx_flush_batches_a_burst_into_one_syscall() {
+    let (a, b) = socketpair();
+    set_nonblocking(a.as_raw_fd()).unwrap();
+
+    let mut tx = GuestTx::new(None);
+    const BURST: u8 = 32;
+    for i in 0..BURST {
+        tx.send(vec![i; 64], DeliveryClass::Reliable);
+    }
+
+    tx.flush(a.as_raw_fd());
+
+    assert!(!tx.has_backlog(), "the whole burst should fit");
+    assert_eq!(u64::from(BURST), tx.stats.tx_frames);
+    assert_eq!(
+        tx.stats.tx_syscalls, 1,
+        "{BURST} frames must cost a single sendmsg_x"
+    );
+
+    let mut buf = [0u8; 128];
+    for i in 0..BURST {
+        let n = fd_read(b.as_raw_fd(), &mut buf).unwrap();
+        assert_eq!(n, 64);
+        assert_eq!(buf[0], i, "batched frames must arrive in send order");
+    }
 }
 
 /// Regression test for the container-egress black hole: when the socketpair
@@ -140,14 +170,15 @@ fn guest_tx_reliable_survives_socketpair_overflow() {
         f
     };
 
+    // Queue in bursts so the batched write — not just the single-write
+    // fallback — is what overruns the socketpair.
     let mut sent = 0usize;
-    for _ in 0..10_000 {
-        tx.send(
-            a.as_raw_fd(),
-            &make_frame(sent as u32),
-            DeliveryClass::Reliable,
-        );
-        sent += 1;
+    for _ in 0..1_000 {
+        for _ in 0..16 {
+            tx.send(make_frame(sent as u32), DeliveryClass::Reliable);
+            sent += 1;
+        }
+        tx.flush(a.as_raw_fd());
         if tx.has_backlog() {
             break;
         }
@@ -158,11 +189,7 @@ fn guest_tx_reliable_survives_socketpair_overflow() {
     assert!(tx.awaits_retry(), "backlog must arm the retry timer");
     // Keep producing while blocked — everything must queue.
     for _ in 0..16 {
-        tx.send(
-            a.as_raw_fd(),
-            &make_frame(sent as u32),
-            DeliveryClass::Reliable,
-        );
+        tx.send(make_frame(sent as u32), DeliveryClass::Reliable);
         sent += 1;
     }
 
@@ -184,7 +211,7 @@ fn guest_tx_reliable_survives_socketpair_overflow() {
             received += 1;
             progressed = true;
         }
-        tx.drain(a.as_raw_fd());
+        tx.flush(a.as_raw_fd());
         if !progressed {
             idle_rounds += 1;
         }
@@ -216,7 +243,7 @@ fn guest_tx_lossy_capped_reliable_uncapped() {
     send_until_backlog(&mut tx, a.as_raw_fd(), &frame);
 
     for _ in 0..(LOSSY_QUEUE_CAP + 100) {
-        tx.send(a.as_raw_fd(), &frame, DeliveryClass::Lossy);
+        tx.send(frame.clone(), DeliveryClass::Lossy);
     }
     assert!(
         tx.stats.lossy_dropped >= 100,
@@ -225,7 +252,7 @@ fn guest_tx_lossy_capped_reliable_uncapped() {
     );
 
     let hwm_before = tx.stats.queue_high_water;
-    tx.send(a.as_raw_fd(), &frame, DeliveryClass::Reliable);
+    tx.send(frame.clone(), DeliveryClass::Reliable);
     assert!(
         tx.stats.queue_high_water > hwm_before,
         "reliable frames must still be accepted past the lossy cap"


### PR DESCRIPTION
Closes #194 (ABX-313).

Every frame the macOS datapath exchanged with the guest socketpair cost its own syscall — one `write(2)` per guest-bound frame, one `read(2)` per guest-sourced frame. At 1500-byte frames a 10 Gbps link is ~833K frames/s in each direction.

Both directions now go through `arcbox-xnu-net`, the batch-datagram crate that has been sitting in the workspace with zero consumers since it was written.

## Measured

One `network_iperf` run on real VZ hardware, from the daemon's own `guest-tx delivery counters`:

```
tx_frames 7,185,256   tx_syscalls 182,687   -> 39.3 frames per syscall
rx_frames 4,295,448
enobufs 0  would_block 0  lossy_dropped 0  short_writes 0  io_errors 0
gated_polls 0         queue_high_water 9,776
```

That is a **97.5% cut in guest-bound write syscalls** (7.19M -> 183K). The counters also say the delivery contract held: zero drops, zero short writes, zero blocked writes.

`gated_polls: 0` is the load-bearing one. The fast-path poll is gated on `has_backlog()`, which only means *backpressure* once the frames have been offered to the fd — so the tail flush has to happen **before** that gate. Flushing after it would make every iteration look backed up and starve the poll; this counter is what proves it doesn't.

This PR does **not** claim a throughput change. The measured ceilings on this path live elsewhere (`docs/net-perf-limits.md`), and VZ throughput is too run-to-run variable to attribute a delta without a same-day A/B. The syscall count is the claim.

## TX — `GuestTx` becomes queue-then-flush

`send` now only enqueues; the new `flush` issues the syscalls. Everything an event-loop iteration produces (a fast-path poll returns every frame read from every host socket; a guest read burst produces one ACK per frame) leaves in one `sendmsg_x`. The loop flushes twice per iteration, so a frame never waits for a later wakeup.

Taking the frame by value also drops the `to_vec` that both the pending queue and the HV inject sink used to do.

`sendmsg_x` reports only an accepted count, and carries **no errno** once it accepted anything — so `flush` hands the first refusal to a single `write(2)`, which is what the `EAGAIN`-vs-`ENOBUFS` blocked-state machine needs. Both halves of the existing contract are intact: reliable frames are still never dropped, and `has_backlog` still means backpressure.

New counter `tx_syscalls`; `tx_frames / tx_syscalls` is the realised batching factor, readable from any running daemon.

## RX — `FdFrameSource::drain` collects 32 frames per syscall

Via a new `recv_batch_chunked`, which fills the pre-allocated iovec array straight from a slab of fixed slots — a `chunks_mut` slice would allocate on every syscall.

The drain still runs to `WouldBlock` rather than stopping at the first short batch: the datapath clears read readiness right afterwards, so a frame that arrived mid-drain would otherwise wait for an unrelated wakeup.

The `utun` host-tunnel harness is untouched — it has its own L3 `UtunFrameSource`.

## Kernel behaviour this pinned down

Two XNU semantics that are not in any man page, both now covered by tests:

- **`recvmsg_x` truncates an oversized datagram silently.** It leaves `msg_flags` zeroed instead of raising `MSG_TRUNC` the way plain `recvmsg` does (measured macOS 26.4), and the discarded tail is not left queued. A short `len` is the only trace, and a full-slot `len` is indistinguishable from a datagram that fit. This is why `MAX_FRAME_SIZE` stays 65535 — slots must cover the largest datagram the peer can send, and cannot grow mid-call.
- **An overrunning `sendmsg_x` is a partial send, not an error** — it returns the accepted count and no errno, so the caller must requeue the remainder and learn *why* from a follow-up call.

`kern.ipc.max{send,recv}msgx` are read once per process and every call is clamped to them. The crate previously told each caller to do this itself, which no caller could without duplicating the sysctl read; a batch above the live value fails with `EINVAL` rather than shortening.

## Drive-by: e2e was re-downloading 250 MB per run

`stage_runtime_binaries` copied into `<data_dir>/runtime/bin`, but `Runtime::init` prepares guest binaries into `<data_dir>/runtime/<boot version>/bin`. Only the *host* tools live in the unversioned directory, so the guest set — dockerd, containerd, k3s, FEX, runc — was never seeded, and every e2e run fetched it from the CDN.

That silently turns each test's readiness budget into a bandwidth test. On a slow link it cost me two `timed out after 180s waiting for READY` failures with the daemon quietly mid-`dockerd` download, which reads exactly like a boot wedge. With the generation directory seeded the same test reaches READY in ~16 s.

## Validation

- `cargo test` — 230 pass across `arcbox-xnu-net`, `splicetcp`, `arcbox-net`. 12 new, each pinning a contract rather than an implementation: batched send order, partial-send semantics, silent truncation, chunked slotting, burst-in-one-syscall, and reliable-frame ordering across a socketpair overflow.
- `cargo clippy --all-targets` — zero warnings.
- `ARCBOX_VM_BACKEND=vz cargo test -p arcbox-e2e --test network_iperf -- --ignored` — green, all 8 matrix cells live (2.5–5.4 Gbps), plus the counters above.
