### PR TITLE
feat(sandbox): enforce template ready probes on boot and warm restore (CORE-107)

### DIFF
--- a/common/arcbox-constants/src/sandbox.rs
+++ b/common/arcbox-constants/src/sandbox.rs
@@ -23,4 +23,10 @@ pub const SANDBOX_FEATURES: &[&str] = &[
     "set_lifecycle",
     // Authoritative host-listener reconciliation (CORE-102).
     "list_exposed_ports",
+    // The template catalog: Build/Publish/Get/List/Delete plus
+    // name[:version] resolution in Create (CORE-107).
+    "templates",
+    // TemplateDefaults.ready_probe gates READY on port/command probes
+    // (CORE-107).
+    "ready_probe",
 ];

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -257,6 +257,7 @@ impl SandboxService {
                         vcpus: warm.vcpus,
                         memory_mib: warm.memory_mib,
                     });
+            spec.ready_probe = resolved.entry.defaults.ready_probe.clone();
         }
 
         let (id, ip_address) = self
@@ -671,8 +672,9 @@ fn proto_to_spec(req: sandbox_v1::CreateSandboxRequest) -> SandboxSpec {
         idle_timeout_seconds: req.idle_timeout_seconds,
         on_idle: idle_action_to_spec(req.on_idle.as_known().unwrap_or_default()),
         // Filled by create_once from the resolved catalog entry; a request
-        // never names a snapshot directly (CORE-54).
+        // never names a snapshot or a probe directly (CORE-54).
         template_warm: None,
+        ready_probe: None,
     }
 }
 

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -141,36 +141,6 @@ pub(super) async fn boot_sandbox(
 
             let ready_at = Utc::now();
 
-            // do_boot persisted every cleanup resource before completing the
-            // handoff, so only the lifecycle phase remains to make Ready.
-            let durable_ready =
-                records
-                    .transition(&id, generation, SandboxTransition::Ready)
-                    .and_then(|commit| match commit.durability_error {
-                        Some(error) => Err(VmmError::Unavailable(format!(
-                            "sandbox {id} ready state is visible, but durability is unconfirmed: {error}"
-                        ))),
-                        None => Ok(()),
-                    });
-            if let Err(record_error) = durable_ready {
-                let message = format!("failed to persist ready state: {record_error}");
-                fail_started_boot(
-                    &id,
-                    generation,
-                    &message,
-                    &vm_dir,
-                    &instances,
-                    &network,
-                    &config,
-                    &cow_manager,
-                    &records,
-                    &events_tx,
-                )
-                .await;
-                error!(sandbox_id = %id, error = %record_error, "sandbox ready state was not durable");
-                return;
-            }
-
             // Hand the post-boot API objects to the instance. Every cleanup
             // resource was transferred before configuration could be aborted.
             let mut vm = Some(vm);
@@ -216,6 +186,77 @@ pub(super) async fn boot_sandbox(
                     .await;
             }
 
+            // Ready probe (CORE-107): the initial cmd is the only listener
+            // source in a sandbox (vm-agent is init; a docker ENTRYPOINT
+            // never runs), so a probed boot starts the cmd FIRST and holds
+            // READY back until the probe passes; expiry fails the boot. The
+            // durable Ready transition sits after the probe on purpose — a
+            // probe failure then fails from the recorded Starting phase, and
+            // a crash mid-probe reconciles as an interrupted boot rather
+            // than a Ready sandbox that never probed.
+            let probed_cmd_started = if let Some(probe) = spec.ready_probe.clone() {
+                let started = if spec.cmd.is_empty() {
+                    false
+                } else {
+                    run_initial_cmd(&id, spec.clone(), &vsock_uds_path, &instances, &events_tx)
+                        .await
+                };
+                if let Err(probe_error) = run_ready_probe(&probe, &vsock_uds_path).await {
+                    let message = format!("ready probe failed: {probe_error}");
+                    fail_started_boot(
+                        &id,
+                        generation,
+                        &message,
+                        &vm_dir,
+                        &instances,
+                        &network,
+                        &config,
+                        &cow_manager,
+                        &records,
+                        &events_tx,
+                    )
+                    .await;
+                    error!(sandbox_id = %id, error = %probe_error, "sandbox ready probe failed");
+                    return;
+                }
+                // A failed pre-probe start is NOT "started": the ordinary
+                // post-READY launch below then gets its one attempt, exactly
+                // like an unprobed boot.
+                started
+            } else {
+                false
+            };
+
+            // do_boot persisted every cleanup resource before completing the
+            // handoff, so only the lifecycle phase remains to make Ready.
+            let durable_ready =
+                records
+                    .transition(&id, generation, SandboxTransition::Ready)
+                    .and_then(|commit| match commit.durability_error {
+                        Some(error) => Err(VmmError::Unavailable(format!(
+                            "sandbox {id} ready state is visible, but durability is unconfirmed: {error}"
+                        ))),
+                        None => Ok(()),
+                    });
+            if let Err(record_error) = durable_ready {
+                let message = format!("failed to persist ready state: {record_error}");
+                fail_started_boot(
+                    &id,
+                    generation,
+                    &message,
+                    &vm_dir,
+                    &instances,
+                    &network,
+                    &config,
+                    &cow_manager,
+                    &records,
+                    &events_tx,
+                )
+                .await;
+                error!(sandbox_id = %id, error = %record_error, "sandbox ready state was not durable");
+                return;
+            }
+
             let _ = events_tx.send(SandboxEvent::new(&id, action::READY));
             info!(sandbox_id = %id, "sandbox booted and ready");
 
@@ -223,8 +264,8 @@ pub(super) async fn boot_sandbox(
             // sandbox stays alive when it exits (Running → Ready + "idle"),
             // exactly like an explicit Run. A start failure is logged and
             // leaves the sandbox Ready — the caller can still Run/Exec.
-            if !spec.cmd.is_empty() {
-                run_initial_cmd(&id, spec, &vsock_uds_path, &instances, &events_tx).await;
+            if !probed_cmd_started && !spec.cmd.is_empty() {
+                let _ = run_initial_cmd(&id, spec, &vsock_uds_path, &instances, &events_tx).await;
             }
         }
         Err(mut failure) => {
@@ -412,6 +453,122 @@ async fn fail_started_boot(
     }
 }
 
+/// Default probe deadline when the template leaves `timeout_seconds` at 0
+/// (matches the WaitForPort daemon default).
+const READY_PROBE_DEFAULT_TIMEOUT_SECS: u64 = 30;
+/// Delay between command-probe attempts.
+const READY_PROBE_RETRY_MS: u64 = 500;
+
+/// Run a template's readiness probe against the booted guest (CORE-107).
+///
+/// Port form: the vm-agent's listen-table watcher — never a connect probe,
+/// which would perturb the workload. Command form: a one-shot exec retried
+/// until it exits 0 or the deadline elapses.
+pub(super) async fn run_ready_probe(
+    probe: &crate::template_catalog::ReadyProbeSpec,
+    vsock_uds_path: &Path,
+) -> Result<()> {
+    use crate::template_catalog::ReadyProbeSpec;
+    let effective = |timeout_seconds: u32| {
+        std::time::Duration::from_secs(if timeout_seconds == 0 {
+            READY_PROBE_DEFAULT_TIMEOUT_SECS
+        } else {
+            u64::from(timeout_seconds)
+        })
+    };
+    match probe {
+        ReadyProbeSpec::Port {
+            port,
+            timeout_seconds,
+        } => {
+            match vsock::wait_for_port(vsock_uds_path, *port, effective(*timeout_seconds)).await? {
+                vsock::PortWait::Listening => Ok(()),
+                vsock::PortWait::Deadline => Err(VmmError::DeadlineExceeded(format!(
+                    "no listener on port {port} within the ready-probe deadline"
+                ))),
+            }
+        }
+        ReadyProbeSpec::Command {
+            cmd,
+            timeout_seconds,
+        } => {
+            let deadline = tokio::time::Instant::now() + effective(*timeout_seconds);
+            let mut last_status: Option<String> = None;
+            loop {
+                // Each attempt is bounded twice over: the host-side timeout
+                // caps the await even if the exec stream stalls, and the
+                // remaining budget rides StartCommand.timeout_seconds so the
+                // guest kills a never-exiting probe process instead of
+                // leaking it. Without both, `timeout_seconds` would not be
+                // an upper bound at all — a non-exiting probe command parked
+                // this await forever.
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining.is_zero() {
+                    return Err(VmmError::DeadlineExceeded(format!(
+                        "ready-probe command did not exit 0 within the deadline ({})",
+                        last_status.as_deref().unwrap_or("no attempt completed")
+                    )));
+                }
+                // The guest kill timer has whole-second granularity; the
+                // host timeout enforces the exact remaining budget.
+                let budget_secs = u32::try_from(remaining.as_secs().max(1)).unwrap_or(u32::MAX);
+                match tokio::time::timeout(
+                    remaining,
+                    run_probe_command(cmd, vsock_uds_path, budget_secs),
+                )
+                .await
+                {
+                    Ok(Ok(ExitStatus::Code(0))) => return Ok(()),
+                    Ok(Ok(status)) => last_status = Some(format!("last exit: {status:?}")),
+                    Ok(Err(error)) => last_status = Some(format!("last error: {error}")),
+                    Err(_) => {
+                        return Err(VmmError::DeadlineExceeded(format!(
+                            "ready-probe command did not exit within the deadline ({})",
+                            last_status.as_deref().unwrap_or("no attempt completed")
+                        )));
+                    }
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    return Err(VmmError::DeadlineExceeded(format!(
+                        "ready-probe command did not exit 0 within the deadline ({})",
+                        last_status.as_deref().unwrap_or("no attempt completed")
+                    )));
+                }
+                let nap = std::time::Duration::from_millis(READY_PROBE_RETRY_MS)
+                    .min(deadline.saturating_duration_since(tokio::time::Instant::now()));
+                tokio::time::sleep(nap).await;
+            }
+        }
+    }
+}
+
+/// One probe attempt: run the command and wait for its exit status.
+async fn run_probe_command(
+    cmd: &[String],
+    vsock_uds_path: &Path,
+    timeout_seconds: u32,
+) -> Result<ExitStatus> {
+    let start = StartCommand {
+        cmd: cmd.to_vec(),
+        env: HashMap::new(),
+        working_dir: String::new(),
+        user: String::new(),
+        tty: false,
+        tty_width: 80,
+        tty_height: 24,
+        timeout_seconds,
+    };
+    let (_input, mut output) = vsock::exec(vsock_uds_path, start).await?;
+    while let Some(chunk) = output.recv().await {
+        if let OutputChunk::Exit(status) = chunk? {
+            return Ok(status);
+        }
+    }
+    Err(VmmError::Vsock(
+        "probe command stream ended without an exit status".into(),
+    ))
+}
+
 /// Start the initial `cmd` from the creation spec and drain its output.
 ///
 /// Uses the same workload path as `Run` (`start_run_workload`), so state
@@ -419,13 +576,18 @@ async fn fail_started_boot(
 /// and is discarded chunk by chunk to keep the exit handler flowing. Also
 /// driven by the warm-create restore path (CORE-77), which owes a restored
 /// Create the same initial workload a cold boot runs.
+///
+/// Returns whether the workload actually started (`true` = live). Probed
+/// paths record it so a failed pre-probe start still gets the ordinary
+/// post-READY attempt; a `false` from that attempt is final (warned, the
+/// sandbox stays Ready, the caller can still Run/Exec).
 pub(super) async fn run_initial_cmd(
     id: &SandboxId,
     spec: SandboxSpec,
     vsock_uds_path: &Path,
     instances: &super::InstanceMap,
     events_tx: &broadcast::Sender<SandboxEvent>,
-) {
+) -> bool {
     let start = StartCommand {
         cmd: spec.cmd,
         env: spec.env,
@@ -441,9 +603,11 @@ pub(super) async fn run_initial_cmd(
         Ok(mut rx) => {
             info!(sandbox_id = %id, "initial cmd started");
             tokio::spawn(async move { while rx.recv().await.is_some() {} });
+            true
         }
         Err(e) => {
             warn!(sandbox_id = %id, error = %e, "initial cmd failed to start; sandbox stays ready");
+            false
         }
     }
 }

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -987,6 +987,47 @@ impl SandboxManager {
                 .events_tx
                 .send(SandboxEvent::new(&new_id, action::CREATED));
         }
+
+        // Ready probe on a warm create (CORE-107): READY carries the same
+        // promise as a probed cold boot. The cmd starts first (it is the
+        // only listener source); a prewarmed snapshot's listener lives in
+        // the memory image, so the port form passes near-instantly there.
+        // Unlike the cold-boot path, this runs POST-commit — the cmd needs
+        // the populated Ready instance, and the restore transaction's
+        // rollback machinery ends at reservation.commit — so a probe
+        // failure is unwound with the post-commit verb (force remove), and
+        // the caller's create falls back to a cold boot that probes from
+        // scratch — when the teardown succeeded; a failed teardown leaves
+        // the record Removing, which blocks the same-id retry until startup
+        // reconcile clears it (the warn below carries the id). A crash
+        // mid-probe leaves a durable Ready record whose FC process is dead;
+        // startup reconcile normalizes it, and the create RPC never
+        // returned, so no client ever saw an unprobed READY.
+        let mut probed_cmd_started = false;
+        if warm_create && let Some(probe) = effective_spec.ready_probe.clone() {
+            if !effective_spec.cmd.is_empty() {
+                probed_cmd_started = super::boot::run_initial_cmd(
+                    &new_id,
+                    effective_spec.clone(),
+                    &actual_vsock_path,
+                    &self.instances,
+                    &self.events_tx,
+                )
+                .await;
+            }
+            if let Err(probe_error) = super::boot::run_ready_probe(&probe, &actual_vsock_path).await
+            {
+                let message = format!("ready probe failed after restore: {probe_error}");
+                if let Err(remove_error) = self.remove_sandbox(&new_id, true).await {
+                    warn!(
+                        sandbox_id = %new_id,
+                        error = %remove_error,
+                        "failed to tear down the probe-failed restore"
+                    );
+                }
+                return Err(VmmError::FailedPrecondition(message));
+            }
+        }
         let _ = self
             .events_tx
             .send(SandboxEvent::new(&new_id, action::READY));
@@ -1023,8 +1064,8 @@ impl SandboxManager {
         // A warm create still owes the Create contract's initial workload:
         // run it through the same path as a cold boot, after Ready. Kept off
         // the timing log above — the workload is the user's, not restore's.
-        if warm_create && !effective_spec.cmd.is_empty() {
-            super::boot::run_initial_cmd(
+        if warm_create && !probed_cmd_started && !effective_spec.cmd.is_empty() {
+            let _ = super::boot::run_initial_cmd(
                 &new_id,
                 effective_spec,
                 &actual_vsock_path,

--- a/virt/arcbox-vm/src/sandbox/types.rs
+++ b/virt/arcbox-vm/src/sandbox/types.rs
@@ -147,6 +147,10 @@ pub struct SandboxSpec {
     /// journaled effective spec so crash replay keeps working. `None` for
     /// non-catalog templates and warm-less catalog entries.
     pub template_warm: Option<TemplateWarmRef>,
+    /// The catalog template's readiness probe (CORE-107): READY is withheld
+    /// until it passes; expiry fails the boot. `None` = ready on
+    /// exec-acceptance. Filled from the resolved template, never the request.
+    pub ready_probe: Option<crate::template_catalog::ReadyProbeSpec>,
 }
 
 /// A template's pre-warmed boot-to-ready snapshot, threaded through


### PR DESCRIPTION
Part 8 of the template-catalog campaign ([CORE-107](https://linear.app/arcbox/issue/CORE-107)), on top of #599. `TemplateDefaults.ready_probe` (both forms) now gates READY.

## What

- **Ordering is the crux**: the initial cmd is the only listener source in a sandbox (vm-agent is init; a docker ENTRYPOINT never runs), so a probed boot starts the cmd FIRST, then probes, then publishes READY. The durable Ready transition moves after the probe on purpose — a probe failure fails from the recorded Starting phase (`fail_started_boot`), and a crash mid-probe reconciles as an interrupted boot instead of a Ready sandbox that never probed.
- **Port form**: `vsock::wait_for_port` — the vm-agent's /proc/net/tcp listen-table watcher, never a connect probe (which would perturb the workload with accepted connections). **Command form**: a one-shot exec retried every 500ms until exit 0. Timeout 0 → the 30s WaitForPort-aligned default (cap 600s enforced at Build).
- **Warm-create restores probe too**: READY carries the same promise after a fresh network identity — near-instant for prewarmed snapshots whose listener lives in the memory image. A probe-failed restore tears the sandbox down and the create path falls back to a cold boot that probes from scratch. Resume-of-paused deliberately does NOT re-probe (creation-readiness contract).
- `SANDBOX_FEATURES` gains `templates` + `ready_probe` for SDK feature detection.

## Validation

`cargo test -p arcbox-vm --lib` (224), full-workspace clippy `-D warnings`, musl-target agent clippy, `cargo fmt --check` — all at this branch tip in isolation. Probe pass/timeout phases land in the campaign's e2e PR.