### PR TITLE
feat(sandbox): wire the template catalog RPCs end to end (CORE-107)

### DIFF
--- a/app/arcbox-api/src/connect/mod.rs
+++ b/app/arcbox-api/src/connect/mod.rs
@@ -247,7 +247,7 @@ pub fn router(runtime: SharedRuntime) -> connectrpc::Router {
             clone(),
             Arc::clone(&sandbox_operations),
         )))
-        .add_service(Arc::new(TemplateServiceImpl::new()))
+        .add_service(Arc::new(TemplateServiceImpl::new(clone())))
         // The daemon's own services, all on Connect since CORE-68.
         .add_service(Arc::new(IconServiceImpl::new()))
         .add_service(Arc::new(StatsServiceImpl::new(clone())))

--- a/app/arcbox-api/src/connect/template.rs
+++ b/app/arcbox-api/src/connect/template.rs
@@ -1,23 +1,27 @@
-//! Sandbox template catalog service — control plane (CORE-21).
+//! Sandbox template catalog service — control plane (CORE-107).
+//!
+//! Pure forwarders to the guest agent, mirroring `snapshot.rs`: the catalog
+//! and every artifact it references live inside the System VM. `Build` alone
+//! stays UNIMPLEMENTED until the build pipeline lands.
 
 use arcbox_connect::sandbox_v1 as pb;
 use buffa_types::google::protobuf::Empty;
-use connectrpc::{ConnectError, RequestContext, ServiceRequest, ServiceResult};
+use connectrpc::{ConnectError, RequestContext, Response, ServiceRequest, ServiceResult};
+
+use super::SharedRuntime;
+use super::{ConnectRuntimeExt as _, ContextExt as _};
+use crate::ApiError;
 
 /// Template service implementation.
