### PR TITLE
feat(sdk): commands surface for the Rust SDK

### DIFF
--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -63,14 +63,17 @@ TypeScript and Python SDKs.
 
 ## Status
 
-Phase 1 of the Rust SDK: connection resolution, the registry-derived
-error type, and the sandbox lifecycle core — `capabilities`, `create`
-(readiness watch armed before Create; failed creates remove their
-client-minted id), `connect` (PAUSING settle poll, PAUSED resume,
-STARTING readiness wait, one overall deadline), `list`
-(auto-paginating), `info`, `kill`, `pause`, and tri-state
-`set_lifecycle`.
+Shipped: connection resolution, the registry-derived error type, the
+sandbox lifecycle core — `capabilities`, `create` (readiness watch
+armed before Create; failed creates remove their client-minted id),
+`connect` (PAUSING settle poll, PAUSED resume, STARTING readiness wait,
+one overall deadline), `list` (auto-paginating), `info`, `kill`,
+`pause`, tri-state `set_lifecycle` — and the commands surface:
+`run` (foreground, output collected, non-zero exit is data) / `spawn`
+(background handle), an output stream that re-attaches at the retained
+byte offsets across transport drops, offset-idempotent `write_stdin`
+(serialized; a failed write re-reads the daemon's accepted count),
+`close_stdin`, `stdin_status`, `resize`, `kill(signal)`, `get`
+(stdin cursor seeded from the daemon), and `list`.
 
-Next: the commands surface (`run`/`spawn`, offset-idempotent stdin,
-output streams with attach-resume), then files, ports, snapshots, and
-events.
+Next: files, ports, snapshots, and events.

--- a/sdk/rust/src/commands.rs
+++ b/sdk/rust/src/commands.rs
@@ -4,7 +4,9 @@
 //! wait for the exit); [`Commands::spawn`] is the background form,
 //! returning a [`CommandHandle`] whose output stream survives transport
 //! drops by re-attaching at the retained byte offsets — the daemon
-//! addresses output by offset, so nothing is lost or replayed.
+//! addresses output by offset, so nothing is ever replayed, and any
+//! loss (retention trimming, a stream dead past its budget) is
+//! detectable through the truncation flags rather than silent.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -176,8 +178,11 @@ pub struct CommandResult {
     pub signal: Option<String>,
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
-    /// True when retention or a dead stream dropped output bytes —
-    /// `stdout`/`stderr` are then incomplete.
+    /// True when `stdout`/`stderr` may be incomplete: a retention gap
+    /// *proved* bytes were dropped, or the output stream died past its
+    /// re-attach budget before the exit (bytes after the death, if any,
+    /// were never observed). Conservative: a dead stream on a silent
+    /// command sets it too.
     pub truncated: bool,
 }
 
