### PR TITLE
perf(vmnet): event-driven relay read path, drop the 1 kHz poll thread

### DIFF
--- a/virt/AGENTS.md
+++ b/virt/AGENTS.md
@@ -86,6 +86,18 @@ files above.
   release wraps past bounds checks — both are bugs; tests must cover
   near-`u64::MAX` inputs.
 
+## vmnet relay (bridge NIC, `arcbox-vmnet`)
+
+- The vmnet → guest read path is **event-driven** via
+  `vmnet_interface_set_event_callback` (ABX-517) — do not reintroduce a
+  polling/blocking read thread; the deleted 1 kHz poll cost ~half of the
+  daemon's idle CPU and its cancel-then-join teardown could hang
+  `Runtime::drop`. The callback context is owned by the handler block
+  (copy retains, dispose releases) and must never be freed manually;
+  `Vmnet::clear_event_callback` — called from both `Vmnet::stop` and the
+  relay's exit path, idempotent — is what breaks the
+  interface → block → ctx → `Arc<Vmnet>` cycle. Keep both call sites.
+
 ## Debugging — failure signature → first commands → likely cause
 
 Triage rule first: **re-run the same scenario under

--- a/virt/arcbox-vmnet/src/ffi.rs
+++ b/virt/arcbox-vmnet/src/ffi.rs
@@ -370,16 +370,17 @@ unsafe extern "C" {
 }
 
 // ============================================================================
-// Objective-C Block ABI for vmnet completion handler
+// Objective-C Block ABI for vmnet handlers
 // ============================================================================
 //
 // vmnet_start_interface expects a block with signature:
 //   void (^)(vmnet_return_t status, xpc_object_t interface_param)
+// vmnet_interface_set_event_callback expects:
+//   void (^)(interface_event_t event_mask, xpc_object_t event)
 //
-// We build this block manually using the stable C ABI layout described in
+// We build these blocks manually using the stable C ABI layout described in
 // the Clang Block Implementation Specification.
 
-#[cfg(feature = "vmnet")]
 #[repr(C)]
 pub struct BlockDescriptor {
     pub reserved: usize,
@@ -406,7 +407,6 @@ pub struct VmnetCompletionBlock {
     pub semaphore: DispatchSemaphore,
 }
 
-#[cfg(feature = "vmnet")]
 unsafe extern "C" {
     /// Block ISA for stack-allocated blocks.
     #[link_name = "_NSConcreteStackBlock"]
@@ -470,7 +470,6 @@ static VMNET_BLOCK_DESCRIPTOR: BlockDescriptor = BlockDescriptor {
 };
 
 /// Block flags: `BLOCK_HAS_COPY_DISPOSE` (1 << 25).
-#[cfg(feature = "vmnet")]
 const BLOCK_HAS_COPY_DISPOSE: i32 = 1 << 25;
 
 /// Creates a heap-allocated vmnet completion block.
@@ -495,6 +494,111 @@ pub unsafe fn create_vmnet_completion_block(sema: DispatchSemaphore) -> *mut c_v
     };
     // SAFETY: _Block_copy takes a pointer to a valid stack block and returns
     // a heap-allocated copy that is safe to pass to vmnet.
+    unsafe { _Block_copy((&raw const stack_block).cast()) }
+}
+
+/// Event block layout matching the C ABI for Objective-C blocks.
+///
+/// Passed to `vmnet_interface_set_event_callback`; vmnet invokes it as
+/// `void (^)(interface_event_t event_mask, xpc_object_t event)` on the
+/// registered dispatch queue. The captures are a raw context pointer plus
+/// the three function pointers that operate on it; the copy/dispose helpers
+/// route through `retain`/`release`, so the context lives exactly as long
+/// as the framework's copy of the block.
+#[repr(C)]
+pub struct VmnetEventBlock {
+    pub isa: *const c_void,
+    pub flags: i32,
+    pub reserved: i32,
+    /// `event_mask` is deliberately a raw `u32` (`interface_event_t` is
+    /// `OBJC_OPTIONS(uint32_t, ...)`): a Rust enum here would be UB for any
+    /// mask value the framework adds later.
+    pub invoke: unsafe extern "C" fn(*mut Self, u32, XpcObjectT),
+    pub descriptor: *const BlockDescriptor,
+    // Captured variables:
+    pub ctx: *const c_void,
+    pub handler: unsafe extern "C" fn(*const c_void),
+    pub retain: unsafe extern "C" fn(*const c_void),
+    pub release: unsafe extern "C" fn(*const c_void),
+}
+
+/// Event block invoke function: forwards to the captured handler.
+///
+/// # Safety
+///
+/// Called by vmnet.framework on the registered dispatch queue; `block` must
+/// point to a valid `VmnetEventBlock` created by `create_vmnet_event_block`.
+unsafe extern "C" fn vmnet_event_block_invoke(
+    block: *mut VmnetEventBlock,
+    _event_mask: u32,
+    _event: XpcObjectT,
+) {
+    // SAFETY: `block` is a live block copy; `ctx` is kept alive by the
+    // block's retain/release helpers until the copy is disposed.
+    unsafe { ((*block).handler)((*block).ctx) }
+}
+
+/// Event block copy helper: retain the captured context.
+unsafe extern "C" fn vmnet_event_block_copy(dst: *mut c_void, _src: *const c_void) {
+    // SAFETY: dst points to a VmnetEventBlock allocated by _Block_copy.
+    unsafe {
+        let block = dst.cast::<VmnetEventBlock>();
+        ((*block).retain)((*block).ctx);
+    }
+}
+
+/// Event block dispose helper: release the captured context.
+unsafe extern "C" fn vmnet_event_block_dispose(block: *mut c_void) {
+    // SAFETY: block points to a VmnetEventBlock being destroyed.
+    unsafe {
+        let block = block.cast::<VmnetEventBlock>();
+        ((*block).release)((*block).ctx);
+    }
+}
+
+static VMNET_EVENT_BLOCK_DESCRIPTOR: BlockDescriptor = BlockDescriptor {
+    reserved: 0,
+    size: std::mem::size_of::<VmnetEventBlock>(),
+    copy_helper: vmnet_event_block_copy,
+    dispose_helper: vmnet_event_block_dispose,
+};
+
+/// Creates a heap-allocated vmnet event-callback block.
+///
+/// The copy into the returned heap block calls `retain(ctx)` once; the
+/// matching `release(ctx)` runs when the last block copy is disposed. The
+/// caller therefore passes a *borrowed* `ctx` and must:
+/// 1. register the block (the framework takes its own reference), then
+/// 2. drop its own reference with `_Block_release`.
+///
+/// If registration fails, step 2 alone disposes the block and releases the
+/// context — no special error path is needed.
+///
+/// # Safety
+///
+/// `handler`, `retain`, and `release` must be safe to call with `ctx` from
+/// arbitrary dispatch-queue threads for as long as any block copy exists.
+#[must_use]
+pub unsafe fn create_vmnet_event_block(
+    ctx: *const c_void,
+    handler: unsafe extern "C" fn(*const c_void),
+    retain: unsafe extern "C" fn(*const c_void),
+    release: unsafe extern "C" fn(*const c_void),
+) -> *mut c_void {
+    let stack_block = VmnetEventBlock {
+        isa: unsafe { NS_CONCRETE_STACK_BLOCK },
+        flags: BLOCK_HAS_COPY_DISPOSE,
+        reserved: 0,
+        invoke: vmnet_event_block_invoke,
+        descriptor: &raw const VMNET_EVENT_BLOCK_DESCRIPTOR,
+        ctx,
+        handler,
+        retain,
+        release,
+    };
+    // SAFETY: _Block_copy takes a pointer to a valid stack block and returns
+    // a heap-allocated copy (running the copy helper above) that is safe to
+    // pass to vmnet.
     unsafe { _Block_copy((&raw const stack_block).cast()) }
 }
 
