### PR TITLE
feat(sandbox): implement snapshot promotion into templates (CORE-107)

### DIFF
--- a/guest/arcbox-agent/src/sandbox/templates.rs
+++ b/guest/arcbox-agent/src/sandbox/templates.rs
@@ -12,7 +12,9 @@ use std::path::Path;
 use std::sync::Mutex;
 
 use arcbox_connect::sandbox_v1;
-use arcbox_vm::template_catalog::{TemplateDefaultsSpec, TemplateEntry, compute_digest};
+use arcbox_vm::template_catalog::{
+    TemplateDefaultsSpec, TemplateEntry, WarmArtifact, compute_digest,
+};
 use buffa::Message;
 
 use super::{SandboxService, convert, template};
@@ -83,9 +85,82 @@ impl SandboxService {
                 self.build_template_from_dockerfile(&req.name, &dockerfile, defaults, labels)
                     .await
             }
-            Source::SnapshotId(_) => Err(SandboxError::Unsupported(
-                "snapshot promotion is not implemented yet (CORE-107)".into(),
-            )),
+            Source::SnapshotId(snapshot_id) => {
+                self.build_template_from_snapshot(&req.name, &snapshot_id, defaults, labels)
+                    .await
+            }
+        }
+    }
+
+    /// Promote an existing checkpoint into a template: the copied snapshot
+    /// becomes the template's warm start point ("warm by construction" —
+    /// `prewarm` is ignored for this source, per the proto). No build runs.
+    async fn build_template_from_snapshot(
+        &self,
+        name: &str,
+        snapshot_id: &str,
+        defaults: TemplateDefaultsSpec,
+        labels: HashMap<String, String>,
+    ) -> Result<sandbox_v1::Template, SandboxError> {
+        if snapshot_id.trim().is_empty() {
+            return Err(SandboxError::InvalidArgument(
+                "snapshot_id must name a checkpoint".into(),
+            ));
+        }
+        let promoted = self
+            .manager
+            .promote_snapshot_to_template(snapshot_id, name)
+            .await
+            .map_err(SandboxError::from)?;
+        // Source identity is the origin checkpoint; the fresh copy id makes
+        // each promotion a distinct content instance, so a displaced draft's
+        // copy is released rather than aliased.
+        let digest = compute_digest(snapshot_id, Some(&promoted.snapshot_id), &defaults, &labels);
+        // Any failure between the committed copy and its registration must
+        // take the copy with it, or it sits orphaned outside every listing.
+        let rootfs_bytes = match tokio::fs::metadata(&promoted.rootfs_path).await {
+            Ok(meta) => meta.len(),
+            Err(e) => {
+                self.manager
+                    .discard_promoted_snapshot(&promoted.snapshot_id)
+                    .await;
+                return Err(SandboxError::Internal(format!(
+                    "stat {}: {e}",
+                    promoted.rootfs_path
+                )));
+            }
+        };
+        let entry = TemplateEntry {
+            version: String::new(),
+            digest,
+            rootfs_path: promoted.rootfs_path.clone(),
+            warm: Some(WarmArtifact {
+                snapshot_id: promoted.snapshot_id.clone(),
+                vcpus: promoted.geometry.vcpus,
+                memory_mib: promoted.geometry.memory_mib,
+            }),
+            defaults,
+            labels,
+            created_at: chrono::Utc::now(),
+            size_bytes: promoted.artifact_bytes + rootfs_bytes,
+        };
+        match self.manager.register_template_draft(name, entry).await {
+            Ok(entry) => Ok(convert::template_to_proto(name, &entry)),
+            // `Unavailable` is the atomic-write durability-uncertain shape:
+            // the record may already be renamed into place and referencing
+            // the snapshot, so deleting it here would install a template
+            // whose warm restore points at missing artifacts. Leave the
+            // copy; the error is retryable and the referenced-or-orphan
+            // outcome is safe either way.
+            Err(error @ arcbox_vm::VmmError::Unavailable(_)) => Err(SandboxError::from(error)),
+            Err(error) => {
+                // Registration certainly did not commit — the copy is
+                // otherwise orphaned (recoverable, but why wait).
+                self.manager
+                    .discard_promoted_snapshot(&promoted.snapshot_id)
+                    .await;
+                Err(SandboxError::from(error))
+            }
         }
     }
 

