### PR TITLE
feat(sandbox): implement template Build from a docker_ref source (CORE-107)

### DIFF
--- a/app/arcbox-api/src/connect/template.rs
+++ b/app/arcbox-api/src/connect/template.rs
@@ -1,12 +1,12 @@
 //! Sandbox template catalog service — control plane (CORE-107).
 //!
-//! Pure forwarders to the guest agent, mirroring `snapshot.rs`: the catalog
-//! and every artifact it references live inside the System VM. `Build` alone
-//! stays UNIMPLEMENTED until the build pipeline lands.
+//! Pure forwarders to the guest agent, mirroring `snapshot.rs`: the catalog,
+//! every artifact it references, and the build pipeline live inside the
+//! System VM.
 
 use arcbox_connect::sandbox_v1 as pb;
 use buffa_types::google::protobuf::Empty;
-use connectrpc::{ConnectError, RequestContext, Response, ServiceRequest, ServiceResult};
+use connectrpc::{RequestContext, Response, ServiceRequest, ServiceResult};
 
 use super::SharedRuntime;
 use super::{ConnectRuntimeExt as _, ContextExt as _};
@@ -32,17 +32,32 @@ impl TemplateServiceImpl {
               Router rather than named by callers"
 )]
 impl pb::TemplateService for TemplateServiceImpl {
-    /// UNIMPLEMENTED until the build pipeline lands (CORE-107 PR3+); the
-    /// rest of the catalog surface already answers.
+    /// Blocks for the whole build (image export, rootfs conversion). Safe on
+    /// this transport: sandbox RPCs ride the async vsock arm, which applies
+    /// no read deadline.
     async fn build(
         &self,
-        _ctx: RequestContext,
-        _request: ServiceRequest<'_, pb::BuildTemplateRequest>,
+        ctx: RequestContext,
+        request: ServiceRequest<'_, pb::BuildTemplateRequest>,
     ) -> ServiceResult<pb::Template> {
-        Err(ConnectError::unimplemented(
-            "template Build is not implemented yet (CORE-107 build pipeline); \
-             Get/List/Publish/Delete already answer",
-        ))
+        let machine = ctx.sandbox_machine_id()?;
+        let req = request.to_owned_message();
+        let name = req.name.clone();
+        let mut agent = self
+            .runtime
+            .ready()?
+            .get_agent(&machine)
+            .map_err(ApiError::from)?;
+        // The RPC error otherwise reaches only the caller; the daemon log
+        // must record a failed catalog mutation on its own (CORE-82).
+        let resp = agent
+            .sandbox_template_build(req)
+            .await
+            .inspect_err(|error| {
+                tracing::warn!(machine = %machine, template = %name, %error, "template build failed");
+            })
+            .map_err(ApiError::from)?;
+        Response::ok(resp)
     }
 
     async fn publish(

--- a/guest/arcbox-agent/src/agent/linux/sandbox.rs
+++ b/guest/arcbox-agent/src/agent/linux/sandbox.rs
@@ -719,17 +719,20 @@ where
         // -----------------------------------------------------------------
         // Template catalog (CORE-107)
         // -----------------------------------------------------------------
-        MessageType::SandboxTemplateBuildRequest => {
-            // The daemon keeps Build UNIMPLEMENTED until the build pipeline
-            // lands, so this arm is a defensive answer, not a surface.
-            send_sandbox_error(
-                stream,
-                trace_id,
-                500,
-                "template Build is not yet implemented (CORE-107)",
-            )
-            .await?;
-        }
+        MessageType::SandboxTemplateBuildRequest => match svc.build_template(payload).await {
+            Ok(resp) => {
+                write_message(
+                    stream,
+                    MessageType::SandboxTemplateBuildResponse,
+                    trace_id,
+                    &resp.encode_to_vec(),
+                )
+                .await?;
+            }
+            Err(e) => {
+                send_sandbox_error(stream, trace_id, e.status_code(), &e.to_string()).await?;
+            }
+        },
         MessageType::SandboxTemplatePublishRequest => match svc.publish_template(payload).await {
             Ok(resp) => {
                 write_message(

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -60,6 +60,10 @@ pub struct SandboxService {
     manager: Arc<SandboxManager>,
     creates: Arc<CreateRegistry>,
     operations: SandboxOperationLocks,
+    /// Template names with a Build in flight; a second Build on a busy name
+    /// errors instead of silently queueing behind a long conversion
+    /// (CORE-107). See `templates.rs`.
+    template_builds: Mutex<std::collections::HashSet<String>>,
     /// Default rootfs image path; auto-built on first use when missing.
     default_rootfs: String,
 }
@@ -115,6 +119,7 @@ impl SandboxService {
             manager,
             creates,
             operations: SandboxOperationLocks::default(),
+            template_builds: Mutex::new(std::collections::HashSet::new()),
             default_rootfs,
         })
     }

--- a/guest/arcbox-agent/src/sandbox/convert.rs
+++ b/guest/arcbox-agent/src/sandbox/convert.rs
@@ -293,6 +293,80 @@ pub(super) fn template_to_proto(name: &str, entry: &TemplateEntry) -> sandbox_v1
     }
 }
 
+/// Maximum ready-probe timeout accepted at Build time (matches the
+/// WaitForPort cap).
+const MAX_READY_PROBE_TIMEOUT_SECS: u32 = 600;
+
+/// Decode + validate `TemplateDefaults` from a Build request. Validation
+/// happens once here, at the boundary: a stored entry is trusted downstream.
+pub(super) fn template_defaults_from_proto(
+    pb: &sandbox_v1::TemplateDefaults,
+) -> Result<TemplateDefaultsSpec, crate::error::SandboxError> {
+    use crate::error::SandboxError;
+    for port in &pb.exposed_ports {
+        if *port == 0 || *port > u32::from(u16::MAX) {
+            return Err(SandboxError::InvalidArgument(format!(
+                "exposed_ports entry {port} is out of range (1-65535)"
+            )));
+        }
+    }
+    Ok(TemplateDefaultsSpec {
+        vcpus: pb.limits.vcpus,
+        memory_mib: pb.limits.memory_mib,
+        cmd: pb.cmd.clone(),
+        env: pb.env.clone().into_iter().collect(),
+        exposed_ports: pb.exposed_ports.clone(),
+        ready_probe: pb
+            .ready_probe
+            .as_option()
+            .map(ready_probe_from_proto)
+            .transpose()?,
+    })
+}
+
+fn ready_probe_from_proto(
+    pb: &sandbox_v1::ReadyProbe,
+) -> Result<ReadyProbeSpec, crate::error::SandboxError> {
+    use crate::error::SandboxError;
+    use sandbox_v1::ready_probe::Probe;
+    if pb.timeout_seconds > MAX_READY_PROBE_TIMEOUT_SECS {
+        return Err(SandboxError::InvalidArgument(format!(
+            "ready_probe timeout_seconds {} exceeds the {MAX_READY_PROBE_TIMEOUT_SECS}s cap",
+            pb.timeout_seconds
+        )));
+    }
+    match pb.probe.as_ref() {
+        Some(Probe::Port(port)) => {
+            let port = u16::try_from(*port)
+                .ok()
+                .filter(|p| *p != 0)
+                .ok_or_else(|| {
+                    SandboxError::InvalidArgument(format!(
+                        "ready_probe port {port} is out of range (1-65535)"
+                    ))
+                })?;
+            Ok(ReadyProbeSpec::Port {
+                port,
+                timeout_seconds: pb.timeout_seconds,
+            })
+        }
+        Some(Probe::Command(command)) => {
+            if command.cmd.is_empty() {
+                return Err(SandboxError::InvalidArgument(
+                    "ready_probe command must not be empty".into(),
+                ));
+            }
+            Ok(ReadyProbeSpec::Command {
+                cmd: command.cmd.clone(),
+                timeout_seconds: pb.timeout_seconds,
+            })
+        }
+        None => Err(SandboxError::InvalidArgument(
+            "ready_probe requires a port or a command".into(),
+        )),
+    }
+}
+
 fn template_defaults_to_proto(spec: &TemplateDefaultsSpec) -> Option<sandbox_v1::TemplateDefaults> {
     if *spec == TemplateDefaultsSpec::default() {
         return None;

--- a/guest/arcbox-agent/src/sandbox/templates.rs
+++ b/guest/arcbox-agent/src/sandbox/templates.rs
@@ -1,15 +1,21 @@
 //! Template catalog handlers (CORE-107).
 //!
-//! Thin decode → manager → encode glue over the catalog surface on
-//! [`SandboxManager`](arcbox_vm::SandboxManager); build orchestration (the
-//! rootfs pipeline) lands separately and registers its result through the
-//! same manager methods. `template.rs` (singular) is the unrelated
+//! Decode → manager → encode glue over the catalog surface on
+//! [`SandboxManager`](arcbox_vm::SandboxManager), plus the Build
+//! orchestrator, which drives the existing rootfs pipeline (`template.rs`
+//! export + `rootfs_builder` conversion) and registers the result as the
+//! catalog draft. `template.rs` (singular) is the
 //! `CreateSandboxRequest.template` reference parser and docker exporter.
 
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::Mutex;
+
 use arcbox_connect::sandbox_v1;
+use arcbox_vm::template_catalog::{TemplateDefaultsSpec, TemplateEntry, compute_digest};
 use buffa::Message;
 
-use super::{SandboxService, convert};
+use super::{SandboxService, convert, template};
 use crate::error::SandboxError;
 
 /// Operation-lock key for a template name: template builds/publishes/deletes
@@ -19,7 +25,142 @@ fn operation_key(name: &str) -> String {
     format!("template:{name}")
 }
 
+/// Clears the in-flight marker for a template build on drop, so every error
+/// path frees the name.
+struct BuildFlight<'a> {
+    name: String,
+    builds: &'a Mutex<HashSet<String>>,
+}
+
+impl Drop for BuildFlight<'_> {
+    fn drop(&mut self) {
+        self.builds.lock().unwrap().remove(&self.name);
+    }
+}
+
 impl SandboxService {
+    /// Build a template from a source and register it as the catalog draft.
+    /// Blocks for the whole pipeline; a second Build on the same name errors
+    /// instead of queueing behind a long conversion.
+    pub async fn build_template(
+        &self,
+        payload: &[u8],
+    ) -> Result<sandbox_v1::Template, SandboxError> {
+        use sandbox_v1::build_template_request::Source;
+        let req = sandbox_v1::BuildTemplateRequest::decode_from_slice(payload)
+            .map_err(|e| SandboxError::Decode(e.to_string()))?;
+        arcbox_vm::template_catalog::validate_template_name(&req.name)
+            .map_err(SandboxError::from)?;
+        let defaults = convert::template_defaults_from_proto(&req.defaults)?;
+        let source = req.source.clone().ok_or_else(|| {
+            SandboxError::InvalidArgument(
+                "build source is required: docker_ref, dockerfile, or snapshot_id".into(),
+            )
+        })?;
+        if req.prewarm && !matches!(source, Source::SnapshotId(_)) {
+            // Loud, not silently ignored: a caller asking for a warm
+            // template must not receive a cold one labeled as built.
+            return Err(SandboxError::Unsupported(
+                "prewarm is not implemented yet (CORE-107)".into(),
+            ));
+        }
+        let _flight = self.begin_template_build(&req.name)?;
+        let labels: HashMap<String, String> = req.labels.clone().into_iter().collect();
+        match source {
+            Source::DockerRef(image) => {
+                self.build_template_from_docker(&req.name, &image, defaults, labels)
+                    .await
+            }
+            Source::Dockerfile(_) => Err(SandboxError::Unsupported(
+                "dockerfile builds are not implemented yet (CORE-107); \
+                 build the image through the docker context and use docker_ref"
+                    .into(),
+            )),
+            Source::SnapshotId(_) => Err(SandboxError::Unsupported(
+                "snapshot promotion is not implemented yet (CORE-107)".into(),
+            )),
+        }
+    }
+
+    /// Export `image` from the guest's dockerd, convert it to a cached ext4,
+    /// and register the draft entry.
+    async fn build_template_from_docker(
+        &self,
+        name: &str,
+        image: &str,
+        defaults: TemplateDefaultsSpec,
+        labels: HashMap<String, String>,
+    ) -> Result<sandbox_v1::Template, SandboxError> {
+        if image.trim().is_empty() {
+            return Err(SandboxError::InvalidArgument(
+                "docker_ref must name an image".into(),
+            ));
+        }
+        let layout = template::export_docker_image(image)
+            .await
+            .map_err(|e| SandboxError::Internal(format!("template build {image}: {e:#}")))?;
+        // Snapshot-referenced images must survive the conversion's cache
+        // sweep — a restore cannot rebuild its dm-snapshot origin.
+        let pinned = self
+            .manager
+            .pinned_rootfs_paths()
+            .map_err(SandboxError::from)?;
+        let rootfs = crate::rootfs_builder::convert_layer_to_rootfs(&layout, &pinned)
+            .await
+            .map_err(|e| SandboxError::Internal(format!("template build {image}: {e:#}")))?;
+        // The cache file stem (`rootfs-<layer>-<agent>`) is content-derived —
+        // layer diff IDs plus the injected vm-agent — which makes it the
+        // digest's source identity: stable across rebuilds, changed by
+        // either a new image filesystem or a new agent.
+        let source_identity = Path::new(&rootfs)
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .ok_or_else(|| {
+                SandboxError::Internal(format!("unparsable rootfs cache path {rootfs}"))
+            })?
+            .to_owned();
+        let size_bytes = tokio::fs::metadata(&rootfs)
+            .await
+            .map_err(|e| SandboxError::Internal(format!("stat {rootfs}: {e}")))?
+            .len();
+        let digest = compute_digest(&source_identity, None, &defaults, &labels);
+        let entry = TemplateEntry {
+            version: String::new(),
+            digest,
+            rootfs_path: rootfs,
+            warm: None,
+            defaults,
+            labels,
+            created_at: chrono::Utc::now(),
+            size_bytes,
+        };
+        // The registration step joins the same per-name operation lock
+        // Publish/Delete hold, so the final catalog mutation serializes with
+        // theirs; the long build phases above deliberately run outside it
+        // (holding it for minutes would block every other verb on the name —
+        // the in-flight guard already keeps concurrent Builds out).
+        let _operation = self.operations.lock(&operation_key(name)).await;
+        let entry = self
+            .manager
+            .register_template_draft(name, entry)
+            .await
+            .map_err(SandboxError::from)?;
+        Ok(convert::template_to_proto(name, &entry))
+    }
+
+    /// Mark `name` as having a build in flight; the guard clears it on drop.
+    fn begin_template_build(&self, name: &str) -> Result<BuildFlight<'_>, SandboxError> {
+        let mut builds = self.template_builds.lock().unwrap();
+        if !builds.insert(name.to_owned()) {
+            return Err(SandboxError::WrongState(format!(
+                "a build for template {name} is already running"
+            )));
+        }
+        Ok(BuildFlight {
+            name: name.to_owned(),
+            builds: &self.template_builds,
+        })
+    }
     /// Resolve a `name[:version]` reference to its template.
     pub fn get_template(&self, payload: &[u8]) -> Result<sandbox_v1::Template, SandboxError> {
         let req = sandbox_v1::GetTemplateRequest::decode_from_slice(payload)

--- a/virt/arcbox-vm/src/template_catalog.rs
+++ b/virt/arcbox-vm/src/template_catalog.rs
@@ -493,6 +493,75 @@ impl TemplateCatalog {
     }
 }
 
+/// Deterministic content digest for a template entry (`sha256:<hex>`).
+///
+/// Inputs are content identities, never file metadata, so an identical
+/// rebuild reproduces the digest: `source_identity` (the rootfs cache file
+/// stem for image builds — it encodes the layer content key and the injected
+/// vm-agent key — or the promoted snapshot id), the warm snapshot id, and
+/// the canonicalized defaults and labels. Field-tagged and NUL-separated so
+/// adjacent inputs cannot alias.
+#[must_use]
+#[allow(
+    clippy::implicit_hasher,
+    reason = "callers pass the catalog's std-hasher label maps; a hasher type \
+              parameter would serve zero call sites"
+)]
+pub fn compute_digest(
+    source_identity: &str,
+    warm_snapshot_id: Option<&str>,
+    defaults: &TemplateDefaultsSpec,
+    labels: &HashMap<String, String>,
+) -> String {
+    use sha2::{Digest as _, Sha256};
+
+    /// Canonical serialization shadow: map fields become ordered so the JSON
+    /// bytes are deterministic regardless of `HashMap` iteration order.
+    #[derive(Serialize)]
+    struct CanonicalDefaults<'a> {
+        vcpus: u32,
+        memory_mib: u64,
+        cmd: &'a [String],
+        env: std::collections::BTreeMap<&'a str, &'a str>,
+        exposed_ports: &'a [u32],
+        ready_probe: &'a Option<ReadyProbeSpec>,
+    }
+
+    let canonical = CanonicalDefaults {
+        vcpus: defaults.vcpus,
+        memory_mib: defaults.memory_mib,
+        cmd: &defaults.cmd,
+        env: defaults
+            .env
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect(),
+        exposed_ports: &defaults.exposed_ports,
+        ready_probe: &defaults.ready_probe,
+    };
+    let sorted_labels: std::collections::BTreeMap<&str, &str> = labels
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+
+    let mut hasher = Sha256::new();
+    for (tag, value) in [
+        ("source", source_identity),
+        ("warm", warm_snapshot_id.unwrap_or("")),
+    ] {
+        hasher.update(tag.as_bytes());
+        hasher.update([0]);
+        hasher.update(value.as_bytes());
+        hasher.update([0]);
+    }
+    hasher.update(b"defaults\0");
+    hasher.update(serde_json::to_vec(&canonical).expect("plain data serialization cannot fail"));
+    hasher.update(b"\0labels\0");
+    hasher
+        .update(serde_json::to_vec(&sorted_labels).expect("plain data serialization cannot fail"));
+    format!("sha256:{:x}", hasher.finalize())
+}
+
 /// Validate a template name.
 ///
 /// Names become file names, snapshot `vm_id` components, and reference
