### PR TITLE
feat(sandbox): implement template Build from inline Dockerfile content (CORE-107)

### DIFF
--- a/guest/arcbox-agent/src/sandbox/template.rs
+++ b/guest/arcbox-agent/src/sandbox/template.rs
@@ -197,6 +197,8 @@ async fn image_content_key(image_ref: &str) -> Result<String> {
 /// **chunked** transfer-encoding; copying the raw connection bytes splices
 /// the chunk headers into the tar and it fails to unpack with an opaque
 /// "archive header checksum mismatch". Let the HTTP library do framing.
+pub(super) use docker::{build_image, inspect_image};
+
 mod docker {
     use anyhow::{Context, Result, bail};
     use arcbox_constants::paths::DOCKER_API_UNIX_SOCKET;
@@ -210,7 +212,7 @@ mod docker {
     const MAX_INSPECT_BYTES: usize = 4 * 1024 * 1024;
 
     /// `GET /images/{ref}/json`, parsed as JSON.
-    pub(super) async fn inspect_image(image_ref: &str) -> Result<serde_json::Value> {
+    pub(in crate::sandbox) async fn inspect_image(image_ref: &str) -> Result<serde_json::Value> {
         let path = format!("/images/{}/json", urlencode(image_ref));
         let mut response = get(&path).await?;
         let status = response.status();
@@ -263,11 +265,121 @@ mod docker {
         Ok(())
     }
 
+    /// Largest build-progress stream accepted before bailing (a runaway
+    /// build log, not a hostile dockerd, is the realistic trigger).
+    const MAX_BUILD_LOG_BYTES: usize = 64 * 1024 * 1024;
+
+    /// `POST /build` with an in-memory tar context holding one `Dockerfile`,
+    /// tagging the result `tag`.
+    ///
+    /// dockerd answers HTTP 200 even when the build fails: failure arrives
+    /// as `{"error":…,"errorDetail":…}` objects inside the newline-delimited
+    /// JSON progress stream, so the stream is parsed and the last progress
+    /// line is folded into the error. The context contains only the
+    /// Dockerfile — `COPY`/`ADD` of local paths cannot work and fails inside
+    /// the build with dockerd's own "not found" message.
+    pub(in crate::sandbox) async fn build_image(dockerfile: &[u8], tag: &str) -> Result<()> {
+        let mut context_tar = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(dockerfile.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        context_tar
+            .append_data(&mut header, "Dockerfile", dockerfile)
+            .context("failed to build the in-memory build context")?;
+        let context_bytes = context_tar
+            .into_inner()
+            .context("failed to finish the in-memory build context")?;
+
+        let path = format!(
+            "/build?t={}&platform={}",
+            urlencode(tag),
+            urlencode(&platform_slug()?)
+        );
+        let request = hyper::Request::builder()
+            .method(hyper::Method::POST)
+            .uri(path)
+            .header(hyper::header::HOST, "localhost")
+            .header(hyper::header::CONTENT_TYPE, "application/x-tar")
+            .body(http_body_util::Full::new(Bytes::from(context_bytes)))
+            .context("failed to build the docker build request")?;
+        let mut response = send(request).await?;
+        let status = response.status();
+        if !status.is_success() {
+            bail!("docker build returned HTTP {status}");
+        }
+
+        // Newline-delimited JSON progress; remember the last stream line so
+        // a failure names the step that produced it.
+        let mut buffer = Vec::new();
+        let mut last_progress = String::new();
+        let mut seen = 0usize;
+        while let Some(frame) = response.frame().await {
+            let frame = frame.context("failed to stream the docker build progress")?;
+            let Some(chunk) = frame.data_ref() else {
+                continue;
+            };
+            seen += chunk.len();
+            if seen > MAX_BUILD_LOG_BYTES {
+                bail!("docker build progress exceeds {MAX_BUILD_LOG_BYTES} bytes");
+            }
+            buffer.extend_from_slice(chunk);
+            while let Some(newline) = buffer.iter().position(|b| *b == b'\n') {
+                let line: Vec<u8> = buffer.drain(..=newline).collect();
+                check_build_progress_line(&line, &mut last_progress)?;
+            }
+        }
+        if !buffer.is_empty() {
+            check_build_progress_line(&buffer, &mut last_progress)?;
+        }
+        Ok(())
+    }
+
+    /// Parse one build-progress line; `error` objects become failures.
+    fn check_build_progress_line(line: &[u8], last_progress: &mut String) -> Result<()> {
+        let Ok(value) = serde_json::from_slice::<serde_json::Value>(line) else {
+            // Interleaved non-JSON output is progress noise, not a failure.
+            return Ok(());
+        };
+        if let Some(error) = value.get("error").and_then(|e| e.as_str()) {
+            let at = if last_progress.is_empty() {
+                String::new()
+            } else {
+                format!(" (last step: {})", last_progress.trim())
+            };
+            bail!("docker build failed: {error}{at}");
+        }
+        if let Some(stream) = value.get("stream").and_then(|s| s.as_str())
+            && !stream.trim().is_empty()
+        {
+            stream.clone_into(last_progress);
+        }
+        Ok(())
+    }
+
     /// Dial the docker socket and issue a `GET`, returning the response.
+    async fn get(path: &str) -> Result<hyper::Response<hyper::body::Incoming>> {
+        let request = hyper::Request::builder()
+            .method(hyper::Method::GET)
+            .uri(path)
+            .header(hyper::header::HOST, "localhost")
+            .body(Empty::<Bytes>::new())
+            .context("failed to build the docker request")?;
+        send(request).await
+    }
+
+    /// Dial the docker socket and send `request`, returning the response.
     ///
     /// The connection task is detached: it drives the HTTP state machine
     /// while the caller consumes the body, and ends when the body does.
-    async fn get(path: &str) -> Result<hyper::Response<hyper::body::Incoming>> {
+    /// The authority is unused (the connector dials a fixed socket) but
+    /// HTTP/1.1 requires a Host header, which callers set.
+    async fn send<B>(request: hyper::Request<B>) -> Result<hyper::Response<hyper::body::Incoming>>
+    where
+        B: hyper::body::Body + Send + 'static,
+        B::Data: Send,
+        B::Error: std::error::Error + Send + Sync,
+    {
         let stream = UnixStream::connect(DOCKER_API_UNIX_SOCKET)
             .await
             .with_context(|| format!("failed to connect {DOCKER_API_UNIX_SOCKET}"))?;
@@ -281,19 +393,21 @@ mod docker {
             }
         });
 
-        // The authority is unused (the connector dials a fixed socket) but
-        // HTTP/1.1 requires a Host header.
-        let request = hyper::Request::builder()
-            .method(hyper::Method::GET)
-            .uri(path)
-            .header(hyper::header::HOST, "localhost")
-            .body(Empty::<Bytes>::new())
-            .context("failed to build the docker request")?;
-
         sender
             .send_request(request)
             .await
             .context("failed to send the docker request")
+    }
+
+    /// This guest's platform in the `os/arch` form `/build` expects (unlike
+    /// `/images/{ref}/get`, whose `platform` is the JSON OCI shape).
+    fn platform_slug() -> Result<String> {
+        let arch = match std::env::consts::ARCH {
+            "aarch64" => "arm64",
+            "x86_64" => "amd64",
+            other => bail!("unsupported guest architecture for sandbox images: {other}"),
+        };
+        Ok(format!("linux/{arch}"))
     }
 
     /// This guest's platform as the JSON-encoded OCI platform the Engine API
@@ -330,7 +444,46 @@ mod docker {
 
     #[cfg(test)]
     mod tests {
-        use super::{platform_json, urlencode};
+        use super::{check_build_progress_line, platform_json, platform_slug, urlencode};
+
+        #[test]
+        fn build_progress_error_objects_fail_and_name_the_last_step() {
+            let mut last = String::new();
+            check_build_progress_line(br#"{"stream":"Step 2/3 : RUN false\n"}"#, &mut last)
+                .expect("progress is not a failure");
+            assert_eq!(last, "Step 2/3 : RUN false\n");
+
+            let err = check_build_progress_line(
+                br#"{"error":"process did not complete successfully"}"#,
+                &mut last,
+            )
+            .expect_err("error objects must fail the build");
+            let message = err.to_string();
+            assert!(
+                message.contains("process did not complete successfully"),
+                "{message}"
+            );
+            assert!(message.contains("Step 2/3 : RUN false"), "{message}");
+        }
+
+        #[test]
+        fn build_progress_tolerates_noise_and_skips_blank_streams() {
+            let mut last = String::from("Step 1/1 : FROM alpine\n");
+            // Interleaved non-JSON output is progress noise, not a failure.
+            check_build_progress_line(b"not json at all", &mut last).expect("noise tolerated");
+            // Whitespace-only stream frames must not clobber the last step.
+            check_build_progress_line(br#"{"stream":"\n"}"#, &mut last).expect("blank stream");
+            assert_eq!(last, "Step 1/1 : FROM alpine\n");
+            // Non-error JSON (status/aux frames) passes through.
+            check_build_progress_line(br#"{"aux":{"ID":"sha256:ab"}}"#, &mut last)
+                .expect("aux frame");
+        }
+
+        #[test]
+        fn build_platform_is_the_os_arch_slug() {
+            let slug = platform_slug().expect("supported test architecture");
+            assert!(slug == "linux/arm64" || slug == "linux/amd64", "{slug}");
+        }
 
         #[test]
         fn platform_json_is_the_guest_platform() {

--- a/guest/arcbox-agent/src/sandbox/templates.rs
+++ b/guest/arcbox-agent/src/sandbox/templates.rs
@@ -25,6 +25,14 @@ fn operation_key(name: &str) -> String {
     format!("template:{name}")
 }
 
+/// Content-addressed tag for a Dockerfile build:
+/// `arcbox-template-build:<sha256[..16]>` of the Dockerfile bytes.
+fn dockerfile_tag(dockerfile: &[u8]) -> String {
+    use sha2::{Digest as _, Sha256};
+    let hex = format!("{:x}", Sha256::digest(dockerfile));
+    format!("arcbox-template-build:{}", &hex[..16])
+}
+
 /// Clears the in-flight marker for a template build on drop, so every error
 /// path frees the name.
 struct BuildFlight<'a> {
@@ -71,15 +79,46 @@ impl SandboxService {
                 self.build_template_from_docker(&req.name, &image, defaults, labels)
                     .await
             }
-            Source::Dockerfile(_) => Err(SandboxError::Unsupported(
-                "dockerfile builds are not implemented yet (CORE-107); \
-                 build the image through the docker context and use docker_ref"
-                    .into(),
-            )),
+            Source::Dockerfile(dockerfile) => {
+                self.build_template_from_dockerfile(&req.name, &dockerfile, defaults, labels)
+                    .await
+            }
             Source::SnapshotId(_) => Err(SandboxError::Unsupported(
                 "snapshot promotion is not implemented yet (CORE-107)".into(),
             )),
         }
+    }
+
+    /// Build inline Dockerfile content in the guest's dockerd, then proceed
+    /// exactly as a `docker_ref` build of the resulting image.
+    ///
+    /// The tag is content-addressed (`arcbox-template-build:<sha256[..16]>`
+    /// of the Dockerfile bytes): an identical rebuild reuses the image, and
+    /// two concurrent Builds of different templates cannot race one mutable
+    /// tag. The build context holds only the Dockerfile — `COPY`/`ADD` of
+    /// local paths fails inside the build with dockerd's own message.
+    async fn build_template_from_dockerfile(
+        &self,
+        name: &str,
+        dockerfile: &str,
+        defaults: TemplateDefaultsSpec,
+        labels: HashMap<String, String>,
+    ) -> Result<sandbox_v1::Template, SandboxError> {
+        if dockerfile.trim().is_empty() {
+            return Err(SandboxError::InvalidArgument(
+                "dockerfile content must not be empty".into(),
+            ));
+        }
+        let tag = dockerfile_tag(dockerfile.as_bytes());
+        if template::inspect_image(&tag).await.is_ok() {
+            tracing::info!(template = name, %tag, "reusing previously built dockerfile image");
+        } else {
+            template::build_image(dockerfile.as_bytes(), &tag)
+                .await
+                .map_err(|e| SandboxError::Internal(format!("template build {name}: {e:#}")))?;
+        }
+        self.build_template_from_docker(name, &tag, defaults, labels)
+            .await
     }
 
     /// Export `image` from the guest's dockerd, convert it to a cached ext4,
@@ -233,5 +272,24 @@ impl SandboxService {
             .delete_template(&req.reference)
             .await
             .map_err(SandboxError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dockerfile_tag;
+
+    #[test]
+    fn dockerfile_tag_is_content_addressed_and_valid() {
+        let a = dockerfile_tag(b"FROM alpine\n");
+        let b = dockerfile_tag(b"FROM alpine\n");
+        let c = dockerfile_tag(b"FROM debian\n");
+        assert_eq!(a, b, "identical content must reuse the tag");
+        assert_ne!(a, c, "different content must not share a tag");
+        // repo:tag shape docker accepts, 16-hex suffix.
+        let (repo, tag) = a.split_once(':').expect("repo:tag");
+        assert_eq!(repo, "arcbox-template-build");
+        assert_eq!(tag.len(), 16);
+        assert!(tag.bytes().all(|b| b.is_ascii_hexdigit()));
     }
 }


### PR DESCRIPTION
Part 4 of the template-catalog campaign ([CORE-107](https://linear.app/arcbox/issue/CORE-107)), on top of #593. `Build{dockerfile}` builds inline Dockerfile content in the guest's dockerd, then flows through the docker_ref pipeline unchanged.

## What

- **`docker::build_image`** (`sandbox/template.rs`): `POST /build` with an in-memory tar context holding only the `Dockerfile` (`Full<Bytes>` body — Content-Length known, no chunked framing). **dockerd answers HTTP 200 even for failed builds**: failure arrives as `{"error":…}` objects in the newline-delimited JSON progress stream, so the stream is parsed and an error names the last build step. `/build` takes the `os/arch` platform slug — deliberately distinct from the image export's JSON OCI platform parameter.
- **Content-addressed tag**: `arcbox-template-build:<sha256[..16]>` of the Dockerfile bytes — an identical rebuild reuses the image via inspect, and two concurrent Builds of different templates never race one mutable tag.
- Empty build context by design: `COPY`/`ADD` of local paths fails inside the build with dockerd's own message (matches the CLI's `--from-dockerfile` contract).
- The shared `get`/`send` docker-client split keeps one connection path for both verbs.

## Validation

Full-workspace clippy `-D warnings`, musl-target agent clippy, `cargo test -p arcbox-vm --lib` (222), and `cargo fmt --check` — all validated at this branch tip in isolation.