### PR TITLE
feat(sandbox): resolve catalog templates in Create with pinned keys and default merge (CORE-107)

### DIFF
--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -136,15 +136,24 @@ impl SandboxService {
         &self,
         payload: &[u8],
     ) -> Result<sandbox_v1::CreateSandboxResponse, SandboxError> {
-        let request = sandbox_v1::CreateSandboxRequest::decode_from_slice(payload)
+        let mut request = sandbox_v1::CreateSandboxRequest::decode_from_slice(payload)
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
         if create_uses_network(&request) {
             self.manager.wait_startup_cleanup_complete().await;
         }
+        // Catalog resolution runs BEFORE both idempotency layers: the pinned
+        // canonical ref (`name:version@digest`) is substituted into the
+        // request itself, so the durable create key AND the in-process
+        // registry (which compares whole requests) both diverge on a retry
+        // after a Publish changed what the reference means — instead of
+        // silently replaying the old content. Template defaults are folded
+        // in here too, so the key hashes the effective workload and the
+        // `no_default_*` flags need no key-domain change.
+        let source = self.resolve_template_source(&mut request)?;
         let _operation = self.operations.lock(&request.id).await;
         let create_key = crate::create_key::create_key(&request);
         if request.id.is_empty() {
-            return self.create_once(request, &create_key).await;
+            return self.create_once(request, source, &create_key).await;
         }
 
         let id = request.id.clone();
@@ -157,7 +166,7 @@ impl SandboxService {
             })? {
                 CreateReserve::Existing(response) => return Ok(response),
                 CreateReserve::Slot(slot) => {
-                    let response = self.create_once(request, &create_key).await?;
+                    let response = self.create_once(request, source, &create_key).await?;
                     slot.commit(&response);
                     return Ok(response);
                 }
@@ -168,9 +177,36 @@ impl SandboxService {
         }
     }
 
+    /// Classify `request.template` and, for catalog references, pin and
+    /// default-merge the request in place (see `create` for why this happens
+    /// before the idempotency layers).
+    fn resolve_template_source(
+        &self,
+        request: &mut sandbox_v1::CreateSandboxRequest,
+    ) -> Result<templates::TemplateSource, SandboxError> {
+        match template::Template::parse(&request.template) {
+            Ok(template::Template::Default) => return Ok(templates::TemplateSource::Default),
+            Ok(template::Template::DockerImage(image)) => {
+                return Ok(templates::TemplateSource::DockerImage(image));
+            }
+            // Not one of the two local forms — a catalog-shaped reference,
+            // whose grammar and existence the catalog itself decides.
+            Err(_) => {}
+        }
+        let resolved = self
+            .manager
+            .get_template(request.template.trim())
+            .map_err(SandboxError::from)?;
+        templates::validate_template_overrides(request)?;
+        request.template = resolved.canonical_ref();
+        templates::merge_template_defaults(request, &resolved.entry.defaults);
+        Ok(templates::TemplateSource::Catalog(resolved))
+    }
+
     async fn create_once(
         &self,
         request: sandbox_v1::CreateSandboxRequest,
+        source: templates::TemplateSource,
         create_key: &str,
     ) -> Result<sandbox_v1::CreateSandboxResponse, SandboxError> {
         if !request.id.is_empty()
@@ -188,7 +224,6 @@ impl SandboxService {
             });
         }
 
-        let template = template::Template::parse(&request.template)?;
         let mut spec = proto_to_spec(request);
 
         // V1 contract: reject declared-but-unimplemented spec fields
@@ -208,7 +243,7 @@ impl SandboxService {
             ));
         }
 
-        spec.rootfs = self.resolve_template(&template).await?;
+        spec.rootfs = self.resolve_template(&source).await?;
 
         let (id, ip_address) = self
             .manager
@@ -224,13 +259,13 @@ impl SandboxService {
         })
     }
 