@@ -586,5 +690,20 @@ mod tests {
         assert_eq!(offset_of!(VmnetPacket, vm_pkt_iov), 8);
         assert_eq!(offset_of!(VmnetPacket, vm_pkt_iovcnt), 16);
         assert_eq!(offset_of!(VmnetPacket, vm_flags), 20);
+    }
+
+    /// Pins `VmnetEventBlock` to the Clang block ABI: the runtime reads
+    /// `invoke` at offset 16 and `descriptor` at offset 24; a drift there
+    /// makes the framework call through a garbage function pointer.
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn vmnet_event_block_matches_block_abi() {
+        use std::mem::{offset_of, size_of};
+
+        assert_eq!(size_of::<VmnetEventBlock>(), 64);
+        assert_eq!(offset_of!(VmnetEventBlock, isa), 0);
+        assert_eq!(offset_of!(VmnetEventBlock, invoke), 16);
+        assert_eq!(offset_of!(VmnetEventBlock, descriptor), 24);
+        assert_eq!(VMNET_EVENT_BLOCK_DESCRIPTOR.size, 64);
     }
 }

--- a/virt/arcbox-vmnet/src/interface.rs
+++ b/virt/arcbox-vmnet/src/interface.rs
@@ -909,12 +909,27 @@ mod tests {
     #[test]
     #[ignore = "requires macOS vmnet entitlements and root"]
     fn test_vmnet_read_no_data() {
-        let vmnet = Vmnet::new_shared().expect("Failed to create vmnet");
-        let mut buf = [0u8; 1500];
+        // Isolated host-only: every Shared-mode interface joins the same
+        // NAT subnet, so a concurrently running test's broadcast traffic
+        // (e.g. the relay DHCP loopback test) reaches a Shared interface
+        // here and breaks the "no data" premise. Isolation gives this
+        // interface its own empty L2 network. The buffer is sized to
+        // max_packet_size — a bare 1500 is smaller than a full frame and
+        // turns an arriving packet into VMNET_PACKET_TOO_BIG.
+        let vmnet = Vmnet::new(VmnetConfig::host_only().with_isolation(true))
+            .expect("Failed to create vmnet");
+        let mut buf = vec![0u8; vmnet.max_packet_size()];
 
-        let result = vmnet.read_packet(&mut buf);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 0);
+        // Drain any stray host chatter; the contract under test is that an
+        // empty queue reads as Ok(0), never an error.
+        for _ in 0..32 {
+            match vmnet.read_packet(&mut buf) {
+                Ok(0) => return,
+                Ok(_) => {}
+                Err(e) => panic!("read_packet on an idle interface failed: {e}"),
+            }
+        }
+        panic!("queue never drained to empty");
     }
 
     #[test]

--- a/virt/arcbox-vmnet/src/interface.rs
+++ b/virt/arcbox-vmnet/src/interface.rs
@@ -641,9 +641,70 @@ impl Vmnet {
         Ok(data.len())
     }
 