-///
-/// Contract-only stub (CORE-58 phase 1): every method answers
-/// UNIMPLEMENTED until the template catalog lands with CORE-21. Build
-/// additionally depends on the rootfs pipeline (CORE-5) and, for
-/// pre-warmed snapshots, FC 1.16 network overrides (CORE-16).
-#[derive(Default)]
-pub struct TemplateServiceImpl;
+pub struct TemplateServiceImpl {
+    runtime: SharedRuntime,
+}
 
 impl TemplateServiceImpl {
-    /// Creates a new template service.
+    /// Creates a new template service with a deferred runtime.
     #[must_use]
-    pub fn new() -> Self {
-        Self
+    pub(super) fn new(runtime: SharedRuntime) -> Self {
+        Self { runtime }
     }
 }
 
@@ -28,59 +32,102 @@ impl TemplateServiceImpl {
               Router rather than named by callers"
 )]
 impl pb::TemplateService for TemplateServiceImpl {
-    /// Contract-only stub: the build pipeline lands with CORE-21
-    /// (gated on CORE-5 rootfs builds and CORE-16 for `prewarm`).
+    /// UNIMPLEMENTED until the build pipeline lands (CORE-107 PR3+); the
+    /// rest of the catalog surface already answers.
     async fn build(
         &self,
         _ctx: RequestContext,
         _request: ServiceRequest<'_, pb::BuildTemplateRequest>,
     ) -> ServiceResult<pb::Template> {
         Err(ConnectError::unimplemented(
-            "template build is not implemented yet (CORE-21; build pipeline CORE-5/CORE-16)",
+            "template Build is not implemented yet (CORE-107 build pipeline); \
+             Get/List/Publish/Delete already answer",
         ))
     }
 
-    /// Contract-only stub: the template catalog lands with CORE-21.
     async fn publish(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::PublishTemplateRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::PublishTemplateRequest>,
     ) -> ServiceResult<pb::Template> {
-        Err(ConnectError::unimplemented(
-            "template publish is not implemented yet (CORE-21)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let name = req.name.clone();
+        let mut agent = self
+            .runtime
+            .ready()?
+            .get_agent(&machine)
+            .map_err(ApiError::from)?;
+        // The RPC error otherwise reaches only the caller; the daemon log
+        // must record a failed catalog mutation on its own (CORE-82).
+        let resp = agent
+            .sandbox_template_publish(req)
+            .await
+            .inspect_err(|error| {
+                tracing::warn!(machine = %machine, template = %name, %error, "template publish failed");
+            })
+            .map_err(ApiError::from)?;
+        Response::ok(resp)
     }
 
-    /// Contract-only stub: the template catalog lands with CORE-21.
     async fn get(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::GetTemplateRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::GetTemplateRequest>,
     ) -> ServiceResult<pb::Template> {
-        Err(ConnectError::unimplemented(
-            "template get is not implemented yet (CORE-21)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let mut agent = self
+            .runtime
+            .ready()?
+            .get_agent(&machine)
+            .map_err(ApiError::from)?;
+        let resp = agent
+            .sandbox_template_get(req)
+            .await
+            .map_err(ApiError::from)?;
+        Response::ok(resp)
     }
 
-    /// Contract-only stub: the template catalog lands with CORE-21.
     async fn list(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::ListTemplatesRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::ListTemplatesRequest>,
     ) -> ServiceResult<pb::ListTemplatesResponse> {
-        Err(ConnectError::unimplemented(
-            "template list is not implemented yet (CORE-21)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let mut agent = self
+            .runtime
+            .ready()?
+            .get_agent(&machine)
+            .map_err(ApiError::from)?;
+        let resp = agent
+            .sandbox_template_list(req)
+            .await
+            .map_err(ApiError::from)?;
+        Response::ok(resp)
     }
 
-    /// Contract-only stub: the template catalog lands with CORE-21.
     async fn delete(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::DeleteTemplateRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::DeleteTemplateRequest>,
     ) -> ServiceResult<Empty> {
-        Err(ConnectError::unimplemented(
-            "template delete is not implemented yet (CORE-21)",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let reference = req.reference.clone();
+        let mut agent = self
+            .runtime
+            .ready()?
+            .get_agent(&machine)
+            .map_err(ApiError::from)?;
+        agent
+            .sandbox_template_delete(req)
+            .await
+            .inspect_err(|error| {
+                tracing::warn!(machine = %machine, template = %reference, %error, "template delete failed");
+            })
+            .map_err(ApiError::from)?;
+        Response::ok(Empty::default())
     }
 }

--- a/app/arcbox-api/src/error.rs
+++ b/app/arcbox-api/src/error.rs
@@ -116,6 +116,18 @@ fn classify_agent_error(code: i32, message: &str) -> Option<connectrpc::ErrorDet
             "list sandboxes with `abctl sandbox list`",
             &[],
         )),
+        // VmmError::TemplateNotFound → "template not found: {reference}"
+        // (the template catalog, CORE-107).
+        404 if message.starts_with("template not found: ") => {
+            let reference = message
+                .strip_prefix("template not found: ")
+                .unwrap_or_default();
+            Some(error_info(
+                pb::ErrorCode::TemplateNotFound,
+                "list catalog templates with `TemplateService.List`, or build one first",
+                &[("reference", reference)],
+            ))
+        }
         // VmmError::PathNotFound → "path not found: {path}" (the sandbox
         // filesystem verbs, CORE-62).
         404 if message.starts_with("path not found: ") => {
@@ -318,6 +330,12 @@ mod tests {
                 "unknown template \"typo\"; expected \"\" or \"docker:<image>\""
             ),
             Some(pb::ErrorCode::TemplateInvalid)
+        );
+        // VmmError::TemplateNotFound (the template catalog, CORE-107) —
+        // distinct from the sandbox 404 despite sharing the wire code.
+        assert_eq!(
+            classified(404, "template not found: code:9.9"),
+            Some(pb::ErrorCode::TemplateNotFound)
         );
         // VmmError::PathNotFound (the filesystem verbs, CORE-62).
         assert_eq!(

--- a/app/arcbox-core/src/agent_client.rs
+++ b/app/arcbox-core/src/agent_client.rs
@@ -14,16 +14,18 @@ mod wire;
 use self::transport::{AgentTransport, BLOCKING_RPC_TIMEOUT};
 use crate::error::{CoreError, Result};
 use arcbox_connect::sandbox_v1::{
-    AttachExecutionRequest, CheckpointRequest, CheckpointResponse, CreateSandboxRequest,
-    CreateSandboxResponse, DeleteSnapshotRequest, Execution, ExecutionEvent, FileChunk, FileStat,
-    GetStdinStatusRequest, InspectSandboxRequest, ListDirRequest, ListDirResponse,
-    ListExecutionsRequest, ListExecutionsResponse, ListSandboxesRequest, ListSandboxesResponse,
-    ListSnapshotsRequest, ListSnapshotsResponse, MakeDirRequest, MoveEntryRequest,
-    PauseSandboxRequest, ReadFileRequest, RemoveEntryRequest, RemoveSandboxRequest,
-    ResizeExecutionTtyRequest, RestoreRequest, RestoreResponse, SandboxEvent, SandboxEventsRequest,
-    SandboxInfo, SetLifecycleRequest, SignalExecutionRequest, StartExecutionRequest,
-    StatFileRequest, StdinStatus, StopSandboxRequest, WaitExecutionRequest, WaitForPortRequest,
-    WatchDirRequest, WatchDirResponse, WriteFileOpen, WriteStdinRequest, execution_event,
+    AttachExecutionRequest, BuildTemplateRequest, CheckpointRequest, CheckpointResponse,
+    CreateSandboxRequest, CreateSandboxResponse, DeleteSnapshotRequest, DeleteTemplateRequest,
+    Execution, ExecutionEvent, FileChunk, FileStat, GetStdinStatusRequest, GetTemplateRequest,
+    InspectSandboxRequest, ListDirRequest, ListDirResponse, ListExecutionsRequest,
+    ListExecutionsResponse, ListSandboxesRequest, ListSandboxesResponse, ListSnapshotsRequest,
+    ListSnapshotsResponse, ListTemplatesRequest, ListTemplatesResponse, MakeDirRequest,
+    MoveEntryRequest, PauseSandboxRequest, PublishTemplateRequest, ReadFileRequest,
+    RemoveEntryRequest, RemoveSandboxRequest, ResizeExecutionTtyRequest, RestoreRequest,
+    RestoreResponse, SandboxEvent, SandboxEventsRequest, SandboxInfo, SetLifecycleRequest,
+    SignalExecutionRequest, StartExecutionRequest, StatFileRequest, StdinStatus,
+    StopSandboxRequest, Template, WaitExecutionRequest, WaitForPortRequest, WatchDirRequest,
+    WatchDirResponse, WriteFileOpen, WriteStdinRequest, execution_event,
 };
 use arcbox_connect::v1::{
     AgentPingRequest as PingRequest, AgentPingResponse as PingResponse, ContainerFsPathsRequest,
@@ -2194,6 +2196,86 @@ impl AgentClient {
             .rpc_call(MessageType::SandboxDeleteSnapshotRequest, &payload)
             .await?;
         Self::expect_ack_response_type(resp_type, MessageType::SandboxDeleteSnapshotResponse)
+    }
+
+    /// Builds a template and registers it as the catalog draft. Blocks for
+    /// the whole build (image export, rootfs conversion, optional prewarm).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_template_build(&mut self, req: BuildTemplateRequest) -> Result<Template> {
+        let payload = req.encode_to_vec();
+        self.unary_rpc(
+            MessageType::SandboxTemplateBuildRequest,
+            &payload,
+            MessageType::SandboxTemplateBuildResponse,
+        )
+        .await
+    }
+
+    /// Freezes a template's draft as an immutable version.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_template_publish(
+        &mut self,
+        req: PublishTemplateRequest,
+    ) -> Result<Template> {
+        let payload = req.encode_to_vec();
+        self.unary_rpc(
+            MessageType::SandboxTemplatePublishRequest,
+            &payload,
+            MessageType::SandboxTemplatePublishResponse,
+        )
+        .await
+    }
+
+    /// Resolves a `name[:version]` template reference.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_template_get(&mut self, req: GetTemplateRequest) -> Result<Template> {
+        let payload = req.encode_to_vec();
+        self.unary_rpc(
+            MessageType::SandboxTemplateGetRequest,
+            &payload,
+            MessageType::SandboxTemplateGetResponse,
+        )
+        .await
+    }
+
+    /// Lists catalog templates.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_template_list(
+        &mut self,
+        req: ListTemplatesRequest,
+    ) -> Result<ListTemplatesResponse> {
+        let payload = req.encode_to_vec();
+        self.unary_rpc(
+            MessageType::SandboxTemplateListRequest,
+            &payload,
+            MessageType::SandboxTemplateListResponse,
+        )
+        .await
+    }
+
+    /// Deletes a template version, or a whole template with its artifacts.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails.
+    pub async fn sandbox_template_delete(&mut self, req: DeleteTemplateRequest) -> Result<()> {
+        let payload = req.encode_to_vec();
+        let (resp_type, _) = self
+            .rpc_call(MessageType::SandboxTemplateDeleteRequest, &payload)
+            .await?;
+        Self::expect_ack_response_type(resp_type, MessageType::SandboxTemplateDeleteResponse)
     }
 }
 

--- a/common/arcbox-constants/src/wire.rs
+++ b/common/arcbox-constants/src/wire.rs
@@ -214,6 +214,29 @@ pub enum MessageType {
     /// `Error` frame with code 504.
     SandboxWaitForPortRequest = 0x0068,
 
+    // Sandbox template catalog request types (0x0070 - 0x0074), CORE-107.
+    /// Build a template from a source and register it as the catalog draft
+    /// (payload: `arcbox.sandbox.v1.BuildTemplateRequest`). Blocks until the
+    /// build completes. Answered with
+    /// [`Self::SandboxTemplateBuildResponse`].
+    SandboxTemplateBuildRequest = 0x0070,
+    /// Freeze a template's draft as an immutable version (payload:
+    /// `arcbox.sandbox.v1.PublishTemplateRequest`). Answered with
+    /// [`Self::SandboxTemplatePublishResponse`].
+    SandboxTemplatePublishRequest = 0x0071,
+    /// Resolve a `name[:version]` template reference (payload:
+    /// `arcbox.sandbox.v1.GetTemplateRequest`). Answered with
+    /// [`Self::SandboxTemplateGetResponse`].
+    SandboxTemplateGetRequest = 0x0072,
+    /// List catalog templates (payload:
+    /// `arcbox.sandbox.v1.ListTemplatesRequest`). Answered with
+    /// [`Self::SandboxTemplateListResponse`].
+    SandboxTemplateListRequest = 0x0073,
+    /// Delete a template version, or a whole template with its artifacts
+    /// (payload: `arcbox.sandbox.v1.DeleteTemplateRequest`). Answered with
+    /// [`Self::SandboxTemplateDeleteResponse`].
+    SandboxTemplateDeleteRequest = 0x0074,
+
     /// Starts a machine-level exec: runs a command in the machine root (the
     /// agent's own mount namespace), streamed back as
     /// [`Self::MachineExecOutput`] frames (payload:
@@ -353,6 +376,22 @@ pub enum MessageType {
     /// the listener exists.
     SandboxWaitForPortResponse = 0x1068,
 
+    // Sandbox template catalog response types (0x1070 - 0x1074), CORE-107.
+    /// Answers [`Self::SandboxTemplateBuildRequest`] (payload:
+    /// `arcbox.sandbox.v1.Template` — the registered draft).
+    SandboxTemplateBuildResponse = 0x1070,
+    /// Answers [`Self::SandboxTemplatePublishRequest`] (payload:
+    /// `arcbox.sandbox.v1.Template` — the frozen version).
+    SandboxTemplatePublishResponse = 0x1071,
+    /// Answers [`Self::SandboxTemplateGetRequest`] (payload:
+    /// `arcbox.sandbox.v1.Template`).
+    SandboxTemplateGetResponse = 0x1072,
+    /// Answers [`Self::SandboxTemplateListRequest`] (payload:
+    /// `arcbox.sandbox.v1.ListTemplatesResponse`).
+    SandboxTemplateListResponse = 0x1073,
+    /// Acknowledges [`Self::SandboxTemplateDeleteRequest`] (empty payload).
+    SandboxTemplateDeleteResponse = 0x1074,
+
     /// One machine exec output frame (payload: `arcbox.v1.MachineExecOutput`;
     /// `done == true` on the final frame carrying the exit code).
     MachineExecOutput = 0x1050,
@@ -426,6 +465,11 @@ impl MessageType {
             0x0066 => Some(Self::SandboxExecWaitRequest),
             0x0067 => Some(Self::SandboxExecListRequest),
             0x0068 => Some(Self::SandboxWaitForPortRequest),
+            0x0070 => Some(Self::SandboxTemplateBuildRequest),
+            0x0071 => Some(Self::SandboxTemplatePublishRequest),
+            0x0072 => Some(Self::SandboxTemplateGetRequest),
+            0x0073 => Some(Self::SandboxTemplateListRequest),
+            0x0074 => Some(Self::SandboxTemplateDeleteRequest),
             // Machine-level exec.
             0x0050 => Some(Self::MachineExecRequest),
             0x0051 => Some(Self::MachineExecInput),
@@ -491,6 +535,11 @@ impl MessageType {
             0x1066 => Some(Self::SandboxExecWaitResponse),
             0x1067 => Some(Self::SandboxExecListResponse),
             0x1068 => Some(Self::SandboxWaitForPortResponse),
+            0x1070 => Some(Self::SandboxTemplateBuildResponse),
+            0x1071 => Some(Self::SandboxTemplatePublishResponse),
+            0x1072 => Some(Self::SandboxTemplateGetResponse),
+            0x1073 => Some(Self::SandboxTemplateListResponse),
+            0x1074 => Some(Self::SandboxTemplateDeleteResponse),
             0x1050 => Some(Self::MachineExecOutput),
             0x0000 => Some(Self::Empty),
             0xFFFF => Some(Self::Error),
@@ -539,6 +588,11 @@ impl MessageType {
                 | Self::SandboxExecWaitRequest
                 | Self::SandboxExecListRequest
                 | Self::SandboxWaitForPortRequest
+                | Self::SandboxTemplateBuildRequest
+                | Self::SandboxTemplatePublishRequest
+                | Self::SandboxTemplateGetRequest
+                | Self::SandboxTemplateListRequest
+                | Self::SandboxTemplateDeleteRequest
         )
     }
 
@@ -674,6 +728,11 @@ mod tests {
             (0x0066, MessageType::SandboxExecWaitRequest),
             (0x0067, MessageType::SandboxExecListRequest),
             (0x0068, MessageType::SandboxWaitForPortRequest),
+            (0x0070, MessageType::SandboxTemplateBuildRequest),
+            (0x0071, MessageType::SandboxTemplatePublishRequest),
+            (0x0072, MessageType::SandboxTemplateGetRequest),
+            (0x0073, MessageType::SandboxTemplateListRequest),
+            (0x0074, MessageType::SandboxTemplateDeleteRequest),
             (0x1060, MessageType::SandboxExecStartResponse),
             (0x1061, MessageType::SandboxExecEvent),
             (0x1062, MessageType::SandboxStdinStatus),
@@ -682,6 +741,11 @@ mod tests {
             (0x1066, MessageType::SandboxExecWaitResponse),
             (0x1067, MessageType::SandboxExecListResponse),
             (0x1068, MessageType::SandboxWaitForPortResponse),
+            (0x1070, MessageType::SandboxTemplateBuildResponse),
+            (0x1071, MessageType::SandboxTemplatePublishResponse),
+            (0x1072, MessageType::SandboxTemplateGetResponse),
+            (0x1073, MessageType::SandboxTemplateListResponse),
+            (0x1074, MessageType::SandboxTemplateDeleteResponse),
             // Sandbox snapshots.
             (0x0040, MessageType::SandboxCheckpointRequest),
             (0x0041, MessageType::SandboxRestoreRequest),
@@ -734,6 +798,8 @@ mod tests {
         assert!(MessageType::SandboxPauseRequest.is_sandbox_request());
         assert!(MessageType::SandboxResumeRequest.is_sandbox_request());
         assert!(MessageType::SandboxSetLifecycleRequest.is_sandbox_request());
+        assert!(MessageType::SandboxTemplateBuildRequest.is_sandbox_request());
+        assert!(MessageType::SandboxTemplateDeleteRequest.is_sandbox_request());
         assert!(!MessageType::PingRequest.is_sandbox_request());
         assert!(!MessageType::SandboxCreateResponse.is_sandbox_request());
     }

--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -716,6 +716,76 @@ where
                 send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
             }
         },
+        // -----------------------------------------------------------------
+        // Template catalog (CORE-107)
+        // -----------------------------------------------------------------
+        MessageType::SandboxTemplateBuildRequest => {
+            // The daemon keeps Build UNIMPLEMENTED until the build pipeline
+            // lands, so this arm is a defensive answer, not a surface.
+            send_sandbox_error(
+                stream,
+                trace_id,
+                500,
+                "template Build is not yet implemented (CORE-107)",
+            )
+            .await?;
+        }
+        MessageType::SandboxTemplatePublishRequest => match svc.publish_template(payload).await {
+            Ok(resp) => {
+                write_message(
+                    stream,
+                    MessageType::SandboxTemplatePublishResponse,
+                    trace_id,
+                    &resp.encode_to_vec(),
+                )
+                .await?;
+            }
+            Err(e) => {
+                send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+            }
+        },
+        MessageType::SandboxTemplateGetRequest => match svc.get_template(payload) {
+            Ok(resp) => {
+                write_message(
+                    stream,
+                    MessageType::SandboxTemplateGetResponse,
+                    trace_id,
+                    &resp.encode_to_vec(),
+                )
+                .await?;
+            }
+            Err(e) => {
+                send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+            }
+        },
+        MessageType::SandboxTemplateListRequest => match svc.list_templates(payload) {
+            Ok(resp) => {
+                write_message(
+                    stream,
+                    MessageType::SandboxTemplateListResponse,
+                    trace_id,
+                    &resp.encode_to_vec(),
+                )
+                .await?;
+            }
+            Err(e) => {
+                send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+            }
+        },
+        MessageType::SandboxTemplateDeleteRequest => match svc.delete_template(payload).await {
+            Ok(()) => {
+                write_message(
+                    stream,
+                    MessageType::SandboxTemplateDeleteResponse,
+                    trace_id,
+                    &[],
+                )
+                .await?;
+            }
+            Err(e) => {
+                send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+            }
+        },
         _ => {
             send_sandbox_error(stream, trace_id, 400, "unrecognised sandbox message type").await?;
         }

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -11,6 +11,7 @@ mod execution;
 mod files;
 mod snapshots;
 mod template;
+mod templates;
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, Weak};

--- a/guest/arcbox-agent/src/sandbox/convert.rs
+++ b/guest/arcbox-agent/src/sandbox/convert.rs
@@ -3,6 +3,7 @@
 
 use arcbox_connect::sandbox_v1;
 use arcbox_vm::file_io::proto as file_proto;
+use arcbox_vm::template_catalog::{ReadyProbeSpec, TemplateDefaultsSpec, TemplateEntry};
 use arcbox_vm::{
     CheckpointInfo, CheckpointSummary, ExecutionChannel, ExecutionSnapshot, ExitStatus, IdleAction,
     SandboxEvent as VmSandboxEvent, SandboxInfo, SandboxState, SandboxSummary, StdinState,
@@ -266,6 +267,72 @@ pub(super) fn checkpoint_summary_to_proto(s: CheckpointSummary) -> sandbox_v1::S
         name: s.name,
         labels: s.labels.into_iter().collect(),
         created_at: timestamp_from_rfc3339(&s.created_at).into(),
+        ..Default::default()
+    }
+}
+
+// Template catalog entries cross the wire as `Template` messages; the
+// guest-absolute rootfs path is the documented `rootfs_ref` cache reference.
+
+pub(super) fn template_to_proto(name: &str, entry: &TemplateEntry) -> sandbox_v1::Template {
+    sandbox_v1::Template {
+        name: name.to_owned(),
+        version: entry.version.clone(),
+        digest: entry.digest.clone(),
+        rootfs_ref: entry.rootfs_path.clone(),
+        warm_snapshot_id: entry
+            .warm
+            .as_ref()
+            .map(|w| w.snapshot_id.clone())
+            .unwrap_or_default(),
+        defaults: template_defaults_to_proto(&entry.defaults).into(),
+        created_at: timestamp(entry.created_at).into(),
+        labels: entry.labels.clone().into_iter().collect(),
+        size_bytes: entry.size_bytes,
+        ..Default::default()
+    }
+}
+
+fn template_defaults_to_proto(spec: &TemplateDefaultsSpec) -> Option<sandbox_v1::TemplateDefaults> {
+    if *spec == TemplateDefaultsSpec::default() {
+        return None;
+    }
+    let limits = (spec.vcpus != 0 || spec.memory_mib != 0).then(|| sandbox_v1::ResourceLimits {
+        vcpus: spec.vcpus,
+        memory_mib: spec.memory_mib,
+        ..Default::default()
+    });
+    Some(sandbox_v1::TemplateDefaults {
+        limits: limits.into(),
+        cmd: spec.cmd.clone(),
+        env: spec.env.clone().into_iter().collect(),
+        exposed_ports: spec.exposed_ports.clone(),
+        ready_probe: spec.ready_probe.as_ref().map(ready_probe_to_proto).into(),
+        ..Default::default()
+    })
+}
+
+fn ready_probe_to_proto(spec: &ReadyProbeSpec) -> sandbox_v1::ReadyProbe {
+    use sandbox_v1::ready_probe::Probe;
+    let (probe, timeout_seconds) = match spec {
+        ReadyProbeSpec::Port {
+            port,
+            timeout_seconds,
+        } => (Probe::Port(u32::from(*port)), *timeout_seconds),
+        ReadyProbeSpec::Command {
+            cmd,
+            timeout_seconds,
+        } => (
+            Probe::Command(Box::new(sandbox_v1::CommandProbe {
+                cmd: cmd.clone(),
+                ..Default::default()
+            })),
+            *timeout_seconds,
+        ),
+    };
+    sandbox_v1::ReadyProbe {
+        timeout_seconds,
+        probe: Some(probe),
         ..Default::default()
     }
 }

--- a/guest/arcbox-agent/src/sandbox/templates.rs
+++ b/guest/arcbox-agent/src/sandbox/templates.rs
@@ -1,0 +1,96 @@
+//! Template catalog handlers (CORE-107).
+//!
+//! Thin decode → manager → encode glue over the catalog surface on
+//! [`SandboxManager`](arcbox_vm::SandboxManager); build orchestration (the
+//! rootfs pipeline) lands separately and registers its result through the
+//! same manager methods. `template.rs` (singular) is the unrelated
+//! `CreateSandboxRequest.template` reference parser and docker exporter.
+
+use arcbox_connect::sandbox_v1;
+use buffa::Message;
+
+use super::{SandboxService, convert};
+use crate::error::SandboxError;
+
+/// Operation-lock key for a template name: template builds/publishes/deletes
+/// serialize per name, in a namespace sandbox ids cannot collide with
+/// (`:` is invalid in a sandbox id).
+fn operation_key(name: &str) -> String {
+    format!("template:{name}")
+}
+
+impl SandboxService {
+    /// Resolve a `name[:version]` reference to its template.
+    pub fn get_template(&self, payload: &[u8]) -> Result<sandbox_v1::Template, SandboxError> {
+        let req = sandbox_v1::GetTemplateRequest::decode_from_slice(payload)
+            .map_err(|e| SandboxError::Decode(e.to_string()))?;
+        let resolved = self
+            .manager
+            .get_template(&req.reference)
+            .map_err(SandboxError::from)?;
+        Ok(convert::template_to_proto(&resolved.name, &resolved.entry))
+    }
+
+    /// List templates (reference-ordered, paginated, label-filtered).
+    pub fn list_templates(
+        &self,
+        payload: &[u8],
+    ) -> Result<sandbox_v1::ListTemplatesResponse, SandboxError> {
+        let req = sandbox_v1::ListTemplatesRequest::decode_from_slice(payload)
+            .map_err(|e| SandboxError::Decode(e.to_string()))?;
+        let mut rows = self.manager.list_templates().map_err(SandboxError::from)?;
+        // Label filter: every requested pair must match (mirrors snapshots).
+        if !req.labels.is_empty() {
+            rows.retain(|(_, entry)| {
+                req.labels
+                    .iter()
+                    .all(|(key, value)| entry.labels.get(key) == Some(value))
+            });
+        }
+        let rows: Vec<(String, sandbox_v1::Template)> = rows
+            .into_iter()
+            .map(|(name, entry)| {
+                let reference = format!("{name}:{}", entry.version);
+                (reference, convert::template_to_proto(&name, &entry))
+            })
+            .collect();
+        let (page, next_page_token) =
+            convert::paginate(rows, |row| row.0.as_str(), req.page_size, &req.page_token);
+        Ok(sandbox_v1::ListTemplatesResponse {
+            templates: page.into_iter().map(|row| row.1).collect(),
+            next_page_token,
+            ..Default::default()
+        })
+    }
+
+    /// Freeze a template's draft as an immutable version.
+    pub async fn publish_template(
+        &self,
+        payload: &[u8],
+    ) -> Result<sandbox_v1::Template, SandboxError> {
+        let req = sandbox_v1::PublishTemplateRequest::decode_from_slice(payload)
+            .map_err(|e| SandboxError::Decode(e.to_string()))?;
+        let _operation = self.operations.lock(&operation_key(&req.name)).await;
+        let entry = self
+            .manager
+            .publish_template(&req.name, &req.version)
+            .await
+            .map_err(SandboxError::from)?;
+        Ok(convert::template_to_proto(&req.name, &entry))
+    }
+
+    /// Delete a template version or a whole template with its artifacts.
+    pub async fn delete_template(&self, payload: &[u8]) -> Result<(), SandboxError> {
+        let req = sandbox_v1::DeleteTemplateRequest::decode_from_slice(payload)
+            .map_err(|e| SandboxError::Decode(e.to_string()))?;
+        let name = req
+            .reference
+            .split_once(':')
+            .map_or(&*req.reference, |(name, _)| name);
+        let _operation = self.operations.lock(&operation_key(name)).await;
+        self.manager
+            .delete_template(&req.reference)
+            .await
+            .map_err(SandboxError::from)
+    }
+}


### PR DESCRIPTION
Part 2 of the template-catalog campaign ([CORE-107](https://linear.app/arcbox/issue/CORE-107)), on top of #590. After this PR, `TemplateService.Get/List/Publish/Delete` answer end-to-end against the catalog; `Build` stays honestly UNIMPLEMENTED at the daemon until the build pipeline lands (next PRs).

## What

- **Wire**: five MessageType pairs `0x0070–0x0074` / `0x1070–0x1074` — a fresh block because `0x1047` is already taken by `SandboxFileWatchEnd`, so the 0x0047 request range cannot mirror. Routed through `is_sandbox_request()` so they inherit the KVM/data-mount precondition errors; roundtrip test arms included. Purely additive — no `AGENT_PROTOCOL_VERSION` bump.
- **Guest handlers** (`sandbox/templates.rs`, plural — `template.rs` singular remains the create-path reference parser): thin catalog calls via the manager, per-name operation locks in a `template:` namespace sandbox ids cannot collide with, the shared `paginate` idiom keyed on `name:version` references, and the snapshot-style label filter. The Build arm answers a defensive 500 (the daemon never forwards it yet).
- **AgentClient**: `sandbox_template_{build,publish,get,list,delete}` — build included so the daemon side of the pipeline PR needs no client change.
- **Daemon**: the five stubs become forwarders mirroring `snapshot.rs` (`sandbox_machine_id` → `get_agent` → call, warn-on-failed-mutation per CORE-82); `pb ↔ native` converters live in the guest's `convert.rs`, incl. the `ReadyProbe` oneof.
- **Classifier**: `404 + "template not found: "` → `TEMPLATE_NOT_FOUND` with the reference in context (marker-pinned test), ordered alongside the sandbox/file 404 arms.

## Validation

- `cargo test -p arcbox-vm --lib` (221), `-p arcbox-api` classifier markers, `-p arcbox-constants` wire roundtrips — all green.
- `cargo clippy --workspace --exclude arcbox-agent -- -D warnings` clean; musl-target agent clippy clean on changed files.

Sandbox e2e coverage for the whole surface lands with the campaign's e2e PR once Build ships (the daemon-level phases need a buildable template to exercise Get/Publish/Delete meaningfully).