--- a/virt/arcbox-vm/src/manager.rs
+++ b/virt/arcbox-vm/src/manager.rs
@@ -456,8 +456,10 @@ impl VmmManager {
             kernel_path: None,
             rootfs_path: None,
             // General VMs boot whatever network the caller configured; only
-            // sandbox checkpoints carry the invariant identity.
+            // sandbox checkpoints carry the invariant identity, and nothing
+            // restores these onto a differently-shaped VM.
             net_invariant: false,
+            geometry: None,
         })?;
 
         if was_running {

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -98,7 +98,7 @@ pub(super) async fn checkpoint_impl(
     // — a sandbox restored from a pre-warmed pool slot lives in the
     // slot's chroot, and FC resolves snapshot paths inside it — plus
     // the guest's network addressing mode and the VM API handle.
-    let (kernel_path, rootfs_path, chroot_owner, net_invariant, vm) = {
+    let (kernel_path, rootfs_path, chroot_owner, net_invariant, geometry, vm) = {
         let instance = instances
             .read()
             .unwrap()
@@ -130,6 +130,10 @@ pub(super) async fn checkpoint_impl(
                 .clone()
                 .unwrap_or_else(|| sandbox_id.clone()),
             inst.net_invariant,
+            crate::snapshot::SnapshotGeometry {
+                vcpus: inst.spec.vcpus,
+                memory_mib: inst.spec.memory_mib,
+            },
             vm,
         )
     };
@@ -221,6 +225,7 @@ pub(super) async fn checkpoint_impl(
         kernel_path: Some(kernel_path),
         rootfs_path: Some(rootfs_path),
         net_invariant,
+        geometry: Some(geometry),
     })?;
 
     let snap_dir_path = meta

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -1041,6 +1041,7 @@ mod tests {
                 kernel_path: None,
                 rootfs_path: None,
                 net_invariant: false,
+                geometry: None,
             })
             .unwrap();
         let pending = manager.snapshots.begin("box").unwrap();
@@ -1054,6 +1055,7 @@ mod tests {
                 kernel_path: None,
                 rootfs_path: None,
                 net_invariant: false,
+                geometry: None,
             })
             .unwrap();
 
@@ -1093,6 +1095,7 @@ mod tests {
                 kernel_path: None,
                 rootfs_path: None,
                 net_invariant: false,
+                geometry: None,
             })
             .unwrap();
 

--- a/virt/arcbox-vm/src/sandbox/templates.rs
+++ b/virt/arcbox-vm/src/sandbox/templates.rs
@@ -8,11 +8,31 @@
 //!
 //! [`register_template_draft`]: SandboxManager::register_template_draft
 
+use std::collections::HashMap;
+use std::path::Path;
+
 use tracing::{info, warn};
 
 use super::SandboxManager;