+    /// Registers a packets-available event callback block on the
+    /// interface's dispatch queue.
+    ///
+    /// The framework takes its own reference to `block`; the caller keeps
+    /// (and must eventually `_Block_release`) its own.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the framework rejects the registration.
+    pub(crate) fn set_event_callback(&self, block: *const std::ffi::c_void) -> Result<()> {
+        // SAFETY: interface and queue are valid for the lifetime of self;
+        // block is a valid heap block from `create_vmnet_event_block`.
+        let status = unsafe {
+            vmnet_interface_set_event_callback(
+                self.interface,
+                VmnetInterfaceEvent::PacketsAvailable,
+                self.queue,
+                block,
+            )
+        };
+        if !status.is_success() {
+            return Err(VmnetError::config(format!(
+                "vmnet_interface_set_event_callback failed: {}",
+                status.message()
+            )));
+        }
+        Ok(())
+    }
+
+    /// Unregisters the event callback, releasing the framework's reference
+    /// to the handler block (and, through its dispose helper, the context
+    /// the block owns).
+    ///
+    /// Per `vmnet.h`, events are disabled when callback **and queue** are
+    /// both NULL. Idempotent: clearing when nothing is registered is
+    /// harmless, so both `Vmnet::stop` and the relay's exit path call it.
+    pub(crate) fn clear_event_callback(&self) {
+        // SAFETY: NULL queue + NULL callback is the documented disable form;
+        // an in-flight invocation is safe because GCD holds its own
+        // reference to a dispatched block for the invocation's duration.
+        let status = unsafe {
+            vmnet_interface_set_event_callback(
+                self.interface,
+                VmnetInterfaceEvent::PacketsAvailable,
+                ptr::null_mut(),
+                ptr::null(),
+            )
+        };
+        if !status.is_success() {
+            tracing::debug!(
+                "vmnet_interface_set_event_callback(NULL) returned: {}",
+                status.message()
+            );
+        }
+    }
+
     /// Stops the vmnet interface.
     pub fn stop(&self) {
         if self.running.swap(false, Ordering::AcqRel) {
+            // Release the event handler block first: the native interface
+            // holds block → context → Arc<Vmnet>, and this call is what
+            // breaks that cycle when the relay task never got to run its
+            // own clear (e.g. runtime shutdown aborted it).
+            self.clear_event_callback();
             // SAFETY: vmnet_stop_interface is safe when called with valid parameters.
             unsafe {
                 vmnet_stop_interface(self.interface, self.queue, ptr::null());

--- a/virt/arcbox-vmnet/src/lib.rs
+++ b/virt/arcbox-vmnet/src/lib.rs
@@ -5,8 +5,9 @@
 //!   XPC, and the Objective-C block ABI required by `vmnet_start_interface`.
 //! - A high-level [`Vmnet`] interface for creating shared (NAT), host-only,
 //!   and bridged virtual network interfaces.
-//! - A [`VmnetRelay`] that bridges vmnet's blocking read/write API to a
-//!   `socketpair` consumed by `VZFileHandleNetworkDeviceAttachment`.
+//! - A [`VmnetRelay`] that bridges vmnet to a `socketpair` consumed by
+//!   `VZFileHandleNetworkDeviceAttachment`: reads are event-driven via
+//!   `vmnet_interface_set_event_callback`, writes are async on the fd.
 //!
 //! # Operating modes
 //!

--- a/virt/arcbox-vmnet/src/relay.rs
+++ b/virt/arcbox-vmnet/src/relay.rs
@@ -212,6 +212,13 @@ impl VmnetRelay {
         // SAFETY: dup_fd is a valid fd from dup().
         let reader_fd: OwnedFd = unsafe { OwnedFd::from_raw_fd(dup_fd) };
 
+        // Constructed before the callback registration on purpose: it is the
+        // last fallible step, so once the callback is registered the only
+        // exit is the loop below, whose tail always unregisters. An error
+        // path between registration and the loop would strand the callback
+        // (and the Vmnet it retains) until `Vmnet::stop`.
+        let async_fd = AsyncFd::new(guest_fd)?;
+
         // vmnet → guest: event callback on the interface's dispatch queue.
         let ctx = Arc::new(ReadCtx {
             vmnet: Arc::clone(&self.vmnet),
@@ -239,8 +246,6 @@ impl VmnetRelay {
         // SAFETY: block is the live heap block created above.
         unsafe { _Block_release(block) };
         registered.map_err(std::io::Error::other)?;
-
-        let async_fd = AsyncFd::new(guest_fd)?;
 
         // guest → vmnet: async
         let vmnet_write = Arc::clone(&self.vmnet);

--- a/virt/arcbox-vmnet/src/relay.rs
+++ b/virt/arcbox-vmnet/src/relay.rs
@@ -2,23 +2,165 @@
 //!
 //! When the `vmnet` feature is enabled, the bridge NIC uses vmnet.framework
 //! directly instead of `VZNATNetworkDeviceAttachment`. This relay bridges
-//! the vmnet read/write API (blocking) with the socketpair fd that the
+//! the vmnet read/write API with the socketpair fd that the
 //! `VZFileHandleNetworkDeviceAttachment` consumes.
 //!
 //! All DHCP, DNS, and ARP processing is handled by vmnet itself — the relay
 //! is a transparent L2 pipe.
+//!
+//! Two directions:
+//! - **vmnet → guest**: event-driven. A `PACKETS_AVAILABLE` callback on the
+//!   interface's dispatch queue drains `vmnet_read` to empty and writes each
+//!   frame to the socketpair. No polling thread exists; an idle interface
+//!   costs zero wakeups.
+//! - **guest → vmnet**: async via `AsyncFd` on the socketpair.
+//!
+//! The callback context ([`ReadCtx`]) is owned by the handler block: the
+//! block's copy helper takes an `Arc` reference and its dispose helper
+//! releases it, so the context lives exactly as long as the framework's
+//! block copy. Nothing frees it manually. The resulting reference cycle
+//! (native interface → block → `ReadCtx` → `Arc<Vmnet>`) is broken by
+//! `Vmnet::clear_event_callback`, called from both `Vmnet::stop` and this
+//! relay's exit path.
 
+use std::ffi::c_void;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use tokio::io::Interest;
 use tokio::io::unix::AsyncFd;
 use tokio_util::sync::CancellationToken;
 
+use crate::ffi::{_Block_release, create_vmnet_event_block};
 use crate::interface::Vmnet;
 
 /// Maximum Ethernet frame size (jumbo frame capable).
 const MAX_FRAME_SIZE: usize = 9216;
+
+/// Context for the vmnet → guest event callback.
+///
+/// Shared with the dispatch queue through the handler block; every field
+/// must stay safe to touch from an arbitrary dispatch thread.
+struct ReadCtx {
+    vmnet: Arc<Vmnet>,
+    guest_fd: OwnedFd,
+    /// Read buffer. Invocations are serialized on the interface's serial
+    /// dispatch queue, so this lock is never contended — it exists to keep
+    /// the shared-context mutation boring and safe.
+    buf: Mutex<Vec<u8>>,
+    /// Set when the socketpair peer is gone; later events return early.
+    dead: AtomicBool,
+    /// `PACKETS_AVAILABLE` invocations observed.
+    events: AtomicU64,
+    /// Frames delivered to the guest fd.
+    frames: AtomicU64,
+    /// Frames dropped on guest backpressure (EAGAIN / ENOBUFS).
+    drops: AtomicU64,
+}
+
+impl ReadCtx {
+    /// Drains all available vmnet packets to the guest socketpair.
+    ///
+    /// Draining to empty (`Ok(0)` = `VMNET_BUFFER_EXHAUSTED`) makes
+    /// correctness independent of whether the framework's event is edge- or
+    /// level-triggered: a spurious event costs one empty read.
+    fn drain(&self) {
+        if self.dead.load(Ordering::Relaxed) {
+            return;
+        }
+        self.events.fetch_add(1, Ordering::Relaxed);
+        let mut buf = self.buf.lock().expect("relay read buffer poisoned");
+        loop {
+            match self.vmnet.read_packet(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if !self.forward_frame(&buf[..n]) {
+                        self.dead.store(true, Ordering::Relaxed);
+                        break;
+                    }
+                }
+                Err(e) => {
+                    // "interface not running" during stop is expected; any
+                    // other error also has no retry path here — the next
+                    // event re-enters.
+                    tracing::trace!("vmnet read error: {e}");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Writes one frame to the guest fd. Returns `false` when the peer is
+    /// gone (`EPIPE`), which ends the read path for good.
+    fn forward_frame(&self, frame: &[u8]) -> bool {
+        let fd = self.guest_fd.as_raw_fd();
+        // Retry EINTR (a signal interrupted the write before any bytes were
+        // sent); classify everything else.
+        loop {
+            // SAFETY: write to a valid socketpair fd with a valid buffer.
+            let written = unsafe { libc::write(fd, frame.as_ptr().cast::<c_void>(), frame.len()) };
+            if written >= 0 {
+                self.frames.fetch_add(1, Ordering::Relaxed);
+                return true;
+            }
+            let err = std::io::Error::last_os_error();
+            match err.kind() {
+                std::io::ErrorKind::Interrupted => {}
+                std::io::ErrorKind::BrokenPipe => return false,
+                // WouldBlock (EAGAIN) or ENOBUFS: the guest RX ring is
+                // momentarily full — drop this frame; the transport layer
+                // retransmits.
+                std::io::ErrorKind::WouldBlock => {
+                    self.drops.fetch_add(1, Ordering::Relaxed);
+                    return true;
+                }
+                _ if err.raw_os_error() == Some(libc::ENOBUFS) => {
+                    self.drops.fetch_add(1, Ordering::Relaxed);
+                    return true;
+                }
+                _ => {
+                    // Unexpected but non-fatal.
+                    tracing::debug!("vmnet→guest write error: {err}");
+                    return true;
+                }
+            }
+        }
+    }
+}
+
+/// Event-callback trampoline: `ctx` is the `Arc<ReadCtx>` the block retains.
+///
+/// # Safety
+///
+/// Called by the block invoke on the interface's dispatch queue; `ctx` must
+/// be an `Arc<ReadCtx>` pointer kept alive by the block's retain/release.
+unsafe extern "C" fn on_packets_available(ctx: *const c_void) {
+    // SAFETY: the block holds a strong count on this Arc (see retain below),
+    // so the pointee is alive for the whole invocation.
+    let ctx = unsafe { &*ctx.cast::<ReadCtx>() };
+    ctx.drain();
+}
+
+/// Block copy helper target: takes one strong count on the context.
+///
+/// # Safety
+///
+/// `ctx` must originate from `Arc::as_ptr` on a live `Arc<ReadCtx>`.
+unsafe extern "C" fn read_ctx_retain(ctx: *const c_void) {
+    // SAFETY: per contract above; increment pairs with read_ctx_release.
+    unsafe { Arc::increment_strong_count(ctx.cast::<ReadCtx>()) }
+}
+
+/// Block dispose helper target: releases the strong count taken on copy.
+///
+/// # Safety
+///
+/// `ctx` must hold a strong count previously taken by `read_ctx_retain`.
+unsafe extern "C" fn read_ctx_release(ctx: *const c_void) {
+    // SAFETY: per contract above; balances read_ctx_retain exactly once.
+    unsafe { Arc::decrement_strong_count(ctx.cast::<ReadCtx>()) }
+}
 
 /// Bidirectional L2 relay between vmnet and a socketpair.
 pub struct VmnetRelay {
@@ -38,22 +180,20 @@ impl VmnetRelay {
     /// `guest_fd` is one end of a `SOCK_DGRAM` socketpair. The other end is
     /// given to `VZFileHandleNetworkDeviceAttachment`.
     ///
-    /// Two directions:
-    /// - **vmnet → guest**: dedicated blocking thread (vmnet read is blocking)
-    /// - **guest → vmnet**: async via `AsyncFd` on the socketpair
+    /// Registers the vmnet → guest event callback, then serves the
+    /// guest → vmnet direction until cancelled or the peer closes, and
+    /// finally unregisters the callback.
     ///
     /// # Errors
     ///
-    /// Returns an error if the `AsyncFd` cannot be created.
+    /// Returns an error if the fd cannot be prepared, the event callback
+    /// cannot be registered, or the `AsyncFd` cannot be created.
     pub async fn run(self, guest_fd: OwnedFd) -> std::io::Result<()> {
-        // The fd MUST be non-blocking: `AsyncFd` requires it, and a blocking
-        // `read` here wedges the task inside the syscall — the select below
-        // never regains control, cancellation cannot propagate to the
-        // vmnet→guest worker, and the tokio blocking pool then waits forever
-        // in `Runtime::drop`, hanging daemon shutdown. (The write side
-        // already assumes non-blocking: it treats `WouldBlock` as guest
-        // backpressure.) `dup` shares the file status flags, so this covers
-        // the cloned writer fd too.
+        // The fd MUST be non-blocking: `AsyncFd` requires it, and the event
+        // handler's writes rely on EAGAIN/ENOBUFS surfacing as errors (guest
+        // backpressure → drop) instead of blocking the vmnet dispatch queue.
+        // `dup` shares the file status flags, so this covers the handler's
+        // cloned fd too.
         let raw_fd = guest_fd.as_raw_fd();
         // SAFETY: fcntl F_GETFL/F_SETFL on a valid, owned fd.
         unsafe {
@@ -63,7 +203,7 @@ impl VmnetRelay {
             }
         }
 
-        // Clone the fd for the blocking thread (vmnet → guest direction).
+        // Clone the fd for the event handler (vmnet → guest direction).
         // SAFETY: dup is safe on a valid fd.
         let dup_fd = unsafe { libc::dup(raw_fd) };
         if dup_fd < 0 {
@@ -72,136 +212,100 @@ impl VmnetRelay {
         // SAFETY: dup_fd is a valid fd from dup().
         let reader_fd: OwnedFd = unsafe { OwnedFd::from_raw_fd(dup_fd) };
 
-        let async_fd = AsyncFd::new(guest_fd)?;
-
-        // vmnet → guest: blocking thread
-        let vmnet_read = Arc::clone(&self.vmnet);
-        let cancel_read = self.cancel.clone();
-        let mut vmnet_to_guest = tokio::task::spawn_blocking(move || {
-            let mut buf = vec![0u8; MAX_FRAME_SIZE];
-            loop {
-                if cancel_read.is_cancelled() {
-                    break;
-                }
-                match vmnet_read.read_packet(&mut buf) {
-                    Ok(0) => {
-                        // No data available, brief yield.
-                        std::thread::sleep(std::time::Duration::from_millis(1));
-                    }
-                    Ok(n) => {
-                        let fd = reader_fd.as_raw_fd();
-                        // Retry EINTR (a signal interrupted the write before any
-                        // bytes were sent); surface any other error to classify.
-                        let write_err = loop {
-                            // SAFETY: write to a valid socketpair fd with valid buffer.
-                            let written =
-                                unsafe { libc::write(fd, buf.as_ptr().cast::<libc::c_void>(), n) };
-                            if written >= 0 {
-                                break None;
-                            }
-                            let err = std::io::Error::last_os_error();
-                            if err.kind() == std::io::ErrorKind::Interrupted {
-                                continue;
-                            }
-                            break Some(err);
-                        };
-                        if let Some(err) = write_err {
-                            if err.kind() == std::io::ErrorKind::BrokenPipe {
-                                break;
-                            }
-                            // WouldBlock (EAGAIN) or ENOBUFS: the guest RX ring
-                            // is momentarily full — drop this frame; the
-                            // transport layer retransmits. Anything else is
-                            // unexpected but non-fatal.
-                            if err.kind() != std::io::ErrorKind::WouldBlock
-                                && err.raw_os_error() != Some(libc::ENOBUFS)
-                            {
-                                tracing::debug!("vmnet→guest write error: {err}");
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        if cancel_read.is_cancelled() {
-                            break;
-                        }
-                        tracing::debug!("vmnet read error: {e}");
-                        std::thread::sleep(std::time::Duration::from_millis(1));
-                    }
-                }
-            }
+        // vmnet → guest: event callback on the interface's dispatch queue.
+        let ctx = Arc::new(ReadCtx {
+            vmnet: Arc::clone(&self.vmnet),
+            guest_fd: reader_fd,
+            buf: Mutex::new(vec![0u8; MAX_FRAME_SIZE]),
+            dead: AtomicBool::new(false),
+            events: AtomicU64::new(0),
+            frames: AtomicU64::new(0),
+            drops: AtomicU64::new(0),
         });
+        // SAFETY: the trampolines above uphold the block's contract for an
+        // `Arc<ReadCtx>` context; the copy into the heap block retains it.
+        let block = unsafe {
+            create_vmnet_event_block(
+                Arc::as_ptr(&ctx).cast(),
+                on_packets_available,
+                read_ctx_retain,
+                read_ctx_release,
+            )
+        };
+        let registered = self.vmnet.set_event_callback(block);
+        // Drop our block reference regardless: on success the framework
+        // holds its own; on failure this disposes the block and releases
+        // the context's extra count.
+        // SAFETY: block is the live heap block created above.
+        unsafe { _Block_release(block) };
+        registered.map_err(std::io::Error::other)?;
+
+        let async_fd = AsyncFd::new(guest_fd)?;
 
         // guest → vmnet: async
         let vmnet_write = Arc::clone(&self.vmnet);
         let cancel_write = self.cancel.clone();
-        let guest_to_vmnet = async move {
-            let mut buf = vec![0u8; MAX_FRAME_SIZE];
-            loop {
-                tokio::select! {
-                    () = cancel_write.cancelled() => break,
-                    ready = async_fd.ready(Interest::READABLE) => {
-                        let mut guard = match ready {
-                            Ok(g) => g,
-                            Err(e) => {
-                                tracing::debug!("AsyncFd ready error: {e}");
-                                break;
-                            }
-                        };
+        let mut buf = vec![0u8; MAX_FRAME_SIZE];
+        loop {
+            tokio::select! {
+                () = cancel_write.cancelled() => break,
+                ready = async_fd.ready(Interest::READABLE) => {
+                    let mut guard = match ready {
+                        Ok(g) => g,
+                        Err(e) => {
+                            tracing::debug!("AsyncFd ready error: {e}");
+                            break;
+                        }
+                    };
 
-                        // Try to read from the socketpair.
-                        let fd = async_fd.as_raw_fd();
-                        // SAFETY: read from a valid socketpair fd with valid buffer.
-                        let n = unsafe {
-                            libc::read(
-                                fd,
-                                buf.as_mut_ptr().cast::<libc::c_void>(),
-                                buf.len(),
-                            )
-                        };
+                    // Try to read from the socketpair.
+                    let fd = async_fd.as_raw_fd();
+                    // SAFETY: read from a valid socketpair fd with valid buffer.
+                    let n = unsafe {
+                        libc::read(
+                            fd,
+                            buf.as_mut_ptr().cast::<c_void>(),
+                            buf.len(),
+                        )
+                    };
 
-                        match n.cmp(&0) {
-                            std::cmp::Ordering::Greater => {
-                                if let Err(e) = vmnet_write.write_packet(&buf[..n as usize]) {
-                                    tracing::debug!("guest→vmnet write error: {e}");
-                                }
+                    match n.cmp(&0) {
+                        std::cmp::Ordering::Greater => {
+                            if let Err(e) = vmnet_write.write_packet(&buf[..n as usize]) {
+                                tracing::debug!("guest→vmnet write error: {e}");
                             }
-                            std::cmp::Ordering::Equal => break, // Peer closed
-                            std::cmp::Ordering::Less => {
-                                let err = std::io::Error::last_os_error();
-                                match err.kind() {
-                                    std::io::ErrorKind::WouldBlock => guard.clear_ready(),
-                                    // A signal interrupted the read before a
-                                    // frame arrived (EINTR): retry on the next
-                                    // iteration instead of tearing down the
-                                    // whole bridge-NIC relay.
-                                    std::io::ErrorKind::Interrupted => {}
-                                    _ => {
-                                        tracing::debug!("guest→vmnet read error: {err}");
-                                        break;
-                                    }
+                        }
+                        std::cmp::Ordering::Equal => break, // Peer closed
+                        std::cmp::Ordering::Less => {
+                            let err = std::io::Error::last_os_error();
+                            match err.kind() {
+                                std::io::ErrorKind::WouldBlock => guard.clear_ready(),
+                                // A signal interrupted the read before a
+                                // frame arrived (EINTR): retry on the next
+                                // iteration instead of tearing down the
+                                // whole bridge-NIC relay.
+                                std::io::ErrorKind::Interrupted => {}
+                                _ => {
+                                    tracing::debug!("guest→vmnet read error: {err}");
+                                    break;
                                 }
                             }
                         }
                     }
                 }
             }
-        };
-
-        tokio::select! {
-            () = self.cancel.cancelled() => {}
-            _ = &mut vmnet_to_guest => {}
-            () = guest_to_vmnet => {}
         }
 
-        // Ensure the blocking thread exits regardless of which branch won.
-        self.cancel.cancel();
-        if let Err(e) = vmnet_to_guest.await {
-            if e.is_panic() {
-                tracing::error!("vmnet→guest blocking task panicked: {e}");
-            } else {
-                tracing::debug!("vmnet→guest blocking task join error: {e}");
-            }
-        }
+        // Unregister the read callback (idempotent with Vmnet::stop's own
+        // clear). This releases the framework's block reference and with it
+        // the ReadCtx, breaking the block → ctx → Arc<Vmnet> cycle.
+        self.vmnet.clear_event_callback();
+        tracing::debug!(
+            events = ctx.events.load(Ordering::Relaxed),
+            frames = ctx.frames.load(Ordering::Relaxed),
+            drops = ctx.drops.load(Ordering::Relaxed),
+            "vmnet relay stopped"
+        );
 
         Ok(())
     }

--- a/virt/arcbox-vmnet/src/relay.rs
+++ b/virt/arcbox-vmnet/src/relay.rs
@@ -310,3 +310,181 @@ impl VmnetRelay {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Weak;
+    use std::time::{Duration, Instant};
+
+    /// Test context collecting every frame the event callback drains.
+    struct TestCtx {
+        vmnet: Arc<Vmnet>,
+        frames: Mutex<Vec<Vec<u8>>>,
+    }
+
+    impl TestCtx {
+        fn drain(&self) {
+            let mut buf = vec![0u8; MAX_FRAME_SIZE];
+            while let Ok(n) = self.vmnet.read_packet(&mut buf) {
+                if n == 0 {
+                    break;
+                }
+                self.frames.lock().unwrap().push(buf[..n].to_vec());
+            }
+        }
+    }
+
+    /// # Safety
+    /// `ctx` is an `Arc<TestCtx>` pointer kept alive by the block.
+    unsafe extern "C" fn test_on_event(ctx: *const std::ffi::c_void) {
+        // SAFETY: per the block's retain/release contract below.
+        unsafe { &*ctx.cast::<TestCtx>() }.drain();
+    }
+
+    /// # Safety
+    /// `ctx` must originate from `Arc::as_ptr` on a live `Arc<TestCtx>`.
+    unsafe extern "C" fn test_retain(ctx: *const std::ffi::c_void) {
+        // SAFETY: per contract above.
+        unsafe { Arc::increment_strong_count(ctx.cast::<TestCtx>()) }
+    }
+
+    /// # Safety
+    /// `ctx` must hold a strong count taken by `test_retain`.
+    unsafe extern "C" fn test_release(ctx: *const std::ffi::c_void) {
+        // SAFETY: per contract above.
+        unsafe { Arc::decrement_strong_count(ctx.cast::<TestCtx>()) }
+    }
+
+    /// Builds a minimal DHCP DISCOVER as a raw Ethernet frame.
+    fn build_dhcp_discover(mac: [u8; 6]) -> Vec<u8> {
+        // BOOTP fixed part (236 bytes) + magic cookie + options.
+        let mut bootp = vec![0u8; 236];
+        bootp[0] = 1; // op = BOOTREQUEST
+        bootp[1] = 1; // htype = Ethernet
+        bootp[2] = 6; // hlen
+        bootp[4..8].copy_from_slice(&0x2A2A_2A2Au32.to_be_bytes()); // xid
+        bootp[10..12].copy_from_slice(&0x8000u16.to_be_bytes()); // broadcast flag
+        bootp[28..34].copy_from_slice(&mac); // chaddr
+        bootp.extend_from_slice(&[0x63, 0x82, 0x53, 0x63]); // DHCP magic
+        bootp.extend_from_slice(&[53, 1, 1]); // option: DHCP message type = DISCOVER
+        bootp.push(255); // end option
+
+        let udp_len = 8 + bootp.len();
+        let ip_len = 20 + udp_len;
+
+        let mut ip = vec![
+            0x45, 0, // version/IHL, TOS
+        ];
+        ip.extend_from_slice(&u16::try_from(ip_len).unwrap().to_be_bytes());
+        ip.extend_from_slice(&[0, 0, 0, 0]); // id, flags/frag
+        ip.extend_from_slice(&[64, 17, 0, 0]); // TTL, UDP, checksum placeholder
+        ip.extend_from_slice(&[0, 0, 0, 0]); // src 0.0.0.0
+        ip.extend_from_slice(&[255, 255, 255, 255]); // dst broadcast
+        let sum = ip_header_checksum(&ip);
+        ip[10..12].copy_from_slice(&sum.to_be_bytes());
+
+        let mut udp = Vec::new();
+        udp.extend_from_slice(&68u16.to_be_bytes()); // src port
+        udp.extend_from_slice(&67u16.to_be_bytes()); // dst port
+        udp.extend_from_slice(&u16::try_from(udp_len).unwrap().to_be_bytes());
+        udp.extend_from_slice(&[0, 0]); // checksum 0 = disabled
+
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&[0xFF; 6]); // dst broadcast
+        frame.extend_from_slice(&mac);
+        frame.extend_from_slice(&[0x08, 0x00]); // IPv4
+        frame.extend_from_slice(&ip);
+        frame.extend_from_slice(&udp);
+        frame.extend_from_slice(&bootp);
+        frame
+    }
+
+    fn ip_header_checksum(header: &[u8]) -> u16 {
+        let mut sum = 0u32;
+        for chunk in header.chunks(2) {
+            sum += u32::from(u16::from_be_bytes([chunk[0], chunk[1]]));
+        }
+        while sum > 0xFFFF {
+            sum = (sum & 0xFFFF) + (sum >> 16);
+        }
+        !(sum as u16)
+    }
+
+    /// Returns true if `frame` is a UDP datagram from port 67 (a DHCP
+    /// server reply — OFFER for our DISCOVER).
+    fn is_dhcp_reply(frame: &[u8]) -> bool {
+        frame.len() > 36
+            && frame[12..14] == [0x08, 0x00]
+            && frame[23] == 17
+            && u16::from_be_bytes([frame[34], frame[35]]) == 67
+    }
+
+    /// Empirical pin of the event-callback semantics the relay depends on:
+    /// registration delivers `PACKETS_AVAILABLE` when a packet arrives (a
+    /// DHCP OFFER provoked from vmnet's built-in DHCP server), drain-to-empty
+    /// collects it, and `clear_event_callback` releases the framework's
+    /// block copy so the context is disposed rather than leaked.
+    #[test]
+    #[ignore = "requires macOS vmnet entitlements and root"]
+    fn event_callback_delivers_dhcp_offer() {
+        let vmnet = Arc::new(Vmnet::new_shared().expect("failed to create shared vmnet"));
+
+        let ctx = Arc::new(TestCtx {
+            vmnet: Arc::clone(&vmnet),
+            frames: Mutex::new(Vec::new()),
+        });
+        let weak: Weak<TestCtx> = Arc::downgrade(&ctx);
+
+        // SAFETY: trampolines uphold the block contract for Arc<TestCtx>.
+        let block = unsafe {
+            create_vmnet_event_block(
+                Arc::as_ptr(&ctx).cast(),
+                test_on_event,
+                test_retain,
+                test_release,
+            )
+        };
+        vmnet
+            .set_event_callback(block)
+            .expect("event callback registration failed");
+        // SAFETY: block is the live heap block created above.
+        unsafe { _Block_release(block) };
+
+        // Provoke a reply: vmnet's DHCP server answers a DISCOVER. Resend
+        // periodically in case the first lands before the server is ready.
+        let discover = build_dhcp_discover(vmnet.mac());
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut offered = false;
+        while Instant::now() < deadline {
+            vmnet
+                .write_packet(&discover)
+                .expect("write DISCOVER failed");
+            std::thread::sleep(Duration::from_millis(200));
+            if ctx.frames.lock().unwrap().iter().any(|f| is_dhcp_reply(f)) {
+                offered = true;
+                break;
+            }
+        }
+        assert!(
+            offered,
+            "no DHCP reply delivered via event callback; frames seen: {}",
+            ctx.frames.lock().unwrap().len()
+        );
+
+        // Unregister and drop our reference: the framework's dispose must
+        // release the block-owned strong count, leaving the Weak dead.
+        vmnet.clear_event_callback();
+        drop(ctx);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while weak.upgrade().is_some() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            weak.upgrade().is_none(),
+            "TestCtx leaked: block dispose never released the context"
+        );
+
+        vmnet.stop();
+    }
+}


### PR DESCRIPTION
## Summary

The bridge NIC (NIC2) relay's vmnet → guest direction was a `spawn_blocking` thread polling `vmnet_read` at 1000 Hz (`Ok(0)` → `sleep(1ms)`) — the dominant source of daemon idle CPU (ABX-320) and a permanently occupied blocking-pool thread. vmnet is callback-shaped; this replaces the poll with a `VMNET_INTERFACE_PACKETS_AVAILABLE` event callback on the interface's dispatch queue (ABX-517).

- **ffi**: hand-rolled ObjC `VmnetEventBlock` matching `vmnet_interface_set_event_callback`'s handler type, with a layout pin test (invoke @16, descriptor @24). The event mask crosses the ABI as a raw `u32` — `interface_event_t` is `OBJC_OPTIONS(uint32_t, ...)`, and a Rust enum would be UB for future mask values. Shared block-ABI pieces are un-feature-gated (plain libSystem symbols; the relay compiles without the `vmnet` feature).
- **lifetime model**: the callback context is owned by the block — copy retains an `Arc` strong count, dispose releases it — so nothing is freed manually and an unset racing an in-flight invocation is safe (GCD retains a dispatched block for the invocation's duration). The resulting interface → block → ctx → `Arc<Vmnet>` cycle is broken by `Vmnet::clear_event_callback` (per `vmnet.h`, disable requires **both** callback and queue NULL), called idempotently from `Vmnet::stop` and the relay's exit path.
- **relay**: the handler drains `vmnet_read` to empty per event (correct under both edge- and level-trigger semantics) and keeps the existing write classification (EINTR retry, BrokenPipe ends the path, EAGAIN/ENOBUFS drops as guest backpressure). Deletes the `O_NONBLOCK`/dup/cancel-then-join dance whose sole purpose was stopping the blocking thread from wedging `Runtime::drop`.

## Measurements (VZ, isolated release daemon, Apple Silicon)

| Metric | Before | After |
|---|---|---|
| Idle CPU (60 s cputime delta) | 0.76–1.07 % | **0.05 %** |
| Relay poll stack in 10 s `sample` | 1000 wakeups/s | absent |
| Bridge host→guest iperf3 (event-callback path) | — | 7.62 Gbit/s, 0 retr |
| Bridge guest→host iperf3 | — | 7.45 Gbit/s |
| Bridge ping RTT avg | — | 0.35 ms, 0 % loss |

## Validation

1. `cargo test -p arcbox-vmnet` (± `--features vmnet`) + clippy zero-warning both configs.
2. Root-gated integration (`sudo … -- --ignored`): **7/7**, including the new `event_callback_delivers_dhcp_offer` — a hand-built DHCP DISCOVER provokes vmnet's DHCP server; the reply arriving via the callback pins registration, delivery-on-arrival, and drain-to-empty; a `Weak` going dead after unset pins the no-leak half. Also fixes `test_vmnet_read_no_data`, whose shared-subnet premise the new test broke (Shared interfaces all join one NAT subnet) and whose bare 1500-byte buffer turned arriving frames into `VMNET_PACKET_TOO_BIG`.
3. Daemon e2e `boot_assets` (VZ): READY in 7 s, full Docker lifecycle, clean `exit status: 0` shutdown.
4. Bridge datapath probe: table above.

Closes ABX-517. Refs ABX-320.