### PR TITLE
feat(sandbox): prewarm builds and template warm-restore on create (CORE-107)

### DIFF
--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -244,6 +244,20 @@ impl SandboxService {
         }
 
         spec.rootfs = self.resolve_template(&source).await?;
+        if let templates::TemplateSource::Catalog(resolved) = &source {
+            // The template's pre-warmed snapshot rides the spec so the
+            // manager can restore instead of cold-booting when eligible.
+            spec.template_warm =
+                resolved
+                    .entry
+                    .warm
+                    .as_ref()
+                    .map(|warm| arcbox_vm::TemplateWarmRef {
+                        snapshot_id: warm.snapshot_id.clone(),
+                        vcpus: warm.vcpus,
+                        memory_mib: warm.memory_mib,
+                    });
+        }
 
         let (id, ip_address) = self
             .manager
@@ -656,6 +670,9 @@ fn proto_to_spec(req: sandbox_v1::CreateSandboxRequest) -> SandboxSpec {
         ssh_public_key: req.ssh_public_key,
         idle_timeout_seconds: req.idle_timeout_seconds,
         on_idle: idle_action_to_spec(req.on_idle.as_known().unwrap_or_default()),
+        // Filled by create_once from the resolved catalog entry; a request
+        // never names a snapshot directly (CORE-54).
+        template_warm: None,
     }
 }
 

--- a/guest/arcbox-agent/src/sandbox/templates.rs
+++ b/guest/arcbox-agent/src/sandbox/templates.rs
@@ -123,24 +123,25 @@ impl SandboxService {
                 "build source is required: docker_ref, dockerfile, or snapshot_id".into(),
             )
         })?;