-use crate::error::Result;
-use crate::template_catalog::{ReleasedArtifacts, ResolvedTemplate, TemplateEntry};
+use crate::error::{Result, VmmError};
+use crate::snapshot::{SnapshotDraft, SnapshotGeometry};
+use crate::template_catalog::{ReleasedArtifacts, ResolvedTemplate, TEMPLATE_LABEL, TemplateEntry};
+
+/// A checkpoint copied into template ownership: everything the build
+/// orchestrator needs to assemble the catalog entry.
+#[derive(Debug)]
+pub struct PromotedSnapshot {
+    /// The template-owned copy's snapshot id (carries [`TEMPLATE_LABEL`]).
+    pub snapshot_id: String,
+    /// Capture-time geometry the copy restores onto.
+    pub geometry: SnapshotGeometry,
+    /// The origin's rootfs image path (pinned by the copied meta).
+    pub rootfs_path: String,
+    /// On-disk footprint of the copied vmstate + memory files. Nominal on
+    /// Btrfs: the copy reflinks, so blocks are shared until either side
+    /// diverges.
+    pub artifact_bytes: u64,
+}
 
 impl SandboxManager {
     /// Resolve a `name[:version]` catalog reference.
@@ -60,6 +80,78 @@ impl SandboxManager {
         Ok(())
     }
 
+    /// Copy checkpoint `source_snapshot_id` into a template-owned snapshot
+    /// (new id, [`TEMPLATE_LABEL`] = `template_name`), decoupling the
+    /// template's lifetime from the user checkpoint. Files are reflinked
+    /// where the filesystem supports it (the data dir is Btrfs), so the copy
+    /// is cheap; the origin's rootfs stays pinned through the copied meta.
+    pub async fn promote_snapshot_to_template(
+        &self,
+        source_snapshot_id: &str,
+        template_name: &str,
+    ) -> Result<PromotedSnapshot> {
+        self.check_reconcile()?;
+        crate::template_catalog::validate_template_name(template_name)?;
+        let source = self.snapshots.find_by_id(source_snapshot_id)?;
+        if source.name.as_deref() == Some(super::pause::PAUSE_SNAPSHOT_NAME) {
+            return Err(VmmError::FailedPrecondition(format!(
+                "snapshot {source_snapshot_id} is the internal pause checkpoint of a \
+                 paused sandbox; checkpoint the sandbox instead"
+            )));
+        }
+        let geometry = source.geometry.ok_or_else(|| {
+            VmmError::FailedPrecondition(format!(
+                "snapshot {source_snapshot_id} predates geometry recording; \
+                 re-checkpoint the sandbox with this agent and promote the new snapshot"
+            ))
+        })?;
+        let rootfs_path = source.rootfs_path.clone().ok_or_else(|| {
+            VmmError::FailedPrecondition(format!(
+                "snapshot {source_snapshot_id} records no rootfs path; \
+                 re-checkpoint the sandbox and promote the new snapshot"
+            ))
+        })?;
+
+        let pending = self.snapshots.begin(&format!("template-{template_name}"))?;
+        let staging = pending.dir();
+        let mut artifact_bytes = clone_or_copy(&source.vmstate_path, &staging.join("vmstate"))?;
+        if let Some(mem) = &source.mem_path {
+            artifact_bytes += clone_or_copy(mem, &staging.join("mem"))?;
+        }
+        let meta = pending.commit(SnapshotDraft {
+            name: None,
+            labels: HashMap::from([(TEMPLATE_LABEL.to_owned(), template_name.to_owned())]),
+            snapshot_type: source.snapshot_type,
+            parent_id: source.parent_id.clone(),
+            kernel_path: source.kernel_path.clone(),
+            rootfs_path: Some(rootfs_path.clone()),
+            net_invariant: source.net_invariant,
+            geometry: Some(geometry),
+        })?;
+        info!(
+            template = template_name,
+            source = source_snapshot_id,
+            snapshot_id = %meta.id,
+            "checkpoint promoted into template ownership"
+        );
+        Ok(PromotedSnapshot {
+            snapshot_id: meta.id,
+            geometry,
+            rootfs_path,
+            artifact_bytes,
+        })
+    }
+
+    /// Best-effort removal of a just-promoted copy whose catalog
+    /// registration failed — without it the copy would sit as a
+    /// (recoverable) orphan until an operator noticed the log line.
+    pub async fn discard_promoted_snapshot(&self, snapshot_id: &str) {
+        self.delete_released_snapshots(&ReleasedArtifacts {
+            snapshot_ids: vec![snapshot_id.to_owned()],
+        })
+        .await;
+    }
+
     /// Best-effort deletion of snapshots a catalog mutation released,
     /// draining any pre-warmed restore slots staged from each first
     /// (mirroring `delete_checkpoint` — a slot restored from the snapshot
@@ -90,6 +182,43 @@ impl SandboxManager {
             }
         }
     }
