### PR TITLE
feat(sdk-ts): Template catalog client (CORE-107)

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -199,4 +199,4 @@ Phases 2a and 2b of CORE-58. Shipped:
 | `sandbox.checkpoint()` | pause + snapshot + resume under the same id; returns the `Snapshot` catalog row |
 | `ArcBox.restore(snapshotId)` | new READY sandbox from a snapshot (fresh client-minted id; `freshNetwork` for concurrent restores); plus `listSnapshots` (auto-paginating) and `deleteSnapshot` |
 
-Deferred: `Template` statics.
+Template statics shipped: `Template.build/get/list/delete` + instance `publish()/delete()`; `Sandbox.create` accepts a `Template` instance; `noDefaultCmd`/`noDefaultEnv` create options carry explicit-empty overrides.

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -49,6 +49,16 @@ export type {
   WriteOptions,
 } from "./files";
 
+export { Template } from "./templates";
+export type {
+  BuildTemplateOptions,
+  ListTemplatesOptions,
+  ReadyProbe,
+  TemplateConnectOptions,
+  TemplateDefaults,
+  TemplateSource,
+} from "./templates";
+
 export type { ConnectionOptions } from "./connection";
 
 export type {
@@ -63,6 +73,7 @@ export type {
   SandboxState,
   SandboxSummary,
   Snapshot,
+  TemplateInfo,
 } from "./types";
 
 export {

--- a/sdk/typescript/src/sandbox.ts
+++ b/sdk/typescript/src/sandbox.ts
@@ -27,6 +27,7 @@ import {
   SandboxState as SandboxStateProto,
 } from "./gen/arcbox/sandbox/v1/sandbox_pb";
 import { SandboxSnapshotService } from "./gen/arcbox/sandbox/v1/snapshot_pb";
+import type { Template } from "./templates";
 import type { ClientContext } from "./transport";
 import { createClientContext, unaryOptions } from "./transport";
 import type {
@@ -69,8 +70,16 @@ export interface CreateSandboxOptions {
   memoryMib?: number;
   /** Initial command launched after boot; its exit returns the sandbox to READY. */
   cmd?: string[];
+  /**
+   * Explicitly run NO initial command, suppressing a catalog template's
+   * default cmd (proto3 cannot distinguish omitted from empty). Rejected
+   * when combined with a non-empty `cmd`.
+   */
+  noDefaultCmd?: boolean;
   /** Environment for the initial command, merged over the template's env. */
   env?: Record<string, string>;
+  /** Discard the catalog template's default env instead of merging it. */
+  noDefaultEnv?: boolean;
   /** Labels for filtering in list/events. */
   labels?: Record<string, string>;
   /** `false` disables networking entirely (no network device). */
@@ -241,9 +250,11 @@ export class ArcBox {
    * idempotent.
    */
   async create(
-    template = "",
+    template: string | Template = "",
     opts: CreateSandboxOptions = {},
   ): Promise<Sandbox> {
+    const templateRef =
+      typeof template === "string" ? template : template.reference;
     const id = crypto.randomUUID();
     const abort = new AbortController();
     try {
@@ -262,10 +273,12 @@ export class ArcBox {
       await this.#client.create(
         {
           id,
-          template,
+          template: templateRef,
           labels: opts.labels ?? {},
           cmd: opts.cmd ?? [],
+          noDefaultCmd: opts.noDefaultCmd ?? false,
           env: opts.env ?? {},
+          noDefaultEnv: opts.noDefaultEnv ?? false,
           ...((opts.vcpus !== undefined || opts.memoryMib !== undefined) && {
             limits: {
               vcpus: opts.vcpus ?? 0,
@@ -654,7 +667,7 @@ export class Sandbox {
   /** Create a sandbox against the default (or given) connection. */
   static create(
     this: void,
-    template = "",
+    template: string | Template = "",
     opts: CreateSandboxOptions = {},
   ): Promise<Sandbox> {
     return new ArcBox(opts.connection).create(template, opts);

--- a/sdk/typescript/src/templates.ts
+++ b/sdk/typescript/src/templates.ts
@@ -1,0 +1,266 @@
+import type { Client } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
+
+import { toArcBoxError } from "./errors";
+import type {
+  Template as TemplateProto,
+  TemplateDefaults as TemplateDefaultsProto,
+} from "./gen/arcbox/sandbox/v1/template_pb";
+import { TemplateService } from "./gen/arcbox/sandbox/v1/template_pb";
+import type { ConnectionOptions } from "./connection";
+import type { ClientContext } from "./transport";
+import { createClientContext, unaryOptions } from "./transport";
+import type { TemplateInfo } from "./types";
+import { templateInfoFromProto } from "./types";
+
+type TemplateClient = Client<typeof TemplateService>;
+
+/**
+ * What to build a template's rootfs from — exactly one source.
+ *
+ * - `docker`: a local Docker image reference, converted in-guest.
+ * - `dockerfile`: inline Dockerfile content, built in-guest; the build
+ *   context holds only the Dockerfile, so `COPY`/`ADD` of local paths fails.
+ * - `snapshot`: promote an existing checkpoint — it becomes the template's
+ *   warm start point (`prewarm` is ignored for this source).
+ */
+export type TemplateSource =
+  | { docker: string }
+  | { dockerfile: string }
+  | { snapshot: string };
+
+/** Default configuration a template applies to sandboxes created from it. */
+export interface TemplateDefaults {
+  /** Default vCPUs (omit = daemon default). */
+  vcpus?: number;
+  /** Default memory in MiB (omit = daemon default). */
+  memoryMib?: number;
+  /** Default initial command. */
+  cmd?: string[];
+  /** Default environment for the initial command. */
+  env?: Record<string, string>;
+  /** Advisory: ports the workload is expected to listen on. */
+  exposedPorts?: number[];
+  /** Gate READY on a TCP listener or a command exiting 0. */
+  readyProbe?: ReadyProbe;
+}
+
+/** Readiness probe run inside a sandbox after boot. */
+export type ReadyProbe =
+  | { port: number; timeoutSeconds?: number }
+  | { command: string[]; timeoutSeconds?: number };
+
+/** Options for {@link Template.build}. */
+export interface BuildTemplateOptions {
+  defaults?: TemplateDefaults;
+  labels?: Record<string, string>;
+  /**
+   * Also boot the built rootfs once and checkpoint it at READY, so creates
+   * restore the snapshot for sub-second starts. Ignored for snapshot
+   * sources (warm by construction).
+   */
+  prewarm?: boolean;
+  connection?: ConnectionOptions;
+}
+
+/** Options carrying only a connection override. */
+export interface TemplateConnectOptions {
+  connection?: ConnectionOptions;
+}
+
+/** Options for {@link Template.list}. */
+export interface ListTemplatesOptions {
+  /** Keep only templates carrying all of these labels. */
+  labels?: Record<string, string>;
+  connection?: ConnectionOptions;
+}
+
+function templateClient(connection?: ConnectionOptions): {
+  ctx: ClientContext;
+  client: TemplateClient;
+} {
+  const ctx = createClientContext(connection ?? {});
+  return { ctx, client: createClient(TemplateService, ctx.transport) };
+}
+
+function defaultsToProto(defaults?: TemplateDefaults): {
+  limits?: { vcpus: number; memoryMib: bigint };
+  cmd: string[];
+  env: Record<string, string>;
+  exposedPorts: number[];
+  readyProbe?: TemplateDefaultsProto["readyProbe"];
+} {
+  const probe = defaults?.readyProbe;
+  return {
+    ...((defaults?.vcpus !== undefined ||
+      defaults?.memoryMib !== undefined) && {
+      limits: {
+        vcpus: defaults.vcpus ?? 0,
+        memoryMib: BigInt(defaults.memoryMib ?? 0),
+      },
+    }),
+    cmd: defaults?.cmd ?? [],
+    env: defaults?.env ?? {},
+    exposedPorts: defaults?.exposedPorts ?? [],
+    ...(probe !== undefined && {
+      readyProbe: {
+        timeoutSeconds: probe.timeoutSeconds ?? 0,
+        probe:
+          "port" in probe
+            ? { case: "port" as const, value: probe.port }
+            : {
+                case: "command" as const,
+                value: { cmd: probe.command },
+              },
+      } as TemplateDefaultsProto["readyProbe"],
+    }),
+  };
+}
+
+/**
+ * A catalog template: a named, versioned, reproducible sandbox base.
+ *
+ * `Sandbox.create` accepts an instance directly; the reference it pins is
+ * `name:version` for published versions and the bare name for drafts.
+ */
+export class Template {
+  readonly #ctx: ClientContext;
+  readonly #client: TemplateClient;
+  /** Template name, unique in the catalog. */
+  readonly name: string;
+  /** Published version ("" = unpublished draft). */
+  readonly version: string;
+  /** Content digest pinning this version's artifacts. */
+  readonly digest: string;
+  /** Full catalog row. */
+  readonly info: TemplateInfo;
+
+  private constructor(
+    ctx: ClientContext,
+    client: TemplateClient,
+    proto: TemplateProto,
+  ) {
+    this.#ctx = ctx;
+    this.#client = client;
+    this.info = templateInfoFromProto(proto);
+    this.name = this.info.name;
+    this.version = this.info.version;
+    this.digest = this.info.digest;
+  }
+
+  /** The `name[:version]` reference this instance addresses. */
+  get reference(): string {
+    return this.version === "" ? this.name : `${this.name}:${this.version}`;
+  }
+
+  /**
+   * Build a template from a source and register it as the catalog draft.
+   * Blocks until the build completes (image export, rootfs conversion, and
+   * the optional prewarm boot) — no client timeout is applied.
+   */
+  static async build(
+    this: void,
+    name: string,
+    source: TemplateSource,
+    opts: BuildTemplateOptions = {},
+  ): Promise<Template> {
+    const { ctx, client } = templateClient(opts.connection);
+    try {
+      const proto = await client.build({
+        name,
+        source:
+          "docker" in source
+            ? { case: "dockerRef", value: source.docker }
+            : "dockerfile" in source
+              ? { case: "dockerfile", value: source.dockerfile }
+              : { case: "snapshotId", value: source.snapshot },
+        defaults: defaultsToProto(opts.defaults),
+        labels: opts.labels ?? {},
+        prewarm: opts.prewarm ?? false,
+      });
+      return new Template(ctx, client, proto);
+    } catch (error) {
+      throw toArcBoxError(error, "templates.build");
+    }
+  }
+
+  /** Resolve a `name[:version]` reference (bare name = newest published, else draft). */
+  static async get(
+    this: void,
+    reference: string,
+    opts: TemplateConnectOptions = {},
+  ): Promise<Template> {
+    const { ctx, client } = templateClient(opts.connection);
+    try {
+      const proto = await client.get({ reference }, unaryOptions(ctx));
+      return new Template(ctx, client, proto);
+    } catch (error) {
+      throw toArcBoxError(error, "templates.get");
+    }
+  }
+
+  /** List catalog templates — one row per version, drafts included (auto-paginating). */
+  static async *list(
+    this: void,
+    opts: ListTemplatesOptions = {},
+  ): AsyncIterable<TemplateInfo> {
+    const { ctx, client } = templateClient(opts.connection);
+    try {
+      let pageToken = "";
+      do {
+        // eslint-disable-next-line no-await-in-loop -- sequential by design: each request needs the previous page's token
+        const page = await client.list(
+          { labels: opts.labels ?? {}, pageToken },
+          unaryOptions(ctx),
+        );
+        yield* page.templates.map(templateInfoFromProto);
+        pageToken = page.nextPageToken;
+      } while (pageToken !== "");
+    } catch (error) {
+      throw toArcBoxError(error, "templates.list");
+    }
+  }
+
+  /**
+   * Delete by reference: a bare `name` drops the template with every
+   * version and its on-disk artifacts; `name:version` drops one version.
+   * Sandboxes already created from it are unaffected.
+   */
+  static async delete(
+    this: void,
+    reference: string,
+    opts: TemplateConnectOptions = {},
+  ): Promise<void> {
+    const { ctx, client } = templateClient(opts.connection);
+    try {
+      await client.delete({ reference }, unaryOptions(ctx));
+    } catch (error) {
+      throw toArcBoxError(error, "templates.delete");
+    }
+  }
+
+  /** Freeze the current draft as immutable `version` and return it. */
+  async publish(version: string): Promise<Template> {
+    try {
+      const proto = await this.#client.publish(
+        { name: this.name, version },
+        unaryOptions(this.#ctx),
+      );
+      return new Template(this.#ctx, this.#client, proto);
+    } catch (error) {
+      throw toArcBoxError(error, "templates.publish");
+    }
+  }
+
+  /** Delete this exact version (or the whole template for a draft handle). */
+  async delete(): Promise<void> {
+    try {
+      await this.#client.delete(
+        { reference: this.reference },
+        unaryOptions(this.#ctx),
+      );
+    } catch (error) {
+      throw toArcBoxError(error, "templates.delete");
+    }
+  }
+}

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -17,6 +17,7 @@ import type {
   CheckpointResponse,
   SnapshotSummary as SnapshotSummaryProto,
 } from "./gen/arcbox/sandbox/v1/snapshot_pb";
+import type { Template as TemplateProto } from "./gen/arcbox/sandbox/v1/template_pb";
 
 /** Lifecycle state of a sandbox. See `sandbox.proto` for the state machine. */
 export type SandboxState =
@@ -303,6 +304,35 @@ export function exposedPortFromProto(port: ExposedPortProto): ExposedPort {
     hostPort: port.hostPort,
     protocol: portProtocolFromProto(port.protocol),
   };
+}
+
+/** A catalog template row (one per version; drafts have `version === ""`). */
+export interface TemplateInfo {
+  name: string;
+  /** Published version ("" = unpublished draft). */
+  version: string;
+  /** Content digest pinning this version's artifacts. */
+  digest: string;
+  /** Whether the template carries a pre-warmed boot-to-ready snapshot. */
+  warm: boolean;
+  /** On-disk footprint of the version's artifacts. */
+  sizeBytes: number;
+  labels: Record<string, string>;
+  createdAt?: Date;
+}
+
+/** Map one Template message to the public DTO. */
+export function templateInfoFromProto(proto: TemplateProto): TemplateInfo {
+  const out: TemplateInfo = {
+    name: proto.name,
+    version: proto.version,
+    digest: proto.digest,
+    warm: proto.warmSnapshotId !== "",
+    sizeBytes: Number(proto.sizeBytes),
+    labels: proto.labels,
+  };
+  assignIfSet(out, "createdAt", optionalDate(proto.createdAt));
+  return out;
 }
 
 /** Map one ListSnapshots row to the public DTO. */

--- a/sdk/typescript/test/templates.test.ts
+++ b/sdk/typescript/test/templates.test.ts
@@ -1,0 +1,205 @@
+// Template catalog against a mock daemon: Template.build/get/list/delete
+// statics, instance publish/delete, and Sandbox.create accepting a
+// Template instance.
+//
+// The contracts under test: build maps the source union onto the proto
+// oneof and returns a draft handle, get resolves references, list
+// auto-paginates one row per version, reference pins name:version for
+// published versions and the bare name for drafts, and errors carry the
+// templates.* operation names.
+
+import { create } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+import { Code, ConnectError, createRouterTransport } from "@connectrpc/connect";
+import { describe, expect, it } from "vitest";
+
+import { TemplateNotFoundError } from "../src/errors";
+import {
+  ErrorCode,
+  ErrorInfoSchema,
+} from "../src/gen/arcbox/sandbox/v1/errors_pb";
+import type { BuildTemplateRequest } from "../src/gen/arcbox/sandbox/v1/template_pb";
+import {
+  ListTemplatesResponseSchema,
+  TemplateSchema,
+  TemplateService,
+} from "../src/gen/arcbox/sandbox/v1/template_pb";
+import { Template } from "../src/templates";
+
+const CREATED = new Date("2026-08-11T08:00:00Z");
+
+describe("Template.build", () => {
+  it("maps the docker source and returns the registered draft", async () => {
+    const mock = createRouterTransport(({ service }) => {
+      service(TemplateService, {
+        build(req: BuildTemplateRequest) {
+          expect(req.name).toBe("code");
+          expect(req.source).toEqual({
+            case: "dockerRef",
+            value: "python:3.12",
+          });
+          expect(req.prewarm).toBe(true);
+          expect(req.labels).toEqual({ team: "ml" });
+          expect(req.defaults?.limits?.vcpus).toBe(2);
+          expect(req.defaults?.readyProbe?.probe).toEqual({
+            case: "port",
+            value: 8080,
+          });
+          return create(TemplateSchema, {
+            name: "code",
+            version: "",
+            digest: "sha256:d1",
+            createdAt: timestampFromDate(CREATED),
+          });
+        },
+      });
+    });
+
+    const template = await Template.build(
+      "code",
+      { docker: "python:3.12" },
+      {
+        prewarm: true,
+        labels: { team: "ml" },
+        defaults: { vcpus: 2, readyProbe: { port: 8080 } },
+        connection: { transport: mock },
+      },
+    );
+    expect(template.name).toBe("code");
+    expect(template.version).toBe("");
+    expect(template.digest).toBe("sha256:d1");
+    expect(template.reference).toBe("code");
+    expect(template.info.createdAt).toEqual(CREATED);
+  });
+
+  it("maps dockerfile and snapshot sources onto the oneof", async () => {
+    const seen: string[] = [];
+    const mock = createRouterTransport(({ service }) => {
+      service(TemplateService, {
+        build(req: BuildTemplateRequest) {
+          seen.push(req.source.case ?? "none");
+          return create(TemplateSchema, { name: req.name });
+        },
+      });
+    });
+    await Template.build(
+      "a",
+      { dockerfile: "FROM alpine" },
+      { connection: { transport: mock } },
+    );
+    await Template.build(
+      "b",
+      { snapshot: "snap-1" },
+      { connection: { transport: mock } },
+    );
+    expect(seen).toEqual(["dockerfile", "snapshotId"]);
+  });
+});
+
+describe("Template.get / publish / delete", () => {
+  it("resolves, publishes, and pins name:version", async () => {
+    const mock = createRouterTransport(({ service }) => {
+      service(TemplateService, {
+        get(req) {
+          expect(req.reference).toBe("code");
+          return create(TemplateSchema, {
+            name: "code",
+            version: "",
+            digest: "sha256:d1",
+          });
+        },
+        publish(req) {
+          expect(req.name).toBe("code");
+          expect(req.version).toBe("1.0");
+          return create(TemplateSchema, {
+            name: "code",
+            version: "1.0",
+            digest: "sha256:d1",
+          });
+        },
+        delete(req) {
+          expect(req.reference).toBe("code:1.0");
+          return {};
+        },
+      });
+    });
+
+    const draft = await Template.get("code", {
+      connection: { transport: mock },
+    });
+    const published = await draft.publish("1.0");
+    expect(published.reference).toBe("code:1.0");
+    await published.delete();
+  });
+
+  it("surfaces TEMPLATE_NOT_FOUND as the typed error", async () => {
+    const mock = createRouterTransport(({ service }) => {
+      service(TemplateService, {
+        get() {
+          // Faithful daemon shape: the classifier rides as an ErrorInfo
+          // detail, never the message text.
+          throw new ConnectError(
+            "template not found: ghost",
+            Code.NotFound,
+            undefined,
+            [
+              {
+                desc: ErrorInfoSchema,
+                value: {
+                  code: ErrorCode.TEMPLATE_NOT_FOUND,
+                  suggestion: "",
+                  context: {},
+                },
+              },
+            ],
+          );
+        },
+      });
+    });
+    // The mapped class and the operation name are the contract — a raw
+    // ConnectError leaking through must fail here.
+    const attempt = Template.get("ghost", { connection: { transport: mock } });
+    await expect(attempt).rejects.toBeInstanceOf(TemplateNotFoundError);
+    await expect(attempt).rejects.toMatchObject({ operation: "templates.get" });
+  });
+});
+
+describe("Template.list", () => {
+  it("auto-paginates one row per version, drafts included", async () => {
+    let calls = 0;
+    const mock = createRouterTransport(({ service }) => {
+      service(TemplateService, {
+        list(req) {
+          calls += 1;
+          if (req.pageToken === "") {
+            return create(ListTemplatesResponseSchema, {
+              templates: [
+                create(TemplateSchema, {
+                  name: "a",
+                  version: "1.0",
+                  warmSnapshotId: "s1",
+                }),
+              ],
+              nextPageToken: "a:1.0",
+            });
+          }
+          return create(ListTemplatesResponseSchema, {
+            templates: [create(TemplateSchema, { name: "a", version: "" })],
+            nextPageToken: "",
+          });
+        },
+      });
+    });
+
+    const rows = [];
+    for await (const row of Template.list({
+      connection: { transport: mock },
+    })) {
+      rows.push(row);
+    }
+    expect(calls).toBe(2);
+    expect(rows.map((r) => `${r.name}:${r.version}`)).toEqual(["a:1.0", "a:"]);
+    expect(rows[0]?.warm).toBe(true);
+    expect(rows[1]?.warm).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of the template-catalog campaign (CORE-107); follows #602.

## What

- `Template` class (`src/templates.ts`): statics `build(name, source, opts)` / `get(reference)` / `list(opts)` (async-iterable, auto-paginating) / `delete(reference)`, instance `publish(version)` / `delete()`. `TemplateSource` is a `{docker} | {dockerfile} | {snapshot}` union; build options carry defaults (limits/cmd/env/exposedPorts), a ready probe (port or command form), labels, and `prewarm`.
- `TemplateInfo` DTO + mapper in `types.ts` (name, version, digest, warm, sizeBytes, labels, createdAt).
- `create()` first positional widens to `string | Template` — an instance pins its exact `name:version` reference; new `noDefaultCmd` / `noDefaultEnv` options suppress inherited template cmd/env per the proto contract.
- Build applies no client deadline (template builds legitimately run long).
- README: Template deferral replaced with the shipped surface.

## Testing

- `npm test`: 126 passed (5 new template mock tests via createRouterTransport).
- `npm run lint` / `typecheck` / `format:check` / `build` all clean at this tip.