-    /// Resolve a template to the guest path of a bootable ext4 rootfs.
+    /// Resolve a template source to the guest path of a bootable ext4 rootfs.
     async fn resolve_template(
         &self,
-        template: &template::Template,
+        source: &templates::TemplateSource,
     ) -> Result<String, SandboxError> {
-        match template {
-            template::Template::Default => {
+        match source {
+            templates::TemplateSource::Default => {
                 // Built on first use, and rebuilt when the staged vm-agent is
                 // newer than the cached image.
                 crate::rootfs_builder::ensure_default_rootfs(&self.default_rootfs)
@@ -238,7 +273,7 @@ impl SandboxService {
                     .map_err(|e| SandboxError::Internal(format!("default template: {e}")))?;
                 Ok(self.default_rootfs.clone())
             }
-            template::Template::DockerImage(image) => {
+            templates::TemplateSource::DockerImage(image) => {
                 let layout = template::export_docker_image(image)
                     .await
                     .map_err(|e| SandboxError::Internal(format!("template {image}: {e:#}")))?;
@@ -252,6 +287,28 @@ impl SandboxService {
                 crate::rootfs_builder::convert_layer_to_rootfs(&layout, &pinned)
                     .await
                     .map_err(|e| SandboxError::Internal(format!("template {image}: {e:#}")))
+            }
+            templates::TemplateSource::Catalog(resolved) => {
+                let path = &resolved.entry.rootfs_path;
+                if !std::path::Path::new(path).is_file() {
+                    // Distinguish the caller-visible race — a concurrent
+                    // Delete unpinned the rootfs and a build's sweep
+                    // reclaimed it — from genuine pin corruption. Neither is
+                    // a rebuild trigger.
+                    return Err(match self.manager.get_template(&resolved.name) {
+                        Err(VmmError::TemplateNotFound(_)) => {
+                            SandboxError::from(VmmError::TemplateNotFound(format!(
+                                "{} (deleted while this create was resolving it)",
+                                resolved.name
+                            )))
+                        }
+                        _ => SandboxError::Internal(format!(
+                            "template {} rootfs {path} is missing; the catalog pin failed",
+                            resolved.name
+                        )),
+                    });
+                }
+                Ok(path.clone())
             }
         }
     }

--- a/guest/arcbox-agent/src/sandbox/templates.rs
+++ b/guest/arcbox-agent/src/sandbox/templates.rs
@@ -27,6 +27,62 @@ fn operation_key(name: &str) -> String {
     format!("template:{name}")
 }
 
+/// What `CreateSandboxRequest.template` resolved to.
+pub(super) enum TemplateSource {
+    /// Built-in busybox + `vm-agent` image.
+    Default,
+    /// `docker:<ref>` — exported and converted at create time.
+    DockerImage(String),
+    /// A catalog template: pre-built rootfs, defaults already merged into
+    /// the request, canonical ref already pinned.
+    Catalog(arcbox_vm::template_catalog::ResolvedTemplate),
+}
+
+/// Reject the contradictory override combination the proto calls out:
+/// `no_default_cmd` claims "explicitly no command" while `cmd` supplies one.
+pub(super) fn validate_template_overrides(
+    request: &sandbox_v1::CreateSandboxRequest,
+) -> Result<(), SandboxError> {
+    if request.no_default_cmd && !request.cmd.is_empty() {
+        return Err(SandboxError::InvalidArgument(
+            "no_default_cmd cannot be combined with a non-empty cmd".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Fold a catalog template's defaults into the request (the proto's
+/// per-field override contract): a set `limits` replaces the default
+/// wholesale (zero subfield = daemon default) while an unset one inherits
+/// the template's; a non-empty `cmd` replaces, an empty one inherits unless
+/// `no_default_cmd` says "explicitly none"; `env` merges per key with the
+/// request winning unless `no_default_env` discards the template's map.
+/// `exposed_ports`/`ready_probe` have no per-create counterpart and stay on
+/// the template entry. Runs before the create key is computed.
+pub(super) fn merge_template_defaults(
+    request: &mut sandbox_v1::CreateSandboxRequest,
+    defaults: &TemplateDefaultsSpec,
+) {
+    if request.limits.as_option().is_none() && (defaults.vcpus != 0 || defaults.memory_mib != 0) {
+        request.limits = Some(sandbox_v1::ResourceLimits {
+            vcpus: defaults.vcpus,
+            memory_mib: defaults.memory_mib,
+            ..Default::default()
+        })
+        .into();
+    }
+    if !request.no_default_cmd && request.cmd.is_empty() {
+        request.cmd = defaults.cmd.clone();
+    }
+    if !request.no_default_env {
+        for (key, value) in &defaults.env {
+            if !request.env.contains_key(key) {
+                request.env.insert(key.clone(), value.clone());
+            }
+        }
+    }
+}
+
 /// Content-addressed tag for a Dockerfile build:
 /// `arcbox-template-build:<sha256[..16]>` of the Dockerfile bytes.
 fn dockerfile_tag(dockerfile: &[u8]) -> String {
@@ -352,7 +408,7 @@ impl SandboxService {
 
 #[cfg(test)]
 mod tests {
-    use super::dockerfile_tag;
+    use super::*;
 
     #[test]
     fn dockerfile_tag_is_content_addressed_and_valid() {
@@ -366,5 +422,109 @@ mod tests {
         assert_eq!(repo, "arcbox-template-build");
         assert_eq!(tag.len(), 16);
         assert!(tag.bytes().all(|b| b.is_ascii_hexdigit()));
+    }
+
+    fn defaults() -> TemplateDefaultsSpec {
+        TemplateDefaultsSpec {
+            vcpus: 4,
+            memory_mib: 2048,
+            cmd: vec!["python".into(), "app.py".into()],
+            env: HashMap::from([
+                ("SHARED".to_string(), "template".to_string()),
+                ("ONLY_TEMPLATE".to_string(), "yes".to_string()),
+            ]),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn unset_limits_inherit_and_set_limits_replace_wholesale() {
+        let mut request = sandbox_v1::CreateSandboxRequest::default();
+        merge_template_defaults(&mut request, &defaults());
+        assert_eq!(request.limits.vcpus, 4);
+        assert_eq!(request.limits.memory_mib, 2048);
+
+        // A set message replaces wholesale: the zero memory_mib means the
+        // DAEMON default, never a per-field fall-through to the template.
+        let mut request = sandbox_v1::CreateSandboxRequest {
+            limits: Some(sandbox_v1::ResourceLimits {
+                vcpus: 1,
+                memory_mib: 0,
+                ..Default::default()
+            })
+            .into(),
+            ..Default::default()
+        };
+        merge_template_defaults(&mut request, &defaults());
+        assert_eq!(request.limits.vcpus, 1);
+        assert_eq!(request.limits.memory_mib, 0);
+    }
+
+    #[test]
+    fn cmd_inherits_replaces_or_suppresses() {
+        let mut request = sandbox_v1::CreateSandboxRequest::default();
+        merge_template_defaults(&mut request, &defaults());
+        assert_eq!(
+            request.cmd,
+            vec!["python".to_string(), "app.py".to_string()]
+        );
+
+        let mut request = sandbox_v1::CreateSandboxRequest {
+            cmd: vec!["bash".into()],
+            ..Default::default()
+        };
+        merge_template_defaults(&mut request, &defaults());
+        assert_eq!(request.cmd, vec!["bash".to_string()]);
+
+        let mut request = sandbox_v1::CreateSandboxRequest {
+            no_default_cmd: true,
+            ..Default::default()
+        };
+        merge_template_defaults(&mut request, &defaults());
+        assert!(request.cmd.is_empty(), "explicit empty must stay empty");
+    }
+
+    #[test]
+    fn env_merges_per_key_with_the_request_winning() {
+        let mut request = sandbox_v1::CreateSandboxRequest::default();
+        request.env.insert("SHARED".into(), "request".into());
+        request.env.insert("ONLY_REQUEST".into(), "yes".into());
+        merge_template_defaults(&mut request, &defaults());
+        assert_eq!(
+            request.env.get("SHARED").map(String::as_str),
+            Some("request")
+        );
+        assert_eq!(
+            request.env.get("ONLY_TEMPLATE").map(String::as_str),
+            Some("yes")
+        );
+        assert_eq!(
+            request.env.get("ONLY_REQUEST").map(String::as_str),
+            Some("yes")
+        );
+
+        let mut request = sandbox_v1::CreateSandboxRequest {
+            no_default_env: true,
+            ..Default::default()
+        };
+        request.env.insert("ONLY_REQUEST".into(), "yes".into());
+        merge_template_defaults(&mut request, &defaults());
+        assert!(!request.env.contains_key("ONLY_TEMPLATE"));
+        assert_eq!(request.env.len(), 1);
+    }
+
+    #[test]
+    fn contradictory_cmd_flags_are_rejected() {
+        let request = sandbox_v1::CreateSandboxRequest {
+            no_default_cmd: true,
+            cmd: vec!["bash".into()],
+            ..Default::default()
+        };
+        assert!(validate_template_overrides(&request).is_err());
+        let request = sandbox_v1::CreateSandboxRequest {
+            no_default_cmd: true,
+            ..Default::default()
+        };
+        assert!(validate_template_overrides(&request).is_ok());
     }
 }


### PR DESCRIPTION
Part 6 of the template-catalog campaign ([CORE-107](https://linear.app/arcbox/issue/CORE-107)), on top of #595. `CreateSandboxRequest.template = "name[:version]"` now works: sandboxes boot from catalog templates with the template's defaults applied.

## What

- **Resolution ahead of BOTH idempotency layers**: the resolved canonical ref (`name:version@sha256:…`, drafts `name:@…`) is substituted into `request.template` itself before the durable create key is computed AND before the in-process `CreateRegistry` (which compares whole requests) sees the request. A same-id retry after a Publish changed the reference's meaning therefore diverges at both layers — `AlreadyExists`, never a silent replay of the old content.
- **Defaults merge before the key** (the proto's override contract): a set `limits` replaces wholesale (zero subfield = daemon default, no per-field shine-through), non-empty `cmd` replaces / empty inherits / `no_default_cmd` = explicitly none (the contradictory flag+cmd combo is rejected), `env` merges per key request-wins, `no_default_env` discards the template map. Merging first means the key hashes the effective workload and the `no_default_*` flags need no key-domain change; `""`/`docker:` requests are untouched, so existing keys are stable.
- **`TemplateSource` enum** threads the classification into `create_once`; the catalog arm boots the pre-built pinned rootfs and treats a missing file as corruption (never a rebuild trigger). `exposed_ports`/`ready_probe` stay on the entry per the proto ("clients may expose them without knowing the workload"; probe enforcement is the next PR).
- Merge-matrix + flag-validation tests (limits wholesale/inherit, cmd inherit/replace/suppress, env merge/discard).

## Validation

`cargo test -p arcbox-vm --lib` (224), full-workspace clippy `-D warnings`, musl-target agent clippy (runs the linux-gated merge tests on CI's Unit tests job), `cargo fmt --check` — all at this branch tip in isolation.