+}
+
+/// Copy `src` to `dst` (mode 0600, fsynced), reflinking when the filesystem
+/// supports it. Returns the byte length copied.
+fn clone_or_copy(src: &Path, dst: &Path) -> Result<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::fd::AsRawFd as _;
+        use std::os::unix::fs::OpenOptionsExt as _;
+        let source = std::fs::File::open(src).map_err(VmmError::Io)?;
+        let dest = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(dst)
+            .map_err(VmmError::Io)?;
+        // SAFETY: both fds are open for the duration of the call; FICLONE
+        // only clones extents from the source fd into the destination fd.
+        let rc = unsafe { libc::ioctl(dest.as_raw_fd(), libc::FICLONE as _, source.as_raw_fd()) };
+        if rc == 0 {
+            dest.sync_all().map_err(VmmError::Io)?;
+            return Ok(source.metadata().map_err(VmmError::Io)?.len());
+        }
+        // Reflink unsupported here (non-Btrfs staging, cross-subvolume
+        // boundary) — fall back to a plain copy below.
+        drop(dest);
+        let _ = std::fs::remove_file(dst);
+    }
+    let bytes = std::fs::copy(src, dst).map_err(VmmError::Io)?;
+    let dest = std::fs::File::open(dst).map_err(VmmError::Io)?;
+    std::fs::set_permissions(dst, {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::Permissions::from_mode(0o600)
+    })
+    .map_err(VmmError::Io)?;
+    dest.sync_all().map_err(VmmError::Io)?;
+    Ok(bytes)
 }
 
 #[cfg(test)]
@@ -124,6 +253,7 @@ mod tests {
                 kernel_path: None,
                 rootfs_path: Some("/cache/rootfs-tpl.ext4".into()),
                 net_invariant: true,
+                geometry: None,
             })
             .unwrap()
             .id
@@ -170,6 +300,73 @@ mod tests {
         assert!(
             catalog.find_by_id(&snapshot_id).is_ok(),
             "guard must not delete"
+        );
+    }
+
+    #[tokio::test]
+    async fn promotion_copies_the_checkpoint_with_independent_lifetime() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = manager(dir.path()).await;
+        let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
+        // A user checkpoint with recorded geometry and a memory file.
+        let pending = catalog.begin("box-1").unwrap();
+        std::fs::write(pending.dir().join("vmstate"), b"vmstate").unwrap();
+        std::fs::write(pending.dir().join("mem"), b"memory-image").unwrap();
+        let source_id = pending
+            .commit(crate::snapshot::SnapshotDraft {
+                name: Some("user-checkpoint".into()),
+                labels: HashMap::new(),
+                snapshot_type: crate::config::SnapshotType::Full,
+                parent_id: None,
+                kernel_path: Some("/kernel".into()),
+                rootfs_path: Some("/cache/rootfs-tpl.ext4".into()),
+                net_invariant: true,
+                geometry: Some(crate::snapshot::SnapshotGeometry {
+                    vcpus: 2,
+                    memory_mib: 512,
+                }),
+            })
+            .unwrap()
+            .id;
+
+        let promoted = m
+            .promote_snapshot_to_template(&source_id, "code")
+            .await
+            .unwrap();
+        assert_ne!(promoted.snapshot_id, source_id);
+        assert_eq!(promoted.geometry.vcpus, 2);
+        assert_eq!(promoted.rootfs_path, "/cache/rootfs-tpl.ext4");
+        assert_eq!(
+            promoted.artifact_bytes,
+            b"vmstate".len() as u64 + b"memory-image".len() as u64
+        );
+
+        let copy = catalog.find_by_id(&promoted.snapshot_id).unwrap();
+        assert_eq!(
+            copy.labels.get(TEMPLATE_LABEL).map(String::as_str),
+            Some("code")
+        );
+        assert!(copy.net_invariant);
+
+        // Deleting the origin leaves the template copy intact.
+        m.delete_checkpoint(&source_id).await.unwrap();
+        assert!(catalog.find_by_id(&promoted.snapshot_id).is_ok());
+    }
+
+    #[tokio::test]
+    async fn promotion_refuses_a_snapshot_without_geometry() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = manager(dir.path()).await;
+        let catalog = SnapshotCatalog::new(dir.path().to_str().unwrap());
+        let source_id = publish_template_snapshot(&catalog, "seed");
+
+        let err = m
+            .promote_snapshot_to_template(&source_id, "code")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("predates geometry recording"),
+            "unexpected error: {err}"
         );
     }
 

--- a/virt/arcbox-vm/src/sandbox/warm.rs
+++ b/virt/arcbox-vm/src/sandbox/warm.rs
@@ -609,6 +609,7 @@ mod tests {
                 kernel_path: None,
                 rootfs_path: None,
                 net_invariant: true,
+                geometry: None,
             })
             .unwrap()
             .id