-        if req.prewarm && !matches!(source, Source::SnapshotId(_)) {
-            // Loud, not silently ignored: a caller asking for a warm
-            // template must not receive a cold one labeled as built.
-            return Err(SandboxError::Unsupported(
-                "prewarm is not implemented yet (CORE-107)".into(),
-            ));
-        }
         let _flight = self.begin_template_build(&req.name)?;
         let labels: HashMap<String, String> = req.labels.clone().into_iter().collect();
         match source {
             Source::DockerRef(image) => {
-                self.build_template_from_docker(&req.name, &image, defaults, labels)
+                self.build_template_from_docker(&req.name, &image, defaults, labels, req.prewarm)
                     .await
             }
             Source::Dockerfile(dockerfile) => {
-                self.build_template_from_dockerfile(&req.name, &dockerfile, defaults, labels)
-                    .await
+                self.build_template_from_dockerfile(
+                    &req.name,
+                    &dockerfile,
+                    defaults,
+                    labels,
+                    req.prewarm,
+                )
+                .await
             }
+            // `prewarm` is ignored for snapshot sources — warm by
+            // construction, per the proto.
             Source::SnapshotId(snapshot_id) => {
                 self.build_template_from_snapshot(&req.name, &snapshot_id, defaults, labels)
                     .await
@@ -168,10 +169,11 @@ impl SandboxService {
             .promote_snapshot_to_template(snapshot_id, name)
             .await
             .map_err(SandboxError::from)?;
-        // Source identity is the origin checkpoint; the fresh copy id makes
-        // each promotion a distinct content instance, so a displaced draft's
-        // copy is released rather than aliased.
-        let digest = compute_digest(snapshot_id, Some(&promoted.snapshot_id), &defaults, &labels);
+        // Content identity is the ORIGIN checkpoint, never the fresh copy id:
+        // re-promoting the same source must reproduce the digest so Publish
+        // stays idempotent and canonical refs pin content. Displaced copies
+        // are released by snapshot id, which needs no digest involvement.
+        let digest = compute_digest(snapshot_id, Some("promoted"), &defaults, &labels);
         // Any failure between the committed copy and its registration must
         // take the copy with it, or it sits orphaned outside every listing.
         let rootfs_bytes = match tokio::fs::metadata(&promoted.rootfs_path).await {
@@ -200,6 +202,24 @@ impl SandboxService {
             created_at: chrono::Utc::now(),
             size_bytes: promoted.artifact_bytes + rootfs_bytes,
         };
+        self.register_draft(name, entry).await
+    }
+
+    /// Register a built entry, discarding its warm snapshot when
+    /// registration fails — the snapshot would otherwise sit as a
+    /// (recoverable) orphan until an operator noticed the log line.
+    async fn register_draft(
+        &self,
+        name: &str,
+        entry: TemplateEntry,
+    ) -> Result<sandbox_v1::Template, SandboxError> {
+        // The registration step joins the same per-name operation lock
+        // Publish/Delete hold, so the final catalog mutation serializes with
+        // theirs; the long build phases deliberately run outside it (holding
+        // it for minutes would block every other verb on the name — the
+        // in-flight guard already keeps concurrent Builds out).
+        let _operation = self.operations.lock(&operation_key(name)).await;
+        let warm_id = entry.warm.as_ref().map(|w| w.snapshot_id.clone());
         match self.manager.register_template_draft(name, entry).await {
             Ok(entry) => Ok(convert::template_to_proto(name, &entry)),
             // `Unavailable` is the atomic-write durability-uncertain shape:
@@ -212,9 +232,9 @@ impl SandboxService {
             Err(error) => {
                 // Registration certainly did not commit — the copy is
                 // otherwise orphaned (recoverable, but why wait).
-                self.manager
-                    .discard_promoted_snapshot(&promoted.snapshot_id)
-                    .await;
+                if let Some(snapshot_id) = warm_id {
+                    self.manager.discard_promoted_snapshot(&snapshot_id).await;
+                }
                 Err(SandboxError::from(error))
             }
         }
@@ -234,6 +254,7 @@ impl SandboxService {
         dockerfile: &str,
         defaults: TemplateDefaultsSpec,
         labels: HashMap<String, String>,
+        prewarm: bool,
     ) -> Result<sandbox_v1::Template, SandboxError> {
         if dockerfile.trim().is_empty() {
             return Err(SandboxError::InvalidArgument(
@@ -248,18 +269,19 @@ impl SandboxService {
                 .await
                 .map_err(|e| SandboxError::Internal(format!("template build {name}: {e:#}")))?;
         }
-        self.build_template_from_docker(name, &tag, defaults, labels)
+        self.build_template_from_docker(name, &tag, defaults, labels, prewarm)
             .await
     }
 
     /// Export `image` from the guest's dockerd, convert it to a cached ext4,
-    /// and register the draft entry.
+    /// optionally boot-and-checkpoint it (prewarm), and register the draft.
     async fn build_template_from_docker(
         &self,
         name: &str,
         image: &str,
         defaults: TemplateDefaultsSpec,
         labels: HashMap<String, String>,
+        prewarm: bool,
     ) -> Result<sandbox_v1::Template, SandboxError> {
         if image.trim().is_empty() {
             return Err(SandboxError::InvalidArgument(
@@ -289,33 +311,38 @@ impl SandboxService {
                 SandboxError::Internal(format!("unparsable rootfs cache path {rootfs}"))
             })?
             .to_owned();
-        let size_bytes = tokio::fs::metadata(&rootfs)
+        let rootfs_bytes = tokio::fs::metadata(&rootfs)
             .await
             .map_err(|e| SandboxError::Internal(format!("stat {rootfs}: {e}")))?
             .len();
-        let digest = compute_digest(&source_identity, None, &defaults, &labels);
+        let (warm, artifact_bytes) = if prewarm {
+            let outcome = self
+                .manager
+                .prewarm_template(name, &rootfs, &defaults)
+                .await
+                .map_err(SandboxError::from)?;
+            (Some(outcome.warm), outcome.artifact_bytes)
+        } else {
+            (None, 0)
+        };
+        // The warm input is a content TAG (prewarmed + geometry), never the
+        // freshly minted snapshot id — an identical rebuild must reproduce
+        // the digest or idempotent re-publish breaks.
+        let warm_tag = warm
+            .as_ref()
+            .map(|w| format!("prewarmed:{}x{}", w.vcpus, w.memory_mib));
+        let digest = compute_digest(&source_identity, warm_tag.as_deref(), &defaults, &labels);
         let entry = TemplateEntry {
             version: String::new(),
             digest,
             rootfs_path: rootfs,
-            warm: None,
+            warm,
             defaults,
             labels,
             created_at: chrono::Utc::now(),
-            size_bytes,
+            size_bytes: rootfs_bytes + artifact_bytes,
         };
-        // The registration step joins the same per-name operation lock
-        // Publish/Delete hold, so the final catalog mutation serializes with
-        // theirs; the long build phases above deliberately run outside it
-        // (holding it for minutes would block every other verb on the name —
-        // the in-flight guard already keeps concurrent Builds out).
-        let _operation = self.operations.lock(&operation_key(name)).await;
-        let entry = self
-            .manager
-            .register_template_draft(name, entry)
-            .await
-            .map_err(SandboxError::from)?;
-        Ok(convert::template_to_proto(name, &entry))
+        self.register_draft(name, entry).await
     }
 
     /// Mark `name` as having a build in flight; the guard clears it on drop.

--- a/virt/arcbox-vm/src/lib.rs
+++ b/virt/arcbox-vm/src/lib.rs
@@ -59,6 +59,7 @@ pub use sandbox::{
     CheckpointInfo, CheckpointSummary, IdleAction, LifecycleUpdate, RestoreSandboxSpec,
     SandboxEvent, SandboxId, SandboxInfo, SandboxManager, SandboxMountSpec, SandboxNetworkIdentity,
     SandboxNetworkInfo, SandboxNetworkSpec, SandboxSpec, SandboxState, SandboxSummary,
+    TemplateWarmRef,
 };
 pub use sandbox::{
     ExecutionChannel, ExecutionOutput, ExecutionSnapshot, ExecutionSpec, StdinState,

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -57,7 +57,7 @@ pub use pause::reason as pause_reason;
 pub use types::{
     CheckpointInfo, CheckpointSummary, IdleAction, LifecycleUpdate, RestoreSandboxSpec,
     SandboxEvent, SandboxId, SandboxInfo, SandboxInstance, SandboxMountSpec, SandboxNetworkInfo,
-    SandboxNetworkSpec, SandboxSpec, SandboxState, SandboxSummary,
+    SandboxNetworkSpec, SandboxSpec, SandboxState, SandboxSummary, TemplateWarmRef,
 };
 
 const EVENT_CHANNEL_CAPACITY: usize = 256;

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -4,6 +4,14 @@ use super::persistence::{ProvisionIntent, SandboxProvisionOutcome, SandboxTransi
 use super::types::{SandboxBootTask, action};
 use super::*;
 
+/// Whether a create may restore from warm sources and publish into the
+/// warm-cache LRU. [`Disabled`](Self::Disabled) exists for the prewarm
+/// builder (CORE-107), whose boot must be a plain cold boot.
+pub(super) enum WarmPolicy {
+    Auto,
+    Disabled,
+}
+
 impl SandboxManager {
     /// Replay a durable Create outcome without resolving its template again.
     pub async fn replay_sandbox_create(
@@ -25,8 +33,23 @@ impl SandboxManager {
     /// Create a sandbox with a stable key for durable request replay.
     pub async fn create_sandbox_keyed(
         &self,
+        spec: SandboxSpec,
+        request_key: &str,
+    ) -> Result<(SandboxId, String)> {
+        self.create_sandbox_inner(spec, request_key, WarmPolicy::Auto)
+            .await
+    }
+
+    /// [`Self::create_sandbox_keyed`] with explicit warm behaviour: the
+    /// prewarm builder (CORE-107) passes [`WarmPolicy::Disabled`] so its own
+    /// boot neither restores from a warm source nor publishes into the
+    /// warm-cache LRU (which would burn one of the `MAX_WARM_KEYS` slots on
+    /// a duplicate full-memory snapshot).
+    pub(super) async fn create_sandbox_inner(
+        &self,
         mut spec: SandboxSpec,
         request_key: &str,
+        warm_policy: WarmPolicy,
     ) -> Result<(SandboxId, String)> {
         // Do not allocate any per-id resources until the startup orphan sweep
         // has run — otherwise a re-created same-id sandbox races it.
@@ -68,6 +91,61 @@ impl SandboxManager {
         super::validate_id("sandbox id", &id)?;
         spec.id = Some(id.clone());
 
+        // Template warm-restore (CORE-107): a catalog template carrying a
+        // pre-warmed snapshot restores it directly — the sub-second start the
+        // template was built for. Same restore path as the warm cache below
+        // (`WarmCreate` origin delivers the CREATED→READY event contract and
+        // runs the effective spec's cmd after Ready; the checkpoint was taken
+        // idle and cmd-less, so defaults-vs-checkpoint divergence resolves to
+        // the spec). A geometry mismatch — the caller overrode `limits` —
+        // makes the snapshot unusable and cold-boots from the template
+        // rootfs, correct per the wholesale-replace contract. Unlike the
+        // warm cache, a kernel bump does NOT invalidate a template snapshot:
+        // a published template pins its artifacts, and the restore resurrects
+        // the kernel it was built with.
+        if matches!(warm_policy, WarmPolicy::Auto)
+            && let Some(warm) = spec.template_warm.clone()
+            && super::templates::template_restore_eligible(
+                &self.config,
+                &spec,
+                caller_supplied_boot,
+                &warm,
+            )
+        {
+            info!(
+                sandbox_id = %id,
+                snapshot_id = %warm.snapshot_id,
+                "template create: restoring the template's pre-warmed snapshot"
+            );
+            let mut warm_spec = spec.clone();
+            warm_spec.id = Some(id.clone());
+            match self
+                .restore_from_snapshot(
+                    super::checkpoint::RestoreRequest {
+                        snapshot_id: warm.snapshot_id.clone(),
+                        network_override: true,
+                        spec: warm_spec,
+                        origin: super::checkpoint::RestoreOrigin::WarmCreate,
+                    },
+                    request_key,
+                )
+                .await
+            {
+                Ok(result) => return Ok(result),
+                // Post-commit ambiguity: the sandbox is running under this
+                // id — cold-booting would recreate a live sandbox.
+                Err(error @ VmmError::AckUnconfirmed { .. }) => return Err(error),
+                Err(error) => {
+                    warn!(
+                        sandbox_id = %id,
+                        snapshot_id = %warm.snapshot_id,
+                        %error,
+                        "template warm restore failed; cold-booting from the template rootfs"
+                    );
+                }
+            }
+        }
+
         // Warm create (CORE-77): a Create whose boot shape matches a cached
         // template snapshot restores instead of cold-booting. Decided before
         // any resource allocation — the restore path owns its own id
@@ -75,7 +153,9 @@ impl SandboxManager {
         // (`network_override`, free with net-invariant snapshots). On a miss
         // the boot task publishes the snapshot once the guest is Ready.
         let mut warm_publish = None;
-        if super::warm::warm_eligible(&self.config, &spec, caller_supplied_boot) {
+        if matches!(warm_policy, WarmPolicy::Auto)
+            && super::warm::warm_eligible(&self.config, &spec, caller_supplied_boot)
+        {
             match super::warm::derive_warm_key(&spec) {
                 Ok(key) => match super::warm::find_warm_snapshot(&self.snapshots, &key) {
                     Ok(Some(snapshot_id)) => {

--- a/virt/arcbox-vm/src/sandbox/templates.rs
+++ b/virt/arcbox-vm/src/sandbox/templates.rs
@@ -12,11 +12,15 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use tracing::{info, warn};
+use uuid::Uuid;
 
 use super::SandboxManager;
+use super::types::{SandboxId, SandboxSpec, SandboxState};
 use crate::error::{Result, VmmError};
 use crate::snapshot::{SnapshotDraft, SnapshotGeometry};
-use crate::template_catalog::{ReleasedArtifacts, ResolvedTemplate, TEMPLATE_LABEL, TemplateEntry};
+use crate::template_catalog::{
+    ReleasedArtifacts, ResolvedTemplate, TEMPLATE_LABEL, TemplateDefaultsSpec, TemplateEntry,
+};
 
 /// A checkpoint copied into template ownership: everything the build
 /// orchestrator needs to assemble the catalog entry.
@@ -142,6 +146,125 @@ impl SandboxManager {
         })
     }
 
+    /// Boot the built rootfs once with the template's effective geometry and
+    /// an empty cmd, checkpoint at READY, and destroy the builder — the
+    /// snapshot then serves creates as the template's warm start point.
+    /// Requires jailer mode (restore does). The builder's warm behaviour is
+    /// disabled so a prewarm neither restores from nor publishes into the
+    /// warm-cache LRU.
+    pub async fn prewarm_template(
+        &self,
+        name: &str,
+        rootfs_path: &str,
+        defaults: &TemplateDefaultsSpec,
+    ) -> Result<PrewarmOutcome> {
+        if self.config.firecracker.jailer.is_none() {
+            return Err(VmmError::FailedPrecondition(
+                "prewarm requires jailer mode (snapshot restore does)".into(),
+            ));
+        }
+        let vcpus = if defaults.vcpus != 0 {
+            defaults.vcpus
+        } else {
+            u32::try_from(self.config.defaults.vcpus).unwrap_or(1)
+        };
+        let memory_mib = if defaults.memory_mib != 0 {
+            defaults.memory_mib
+        } else {
+            self.config.defaults.memory_mib
+        };
+        let builder_id = format!("template-build-{}", Uuid::new_v4());
+        let spec = SandboxSpec {
+            id: Some(builder_id.clone()),
+            rootfs: rootfs_path.to_owned(),
+            vcpus,
+            memory_mib,
+            // Deliberately no cmd: the checkpoint captures freshly-Ready and
+            // idle. A cmd baked into the memory image would re-run on every
+            // restore on top of the effective spec's cmd.
+            ..Default::default()
+        };
+        let (id, _ip) = self
+            .create_sandbox_inner(
+                spec,
+                &Uuid::new_v4().to_string(),
+                super::lifecycle::WarmPolicy::Disabled,
+            )
+            .await?;
+        let checkpoint = self.prewarm_checkpoint(&id, name).await;
+        // The builder dies regardless of checkpoint success. A failed
+        // teardown fails the build: a leaked live builder VM has no reaper
+        // (no HealthMonitor loop), so success here would silently keep its
+        // vCPUs/memory allocated. The fresh snapshot is dropped too — no
+        // record references it yet — and the error names the builder id so
+        // the operator can remove it and retry.
+        if let Err(remove_error) = self.remove_sandbox(&id, true).await {
+            if let Ok((snapshot_id, _)) = &checkpoint {
+                self.discard_promoted_snapshot(snapshot_id).await;
+            }
+            return Err(VmmError::Unavailable(format!(
+                "prewarm builder sandbox {id} could not be removed ({remove_error}); \
+                 remove it manually and retry the build"
+            )));
+        }
+        let (snapshot_id, artifact_bytes) = checkpoint?;
+        Ok(PrewarmOutcome {
+            warm: crate::template_catalog::WarmArtifact {
+                snapshot_id,
+                vcpus,
+                memory_mib,
+            },
+            artifact_bytes,
+        })
+    }
+
+    /// Wait for the builder to reach READY, then checkpoint it under the
+    /// template label. Polled rather than event-driven: a lagged broadcast
+    /// receiver would miss the READY edge, while polling cannot.
+    async fn prewarm_checkpoint(&self, id: &SandboxId, template: &str) -> Result<(String, u64)> {
+        const READY_POLL_MS: u64 = 250;
+        const READY_TIMEOUT_SECS: u64 = 180;
+        let deadline =
+            tokio::time::Instant::now() + std::time::Duration::from_secs(READY_TIMEOUT_SECS);
+        loop {
+            let info = self.inspect_sandbox(id)?;
+            match info.state {
+                SandboxState::Ready => break,
+                SandboxState::Failed => {
+                    return Err(VmmError::FailedPrecondition(format!(
+                        "prewarm boot failed: {}",
+                        info.error.unwrap_or_else(|| "unknown boot failure".into())
+                    )));
+                }
+                _ if tokio::time::Instant::now() >= deadline => {
+                    return Err(VmmError::DeadlineExceeded(format!(
+                        "prewarm builder did not reach READY within {READY_TIMEOUT_SECS}s"
+                    )));
+                }
+                _ => tokio::time::sleep(std::time::Duration::from_millis(READY_POLL_MS)).await,
+            }
+        }
+        let info = super::checkpoint::checkpoint_impl(
+            &self.instances,
+            &self.snapshots,
+            &self.config,
+            id,
+            super::checkpoint::CheckpointRequest {
+                name: format!("template-{template}"),
+                labels: HashMap::from([(TEMPLATE_LABEL.to_owned(), template.to_owned())]),
+                expected_state: SandboxState::Ready,
+                resume_after: true,
+            },
+        )
+        .await?;
+        let meta = self.snapshots.find_by_id(&info.snapshot_id)?;
+        let mut artifact_bytes = std::fs::metadata(&meta.vmstate_path).map_or(0, |m| m.len());
+        if let Some(mem) = &meta.mem_path {
+            artifact_bytes += std::fs::metadata(mem).map_or(0, |m| m.len());
+        }
+        Ok((info.snapshot_id, artifact_bytes))
+    }
+
     /// Best-effort removal of a just-promoted copy whose catalog
     /// registration failed — without it the copy would sit as a
     /// (recoverable) orphan until an operator noticed the log line.
@@ -182,6 +305,41 @@ impl SandboxManager {
             }
         }
     }
+}
+
+/// Result of a prewarm boot-and-checkpoint.
+#[derive(Debug)]
+pub struct PrewarmOutcome {
+    /// The template's warm artifact (snapshot id + capture geometry).
+    pub warm: crate::template_catalog::WarmArtifact,
+    /// On-disk footprint of the checkpoint files.
+    pub artifact_bytes: u64,
+}
+
+/// Whether a template's pre-warmed snapshot can serve this create: restore
+/// needs the jailer, the invariant tap identity, no caller-pinned boot
+/// recipe, and an exactly matching geometry — a memory snapshot resumes
+/// only onto its capture shape. Checked against the effective
+/// (defaults-applied) spec. Deliberately NOT gated on
+/// `config.firecracker.warm_create`: that flag governs the implicit CORE-77
+/// cache, while a template's prewarm was explicitly requested at build time
+/// — adding the gate would silently disable prewarm for anyone running with
+/// the cache off. Stopping restores from a bad snapshot = rebuild or delete
+/// the template.
+pub(super) fn template_restore_eligible(
+    config: &crate::config::VmmConfig,
+    spec: &SandboxSpec,
+    caller_supplied_boot: bool,
+    warm: &crate::sandbox::TemplateWarmRef,
+) -> bool {
+    config.firecracker.jailer.is_some()
+        && !caller_supplied_boot
+        && spec.network.mode == "tap"
+        && !spec.boot_args.contains("ip=")
+        && spec.mounts.is_empty()
+        && spec.ssh_public_key.is_none()
+        && spec.vcpus == warm.vcpus
+        && spec.memory_mib == warm.memory_mib
 }
 
 /// Copy `src` to `dst` (mode 0600, fsynced), reflinking when the filesystem

--- a/virt/arcbox-vm/src/sandbox/types.rs
+++ b/virt/arcbox-vm/src/sandbox/types.rs
@@ -141,6 +141,23 @@ pub struct SandboxSpec {
     pub idle_timeout_seconds: u32,
     /// What to do when the idle timeout expires.
     pub on_idle: IdleAction,
+    /// The catalog template's pre-warmed snapshot, when the create resolved
+    /// one (CORE-107). A boot-recipe input like `rootfs`: the create path
+    /// restores it instead of cold-booting when eligible, and it rides the
+    /// journaled effective spec so crash replay keeps working. `None` for
+    /// non-catalog templates and warm-less catalog entries.
+    pub template_warm: Option<TemplateWarmRef>,
+}
+
+/// A template's pre-warmed boot-to-ready snapshot, threaded through
+/// [`SandboxSpec`] (CORE-107).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TemplateWarmRef {
+    /// Snapshot id in the snapshot catalog.
+    pub snapshot_id: String,
+    /// Capture-time geometry; restore is eligible only on an exact match.
+    pub vcpus: u32,
+    pub memory_mib: u64,
 }
 
 /// Parameters to restore a sandbox from a checkpoint.

--- a/virt/arcbox-vm/src/template_catalog.rs
+++ b/virt/arcbox-vm/src/template_catalog.rs
@@ -498,8 +498,10 @@ impl TemplateCatalog {
 /// Inputs are content identities, never file metadata, so an identical
 /// rebuild reproduces the digest: `source_identity` (the rootfs cache file
 /// stem for image builds — it encodes the layer content key and the injected
-/// vm-agent key — or the promoted snapshot id), the warm snapshot id, and
-/// the canonicalized defaults and labels. Field-tagged and NUL-separated so
+/// vm-agent key — or the promoted ORIGIN snapshot id), `warm_identity` (a
+/// content tag like `prewarmed:<geometry>` or `promoted` — never a freshly
+/// minted snapshot id, which would randomize the digest per build), and the
+/// canonicalized defaults and labels. Field-tagged and NUL-separated so
 /// adjacent inputs cannot alias.
 #[must_use]
 #[allow(
@@ -509,7 +511,7 @@ impl TemplateCatalog {
 )]
 pub fn compute_digest(
     source_identity: &str,
-    warm_snapshot_id: Option<&str>,
+    warm_identity: Option<&str>,
     defaults: &TemplateDefaultsSpec,
     labels: &HashMap<String, String>,
 ) -> String {
@@ -547,7 +549,7 @@ pub fn compute_digest(
     let mut hasher = Sha256::new();
     for (tag, value) in [
         ("source", source_identity),
-        ("warm", warm_snapshot_id.unwrap_or("")),
+        ("warm", warm_identity.unwrap_or("")),
     ] {
         hasher.update(tag.as_bytes());
         hasher.update([0]);


### PR DESCRIPTION
Part 7 of the template-catalog campaign ([CORE-107](https://linear.app/arcbox/issue/CORE-107)), on top of #597. `Build{prewarm}` produces boot-to-ready templates, and Create restores them for sub-second starts — the fast-start half of the CORE-21 design.

## What

- **Prewarm build**: boots the converted rootfs once with the template's effective geometry and an **empty cmd** (a cmd baked into the memory image would re-run on every restore on top of the effective spec's cmd), waits READY, `checkpoint_impl`s under the `arcbox.template` label, destroys the builder. Requires jailer mode (restore does).
- **`WarmPolicy` refactor**: `create_sandbox_keyed` keeps its public signature; the builder passes `Disabled` so its boot neither restores from a warm source nor burns one of the `MAX_WARM_KEYS` LRU slots on a duplicate memory snapshot.
- **Template warm-restore**: a new first hit-source in the create path ahead of the warm cache. Eligibility = jailer + invariant tap identity + no caller-pinned boot recipe + **exact geometry match** (a `limits` override cold-boots from the template rootfs — correct per the wholesale-replace contract). Reuses `RestoreOrigin::WarmCreate` (fresh network identity, CREATED→READY events, effective-spec cmd after Ready). `AckUnconfirmed` is the one non-fallback; other restore failures fall through to cold boot + the ordinary warm cache. Deliberate contract divergence, documented in-line: kernel bumps do NOT invalidate a template snapshot — a published template pins its artifacts.
- The warm ref rides `SandboxSpec` (journaled effective spec), so crash replay keeps working; `register_draft` failure paths discard fresh artifacts except on the durability-uncertain shape (same rule #595 landed).

## Validation

`cargo test -p arcbox-vm --lib` (224), full-workspace clippy `-D warnings`, musl-target agent clippy, `cargo fmt --check` — all at this branch tip in isolation. End-to-end warm-restore latency assertion lands with the campaign's e2e PR.