@@ -778,6 +847,40 @@ mod tests {
         for path in ["/cache/ra.ext4", "/cache/ra2.ext4", "/cache/rb.ext4"] {
             assert!(pinned.contains(Path::new(path)), "missing {path}");
         }
+    }
+
+    #[test]
+    fn digest_is_deterministic_and_input_sensitive() {
+        let mut defaults = TemplateDefaultsSpec {
+            vcpus: 2,
+            ..Default::default()
+        };
+        defaults.env.insert("A".into(), "1".into());
+        defaults.env.insert("B".into(), "2".into());
+        let labels = HashMap::from([("team".to_string(), "ml".to_string())]);
+
+        let d1 = compute_digest("rootfs-aa-bb", Some("snap-1"), &defaults, &labels);
+        let d2 = compute_digest("rootfs-aa-bb", Some("snap-1"), &defaults, &labels);
+        assert_eq!(d1, d2, "same inputs must reproduce the digest");
+        assert!(d1.starts_with("sha256:"));
+
+        for (source, warm) in [
+            ("rootfs-aa-cc", Some("snap-1")),
+            ("rootfs-aa-bb", Some("snap-2")),
+            ("rootfs-aa-bb", None),
+        ] {
+            assert_ne!(d1, compute_digest(source, warm, &defaults, &labels));
+        }
+        let mut other = defaults.clone();
+        other.cmd = vec!["python".into()];
+        assert_ne!(
+            d1,
+            compute_digest("rootfs-aa-bb", Some("snap-1"), &other, &labels)
+        );
+        assert_ne!(
+            d1,
+            compute_digest("rootfs-aa-bb", Some("snap-1"), &defaults, &HashMap::new())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Part 3 of the template-catalog campaign ([CORE-107](https://linear.app/arcbox/issue/CORE-107)), on top of #592. `TemplateService.Build{docker_ref}` now works end-to-end: export the image from the guest's dockerd, convert to ext4 in the pinned rootfs cache, register the catalog draft.

## What

- **Guest orchestrator** (`sandbox/templates.rs`): `build_template` validates the name and defaults at the boundary (exposed/probe ports 1–65535, probe command non-empty, probe timeout ≤ the WaitForPort 600s cap), then drives the existing pipeline — `export_docker_image` (content-addressed OCI staging) → `convert_layer_to_rootfs` (pinned cache) → `register_template_draft`. Repeat builds are cache hits at both stages.
- **Content digest** (`arcbox-vm::template_catalog::compute_digest`): SHA-256 over content identities only — the rootfs cache file stem (which encodes the layer diff-ID key and the injected vm-agent key), the warm snapshot id, and canonicalized defaults + labels (BTreeMap shadow so HashMap order can't flip it). File metadata is deliberately excluded: an identical rebuild must reproduce the digest. Determinism + input-sensitivity pinned by tests.
- **Single-flight per name**: a drop-guard registry; a second Build on a busy name errors (`FAILED_PRECONDITION`) instead of silently queueing behind a long conversion.
- **Honest rejections**: `prewarm` and the `dockerfile`/`snapshot_id` sources answer a loud Unsupported until their PRs land (next in the stack) — never a cold template silently labeled as warm.
- Daemon `Build` flips from UNIMPLEMENTED to the forwarder (async vsock arm — no read deadline, so the blocking-build contract is safe).

## Validation

`cargo test -p arcbox-vm --lib` (incl. new digest tests) green; workspace clippy `-D warnings` clean; musl-target agent clippy clean on changed files; `cargo fmt --check` clean. Daemon-level e2e phases for the whole Build surface land with the campaign's e2e PR.