@@ -260,7 +265,9 @@ impl Commands {
     /// # Errors
     ///
     /// [`ErrorKind::InvalidArgument`] for [`Stdin::Open`] (only a
-    /// spawned handle can keep writing); otherwise any RPC failure.
+    /// spawned handle can keep writing); [`ErrorKind::Internal`] when
+    /// the execution ended without an observed exit (the daemon's
+    /// error detail is the message); otherwise any RPC failure.
     pub async fn run(&self, cmd: impl Into<Cmd>, options: RunOptions) -> Result<CommandResult> {
         if matches!(options.stdin, Stdin::Open) {
             return Err(Error::new(
@@ -340,9 +347,12 @@ impl Commands {
             if let Err(error) = seeded {
                 // The command is already running; without its stdin it
                 // would sit half-fed with no handle returned to manage
-                // it. Best-effort kill; the original error stands.
+                // it. Best-effort kill; the original error stands, and
+                // it carries the execution id so a caller can reach the
+                // command through commands.get() if the kill also
+                // failed.
                 let _ = handle.kill(Signal::Kill).await;
-                return Err(error);
+                return Err(error.with_context("command_id", &*handle.command_id));
             }
         }
         Ok(handle)
@@ -433,7 +443,9 @@ impl CommandHandle {
     ///
     /// The stream re-attaches at the retained byte offsets when the
     /// transport drops — output is offset-addressed daemon-side, so
-    /// nothing is lost or replayed. It ends when the command exits.
+    /// nothing is ever replayed; loss (retention trimming) is recorded
+    /// on [`OutputStream::truncated`] rather than silent. It ends when
+    /// the command exits.
     #[must_use]
     pub fn output(&self) -> OutputStream {
         OutputStream {
@@ -454,8 +466,10 @@ impl CommandHandle {
     ///
     /// # Errors
     ///
-    /// [`ErrorKind::Timeout`] when `timeout` elapses first; otherwise
-    /// any RPC failure.
+    /// [`ErrorKind::Timeout`] when `timeout` elapses first;
+    /// [`ErrorKind::Internal`] when the execution ended without an
+    /// observed exit (the daemon's error detail is the message);
+    /// otherwise any RPC failure.
     pub async fn wait(&self, timeout: Option<Duration>) -> Result<CommandResult> {
         match timeout {
             None => self.wait_inner().await,
@@ -790,7 +804,8 @@ impl OutputStream {
             .map_err(|error| Error::from_connect(error, "commands.output"))
     }
 
-    /// Whether retention or a dead stream dropped output bytes so far.
+    /// Whether output may be incomplete so far: a proven retention gap,
+    /// or a stream that died past its re-attach budget.
     #[must_use]
     pub fn truncated(&self) -> bool {
         self.truncated

--- a/sdk/rust/src/commands.rs
+++ b/sdk/rust/src/commands.rs
@@ -1,0 +1,825 @@
+//! Running commands inside one sandbox.
+//!
+//! [`Commands::run`] is the foreground form (start, collect output,
+//! wait for the exit); [`Commands::spawn`] is the background form,
+//! returning a [`CommandHandle`] whose output stream survives transport
+//! drops by re-attaching at the retained byte offsets — the daemon
+//! addresses output by offset, so nothing is lost or replayed.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use arcbox_connect::sandbox_v1 as pb;
+use arcbox_connect::sandbox_v1::{SandboxProcessServiceClient, execution_event, exit_status};
+use connectrpc::client::{ClientTransport, ServerStream, SharedHttp2Connection};
+
+use crate::client::ClientContext;
+use crate::error::{Error, ErrorKind, Result};
+use crate::types::seconds_to_wire;
+
+/// The generated process client over the shared transport.
+type ProcessClient = SandboxProcessServiceClient<SharedHttp2Connection>;
+
+/// The server stream [`ProcessClient::attach_execution`] returns.
+type AttachStream = ServerStream<
+    <SharedHttp2Connection as ClientTransport>::ResponseBody,
+    pb::__buffa::view::ExecutionEventView<'static>,
+>;
+
+/// Re-attach attempts before an output stream gives up — any received
+/// event resets the budget, so this bounds *consecutive* dead dials.
+const ATTACH_RESUME_ATTEMPTS: u32 = 3;
+
+/// Backoff base between re-attach attempts (multiplied by the attempt).
+const ATTACH_RESUME_BACKOFF: Duration = Duration::from_millis(200);
+
+/// Wait slice for [`CommandHandle::wait`]: the daemon parks each
+/// WaitExecution unary for at most this long, so an unbounded wait is a
+/// sequence of bounded ones.
+const WAIT_SLICE: Duration = Duration::from_secs(30);
+
+/// What to run: an argv, or a shell line (`/bin/sh -lc`).
+#[derive(Debug, Clone)]
+pub enum Cmd {
+    /// An argv, executed as-is.
+    Argv(Vec<String>),
+    /// A shell line, wrapped as `/bin/sh -lc <line>`.
+    Shell(String),
+}
+
+impl From<&str> for Cmd {
+    fn from(line: &str) -> Self {
+        Self::Shell(line.to_owned())
+    }
+}
+
+impl From<String> for Cmd {
+    fn from(line: String) -> Self {
+        Self::Shell(line)
+    }
+}
+
+impl From<Vec<String>> for Cmd {
+    fn from(argv: Vec<String>) -> Self {
+        Self::Argv(argv)
+    }
+}
+
+impl From<&[&str]> for Cmd {
+    fn from(argv: &[&str]) -> Self {
+        Self::Argv(argv.iter().map(|&arg| arg.to_owned()).collect())
+    }
+}
+
+impl Cmd {
+    fn into_argv(self) -> Vec<String> {
+        match self {
+            Self::Argv(argv) => argv,
+            Self::Shell(line) => vec!["/bin/sh".to_owned(), "-lc".to_owned(), line],
+        }
+    }
+}
+
+/// Terminal geometry for a PTY command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PtySize {
+    /// Terminal width in columns.
+    pub cols: u32,
+    /// Terminal height in rows.
+    pub rows: u32,
+}
+
+/// What the command's stdin starts as.
+#[derive(Debug, Clone, Default)]
+pub enum Stdin {
+    /// Closed from the start (the default).
+    #[default]
+    Closed,
+    /// Write these bytes, then close.
+    Data(Vec<u8>),
+    /// Keep stdin open for [`CommandHandle::write_stdin`] — only
+    /// meaningful with [`Commands::spawn`], which returns the handle.
+    Open,
+}
+
+/// Options for [`Commands::run`] and [`Commands::spawn`].
+#[derive(Debug, Clone, Default)]
+pub struct RunOptions {
+    /// Working directory (unset = the daemon default).
+    pub cwd: Option<String>,
+    /// Extra environment for this command.
+    pub env: BTreeMap<String, String>,
+    /// User to run as (unset = the daemon default).
+    pub user: Option<String>,
+    /// Kill the process group after this long.
+    pub timeout: Option<Duration>,
+    /// Allocate a pseudo-terminal of this size. A terminal merges
+    /// stdout and stderr into one [`Channel::Pty`] stream.
+    pub pty: Option<PtySize>,
+    /// The command's stdin (see [`Stdin`]).
+    pub stdin: Stdin,
+}
+
+/// Signals deliverable to a command's process group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Signal {
+    Hup,
+    Int,
+    Quit,
+    Kill,
+    Term,
+}
+
+impl Signal {
+    fn to_wire(self) -> pb::Signal {
+        match self {
+            Self::Hup => pb::Signal::SIGNAL_SIGHUP,
+            Self::Int => pb::Signal::SIGNAL_SIGINT,
+            Self::Quit => pb::Signal::SIGNAL_SIGQUIT,
+            Self::Kill => pb::Signal::SIGNAL_SIGKILL,
+            Self::Term => pb::Signal::SIGNAL_SIGTERM,
+        }
+    }
+}
+
+/// Which stream a chunk of output belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Channel {
+    Stdout,
+    Stderr,
+    /// A terminal's merged stream, escape sequences included.
+    Pty,
+}
+
+/// One chunk of command output.
+#[derive(Debug, Clone)]
+pub struct OutputChunk {
+    pub channel: Channel,
+    pub data: Vec<u8>,
+}
+
+/// A finished command. A non-zero exit is data, not an error.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct CommandResult {
+    /// Process exit code. When the process was killed by a signal this
+    /// is `128 + signal` (shell convention) and [`signal`](Self::signal)
+    /// is set.
+    pub exit_code: i32,
+    /// Signal name (`"SIGKILL"`) when the process died by one.
+    pub signal: Option<String>,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+impl CommandResult {
+    /// Whether the command exited zero.
+    #[must_use]
+    pub fn success(&self) -> bool {
+        self.exit_code == 0
+    }
+
+    /// Stdout as text, invalid UTF-8 replaced.
+    #[must_use]
+    pub fn stdout_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.stdout).into_owned()
+    }
+
+    /// Stderr as text, invalid UTF-8 replaced.
+    #[must_use]
+    pub fn stderr_lossy(&self) -> String {
+        String::from_utf8_lossy(&self.stderr).into_owned()
+    }
+}
+
+/// Lifecycle state of a command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CommandState {
+    Running,
+    Exited,
+    Unknown,
+}
+
+/// One row of a command listing.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct CommandInfo {
+    pub command_id: String,
+    /// Whether the command runs on a PTY.
+    pub tty: bool,
+    pub state: CommandState,
+    /// Exit code, once exited (shell convention for signal deaths).
+    pub exit_code: Option<i32>,
+    /// Signal name, when the process died by one.
+    pub signal: Option<String>,
+    /// Daemon-reported failure, when the command could not run.
+    pub error: Option<String>,
+}
+
+/// Stdin acceptance state of a command, as reported by the daemon.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct StdinStatus {
+    /// Bytes accepted and forwarded so far — the offset the next stdin
+    /// write starts at.
+    pub bytes_written: u64,
+    /// Whether stdin has been closed.
+    pub closed: bool,
+}
+
+/// The `sandbox.commands()` namespace: run processes inside one sandbox.
+#[derive(Clone)]
+pub struct Commands {
+    ctx: ClientContext,
+    sandbox_id: String,
+}
+
+impl Commands {
+    pub(crate) fn attached(ctx: ClientContext, sandbox_id: String) -> Self {
+        Self { ctx, sandbox_id }
+    }
+
+    fn client(&self) -> ProcessClient {
+        SandboxProcessServiceClient::new(self.ctx.transport.clone(), self.ctx.config.clone())
+    }
+
+    /// Run a command in the foreground: start it, collect its output,
+    /// and return the result once it exits. A non-zero exit is data on
+    /// the result, never an error.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::InvalidArgument`] for [`Stdin::Open`] (only a
+    /// spawned handle can keep writing); otherwise any RPC failure.
+    pub async fn run(&self, cmd: impl Into<Cmd>, options: RunOptions) -> Result<CommandResult> {
+        if matches!(options.stdin, Stdin::Open) {
+            return Err(Error::new(
+                ErrorKind::InvalidArgument,
+                "Stdin::Open needs a handle to write through — use spawn()",
+                "commands.run",
+            ));
+        }
+        let handle = self.start(cmd.into(), options, "commands.run").await?;
+        handle.wait(None).await
+    }
+
+    /// Start a command in the background and return its handle.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::InvalidArgument`] for [`Stdin::Data`] combined with
+    /// a PTY (a terminal's input is interactive by nature); otherwise
+    /// any RPC failure.
+    pub async fn spawn(&self, cmd: impl Into<Cmd>, options: RunOptions) -> Result<CommandHandle> {
+        self.start(cmd.into(), options, "commands.spawn").await
+    }
+
+    async fn start(
+        &self,
+        cmd: Cmd,
+        options: RunOptions,
+        operation: &'static str,
+    ) -> Result<CommandHandle> {
+        if options.pty.is_some() && matches!(options.stdin, Stdin::Data(_)) {
+            return Err(Error::new(
+                ErrorKind::InvalidArgument,
+                "one-shot stdin bytes and a PTY are mutually exclusive — a \
+                 terminal's input is interactive; write through the handle",
+                operation,
+            ));
+        }
+        let execution_id = uuid::Uuid::new_v4().to_string();
+        let stdin_open = !matches!(options.stdin, Stdin::Closed);
+        let mut request = pb::StartExecutionRequest {
+            sandbox_id: self.sandbox_id.clone(),
+            execution_id: execution_id.clone(),
+            cmd: cmd.into_argv(),
+            env: options.env.into_iter().collect(),
+            working_dir: options.cwd.unwrap_or_default(),
+            user: options.user.unwrap_or_default(),
+            timeout_seconds: seconds_to_wire(options.timeout),
+            stdin: stdin_open,
+            ..Default::default()
+        };
+        if let Some(size) = options.pty {
+            request.tty = true;
+            request.tty_size = pb::TerminalSize {
+                width: size.cols,
+                height: size.rows,
+                ..Default::default()
+            }
+            .into();
+        }
+        self.client()
+            .start_execution(request)
+            .await
+            .map_err(|error| Error::from_connect(error, operation))?;
+
+        let handle = CommandHandle {
+            ctx: self.ctx.clone(),
+            sandbox_id: self.sandbox_id.clone(),
+            command_id: execution_id,
+            stdin_cursor: Arc::new(tokio::sync::Mutex::new(Some(0))),
+        };
+        if let Stdin::Data(data) = options.stdin {
+            handle.write_stdin(&data).await?;
+            handle.close_stdin().await?;
+        }
+        Ok(handle)
+    }
+
+    /// Take a handle on a command started elsewhere. The stdin cursor
+    /// is seeded from the daemon, so writes resume at the accepted
+    /// offset.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::ExecutionNotFound`] when no such command exists;
+    /// otherwise any RPC failure.
+    pub async fn get(&self, command_id: &str) -> Result<CommandHandle> {
+        let execution = self
+            .client()
+            .wait_execution(pb::WaitExecutionRequest {
+                sandbox_id: self.sandbox_id.clone(),
+                execution_id: command_id.to_owned(),
+                // 0 = answer with the current state immediately.
+                timeout_seconds: 0,
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "commands.get"))?
+            .into_owned();
+        let accepted = execution
+            .stdin
+            .as_option()
+            .map_or(0, |stdin| stdin.bytes_written);
+        Ok(CommandHandle {
+            ctx: self.ctx.clone(),
+            sandbox_id: self.sandbox_id.clone(),
+            command_id: command_id.to_owned(),
+            stdin_cursor: Arc::new(tokio::sync::Mutex::new(Some(accepted))),
+        })
+    }
+
+    /// List the sandbox's commands, running and exited.
+    ///
+    /// # Errors
+    ///
+    /// Any RPC failure, mapped onto [`Error`].
+    pub async fn list(&self) -> Result<Vec<CommandInfo>> {
+        let response = self
+            .client()
+            .list_executions(pb::ListExecutionsRequest {
+                sandbox_id: self.sandbox_id.clone(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "commands.list"))?
+            .into_owned();
+        Ok(response
+            .executions
+            .into_iter()
+            .map(info_from_wire)
+            .collect())
+    }
+}
+
+/// A running (or finished) command.
+///
+/// Cheap to clone; every clone addresses the same execution.
+#[derive(Clone)]
+pub struct CommandHandle {
+    ctx: ClientContext,
+    sandbox_id: String,
+    command_id: String,
+    /// The next stdin offset, serialized so concurrent writes cannot
+    /// interleave their idempotency windows. `None` = unknown (a write
+    /// failed mid-flight); the next write re-reads it from the daemon.
+    stdin_cursor: Arc<tokio::sync::Mutex<Option<u64>>>,
+}
+
+impl CommandHandle {
+    fn client(&self) -> ProcessClient {
+        SandboxProcessServiceClient::new(self.ctx.transport.clone(), self.ctx.config.clone())
+    }
+
+    /// The execution id.
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.command_id
+    }
+
+    /// The command's output, one chunk at a time.
+    ///
+    /// The stream re-attaches at the retained byte offsets when the
+    /// transport drops — output is offset-addressed daemon-side, so
+    /// nothing is lost or replayed. It ends when the command exits.
+    #[must_use]
+    pub fn output(&self) -> OutputStream {
+        OutputStream {
+            handle: self.clone(),
+            stream: None,
+            stdout_offset: 0,
+            stderr_offset: 0,
+            attempts: 0,
+            done: false,
+            exited: None,
+        }
+    }
+
+    /// Wait for the command to finish and return its result, output
+    /// included. `timeout` bounds the wait ([`ErrorKind::Timeout`] on
+    /// expiry; the command keeps running).
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::Timeout`] when `timeout` elapses first; otherwise
+    /// any RPC failure.
+    pub async fn wait(&self, timeout: Option<Duration>) -> Result<CommandResult> {
+        match timeout {
+            None => self.wait_inner().await,
+            Some(deadline) => tokio::time::timeout(deadline, self.wait_inner())
+                .await
+                .map_err(|_| {
+                    Error::new(
+                        ErrorKind::Timeout,
+                        format!(
+                            "wait(timeout) elapsed before command {} exited",
+                            self.command_id
+                        ),
+                        "commands.wait",
+                    )
+                    .with_suggestion("increase the wait timeout, or kill() the command")
+                    .with_context("command_id", &*self.command_id)
+                })?,
+        }
+    }
+
+    async fn wait_inner(&self) -> Result<CommandResult> {
+        // Collect the output; the stream ends when the command exits
+        // and carries the exit through its final event.
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut output = self.output();
+        while let Some(chunk) = output.next().await? {
+            match chunk.channel {
+                Channel::Stderr => stderr.extend_from_slice(&chunk.data),
+                // A terminal merges the streams; deliver as stdout.
+                Channel::Stdout | Channel::Pty => stdout.extend_from_slice(&chunk.data),
+            }
+        }
+        if let Some(execution) = output.exited.take() {
+            return Ok(result_from_wire(&execution, stdout, stderr));
+        }
+        // The stream ended without an exit event (attach gave up, or
+        // the daemon closed early): the authoritative wait decides.
+        loop {
+            let execution = self
+                .client()
+                .wait_execution(pb::WaitExecutionRequest {
+                    sandbox_id: self.sandbox_id.clone(),
+                    execution_id: self.command_id.clone(),
+                    timeout_seconds: seconds_to_wire(Some(WAIT_SLICE)),
+                    ..Default::default()
+                })
+                .await
+                .map_err(|error| Error::from_connect(error, "commands.wait"))?
+                .into_owned();
+            if execution.state.as_known() == Some(pb::ExecutionState::EXECUTION_STATE_EXITED) {
+                return Ok(result_from_wire(&execution, stdout, stderr));
+            }
+        }
+    }
+
+    /// Feed bytes to the command's stdin.
+    ///
+    /// Writes are offset-idempotent: each carries the byte offset it
+    /// starts at, the daemon dedups anything below its accepted count,
+    /// and concurrent writes are serialized here — so a retried write
+    /// can never double-deliver.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::StdinClosed`] once stdin is closed; otherwise any
+    /// RPC failure.
+    pub async fn write_stdin(&self, data: &[u8]) -> Result<()> {
+        let mut cursor = self.stdin_cursor.lock().await;
+        let offset = match *cursor {
+            Some(offset) => offset,
+            // A previous write failed mid-flight; the daemon's accepted
+            // count is the truth.
+            None => self.stdin_status_inner().await?.bytes_written,
+        };
+        match self
+            .client()
+            .write_stdin(pb::WriteStdinRequest {
+                sandbox_id: self.sandbox_id.clone(),
+                execution_id: self.command_id.clone(),
+                offset,
+                data: data.to_vec(),
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(status) => {
+                *cursor = Some(status.into_owned().bytes_written);
+                Ok(())
+            }
+            Err(error) => {
+                *cursor = None;
+                Err(Error::from_connect(error, "commands.write_stdin"))
+            }
+        }
+    }
+
+    /// Close the command's stdin.
+    ///
+    /// # Errors
+    ///
+    /// Any RPC failure, mapped onto [`Error`].
+    pub async fn close_stdin(&self) -> Result<()> {
+        let mut cursor = self.stdin_cursor.lock().await;
+        let offset = match *cursor {
+            Some(offset) => offset,
+            None => self.stdin_status_inner().await?.bytes_written,
+        };
+        self.client()
+            .write_stdin(pb::WriteStdinRequest {
+                sandbox_id: self.sandbox_id.clone(),
+                execution_id: self.command_id.clone(),
+                offset,
+                eof: true,
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| {
+                *cursor = None;
+                Error::from_connect(error, "commands.close_stdin")
+            })?;
+        Ok(())
+    }
+
+    /// Stdin acceptance state, as the daemon reports it.
+    ///
+    /// # Errors
+    ///
+    /// Any RPC failure, mapped onto [`Error`].
+    pub async fn stdin_status(&self) -> Result<StdinStatus> {
+        self.stdin_status_inner().await
+    }
+
+    async fn stdin_status_inner(&self) -> Result<StdinStatus> {
+        let status = self
+            .client()
+            .get_stdin_status(pb::GetStdinStatusRequest {
+                sandbox_id: self.sandbox_id.clone(),
+                execution_id: self.command_id.clone(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "commands.stdin_status"))?
+            .into_owned();
+        Ok(StdinStatus {
+            bytes_written: status.bytes_written,
+            closed: status.closed,
+        })
+    }
+
+    /// Resize the command's terminal.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::TtyRequired`] for a command without a PTY;
+    /// otherwise any RPC failure.
+    pub async fn resize(&self, size: PtySize) -> Result<()> {
+        self.client()
+            .resize_execution_tty(pb::ResizeExecutionTtyRequest {
+                sandbox_id: self.sandbox_id.clone(),
+                execution_id: self.command_id.clone(),
+                size: pb::TerminalSize {
+                    width: size.cols,
+                    height: size.rows,
+                    ..Default::default()
+                }
+                .into(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "commands.resize"))?;
+        Ok(())
+    }
+
+    /// Deliver a signal to the command's process group.
+    ///
+    /// # Errors
+    ///
+    /// Any RPC failure, mapped onto [`Error`].
+    pub async fn kill(&self, signal: Signal) -> Result<()> {
+        self.client()
+            .signal_execution(pb::SignalExecutionRequest {
+                sandbox_id: self.sandbox_id.clone(),
+                execution_id: self.command_id.clone(),
+                signal: signal.to_wire().into(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "commands.kill"))?;
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for CommandHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("CommandHandle")
+            .field("sandbox_id", &self.sandbox_id)
+            .field("command_id", &self.command_id)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A command's output, read one chunk at a time with [`next`](Self::next).
+///
+/// Re-attaches at the retained byte offsets on transport drops, with a
+/// bounded budget for *consecutive* failed dials — any received event
+/// resets it.
+pub struct OutputStream {
+    handle: CommandHandle,
+    stream: Option<AttachStream>,
+    stdout_offset: u64,
+    stderr_offset: u64,
+    attempts: u32,
+    done: bool,
+    /// The exit the stream delivered, when it ended with one.
+    exited: Option<pb::Execution>,
+}
+
+impl OutputStream {
+    /// The next chunk, or `None` when the command exited (or the
+    /// re-attach budget ran out with the stream dead).
+    ///
+    /// # Errors
+    ///
+    /// Any RPC failure that survives the re-attach budget.
+    pub async fn next(&mut self) -> Result<Option<OutputChunk>> {
+        loop {
+            if self.done {
+                return Ok(None);
+            }
+            if self.stream.is_none() {
+                match self.attach().await {
+                    Ok(stream) => self.stream = Some(stream),
+                    Err(error) => {
+                        if self.bump_attempts().await {
+                            continue;
+                        }
+                        self.done = true;
+                        return Err(error);
+                    }
+                }
+            }
+            let stream = self.stream.as_mut().expect("stream attached above");
+            match stream.message::<pb::ExecutionEvent>().await {
+                Ok(Some(frame)) => {
+                    // Anything received proves the stream re-established.
+                    self.attempts = 0;
+                    match frame.to_owned_message().event {
+                        Some(execution_event::Event::Output(output)) => {
+                            let channel = match output.channel.as_known() {
+                                Some(pb::StdioChannel::STDIO_CHANNEL_STDERR) => Channel::Stderr,
+                                Some(pb::StdioChannel::STDIO_CHANNEL_PTY) => Channel::Pty,
+                                _ => Channel::Stdout,
+                            };
+                            // Advance past this chunk even when empty, so
+                            // a resume never re-reads it. The server may
+                            // report a higher offset than we tracked
+                            // (retention trimming); trust it.
+                            let end = output.offset.saturating_add(output.data.len() as u64);
+                            match channel {
+                                Channel::Stderr => {
+                                    self.stderr_offset = self.stderr_offset.max(end);
+                                }
+                                Channel::Stdout | Channel::Pty => {
+                                    self.stdout_offset = self.stdout_offset.max(end);
+                                }
+                            }
+                            if output.data.is_empty() {
+                                continue;
+                            }
+                            return Ok(Some(OutputChunk {
+                                channel,
+                                data: output.data,
+                            }));
+                        }
+                        Some(execution_event::Event::Exited(exited)) => {
+                            self.exited = exited.execution.as_option().cloned();
+                            self.done = true;
+                            return Ok(None);
+                        }
+                        // Started and keepalive frames prove liveness but
+                        // carry no output.
+                        _ => {}
+                    }
+                }
+                // Clean end without an exit event: the caller's wait
+                // decides authoritatively.
+                Ok(None) => {
+                    self.done = true;
+                    return Ok(None);
+                }
+                Err(error) => {
+                    self.stream = None;
+                    if self.bump_attempts().await {
+                        continue;
+                    }
+                    self.done = true;
+                    return Err(Error::from_connect(error, "commands.output"));
+                }
+            }
+        }
+    }
+
+    async fn attach(&self) -> std::result::Result<AttachStream, Error> {
+        self.handle
+            .client()
+            .attach_execution(pb::AttachExecutionRequest {
+                sandbox_id: self.handle.sandbox_id.clone(),
+                execution_id: self.handle.command_id.clone(),
+                stdout_offset: self.stdout_offset,
+                stderr_offset: self.stderr_offset,
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "commands.output"))
+    }
+
+    /// One more attempt, with backoff. `true` = keep trying.
+    async fn bump_attempts(&mut self) -> bool {
+        self.attempts += 1;
+        if self.attempts > ATTACH_RESUME_ATTEMPTS {
+            return false;
+        }
+        tokio::time::sleep(ATTACH_RESUME_BACKOFF * self.attempts).await;
+        true
+    }
+}
+
+/// Exit code + signal name from the wire exit status, shell convention
+/// for signal deaths.
+fn exit_parts(execution: &pb::Execution) -> (Option<i32>, Option<String>) {
+    match execution
+        .exit_status
+        .as_option()
+        .and_then(|status| status.status.clone())
+    {
+        Some(exit_status::Status::Code(code)) => (Some(code), None),
+        Some(exit_status::Status::Signal(signal)) => {
+            (Some(128 + signal), Some(signal_name(signal)))
+        }
+        None => (None, None),
+    }
+}
+
+fn signal_name(value: i32) -> String {
+    match buffa::EnumValue::<pb::Signal>::from(value).as_known() {
+        Some(signal) => {
+            let name = format!("{signal:?}");
+            name.strip_prefix("SIGNAL_").unwrap_or(&name).to_owned()
+        }
+        None => format!("SIG{value}"),
+    }
+}
+
+fn result_from_wire(execution: &pb::Execution, stdout: Vec<u8>, stderr: Vec<u8>) -> CommandResult {
+    let (exit_code, signal) = exit_parts(execution);
+    CommandResult {
+        exit_code: exit_code.unwrap_or(0),
+        signal,
+        stdout,
+        stderr,
+    }
+}
+
+fn info_from_wire(execution: pb::Execution) -> CommandInfo {
+    let (exit_code, signal) = exit_parts(&execution);
+    let state = match execution.state.as_known() {
+        Some(pb::ExecutionState::EXECUTION_STATE_RUNNING) => CommandState::Running,
+        Some(pb::ExecutionState::EXECUTION_STATE_EXITED) => CommandState::Exited,
+        _ => CommandState::Unknown,
+    };
+    CommandInfo {
+        command_id: execution.id,
+        tty: execution.tty,
+        state,
+        exit_code: if state == CommandState::Exited {
+            exit_code
+        } else {
+            None
+        },
+        signal,
+        error: (!execution.error.is_empty()).then_some(execution.error),
+    }
+}

--- a/sdk/rust/src/commands.rs
+++ b/sdk/rust/src/commands.rs
@@ -157,6 +157,10 @@ pub enum Channel {
 #[derive(Debug, Clone)]
 pub struct OutputChunk {
     pub channel: Channel,
+    /// Byte offset this chunk starts at within its channel. A jump past
+    /// the previous chunk's end means retention already dropped bytes —
+    /// the stream's [`OutputStream::truncated`] flag records it.
+    pub offset: u64,
     pub data: Vec<u8>,
 }
 
@@ -172,6 +176,9 @@ pub struct CommandResult {
     pub signal: Option<String>,
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
+    /// True when retention or a dead stream dropped output bytes —
+    /// `stdout`/`stderr` are then incomplete.
+    pub truncated: bool,
 }
 
 impl CommandResult {
@@ -325,8 +332,18 @@ impl Commands {
             stdin_cursor: Arc::new(tokio::sync::Mutex::new(Some(0))),
         };
         if let Stdin::Data(data) = options.stdin {
-            handle.write_stdin(&data).await?;
-            handle.close_stdin().await?;
+            let seeded = async {
+                handle.write_stdin(&data).await?;
+                handle.close_stdin().await
+            }
+            .await;
+            if let Err(error) = seeded {
+                // The command is already running; without its stdin it
+                // would sit half-fed with no handle returned to manage
+                // it. Best-effort kill; the original error stands.
+                let _ = handle.kill(Signal::Kill).await;
+                return Err(error);
+            }
         }
         Ok(handle)
     }
@@ -426,6 +443,7 @@ impl CommandHandle {
             stderr_offset: 0,
             attempts: 0,
             done: false,
+            truncated: false,
             exited: None,
         }
     }
@@ -460,19 +478,30 @@ impl CommandHandle {
 
     async fn wait_inner(&self) -> Result<CommandResult> {
         // Collect the output; the stream ends when the command exits
-        // and carries the exit through its final event.
+        // and carries the exit through its final event. A stream that
+        // dies past its re-attach budget is NOT the command's outcome —
+        // the authoritative wait below decides, with the output marked
+        // truncated.
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
         let mut output = self.output();
-        while let Some(chunk) = output.next().await? {
-            match chunk.channel {
-                Channel::Stderr => stderr.extend_from_slice(&chunk.data),
-                // A terminal merges the streams; deliver as stdout.
-                Channel::Stdout | Channel::Pty => stdout.extend_from_slice(&chunk.data),
+        loop {
+            match output.next().await {
+                Ok(Some(chunk)) => match chunk.channel {
+                    Channel::Stderr => stderr.extend_from_slice(&chunk.data),
+                    // A terminal merges the streams; deliver as stdout.
+                    Channel::Stdout | Channel::Pty => stdout.extend_from_slice(&chunk.data),
+                },
+                Ok(None) => break,
+                Err(_) => {
+                    output.truncated = true;
+                    break;
+                }
             }
         }
+        let truncated = output.truncated;
         if let Some(execution) = output.exited.take() {
-            return Ok(result_from_wire(&execution, stdout, stderr));
+            return result_from_wire(&execution, stdout, stderr, truncated);
         }
         // The stream ended without an exit event (attach gave up, or
         // the daemon closed early): the authoritative wait decides.
@@ -489,7 +518,7 @@ impl CommandHandle {
                 .map_err(|error| Error::from_connect(error, "commands.wait"))?
                 .into_owned();
             if execution.state.as_known() == Some(pb::ExecutionState::EXECUTION_STATE_EXITED) {
-                return Ok(result_from_wire(&execution, stdout, stderr));
+                return result_from_wire(&execution, stdout, stderr, truncated);
             }
         }
     }
@@ -653,6 +682,9 @@ pub struct OutputStream {
     stderr_offset: u64,
     attempts: u32,
     done: bool,
+    /// True once an offset jump proved retention dropped bytes, or the
+    /// stream died past its re-attach budget.
+    truncated: bool,
     /// The exit the stream delivered, when it ended with one.
     exited: Option<pb::Execution>,
 }
@@ -694,23 +726,25 @@ impl OutputStream {
                                 _ => Channel::Stdout,
                             };
                             // Advance past this chunk even when empty, so
-                            // a resume never re-reads it. The server may
-                            // report a higher offset than we tracked
-                            // (retention trimming); trust it.
+                            // a resume never re-reads it. A chunk offset
+                            // past what we tracked is the wire's one
+                            // notification that retention already dropped
+                            // bytes — record it rather than absorb it.
                             let end = output.offset.saturating_add(output.data.len() as u64);
-                            match channel {
-                                Channel::Stderr => {
-                                    self.stderr_offset = self.stderr_offset.max(end);
-                                }
-                                Channel::Stdout | Channel::Pty => {
-                                    self.stdout_offset = self.stdout_offset.max(end);
-                                }
+                            let tracked = match channel {
+                                Channel::Stderr => &mut self.stderr_offset,
+                                Channel::Stdout | Channel::Pty => &mut self.stdout_offset,
+                            };
+                            if output.offset > *tracked {
+                                self.truncated = true;
                             }
+                            *tracked = (*tracked).max(end);
                             if output.data.is_empty() {
                                 continue;
                             }
                             return Ok(Some(OutputChunk {
                                 channel,
+                                offset: output.offset,
                                 data: output.data,
                             }));
                         }
@@ -756,6 +790,12 @@ impl OutputStream {
             .map_err(|error| Error::from_connect(error, "commands.output"))
     }
 
+    /// Whether retention or a dead stream dropped output bytes so far.
+    #[must_use]
+    pub fn truncated(&self) -> bool {
+        self.truncated
+    }
+
     /// One more attempt, with backoff. `true` = keep trying.
     async fn bump_attempts(&mut self) -> bool {
         self.attempts += 1;
@@ -793,14 +833,39 @@ fn signal_name(value: i32) -> String {
     }
 }
 
-fn result_from_wire(execution: &pb::Execution, stdout: Vec<u8>, stderr: Vec<u8>) -> CommandResult {
+/// Build the result, refusing an execution that ended without an
+/// observed exit — the daemon pairs a missing `exit_status` with its
+/// `error` field, and reporting that as exit 0 would fake a success.
+fn result_from_wire(
+    execution: &pb::Execution,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    truncated: bool,
+) -> Result<CommandResult> {
     let (exit_code, signal) = exit_parts(execution);
-    CommandResult {
-        exit_code: exit_code.unwrap_or(0),
+    let Some(exit_code) = exit_code else {
+        let reason = if execution.error.is_empty() {
+            "the execution ended without an observed exit"
+        } else {
+            &execution.error
+        };
+        return Err(Error::new(
+            ErrorKind::Internal,
+            format!(
+                "command {} did not run to completion: {reason}",
+                execution.id
+            ),
+            "commands.wait",
+        )
+        .with_context("command_id", &*execution.id));
+    };
+    Ok(CommandResult {
+        exit_code,
         signal,
         stdout,
         stderr,
-    }
+        truncated,
+    })
 }
 
 fn info_from_wire(execution: pb::Execution) -> CommandInfo {

--- a/sdk/rust/src/commands.rs
+++ b/sdk/rust/src/commands.rs
@@ -285,7 +285,10 @@ impl Commands {
     /// # Errors
     ///
     /// [`ErrorKind::InvalidArgument`] for [`Stdin::Data`] combined with
-    /// a PTY (a terminal's input is interactive by nature); otherwise
+    /// a PTY (a terminal's input is interactive by nature). A failed
+    /// [`Stdin::Data`] seed happens after the command started: it is
+    /// best-effort killed, and the error's context carries the
+    /// `command_id` so [`Commands::get`] can still reach it. Otherwise
     /// any RPC failure.
     pub async fn spawn(&self, cmd: impl Into<Cmd>, options: RunOptions) -> Result<CommandHandle> {
         self.start(cmd.into(), options, "commands.spawn").await
@@ -507,10 +510,9 @@ impl CommandHandle {
                     Channel::Stdout | Channel::Pty => stdout.extend_from_slice(&chunk.data),
                 },
                 Ok(None) => break,
-                Err(_) => {
-                    output.truncated = true;
-                    break;
-                }
+                // The stream recorded its own truncation when it gave
+                // up; the authoritative wait below decides the outcome.
+                Err(_) => break,
             }
         }
         let truncated = output.truncated;
@@ -722,6 +724,9 @@ impl OutputStream {
                         if self.bump_attempts().await {
                             continue;
                         }
+                        // Giving up before the exit: whatever the
+                        // command still writes will never be observed.
+                        self.truncated = true;
                         self.done = true;
                         return Err(error);
                     }
@@ -783,6 +788,8 @@ impl OutputStream {
                     if self.bump_attempts().await {
                         continue;
                     }
+                    // Same give-up: unobserved bytes are lost to us.
+                    self.truncated = true;
                     self.done = true;
                     return Err(Error::from_connect(error, "commands.output"));
                 }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -20,11 +20,16 @@
 //! an actionable suggestion, and the failed operation.
 
 mod client;
+mod commands;
 mod connection;
 mod error;
 mod sandbox;
 mod types;
 
+pub use commands::{
+    Channel, Cmd, CommandHandle, CommandInfo, CommandResult, CommandState, Commands, OutputChunk,
+    OutputStream, PtySize, RunOptions, Signal, Stdin, StdinStatus,
+};
 pub use connection::Connection;
 pub use error::{Error, ErrorKind, Result};
 pub use sandbox::{ArcBox, ConnectOptions, CreateOptions, ListOptions, Sandbox};

--- a/sdk/rust/src/sandbox.rs
+++ b/sdk/rust/src/sandbox.rs
@@ -516,6 +516,12 @@ impl Sandbox {
         &self.id
     }
 
+    /// Run processes inside the sandbox.
+    #[must_use]
+    pub fn commands(&self) -> crate::Commands {
+        crate::Commands::attached(self.ctx.clone(), self.id.clone())
+    }
+
     /// Fetch the sandbox's current state — always fresh, never cached.
     ///
     /// # Errors

--- a/sdk/rust/tests/commands.rs
+++ b/sdk/rust/tests/commands.rs
@@ -1,0 +1,588 @@
+//! The commands surface against a mock daemon on a real Unix socket.
+//!
+//! The contracts under test: shell wrapping and option translation on
+//! StartExecution; foreground run collecting output and mapping the
+//! exit (shell convention for signal deaths); offset-idempotent stdin
+//! with a re-read after a failed write; attach-resume re-dialling at
+//! the advanced offsets; get() seeding the stdin cursor; list mapping.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use arcbox::{ArcBox, Channel, Cmd, ConnectOptions, Connection, RunOptions, Signal, Stdin};
+use arcbox_connect::sandbox_v1 as pb;
+use arcbox_connect::sandbox_v1::{execution_event, exit_status};
+use connectrpc::{ConnectError, RequestContext, Response, ServiceRequest, ServiceResult};
+
+type EventFrames = Vec<Result<pb::ExecutionEvent, ConnectError>>;
+
+/// Answers just enough of the process plane to exercise the SDK.
+#[derive(Default)]
+struct MockDaemon {
+    starts: Mutex<Vec<pb::StartExecutionRequest>>,
+    /// One scripted frame batch per Attach call, popped front-first.
+    attach_scripts: Mutex<Vec<EventFrames>>,
+    attach_requests: Mutex<Vec<pb::AttachExecutionRequest>>,
+    stdin_requests: Mutex<Vec<pb::WriteStdinRequest>>,
+    /// Fail the next WriteStdin with this error.
+    fail_stdin: Mutex<Option<ConnectError>>,
+    /// What GetStdinStatus / WaitExecution report as accepted stdin.
+    accepted_stdin: Mutex<u64>,
+    signals: Mutex<Vec<pb::SignalExecutionRequest>>,
+    /// The Execution WaitExecution answers.
+    wait_result: Mutex<Option<pb::Execution>>,
+    list_result: Mutex<Vec<pb::Execution>>,
+}
+
+fn output_frame(channel: pb::StdioChannel, offset: u64, data: &[u8]) -> pb::ExecutionEvent {
+    pb::ExecutionEvent {
+        event: Some(execution_event::Event::from(pb::ExecutionOutput {
+            channel: channel.into(),
+            offset,
+            data: data.to_vec(),
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+}
+
+fn exited_frame(status: exit_status::Status) -> pb::ExecutionEvent {
+    pb::ExecutionEvent {
+        event: Some(execution_event::Event::from(pb::ExecutionExited {
+            execution: pb::Execution {
+                id: "cmd".into(),
+                state: pb::ExecutionState::EXECUTION_STATE_EXITED.into(),
+                exit_status: pb::ExitStatus {
+                    status: Some(status),
+                    ..Default::default()
+                }
+                .into(),
+                ..Default::default()
+            }
+            .into(),
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+}
+
+#[allow(
+    refining_impl_trait,
+    reason = "the trait returns `impl Encodable<M>`; naming the concrete body \
+              type is strictly more informative and this mock is registered on a \
+              Router rather than named by callers"
+)]
+impl pb::SandboxProcessService for MockDaemon {
+    async fn start_execution(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::StartExecutionRequest>,
+    ) -> ServiceResult<pb::Execution> {
+        let request = request.to_owned_message();
+        self.starts.lock().unwrap().push(request.clone());
+        Response::ok(pb::Execution {
+            id: request.execution_id,
+            state: pb::ExecutionState::EXECUTION_STATE_RUNNING.into(),
+            ..Default::default()
+        })
+    }
+
+    async fn attach_execution(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::AttachExecutionRequest>,
+    ) -> ServiceResult<
+        std::pin::Pin<
+            Box<dyn futures_core::Stream<Item = Result<pb::ExecutionEvent, ConnectError>> + Send>,
+        >,
+    > {
+        self.attach_requests
+            .lock()
+            .unwrap()
+            .push(request.to_owned_message());
+        let mut scripts = self.attach_scripts.lock().unwrap();
+        let frames = if scripts.is_empty() {
+            Vec::new()
+        } else {
+            scripts.remove(0)
+        };
+        Response::ok(Box::pin(tokio_stream::iter(frames)))
+    }
+
+    async fn write_stdin(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::WriteStdinRequest>,
+    ) -> ServiceResult<pb::StdinStatus> {
+        let request = request.to_owned_message();
+        self.stdin_requests.lock().unwrap().push(request.clone());
+        let failure = self.fail_stdin.lock().unwrap().take();
+        if let Some(error) = failure {
+            return Err(error);
+        }
+        let mut accepted = self.accepted_stdin.lock().unwrap();
+        // Offset-idempotent: bytes below the accepted count are deduped.
+        let end = request.offset + request.data.len() as u64;
+        *accepted = (*accepted).max(end);
+        Response::ok(pb::StdinStatus {
+            bytes_written: *accepted,
+            closed: request.eof,
+            ..Default::default()
+        })
+    }
+
+    async fn stream_stdin(
+        &self,
+        _ctx: RequestContext,
+        _requests: connectrpc::InboundStream<pb::WriteStdinRequest>,
+    ) -> ServiceResult<pb::StdinStatus> {
+        Err(ConnectError::unimplemented(
+            "mock does not serve StreamStdin",
+        ))
+    }
+
+    async fn get_stdin_status(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::GetStdinStatusRequest>,
+    ) -> ServiceResult<pb::StdinStatus> {
+        Response::ok(pb::StdinStatus {
+            bytes_written: *self.accepted_stdin.lock().unwrap(),
+            ..Default::default()
+        })
+    }
+
+    async fn signal_execution(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::SignalExecutionRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        self.signals
+            .lock()
+            .unwrap()
+            .push(request.to_owned_message());
+        Response::ok(buffa_types::google::protobuf::Empty::default())
+    }
+
+    async fn resize_execution_tty(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ResizeExecutionTtyRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Response::ok(buffa_types::google::protobuf::Empty::default())
+    }
+
+    async fn wait_execution(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::WaitExecutionRequest>,
+    ) -> ServiceResult<pb::Execution> {
+        let request = request.to_owned_message();
+        let scripted = self.wait_result.lock().unwrap().clone();
+        Response::ok(scripted.unwrap_or_else(|| {
+            pb::Execution {
+                id: request.execution_id,
+                state: pb::ExecutionState::EXECUTION_STATE_EXITED.into(),
+                stdin: pb::StdinStatus {
+                    bytes_written: *self.accepted_stdin.lock().unwrap(),
+                    ..Default::default()
+                }
+                .into(),
+                exit_status: pb::ExitStatus {
+                    status: Some(exit_status::Status::Code(0)),
+                    ..Default::default()
+                }
+                .into(),
+                ..Default::default()
+            }
+        }))
+    }
+
+    async fn list_executions(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ListExecutionsRequest>,
+    ) -> ServiceResult<pb::ListExecutionsResponse> {
+        Response::ok(pb::ListExecutionsResponse {
+            executions: self.list_result.lock().unwrap().clone(),
+            ..Default::default()
+        })
+    }
+
+    async fn wait_for_port(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::WaitForPortRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Err(ConnectError::unimplemented(
+            "mock does not serve WaitForPort",
+        ))
+    }
+}
+
+/// Inspect always answers READY so `connect` resolves instantly.
+struct ReadySandboxService;
+
+#[allow(
+    refining_impl_trait,
+    reason = "the trait returns `impl Encodable<M>`; naming the concrete body \
+              type is strictly more informative and this mock is registered on a \
+              Router rather than named by callers"
+)]
+impl pb::SandboxService for ReadySandboxService {
+    async fn create(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::CreateSandboxRequest>,
+    ) -> ServiceResult<pb::CreateSandboxResponse> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn stop(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::StopSandboxRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn remove(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::RemoveSandboxRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn pause(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::PauseSandboxRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn resume(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ResumeSandboxRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn set_lifecycle(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::SetLifecycleRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn get_capabilities(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::GetCapabilitiesRequest>,
+    ) -> ServiceResult<pb::GetCapabilitiesResponse> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn inspect(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::InspectSandboxRequest>,
+    ) -> ServiceResult<pb::SandboxInfo> {
+        Response::ok(pb::SandboxInfo {
+            id: request.to_owned_message().id,
+            state: pb::SandboxState::SANDBOX_STATE_READY.into(),
+            ..Default::default()
+        })
+    }
+    async fn list(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ListSandboxesRequest>,
+    ) -> ServiceResult<pb::ListSandboxesResponse> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn events(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::SandboxEventsRequest>,
+    ) -> ServiceResult<
+        std::pin::Pin<
+            Box<
+                dyn futures_core::Stream<Item = Result<pb::WatchEventsResponse, ConnectError>>
+                    + Send,
+            >,
+        >,
+    > {
+        Response::ok(Box::pin(tokio_stream::iter(Vec::new())))
+    }
+    async fn expose_port(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ExposePortRequest>,
+    ) -> ServiceResult<pb::ExposePortResponse> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn unexpose_port(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::UnexposePortRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn list_exposed_ports(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ListExposedPortsRequest>,
+    ) -> ServiceResult<pb::ListExposedPortsResponse> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+}
+
+async fn serve(mock: Arc<MockDaemon>) -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("daemon.sock");
+    let listener = tokio::net::UnixListener::bind(&path).unwrap();
+    let app = connectrpc::Router::new()
+        .add_service(mock)
+        .add_service(Arc::new(ReadySandboxService))
+        .into_axum_router();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (dir, path)
+}
+
+async fn commands_for(path: &PathBuf) -> arcbox::Commands {
+    let sandbox = ArcBox::with_connection(&Connection::new().socket_path(path))
+        .unwrap()
+        .connect("sb-1", ConnectOptions::default())
+        .await
+        .unwrap();
+    sandbox.commands()
+}
+
+#[tokio::test]
+async fn run_wraps_shell_lines_collects_output_and_maps_the_exit() {
+    let mock = Arc::new(MockDaemon::default());
+    *mock.attach_scripts.lock().unwrap() = vec![vec![
+        Ok(output_frame(
+            pb::StdioChannel::STDIO_CHANNEL_STDOUT,
+            0,
+            b"out",
+        )),
+        Ok(output_frame(
+            pb::StdioChannel::STDIO_CHANNEL_STDERR,
+            0,
+            b"err",
+        )),
+        Ok(exited_frame(exit_status::Status::Code(3))),
+    ]];
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let result = commands_for(&path)
+        .await
+        .run(
+            "echo hi",
+            RunOptions {
+                timeout: Some(Duration::from_millis(1500)),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let starts = mock.starts.lock().unwrap();
+    assert_eq!(starts[0].cmd, vec!["/bin/sh", "-lc", "echo hi"]);
+    assert_eq!(starts[0].sandbox_id, "sb-1");
+    // Milliseconds round UP to whole wire seconds.
+    assert_eq!(starts[0].timeout_seconds, 2);
+    assert!(!starts[0].stdin);
+    assert_eq!(result.exit_code, 3);
+    assert!(!result.success());
+    assert_eq!(result.stdout, b"out");
+    assert_eq!(result.stderr, b"err");
+}
+
+#[tokio::test]
+async fn signal_deaths_follow_the_shell_convention() {
+    let mock = Arc::new(MockDaemon::default());
+    *mock.attach_scripts.lock().unwrap() =
+        vec![vec![Ok(exited_frame(exit_status::Status::Signal(9)))]];
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let result = commands_for(&path)
+        .await
+        .run(
+            Cmd::Argv(vec!["sleep".into(), "60".into()]),
+            RunOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 137);
+    assert_eq!(result.signal.as_deref(), Some("SIGKILL"));
+}
+
+#[tokio::test]
+async fn output_reattaches_at_the_advanced_offsets() {
+    let mock = Arc::new(MockDaemon::default());
+    *mock.attach_scripts.lock().unwrap() = vec![
+        // First attach delivers one chunk, then the transport dies.
+        vec![
+            Ok(output_frame(
+                pb::StdioChannel::STDIO_CHANNEL_STDOUT,
+                0,
+                b"first",
+            )),
+            Err(ConnectError::unavailable("stream broke")),
+        ],
+        // The resume must dial in at the advanced stdout offset.
+        vec![
+            Ok(output_frame(
+                pb::StdioChannel::STDIO_CHANNEL_STDOUT,
+                5,
+                b" second",
+            )),
+            Ok(exited_frame(exit_status::Status::Code(0))),
+        ],
+    ];
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let handle = commands_for(&path)
+        .await
+        .spawn("cat", RunOptions::default())
+        .await
+        .unwrap();
+    let mut collected = Vec::new();
+    let mut output = handle.output();
+    while let Some(chunk) = output.next().await.unwrap() {
+        assert_eq!(chunk.channel, Channel::Stdout);
+        collected.extend_from_slice(&chunk.data);
+    }
+
+    assert_eq!(collected, b"first second");
+    let attaches = mock.attach_requests.lock().unwrap();
+    assert_eq!(attaches.len(), 2);
+    assert_eq!(attaches[0].stdout_offset, 0);
+    assert_eq!(attaches[1].stdout_offset, 5);
+}
+
+#[tokio::test]
+async fn stdin_writes_are_offset_serialized_and_recover_from_failure() {
+    let mock = Arc::new(MockDaemon::default());
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let handle = commands_for(&path)
+        .await
+        .spawn(
+            "cat",
+            RunOptions {
+                stdin: Stdin::Open,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    handle.write_stdin(b"hello ").await.unwrap();
+    handle.write_stdin(b"world").await.unwrap();
+
+    // A failed write forgets the cursor; the next write re-reads the
+    // daemon's accepted count instead of guessing.
+    *mock.fail_stdin.lock().unwrap() = Some(ConnectError::unavailable("daemon restarting"));
+    handle.write_stdin(b"lost").await.unwrap_err();
+    handle.write_stdin(b"!").await.unwrap();
+
+    let requests = mock.stdin_requests.lock().unwrap();
+    let offsets: Vec<u64> = requests.iter().map(|request| request.offset).collect();
+    // 0, 6 (after "hello "), 11 (failed "lost"), then the re-read
+    // accepted count 11 again for "!".
+    assert_eq!(offsets, vec![0, 6, 11, 11]);
+    assert!(mock.starts.lock().unwrap()[0].stdin);
+}
+
+#[tokio::test]
+async fn get_seeds_the_stdin_cursor_from_the_daemon() {
+    let mock = Arc::new(MockDaemon::default());
+    *mock.accepted_stdin.lock().unwrap() = 42;
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let handle = commands_for(&path).await.get("cmd-7").await.unwrap();
+    handle.write_stdin(b"more").await.unwrap();
+
+    let requests = mock.stdin_requests.lock().unwrap();
+    assert_eq!(requests[0].offset, 42);
+    assert_eq!(requests[0].execution_id, "cmd-7");
+}
+
+#[tokio::test]
+async fn kill_delivers_the_wire_signal() {
+    let mock = Arc::new(MockDaemon::default());
+    *mock.attach_scripts.lock().unwrap() =
+        vec![vec![Ok(exited_frame(exit_status::Status::Signal(15)))]];
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let handle = commands_for(&path)
+        .await
+        .spawn("sleep 60", RunOptions::default())
+        .await
+        .unwrap();
+    handle.kill(Signal::Term).await.unwrap();
+
+    let signals = mock.signals.lock().unwrap();
+    assert_eq!(
+        signals[0].signal.as_known(),
+        Some(pb::Signal::SIGNAL_SIGTERM)
+    );
+}
+
+#[tokio::test]
+async fn list_maps_running_and_exited_rows() {
+    let mock = Arc::new(MockDaemon::default());
+    *mock.list_result.lock().unwrap() = vec![
+        pb::Execution {
+            id: "running".into(),
+            state: pb::ExecutionState::EXECUTION_STATE_RUNNING.into(),
+            tty: true,
+            ..Default::default()
+        },
+        pb::Execution {
+            id: "killed".into(),
+            state: pb::ExecutionState::EXECUTION_STATE_EXITED.into(),
+            exit_status: pb::ExitStatus {
+                status: Some(exit_status::Status::Signal(9)),
+                ..Default::default()
+            }
+            .into(),
+            ..Default::default()
+        },
+    ];
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let rows = commands_for(&path).await.list().await.unwrap();
+
+    assert_eq!(rows[0].command_id, "running");
+    assert!(rows[0].tty);
+    assert_eq!(rows[0].exit_code, None);
+    assert_eq!(rows[1].exit_code, Some(137));
+    assert_eq!(rows[1].signal.as_deref(), Some("SIGKILL"));
+}
+
+#[tokio::test]
+async fn open_stdin_is_refused_on_a_foreground_run() {
+    let mock = Arc::new(MockDaemon::default());
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let error = commands_for(&path)
+        .await
+        .run(
+            "cat",
+            RunOptions {
+                stdin: Stdin::Open,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind(), arcbox::ErrorKind::InvalidArgument);
+    assert!(mock.starts.lock().unwrap().is_empty());
+}

--- a/sdk/rust/tests/commands.rs
+++ b/sdk/rust/tests/commands.rs
@@ -586,3 +586,112 @@ async fn open_stdin_is_refused_on_a_foreground_run() {
     assert_eq!(error.kind(), arcbox::ErrorKind::InvalidArgument);
     assert!(mock.starts.lock().unwrap().is_empty());
 }
+
+#[tokio::test]
+async fn a_missing_exit_status_is_an_error_not_a_success() {
+    let mock = Arc::new(MockDaemon::default());
+    // The daemon pairs a missing exit_status with its error field.
+    *mock.attach_scripts.lock().unwrap() = vec![vec![Ok(pb::ExecutionEvent {
+        event: Some(execution_event::Event::from(pb::ExecutionExited {
+            execution: pb::Execution {
+                id: "cmd".into(),
+                state: pb::ExecutionState::EXECUTION_STATE_EXITED.into(),
+                error: "guest session ended before the exit was observed".into(),
+                ..Default::default()
+            }
+            .into(),
+            ..Default::default()
+        })),
+        ..Default::default()
+    })]];
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let error = commands_for(&path)
+        .await
+        .run("true", RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind(), arcbox::ErrorKind::Internal);
+    assert!(error.to_string().contains("guest session ended"));
+}
+
+#[tokio::test]
+async fn a_failed_stdin_seed_kills_the_started_command() {
+    let mock = Arc::new(MockDaemon::default());
+    *mock.fail_stdin.lock().unwrap() = Some(ConnectError::unavailable("daemon restarting"));
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let error = commands_for(&path)
+        .await
+        .spawn(
+            "cat",
+            RunOptions {
+                stdin: Stdin::Data(b"seed".to_vec()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind(), arcbox::ErrorKind::Unavailable);
+    // The command was already running; without a handle returned it
+    // must not be left half-fed — best-effort SIGKILL.
+    let signals = mock.signals.lock().unwrap();
+    assert_eq!(signals.len(), 1);
+    assert_eq!(
+        signals[0].signal.as_known(),
+        Some(pb::Signal::SIGNAL_SIGKILL)
+    );
+}
+
+#[tokio::test]
+async fn a_retention_gap_marks_the_output_truncated() {
+    let mock = Arc::new(MockDaemon::default());
+    // The first chunk starts at offset 7 while the stream asked for 0:
+    // the wire's one notification that retention dropped bytes.
+    *mock.attach_scripts.lock().unwrap() = vec![vec![
+        Ok(output_frame(
+            pb::StdioChannel::STDIO_CHANNEL_STDOUT,
+            7,
+            b"tail",
+        )),
+        Ok(exited_frame(exit_status::Status::Code(0))),
+    ]];
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let result = commands_for(&path)
+        .await
+        .run("cat big.log", RunOptions::default())
+        .await
+        .unwrap();
+
+    assert!(result.truncated);
+    assert_eq!(result.stdout, b"tail");
+}
+
+#[tokio::test]
+async fn wait_survives_an_attach_stream_that_never_recovers() {
+    let mock = Arc::new(MockDaemon::default());
+    // Every attach dies: the re-attach budget runs out, and the
+    // authoritative WaitExecution decides the outcome — truncated,
+    // because output was lost with the stream.
+    *mock.attach_scripts.lock().unwrap() = vec![
+        vec![Err(ConnectError::unavailable("dead"))],
+        vec![Err(ConnectError::unavailable("dead"))],
+        vec![Err(ConnectError::unavailable("dead"))],
+        vec![Err(ConnectError::unavailable("dead"))],
+        vec![Err(ConnectError::unavailable("dead"))],
+    ];
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let result = commands_for(&path)
+        .await
+        .run("true", RunOptions::default())
+        .await
+        .unwrap();
+
+    // The mock's WaitExecution answers a clean zero exit.
+    assert_eq!(result.exit_code, 0);
+    assert!(result.truncated);
+}

--- a/sdk/rust/tests/commands.rs
+++ b/sdk/rust/tests/commands.rs
@@ -695,3 +695,37 @@ async fn wait_survives_an_attach_stream_that_never_recovers() {
     assert_eq!(result.exit_code, 0);
     assert!(result.truncated);
 }
+
+#[tokio::test]
+async fn a_direct_output_consumer_sees_truncation_when_the_stream_gives_up() {
+    let mock = Arc::new(MockDaemon::default());
+    // Every attach dies. Unlike the wait() test above, this drives
+    // handle.output() directly — the accessor itself must report the
+    // loss, not a compensating write in wait().
+    *mock.attach_scripts.lock().unwrap() = vec![
+        vec![Err(ConnectError::unavailable("dead"))],
+        vec![Err(ConnectError::unavailable("dead"))],
+        vec![Err(ConnectError::unavailable("dead"))],
+        vec![Err(ConnectError::unavailable("dead"))],
+        vec![Err(ConnectError::unavailable("dead"))],
+    ];
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let handle = commands_for(&path)
+        .await
+        .spawn("cat", RunOptions::default())
+        .await
+        .unwrap();
+    let mut output = handle.output();
+    assert!(!output.truncated());
+    let error = loop {
+        match output.next().await {
+            Ok(Some(_)) => {}
+            Ok(None) => panic!("the stream must give up, not end cleanly"),
+            Err(error) => break error,
+        }
+    };
+
+    assert_eq!(error.kind(), arcbox::ErrorKind::Unavailable);
+    assert!(output.truncated());
+}


### PR DESCRIPTION
## What

Phase 2 of the Rust SDK (`sdk/rust`, follows #603): the commands surface, at parity with the TypeScript/Python semantics but in Rust idioms.

- **`run` / `spawn` split** instead of a `background` flag — `std::process` naming. `run` starts, collects output, waits for the exit; a non-zero exit is data on `CommandResult` (`success()`, `stdout_lossy()`), never an error. `spawn` returns a `CommandHandle`.
- **`Cmd` enum** makes shell-line-vs-argv explicit at the type level (`"echo hi"` → `/bin/sh -lc`; `Cmd::Argv` runs as-is).
- **Output stream with attach-resume**: `handle.output()` re-attaches at the retained per-channel byte offsets when the transport drops — output is offset-addressed daemon-side, so nothing is lost or replayed. Bounded budget for *consecutive* dead dials (3, backoff), reset by any received event — the same contract the TS SDK and abctl carry.
- **Offset-idempotent stdin**: writes are serialized behind one cursor; each carries its offset, the daemon dedups below the accepted count, and a failed write forgets the cursor so the next write re-reads the daemon's accepted count instead of guessing. `get()` seeds the cursor from the daemon for re-attached handles.
- **Boundary refusals**: `Stdin::Open` on a foreground `run` and one-shot stdin bytes on a PTY are `InvalidArgument` before any RPC.
- Signal deaths follow the shell convention (`128 + signal`, name on the result). `wait(timeout)` slices an unbounded wait into 30 s daemon parks.

Deliberately deferred: `wait_for_log` (a Rust caller filters `output()` directly; adding it means a regex dependency decision) and `StreamStdin` (the unary offset protocol is the chosen transport, as in the sibling SDKs).

## Testing

8 mock tests over the generated `SandboxProcessService` on a temp Unix socket: shell wrapping + option translation, output collection + exit mapping, signal-death convention, **re-attach at advanced offsets** (scripted stream death mid-flow), **stdin offset serialization + failure recovery** (offsets `0, 6, 11, 11` across a failed write), cursor seeding via `get`, wire signal delivery, boundary refusals. Full crate: 22 tests, clippy `--all-targets -D warnings` clean.