--- a/virt/arcbox-vm/src/snapshot.rs
+++ b/virt/arcbox-vm/src/snapshot.rs
@@ -11,6 +11,18 @@ use uuid::Uuid;
 use crate::config::SnapshotType;
 use crate::error::{Result, VmmError};
 
+/// VM geometry a memory snapshot was captured with.
+///
+/// A Firecracker memory snapshot restores only onto identical
+/// vcpus/memory, so anything that restores a snapshot onto a caller-shaped
+/// VM (template promotion, CORE-107) needs the capture-time geometry.
+/// Absent on metas written before this field existed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SnapshotGeometry {
+    pub vcpus: u32,
+    pub memory_mib: u64,
+}
+
 /// Metadata stored alongside each snapshot on disk.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SnapshotMeta {
@@ -48,6 +60,10 @@ pub struct SnapshotMeta {
     /// legacy snapshots read back `false` and keep the reconfig-RPC path.
     #[serde(default)]
     pub net_invariant: bool,
+    /// Capture-time VM geometry. `serde(default)` so legacy metas read back
+    /// `None` (consumers that need it reject with an actionable error).
+    #[serde(default)]
+    pub geometry: Option<SnapshotGeometry>,
 }
 
 /// Info returned to callers / gRPC layer.
@@ -154,6 +170,8 @@ pub struct SnapshotDraft {
     pub rootfs_path: Option<String>,
     /// Whether the origin guest ran the invariant network identity (CORE-81).
     pub net_invariant: bool,
+    /// Capture-time VM geometry, when the producer knows it.
+    pub geometry: Option<SnapshotGeometry>,
 }
 
 /// A snapshot being written, not yet part of the catalog.
@@ -208,6 +226,7 @@ impl PendingSnapshot<'_> {
             kernel_path: draft.kernel_path,
             rootfs_path: draft.rootfs_path,
             net_invariant: draft.net_invariant,
+            geometry: draft.geometry,
         };
 
         sync_private_file(&staging.join(VMSTATE_FILE))?;
@@ -497,6 +516,7 @@ mod tests {
             kernel_path: None,
             rootfs_path: None,
             net_invariant: false,
+            geometry: None,
         }
     }
 

--- a/virt/arcbox-vm/tests/integration.rs
+++ b/virt/arcbox-vm/tests/integration.rs
@@ -29,6 +29,7 @@ fn snapshot_catalog_persists_across_instances() {
                 kernel_path: None,
                 rootfs_path: None,
                 net_invariant: false,
+                geometry: None,
             })
             .unwrap()
             .id


### PR DESCRIPTION
Part 5 of the template-catalog campaign ([CORE-107](https://linear.app/arcbox/issue/CORE-107)), on top of #594. `Build{snapshot_id}` promotes an existing checkpoint into a template — no build runs, and the copy becomes the template's warm start point.

## What

- **`promote_snapshot_to_template`** (manager): copies vmstate/mem into a new snapshot-catalog entry under `vm_id = template-<name>` with the `arcbox.template` label — a fresh UUID id, so template and user-checkpoint lifetimes decouple (deleting the origin leaves the copy intact, pinned by its own meta). Files reflink via the `FICLONE` ioctl (the data dir is one Btrfs subvolume; plain-copy fallback on unsupported filesystems), so the copy is cheap.
- **`SnapshotMeta`/`SnapshotDraft` gain capture-time geometry** (`SnapshotGeometry {vcpus, memory_mib}`, serde-default for legacy metas), recorded by `checkpoint_impl` from the instance spec. A memory snapshot restores only onto identical geometry, so promotion **rejects** geometry-less legacy snapshots with a re-checkpoint pointer instead of producing a template that fails at first create. The internal pause checkpoint is likewise refused.
- Guest arm: digest = source snapshot id + fresh copy id (each promotion is a distinct content instance, so a displaced draft's copy is released, never aliased); a failed registration discards the copy immediately rather than leaving a recoverable orphan.

## Validation

`cargo test -p arcbox-vm --lib` (224 — incl. promotion copy/lifetime-decouple and geometry-refusal regressions), full-workspace clippy `-D warnings`, musl-target agent clippy, `cargo fmt --check` — all at this branch tip in isolation.