### PR TITLE
feat(sdk): files, ports, snapshots and events for the Rust SDK

### DIFF
--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -76,4 +76,22 @@ byte offsets across transport drops, offset-idempotent `write_stdin`
 `close_stdin`, `stdin_status`, `resize`, `kill(signal)`, `get`
 (stdin cursor seeded from the daemon), and `list`.
 
-Next: files, ports, snapshots, and events.
+Also shipped, completing the data plane:
+
+- **files**: streamed `read`/`write` (bytes end to end; `write` takes
+  `impl AsRef<[u8]>`), `stat`/`list`/`mkdir`/`remove`/`rename` (typed
+  `FileStat`, `mkdir -p` semantics, symlinks reported not followed),
+  and `watch` — a typed `FsEvent` stream, keepalives filtered, clean
+  end on sandbox stop.
+- **ports**: `wait_for_port` (guest-side listen-table wait; expiry is a
+  `Timeout` naming this knob), `expose`/`unexpose`/`list` (host
+  loopback publishing; `list` reads the daemon's authoritative live
+  listener table).
+- **snapshots**: `checkpoint` (pause + snapshot + resume under the same
+  id), `restore` (fresh client-minted id; failed restores force-remove
+  it), auto-paginating `list_snapshots`, `delete_snapshot`.
+- **events**: `Sandbox::events()` — typed lifecycle events, keepalives
+  filtered.
+
+Deferred: `wait_for_log` (filter `output()` directly), the remote tier
+(CORE-63), and Template statics.

--- a/sdk/rust/src/files.rs
+++ b/sdk/rust/src/files.rs
@@ -1,0 +1,446 @@
+//! Moving bytes in and out of one sandbox, and operating on its paths.
+//!
+//! Content is bytes end to end — `write` takes `impl AsRef<[u8]>` so
+//! `&str` works directly, and `read` returns the exact bytes; text
+//! decoding is the caller's one-liner. Paths are sandbox-side POSIX
+//! paths carried as strings.
+
+use std::time::SystemTime;
+
+use arcbox_connect::sandbox_v1 as pb;
+use arcbox_connect::sandbox_v1::{SandboxFilesystemServiceClient, write_file_request};
+use connectrpc::client::{ClientTransport, ServerStream, SharedHttp2Connection};
+
+use crate::client::ClientContext;
+use crate::error::{Error, ErrorKind, Result};
+use crate::types::time_from_wire;
+
+/// The generated filesystem client over the shared transport.
+type FilesystemClient = SandboxFilesystemServiceClient<SharedHttp2Connection>;
+
+/// The server stream [`FilesystemClient::read_file`] returns.
+type ReadStream = ServerStream<
+    <SharedHttp2Connection as ClientTransport>::ResponseBody,
+    pb::__buffa::view::FileChunkView<'static>,
+>;
+
+/// The server stream [`FilesystemClient::watch_dir`] returns.
+type WatchWireStream = ServerStream<
+    <SharedHttp2Connection as ClientTransport>::ResponseBody,
+    pb::__buffa::view::WatchDirResponseView<'static>,
+>;
+
+/// Per-file transfer cap enforced by the daemon (`filesystem.proto`).
+pub const MAX_FILE_BYTES: usize = 256 * 1024 * 1024;
+
+/// Chunk size for streamed writes, matching the sibling SDKs.
+const WRITE_CHUNK_BYTES: usize = 256 * 1024;
+
+/// Default permission bits for created files (the daemon's default).
+const DEFAULT_WRITE_MODE: u32 = 0o644;
+
+/// Kind of a filesystem entry. `Unknown` covers wire values this SDK
+/// predates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FileKind {
+    File,
+    Directory,
+    Symlink,
+    Other,
+    Unknown,
+}
+
+/// Metadata of one filesystem entry. Symlinks are reported, never
+/// followed; `mode` is the low permission bits of `st_mode`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct FileStat {
+    pub name: String,
+    pub kind: FileKind,
+    /// Size in bytes (0 for non-regular files).
+    pub size: u64,
+    /// Unix permission bits.
+    pub mode: u32,
+    pub modified_at: Option<SystemTime>,
+    pub uid: u32,
+    pub gid: u32,
+    /// Target of a symlink; `None` for every other kind.
+    pub symlink_target: Option<String>,
+}
+
+/// Kind of a filesystem event. `Unknown` covers wire values this SDK
+/// predates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FsEventKind {
+    Created,
+    Modified,
+    Removed,
+    Renamed,
+    Unknown,
+}
+
+/// One filesystem event, as delivered by [`Files::watch`]. `path` is
+/// the old path for renames, with `renamed_to` set only then.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct FsEvent {
+    pub kind: FsEventKind,
+    pub path: String,
+    pub renamed_to: Option<String>,
+}
+
+/// Options for [`Files::write`].
+#[derive(Debug, Clone, Default)]
+pub struct WriteOptions {
+    /// Unix permission bits for the created file (unset = `0o644`).
+    pub mode: Option<u32>,
+}
+
+/// Options for [`Files::mkdir`].
+#[derive(Debug, Clone, Default)]
+pub struct MkdirOptions {
+    /// Unix permission bits for created directories (unset = the
+    /// daemon default).
+    pub mode: Option<u32>,
+}
+
+/// Options for [`Files::remove`].
+#[derive(Debug, Clone, Default)]
+pub struct RemoveOptions {
+    /// Remove a non-empty directory and its contents. Without it, a
+    /// non-empty directory is refused.
+    pub recursive: bool,
+}
+
+/// Options for [`Files::watch`].
+#[derive(Debug, Clone, Default)]
+pub struct WatchOptions {
+    /// Watch subdirectories too.
+    pub recursive: bool,
+}
+
+/// The `sandbox.files()` namespace: move bytes in and out of one
+/// sandbox, and operate on its paths.
+#[derive(Clone)]
+pub struct Files {
+    ctx: ClientContext,
+    sandbox_id: String,
+}
+
+impl Files {
+    pub(crate) fn attached(ctx: ClientContext, sandbox_id: String) -> Self {
+        Self { ctx, sandbox_id }
+    }
+
+    fn client(&self) -> FilesystemClient {
+        SandboxFilesystemServiceClient::new(self.ctx.transport.clone(), self.ctx.config.clone())
+    }
+
+    /// Read the file at `path` and return its bytes.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::FileNotFound`] for a missing path;
+    /// [`ErrorKind::FileTooLarge`] past the daemon's per-file cap;
+    /// otherwise any RPC failure.
+    pub async fn read(&self, path: &str) -> Result<Vec<u8>> {
+        let mut stream: ReadStream = self
+            .client()
+            .read_file(pb::ReadFileRequest {
+                id: self.sandbox_id.clone(),
+                path: path.to_owned(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "files.read"))?;
+        let mut content = Vec::new();
+        loop {
+            match stream.message::<pb::FileChunk>().await {
+                Ok(Some(chunk)) => {
+                    let chunk = chunk.to_owned_message();
+                    content.extend_from_slice(&chunk.data);
+                    if chunk.done {
+                        return Ok(content);
+                    }
+                }
+                Ok(None) => return Ok(content),
+                Err(error) => return Err(Error::from_connect(error, "files.read")),
+            }
+        }
+    }
+
+    /// Write `data` to `path`, creating missing parent directories.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::FileTooLarge`] past the daemon's per-file cap
+    /// (checked client-side before any byte is sent); otherwise any RPC
+    /// failure.
+    pub async fn write(
+        &self,
+        path: &str,
+        data: impl AsRef<[u8]>,
+        options: WriteOptions,
+    ) -> Result<()> {
+        let data = data.as_ref();
+        if data.len() > MAX_FILE_BYTES {
+            return Err(Error::new(
+                ErrorKind::FileTooLarge,
+                format!(
+                    "{} bytes exceed the {MAX_FILE_BYTES}-byte per-file cap",
+                    data.len()
+                ),
+                "files.write",
+            )
+            .with_context("limit_bytes", MAX_FILE_BYTES.to_string()));
+        }
+        let mut frames = vec![pb::WriteFileRequest {
+            payload: Some(write_file_request::Payload::from(pb::WriteFileOpen {
+                id: self.sandbox_id.clone(),
+                path: path.to_owned(),
+                mode: options.mode.unwrap_or(DEFAULT_WRITE_MODE),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }];
+        for chunk in data.chunks(WRITE_CHUNK_BYTES) {
+            frames.push(pb::WriteFileRequest {
+                payload: Some(write_file_request::Payload::from(pb::FileChunk {
+                    data: chunk.to_vec(),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            });
+        }
+        frames.push(pb::WriteFileRequest {
+            payload: Some(write_file_request::Payload::from(pb::FileChunk {
+                done: true,
+                ..Default::default()
+            })),
+            ..Default::default()
+        });
+        self.client()
+            .write_file(connectrpc::client::stream_iter(frames))
+            .await
+            .map_err(|error| Error::from_connect(error, "files.write"))?;
+        Ok(())
+    }
+
+    /// Metadata of one path (symlinks reported, not followed).
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::FileNotFound`] for a missing path; otherwise any
+    /// RPC failure.
+    pub async fn stat(&self, path: &str) -> Result<FileStat> {
+        let stat = self
+            .client()
+            .stat(pb::StatFileRequest {
+                id: self.sandbox_id.clone(),
+                path: path.to_owned(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "files.stat"))?
+            .into_owned();
+        Ok(stat_from_wire(stat))
+    }
+
+    /// List a directory's entries, non-recursively, sorted by name.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::FileNotFound`] for a missing path; otherwise any
+    /// RPC failure.
+    pub async fn list(&self, path: &str) -> Result<Vec<FileStat>> {
+        let response = self
+            .client()
+            .list_dir(pb::ListDirRequest {
+                id: self.sandbox_id.clone(),
+                path: path.to_owned(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "files.list"))?
+            .into_owned();
+        Ok(response.entries.into_iter().map(stat_from_wire).collect())
+    }
+
+    /// Create a directory and any missing parents (`mkdir -p`
+    /// semantics: an existing directory succeeds).
+    ///
+    /// # Errors
+    ///
+    /// Any RPC failure, mapped onto [`Error`].
+    pub async fn mkdir(&self, path: &str, options: MkdirOptions) -> Result<()> {
+        self.client()
+            .make_dir(pb::MakeDirRequest {
+                id: self.sandbox_id.clone(),
+                path: path.to_owned(),
+                mode: options.mode.unwrap_or(0),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "files.mkdir"))?;
+        Ok(())
+    }
+
+    /// Remove a file, symlink, or directory.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::FileNotFound`] for a missing path; a non-empty
+    /// directory without [`RemoveOptions::recursive`] is a state error;
+    /// otherwise any RPC failure.
+    pub async fn remove(&self, path: &str, options: RemoveOptions) -> Result<()> {
+        self.client()
+            .remove(pb::RemoveEntryRequest {
+                id: self.sandbox_id.clone(),
+                path: path.to_owned(),
+                recursive: options.recursive,
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "files.remove"))?;
+        Ok(())
+    }
+
+    /// Rename or move an entry.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::FileNotFound`] for a missing source; otherwise any
+    /// RPC failure.
+    pub async fn rename(&self, from: &str, to: &str) -> Result<()> {
+        self.client()
+            .r#move(pb::MoveEntryRequest {
+                id: self.sandbox_id.clone(),
+                from_path: from.to_owned(),
+                to_path: to.to_owned(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "files.rename"))?;
+        Ok(())
+    }
+
+    /// Watch a directory, one typed event at a time. The stream ends
+    /// cleanly when the sandbox stops; keepalive frames are filtered.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::FileNotFound`] for a missing path; otherwise any
+    /// RPC failure — at subscription (first
+    /// [`next`](WatchStream::next)) or mid-stream.
+    #[must_use]
+    pub fn watch(&self, path: &str, options: WatchOptions) -> WatchStream {
+        WatchStream {
+            files: self.clone(),
+            path: path.to_owned(),
+            recursive: options.recursive,
+            stream: None,
+            done: false,
+        }
+    }
+}
+
+/// A directory watch, read one event at a time with
+/// [`next`](Self::next). The subscription is dialled on the first call.
+pub struct WatchStream {
+    files: Files,
+    path: String,
+    recursive: bool,
+    stream: Option<WatchWireStream>,
+    done: bool,
+}
+
+impl WatchStream {
+    /// The next event, or `None` when the watch ended cleanly (the
+    /// sandbox stopped).
+    ///
+    /// # Errors
+    ///
+    /// Any RPC failure, mapped onto [`Error`]. Events cannot be
+    /// replayed, so re-subscribing after an error is the caller's
+    /// decision.
+    pub async fn next(&mut self) -> Result<Option<FsEvent>> {
+        if self.done {
+            return Ok(None);
+        }
+        if self.stream.is_none() {
+            let stream = self
+                .files
+                .client()
+                .watch_dir(pb::WatchDirRequest {
+                    id: self.files.sandbox_id.clone(),
+                    path: self.path.clone(),
+                    recursive: self.recursive,
+                    ..Default::default()
+                })
+                .await
+                .map_err(|error| {
+                    self.done = true;
+                    Error::from_connect(error, "files.watch")
+                })?;
+            self.stream = Some(stream);
+        }
+        let stream = self.stream.as_mut().expect("stream attached above");
+        loop {
+            match stream.message::<pb::WatchDirResponse>().await {
+                Ok(Some(frame)) => {
+                    if let Some(pb::watch_dir_response::Payload::Event(event)) =
+                        frame.to_owned_message().payload
+                    {
+                        return Ok(Some(fs_event_from_wire(*event)));
+                    }
+                    // Keepalives prove liveness but carry no event.
+                }
+                Ok(None) => {
+                    self.done = true;
+                    return Ok(None);
+                }
+                Err(error) => {
+                    self.done = true;
+                    return Err(Error::from_connect(error, "files.watch"));
+                }
+            }
+        }
+    }
+}
+
+fn stat_from_wire(stat: pb::FileStat) -> FileStat {
+    let kind = match stat.kind.as_known() {
+        Some(pb::FileKind::FILE_KIND_FILE) => FileKind::File,
+        Some(pb::FileKind::FILE_KIND_DIRECTORY) => FileKind::Directory,
+        Some(pb::FileKind::FILE_KIND_SYMLINK) => FileKind::Symlink,
+        Some(pb::FileKind::FILE_KIND_OTHER) => FileKind::Other,
+        _ => FileKind::Unknown,
+    };
+    FileStat {
+        name: stat.name,
+        kind,
+        size: stat.size,
+        mode: stat.mode,
+        modified_at: time_from_wire(stat.modified_at.as_option()),
+        uid: stat.uid,
+        gid: stat.gid,
+        symlink_target: (!stat.symlink_target.is_empty()).then_some(stat.symlink_target),
+    }
+}
+
+fn fs_event_from_wire(event: pb::FsEvent) -> FsEvent {
+    let kind = match event.kind.as_known() {
+        Some(pb::FsEventKind::FS_EVENT_KIND_CREATED) => FsEventKind::Created,
+        Some(pb::FsEventKind::FS_EVENT_KIND_MODIFIED) => FsEventKind::Modified,
+        Some(pb::FsEventKind::FS_EVENT_KIND_REMOVED) => FsEventKind::Removed,
+        Some(pb::FsEventKind::FS_EVENT_KIND_RENAMED) => FsEventKind::Renamed,
+        _ => FsEventKind::Unknown,
+    };
+    FsEvent {
+        kind,
+        path: event.path,
+        renamed_to: (!event.renamed_to.is_empty()).then_some(event.renamed_to),
+    }
+}

--- a/sdk/rust/src/files.rs
+++ b/sdk/rust/src/files.rs
@@ -143,8 +143,11 @@ impl Files {
     /// # Errors
     ///
     /// [`ErrorKind::FileNotFound`] for a missing path;
-    /// [`ErrorKind::FileTooLarge`] past the daemon's per-file cap;
-    /// otherwise any RPC failure.
+    /// [`ErrorKind::FileTooLarge`] past [`MAX_FILE_BYTES`], checked
+    /// client-side while collecting (nothing bounds a read wire-side);
+    /// [`ErrorKind::ConnectionLost`] when the stream ends before the
+    /// final chunk's done marker — a truncated transfer is never
+    /// returned as a success. Otherwise any RPC failure.
     pub async fn read(&self, path: &str) -> Result<Vec<u8>> {
         let mut stream: ReadStream = self
             .client()
@@ -161,17 +164,41 @@ impl Files {
                 Ok(Some(chunk)) => {
                     let chunk = chunk.to_owned_message();
                     content.extend_from_slice(&chunk.data);
+                    if content.len() > MAX_FILE_BYTES {
+                        return Err(Error::new(
+                            ErrorKind::FileTooLarge,
+                            format!(
+                                "the file exceeds the {MAX_FILE_BYTES}-byte cap this \
+                                 client collects into memory"
+                            ),
+                            "files.read",
+                        )
+                        .with_context("limit_bytes", MAX_FILE_BYTES.to_string()));
+                    }
                     if chunk.done {
                         return Ok(content);
                     }
                 }
-                Ok(None) => return Ok(content),
+                // The done marker is the transfer's integrity signal: a
+                // stream that ends without it delivered a prefix, not
+                // the file.
+                Ok(None) => {
+                    return Err(Error::new(
+                        ErrorKind::ConnectionLost,
+                        "the read stream ended before the file was fully transferred",
+                        "files.read",
+                    ));
+                }
                 Err(error) => return Err(Error::from_connect(error, "files.read")),
             }
         }
     }
 
     /// Write `data` to `path`, creating missing parent directories.
+    ///
+    /// `data` is taken by value (`Vec<u8>` moves in for free; `&str` /
+    /// `&[u8]` copy once) and streamed lazily, so the peak footprint is
+    /// the payload plus one wire chunk — never a second full copy.
     ///
     /// # Errors
     ///
@@ -181,10 +208,10 @@ impl Files {
     pub async fn write(
         &self,
         path: &str,
-        data: impl AsRef<[u8]>,
+        data: impl Into<Vec<u8>>,
         options: WriteOptions,
     ) -> Result<()> {
-        let data = data.as_ref();
+        let data: Vec<u8> = data.into();
         if data.len() > MAX_FILE_BYTES {
             return Err(Error::new(
                 ErrorKind::FileTooLarge,
@@ -196,7 +223,7 @@ impl Files {
             )
             .with_context("limit_bytes", MAX_FILE_BYTES.to_string()));
         }
-        let mut frames = vec![pb::WriteFileRequest {
+        let open = pb::WriteFileRequest {
             payload: Some(write_file_request::Payload::from(pb::WriteFileOpen {
                 id: self.sandbox_id.clone(),
                 path: path.to_owned(),
@@ -204,23 +231,28 @@ impl Files {
                 ..Default::default()
             })),
             ..Default::default()
-        }];
-        for chunk in data.chunks(WRITE_CHUNK_BYTES) {
-            frames.push(pb::WriteFileRequest {
+        };
+        let total = data.len();
+        let chunks = (0..total).step_by(WRITE_CHUNK_BYTES).map(move |start| {
+            let end = (start + WRITE_CHUNK_BYTES).min(total);
+            pb::WriteFileRequest {
                 payload: Some(write_file_request::Payload::from(pb::FileChunk {
-                    data: chunk.to_vec(),
+                    data: data[start..end].to_vec(),
                     ..Default::default()
                 })),
                 ..Default::default()
-            });
-        }
-        frames.push(pb::WriteFileRequest {
+            }
+        });
+        let done = pb::WriteFileRequest {
             payload: Some(write_file_request::Payload::from(pb::FileChunk {
                 done: true,
                 ..Default::default()
             })),
             ..Default::default()
-        });
+        };
+        let frames = std::iter::once(open)
+            .chain(chunks)
+            .chain(std::iter::once(done));
         self.client()
             .write_file(connectrpc::client::stream_iter(frames))
             .await
@@ -245,7 +277,7 @@ impl Files {
             .await
             .map_err(|error| Error::from_connect(error, "files.stat"))?
             .into_owned();
-        Ok(stat_from_wire(stat))
+        Ok(FileStat::from(stat))
     }
 
     /// List a directory's entries, non-recursively, sorted by name.
@@ -265,7 +297,7 @@ impl Files {
             .await
             .map_err(|error| Error::from_connect(error, "files.list"))?
             .into_owned();
-        Ok(response.entries.into_iter().map(stat_from_wire).collect())
+        Ok(response.entries.into_iter().map(FileStat::from).collect())
     }
 
     /// Create a directory and any missing parents (`mkdir -p`
@@ -393,7 +425,7 @@ impl WatchStream {
                     if let Some(pb::watch_dir_response::Payload::Event(event)) =
                         frame.to_owned_message().payload
                     {
-                        return Ok(Some(fs_event_from_wire(*event)));
+                        return Ok(Some(FsEvent::from(*event)));
                     }
                     // Keepalives prove liveness but carry no event.
                 }
@@ -410,37 +442,41 @@ impl WatchStream {
     }
 }
 
-fn stat_from_wire(stat: pb::FileStat) -> FileStat {
-    let kind = match stat.kind.as_known() {
-        Some(pb::FileKind::FILE_KIND_FILE) => FileKind::File,
-        Some(pb::FileKind::FILE_KIND_DIRECTORY) => FileKind::Directory,
-        Some(pb::FileKind::FILE_KIND_SYMLINK) => FileKind::Symlink,
-        Some(pb::FileKind::FILE_KIND_OTHER) => FileKind::Other,
-        _ => FileKind::Unknown,
-    };
-    FileStat {
-        name: stat.name,
-        kind,
-        size: stat.size,
-        mode: stat.mode,
-        modified_at: time_from_wire(stat.modified_at.as_option()),
-        uid: stat.uid,
-        gid: stat.gid,
-        symlink_target: (!stat.symlink_target.is_empty()).then_some(stat.symlink_target),
+impl From<pb::FileStat> for FileStat {
+    fn from(stat: pb::FileStat) -> Self {
+        let kind = match stat.kind.as_known() {
+            Some(pb::FileKind::FILE_KIND_FILE) => FileKind::File,
+            Some(pb::FileKind::FILE_KIND_DIRECTORY) => FileKind::Directory,
+            Some(pb::FileKind::FILE_KIND_SYMLINK) => FileKind::Symlink,
+            Some(pb::FileKind::FILE_KIND_OTHER) => FileKind::Other,
+            _ => FileKind::Unknown,
+        };
+        Self {
+            name: stat.name,
+            kind,
+            size: stat.size,
+            mode: stat.mode,
+            modified_at: time_from_wire(stat.modified_at.as_option()),
+            uid: stat.uid,
+            gid: stat.gid,
+            symlink_target: (!stat.symlink_target.is_empty()).then_some(stat.symlink_target),
+        }
     }
 }
 
-fn fs_event_from_wire(event: pb::FsEvent) -> FsEvent {
-    let kind = match event.kind.as_known() {
-        Some(pb::FsEventKind::FS_EVENT_KIND_CREATED) => FsEventKind::Created,
-        Some(pb::FsEventKind::FS_EVENT_KIND_MODIFIED) => FsEventKind::Modified,
-        Some(pb::FsEventKind::FS_EVENT_KIND_REMOVED) => FsEventKind::Removed,
-        Some(pb::FsEventKind::FS_EVENT_KIND_RENAMED) => FsEventKind::Renamed,
-        _ => FsEventKind::Unknown,
-    };
-    FsEvent {
-        kind,
-        path: event.path,
-        renamed_to: (!event.renamed_to.is_empty()).then_some(event.renamed_to),
+impl From<pb::FsEvent> for FsEvent {
+    fn from(event: pb::FsEvent) -> Self {
+        let kind = match event.kind.as_known() {
+            Some(pb::FsEventKind::FS_EVENT_KIND_CREATED) => FsEventKind::Created,
+            Some(pb::FsEventKind::FS_EVENT_KIND_MODIFIED) => FsEventKind::Modified,
+            Some(pb::FsEventKind::FS_EVENT_KIND_REMOVED) => FsEventKind::Removed,
+            Some(pb::FsEventKind::FS_EVENT_KIND_RENAMED) => FsEventKind::Renamed,
+            _ => FsEventKind::Unknown,
+        };
+        Self {
+            kind,
+            path: event.path,
+            renamed_to: (!event.renamed_to.is_empty()).then_some(event.renamed_to),
+        }
     }
 }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -23,6 +23,8 @@ mod client;
 mod commands;
 mod connection;
 mod error;
+mod files;
+mod ports;
 mod sandbox;
 mod types;
 
@@ -32,8 +34,16 @@ pub use commands::{
 };
 pub use connection::Connection;
 pub use error::{Error, ErrorKind, Result};
-pub use sandbox::{ArcBox, ConnectOptions, CreateOptions, ListOptions, Sandbox};
+pub use files::{
+    FileKind, FileStat, Files, FsEvent, FsEventKind, MAX_FILE_BYTES, MkdirOptions, RemoveOptions,
+    WatchOptions, WatchStream, WriteOptions,
+};
+pub use ports::{ExposeOptions, ExposedPort, Ports, Protocol};
+pub use sandbox::{
+    ArcBox, CheckpointOptions, ConnectOptions, CreateOptions, EventStream, ListOptions,
+    ListSnapshotsOptions, RestoreOptions, Sandbox,
+};
 pub use types::{
-    Capabilities, IdlePolicy, LifecycleUpdate, NestedVirtCapability, SandboxInfo, SandboxState,
-    SandboxSummary, Update,
+    Capabilities, IdlePolicy, LifecycleUpdate, NestedVirtCapability, SandboxEvent,
+    SandboxEventKind, SandboxInfo, SandboxState, SandboxSummary, Snapshot, Update,
 };

--- a/sdk/rust/src/ports.rs
+++ b/sdk/rust/src/ports.rs
@@ -1,0 +1,213 @@
+//! Network reachability and readiness of one sandbox — publish guest
+//! ports on host loopback, and wait for the workload to listen.
+
+use std::time::Duration;
+
+use arcbox_connect::sandbox_v1 as pb;
+use arcbox_connect::sandbox_v1::{SandboxProcessServiceClient, SandboxServiceClient};
+use connectrpc::client::SharedHttp2Connection;
+
+use crate::client::ClientContext;
+use crate::error::{Error, ErrorKind, Result};
+use crate::types::seconds_to_wire;
+
+type ProcessClient = SandboxProcessServiceClient<SharedHttp2Connection>;
+type SandboxClient = SandboxServiceClient<SharedHttp2Connection>;
+
+/// Daemon default wait budget when no timeout is given (`process.proto`).
+const DEFAULT_WAIT_FOR_PORT: Duration = Duration::from_secs(30);
+
+/// Daemon cap on the wait budget — longer requests are clamped
+/// server-side (each wait pins a guest exec-channel slot).
+const MAX_WAIT_FOR_PORT: Duration = Duration::from_secs(600);
+
+/// Transport protocol of an exposed port.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Protocol {
+    #[default]
+    Tcp,
+    Udp,
+}
+
+impl Protocol {
+    fn to_wire(self) -> pb::PortProtocol {
+        match self {
+            Self::Tcp => pb::PortProtocol::PORT_PROTOCOL_TCP,
+            Self::Udp => pb::PortProtocol::PORT_PROTOCOL_UDP,
+        }
+    }
+
+    fn from_wire(protocol: buffa::EnumValue<pb::PortProtocol>) -> Self {
+        match protocol.as_known() {
+            Some(pb::PortProtocol::PORT_PROTOCOL_UDP) => Self::Udp,
+            // The wire reserves UNSPECIFIED for TCP.
+            _ => Self::Tcp,
+        }
+    }
+}
+
+/// One host listener currently forwarding into a sandbox.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ExposedPort {
+    /// Port the workload listens on inside the sandbox.
+    pub sandbox_port: u16,
+    /// Loopback host port where the service is reachable.
+    pub host_port: u16,
+    pub protocol: Protocol,
+}
+
+/// Options for [`Ports::expose`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExposeOptions {
+    /// Specific host port to bind. Unset = the daemon allocates one —
+    /// the allocated port is in the returned mapping. Ports below 1024
+    /// fail under the unprivileged daemon.
+    pub host_port: Option<u16>,
+    pub protocol: Protocol,
+}
+
+/// The `sandbox.ports()` namespace: network reachability and readiness
+/// of one sandbox.
+#[derive(Clone)]
+pub struct Ports {
+    ctx: ClientContext,
+    sandbox_id: String,
+}
+
+impl Ports {
+    pub(crate) fn attached(ctx: ClientContext, sandbox_id: String) -> Self {
+        Self { ctx, sandbox_id }
+    }
+
+    fn process(&self) -> ProcessClient {
+        SandboxProcessServiceClient::new(self.ctx.transport.clone(), self.ctx.config.clone())
+    }
+
+    fn sandbox(&self) -> SandboxClient {
+        SandboxServiceClient::new(self.ctx.transport.clone(), self.ctx.config.clone())
+    }
+
+    /// Wait until something inside the sandbox listens on the given TCP
+    /// port. The guest agent watches its own listen table — no
+    /// client-side polling. Returns as soon as a listener is up.
+    ///
+    /// `timeout` defaults to the daemon's 30 s and is capped at its
+    /// 600 s limit; the wire's granularity is whole seconds, rounded up.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::Timeout`] when the budget elapses first; otherwise
+    /// any RPC failure.
+    pub async fn wait_for_port(&self, port: u16, timeout: Option<Duration>) -> Result<()> {
+        let requested = seconds_to_wire(timeout.map(|budget| budget.min(MAX_WAIT_FOR_PORT)));
+        let effective = if requested == 0 {
+            DEFAULT_WAIT_FOR_PORT
+        } else {
+            Duration::from_secs(u64::from(requested))
+        };
+        self.process()
+            .wait_for_port(pb::WaitForPortRequest {
+                sandbox_id: self.sandbox_id.clone(),
+                port: u32::from(port),
+                timeout_seconds: requested,
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| {
+                let mapped = Error::from_connect(error, "ports.wait_for_port");
+                // A deadline expiry here is THIS wait's budget, not a
+                // transport knob — name it, mirroring the sibling SDKs.
+                if mapped.kind() == ErrorKind::Timeout {
+                    Error::new(
+                        ErrorKind::Timeout,
+                        format!("wait_for_port(timeout) elapsed before port {port} was listening"),
+                        "ports.wait_for_port",
+                    )
+                    .with_suggestion(
+                        "increase the wait_for_port timeout, or check that the \
+                         workload actually binds this port",
+                    )
+                    .with_context("port", port.to_string())
+                    .with_context("timeout_seconds", effective.as_secs().to_string())
+                } else {
+                    mapped
+                }
+            })?;
+        Ok(())
+    }
+
+    /// Publish a sandbox port on host loopback and return the mapping.
+    /// Idempotent for an existing identical mapping. The daemon owns
+    /// the host listener; it disappears with the sandbox (and on
+    /// [`unexpose`](Self::unexpose)).
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::PortInUse`] when the requested host port is taken;
+    /// otherwise any RPC failure.
+    pub async fn expose(&self, port: u16, options: ExposeOptions) -> Result<ExposedPort> {
+        let response = self
+            .sandbox()
+            .expose_port(pb::ExposePortRequest {
+                id: self.sandbox_id.clone(),
+                sandbox_port: u32::from(port),
+                host_port: options.host_port.map_or(0, u32::from),
+                protocol: options.protocol.to_wire().into(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "ports.expose"))?
+            .into_owned();
+        Ok(ExposedPort {
+            sandbox_port: port,
+            host_port: u16::try_from(response.host_port).unwrap_or(0),
+            protocol: options.protocol,
+        })
+    }
+
+    /// Remove a previously exposed mapping and close its host listener.
+    ///
+    /// # Errors
+    ///
+    /// Any RPC failure, mapped onto [`Error`].
+    pub async fn unexpose(&self, port: u16, protocol: Protocol) -> Result<()> {
+        self.sandbox()
+            .unexpose_port(pb::UnexposePortRequest {
+                id: self.sandbox_id.clone(),
+                sandbox_port: u32::from(port),
+                protocol: protocol.to_wire().into(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "ports.unexpose"))?;
+        Ok(())
+    }
+
+    /// The sandbox's current exposed-port mappings, from the daemon's
+    /// authoritative live listener table — never a session-local cache.
+    ///
+    /// # Errors
+    ///
+    /// Any RPC failure, mapped onto [`Error`].
+    pub async fn list(&self) -> Result<Vec<ExposedPort>> {
+        let response = self
+            .sandbox()
+            .list_exposed_ports(pb::ListExposedPortsRequest {
+                id: self.sandbox_id.clone(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "ports.list"))?
+            .into_owned();
+        Ok(response
+            .ports
+            .into_iter()
+            .map(|port| ExposedPort {
+                sandbox_port: u16::try_from(port.sandbox_port).unwrap_or(0),
+                host_port: u16::try_from(port.host_port).unwrap_or(0),
+                protocol: Protocol::from_wire(port.protocol),
+            })
+            .collect())
+    }
+}

--- a/sdk/rust/src/sandbox.rs
+++ b/sdk/rust/src/sandbox.rs
@@ -19,8 +19,7 @@ use crate::error::{Error, ErrorKind, Result};
 use crate::types::{
     Capabilities, IdlePolicy, LifecycleUpdate, SandboxEvent, SandboxInfo, SandboxState,
     SandboxSummary, Snapshot, Update, capabilities_from_wire, idle_action_to_wire, info_from_wire,
-    sandbox_event_from_wire, seconds_to_wire, snapshot_from_wire, state_to_wire, summary_from_wire,
-    time_from_wire,
+    seconds_to_wire, state_to_wire, summary_from_wire, time_from_wire,
 };
 
 /// The one concrete client this SDK drives: the generated Connect
@@ -130,7 +129,7 @@ pub struct CheckpointOptions {
     pub name: Option<String>,
     /// Labels recorded on the snapshot, filterable in
     /// [`ArcBox::list_snapshots`].
-    pub labels: std::collections::BTreeMap<String, String>,
+    pub labels: BTreeMap<String, String>,
 }
 
 /// Options for [`ArcBox::restore`].
@@ -140,10 +139,11 @@ pub struct RestoreOptions {
     /// limit). Same semantics as [`CreateOptions::ttl`].
     pub ttl: Option<Duration>,
     /// Labels for the restored sandbox.
-    pub labels: std::collections::BTreeMap<String, String>,
+    pub labels: BTreeMap<String, String>,
     /// Assign a fresh TAP interface and IP to the restored sandbox.
-    /// Required when running several sandboxes restored from the same
-    /// snapshot concurrently.
+    /// Without it the restored sandbox reuses the origin's recorded
+    /// NIC — the origin must not be running. Required when running
+    /// several sandboxes restored from the same snapshot concurrently.
     pub fresh_network: bool,
 }
 
@@ -153,7 +153,7 @@ pub struct ListSnapshotsOptions {
     /// Keep only snapshots checkpointed from this sandbox.
     pub sandbox_id: Option<String>,
     /// Keep only snapshots carrying all of these labels.
-    pub labels: std::collections::BTreeMap<String, String>,
+    pub labels: BTreeMap<String, String>,
 }
 
 /// Client entry point. Holds one lazily-dialled connection; every
@@ -440,7 +440,10 @@ impl ArcBox {
     /// Restore a new sandbox from a snapshot. The restored sandbox
     /// starts READY — there is no boot to wait for. It gets a fresh id,
     /// minted client-side so retries stay idempotent (the create()
-    /// rule); the origin sandbox is untouched.
+    /// rule). Without [`RestoreOptions::fresh_network`] the restored
+    /// sandbox reuses the origin's recorded NIC, so the origin must not
+    /// be running — and [`Sandbox::checkpoint`] resumes it, so pause or
+    /// kill it first (or set `fresh_network`).
     ///
     /// # Errors
     ///
@@ -499,7 +502,7 @@ impl ArcBox {
                 .await
                 .map_err(|error| Error::from_connect(error, "snapshots.list"))?
                 .into_owned();
-            rows.extend(page.snapshots.into_iter().map(snapshot_from_wire));
+            rows.extend(page.snapshots.into_iter().map(Snapshot::from));
             page_token = page.next_page_token;
             if page_token.is_empty() {
                 return Ok(rows);
@@ -851,7 +854,7 @@ impl EventStream {
                     if let Some(watch_events_response::Payload::Event(event)) =
                         frame.to_owned_message().payload
                     {
-                        return Ok(Some(sandbox_event_from_wire(*event)));
+                        return Ok(Some(SandboxEvent::from(*event)));
                     }
                     // Keepalives prove liveness but carry no event.
                 }

--- a/sdk/rust/src/sandbox.rs
+++ b/sdk/rust/src/sandbox.rs
@@ -7,7 +7,9 @@ use std::collections::BTreeMap;
 use std::time::Duration;
 
 use arcbox_connect::sandbox_v1 as pb;
-use arcbox_connect::sandbox_v1::{SandboxServiceClient, watch_events_response};
+use arcbox_connect::sandbox_v1::{
+    SandboxServiceClient, SandboxSnapshotServiceClient, watch_events_response,
+};
 use connectrpc::client::{ClientTransport, ServerStream, SharedHttp2Connection};
 use tokio::sync::OnceCell;
 
@@ -15,17 +17,21 @@ use crate::client::ClientContext;
 use crate::connection::Connection;
 use crate::error::{Error, ErrorKind, Result};
 use crate::types::{
-    Capabilities, IdlePolicy, LifecycleUpdate, SandboxInfo, SandboxState, SandboxSummary, Update,
-    capabilities_from_wire, idle_action_to_wire, info_from_wire, seconds_to_wire, state_to_wire,
-    summary_from_wire,
+    Capabilities, IdlePolicy, LifecycleUpdate, SandboxEvent, SandboxInfo, SandboxState,
+    SandboxSummary, Snapshot, Update, capabilities_from_wire, idle_action_to_wire, info_from_wire,
+    sandbox_event_from_wire, seconds_to_wire, snapshot_from_wire, state_to_wire, summary_from_wire,
+    time_from_wire,
 };
 
 /// The one concrete client this SDK drives: the generated Connect
 /// client over the shared lazy HTTP/2 Unix-socket transport.
 type SandboxClient = SandboxServiceClient<SharedHttp2Connection>;
 
+/// The generated snapshot client over the shared transport.
+type SnapshotClient = SandboxSnapshotServiceClient<SharedHttp2Connection>;
+
 /// The server stream [`SandboxClient::events`] returns.
-type EventStream = ServerStream<
+type EventWireStream = ServerStream<
     <SharedHttp2Connection as ClientTransport>::ResponseBody,
     pb::__buffa::view::WatchEventsResponseView<'static>,
 >;
@@ -117,6 +123,39 @@ pub struct ListOptions {
     pub labels: BTreeMap<String, String>,
 }
 
+/// Options for [`Sandbox::checkpoint`].
+#[derive(Debug, Clone, Default)]
+pub struct CheckpointOptions {
+    /// Human-readable name recorded on the snapshot.
+    pub name: Option<String>,
+    /// Labels recorded on the snapshot, filterable in
+    /// [`ArcBox::list_snapshots`].
+    pub labels: std::collections::BTreeMap<String, String>,
+}
+
+/// Options for [`ArcBox::restore`].
+#[derive(Debug, Clone, Default)]
+pub struct RestoreOptions {
+    /// Hard maximum lifetime of the restored sandbox (unset = no
+    /// limit). Same semantics as [`CreateOptions::ttl`].
+    pub ttl: Option<Duration>,
+    /// Labels for the restored sandbox.
+    pub labels: std::collections::BTreeMap<String, String>,
+    /// Assign a fresh TAP interface and IP to the restored sandbox.
+    /// Required when running several sandboxes restored from the same
+    /// snapshot concurrently.
+    pub fresh_network: bool,
+}
+
+/// Options for [`ArcBox::list_snapshots`].
+#[derive(Debug, Clone, Default)]
+pub struct ListSnapshotsOptions {
+    /// Keep only snapshots checkpointed from this sandbox.
+    pub sandbox_id: Option<String>,
+    /// Keep only snapshots carrying all of these labels.
+    pub labels: std::collections::BTreeMap<String, String>,
+}
+
 /// Client entry point. Holds one lazily-dialled connection; every
 /// handle it creates shares it. Cheap to clone.
 #[derive(Clone)]
@@ -152,6 +191,10 @@ impl ArcBox {
 
     fn client(&self) -> SandboxClient {
         SandboxServiceClient::new(self.ctx.transport.clone(), self.ctx.config.clone())
+    }
+
+    fn snapshots(&self) -> SnapshotClient {
+        SandboxSnapshotServiceClient::new(self.ctx.transport.clone(), self.ctx.config.clone())
     }
 
     /// What the daemon can do: version, protocol level, feature flags,
@@ -394,6 +437,93 @@ impl ArcBox {
         }
     }
 
+    /// Restore a new sandbox from a snapshot. The restored sandbox
+    /// starts READY — there is no boot to wait for. It gets a fresh id,
+    /// minted client-side so retries stay idempotent (the create()
+    /// rule); the origin sandbox is untouched.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::NotFound`] for a missing snapshot; otherwise any
+    /// RPC failure. On failure the minted id gets a best-effort forced
+    /// removal so nothing leaks.
+    pub async fn restore(&self, snapshot_id: &str, options: RestoreOptions) -> Result<Sandbox> {
+        let id = uuid::Uuid::new_v4().to_string();
+        // No client-side deadline: restoring takes as long as it takes.
+        let restored = self
+            .snapshots()
+            .restore(pb::RestoreRequest {
+                id: id.clone(),
+                snapshot_id: snapshot_id.to_owned(),
+                labels: options.labels.into_iter().collect(),
+                network_override: options.fresh_network,
+                ttl_seconds: seconds_to_wire(options.ttl),
+                ..Default::default()
+            })
+            .await;
+        if let Err(error) = restored {
+            // The sandbox may exist even though restore() failed
+            // (response lost) and ttl is optional, so a leaked VM could
+            // run forever. Best-effort removal; a failure here must not
+            // mask the original error.
+            let _ = self
+                .client()
+                .remove(pb::RemoveSandboxRequest {
+                    id,
+                    force: true,
+                    ..Default::default()
+                })
+                .await;
+            return Err(Error::from_connect(error, "snapshots.restore"));
+        }
+        Ok(Sandbox::attached(self.ctx.clone(), id))
+    }
+
+    /// List the snapshot catalog, auto-paginating server-side pages.
+    ///
+    /// # Errors
+    ///
+    /// Any RPC failure, mapped onto [`Error`].
+    pub async fn list_snapshots(&self, options: ListSnapshotsOptions) -> Result<Vec<Snapshot>> {
+        let client = self.snapshots();
+        let mut rows = Vec::new();
+        let mut page_token = String::new();
+        loop {
+            let page = client
+                .list_snapshots(pb::ListSnapshotsRequest {
+                    sandbox_id: options.sandbox_id.clone().unwrap_or_default(),
+                    labels: options.labels.clone().into_iter().collect(),
+                    page_token,
+                    ..Default::default()
+                })
+                .await
+                .map_err(|error| Error::from_connect(error, "snapshots.list"))?
+                .into_owned();
+            rows.extend(page.snapshots.into_iter().map(snapshot_from_wire));
+            page_token = page.next_page_token;
+            if page_token.is_empty() {
+                return Ok(rows);
+            }
+        }
+    }
+
+    /// Delete a snapshot and its on-disk data.
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::NotFound`] for a missing snapshot; otherwise any
+    /// RPC failure.
+    pub async fn delete_snapshot(&self, snapshot_id: &str) -> Result<()> {
+        self.snapshots()
+            .delete_snapshot(pb::DeleteSnapshotRequest {
+                snapshot_id: snapshot_id.to_owned(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| Error::from_connect(error, "snapshots.delete"))?;
+        Ok(())
+    }
+
     /// Consume lifecycle events until READY/RUNNING, or fail on a
     /// terminal transition. The subscription was armed before Create;
     /// the one residual window — Create processed before the
@@ -402,7 +532,7 @@ impl ArcBox {
     async fn wait_ready(
         &self,
         id: &str,
-        mut events: EventStream,
+        mut events: EventWireStream,
         operation: &'static str,
     ) -> Result<()> {
         let check = |state: SandboxState, error: &Option<String>| -> Result<bool> {
@@ -522,6 +652,69 @@ impl Sandbox {
         crate::Commands::attached(self.ctx.clone(), self.id.clone())
     }
 
+    /// Move bytes in and out of the sandbox.
+    #[must_use]
+    pub fn files(&self) -> crate::Files {
+        crate::Files::attached(self.ctx.clone(), self.id.clone())
+    }
+
+    /// Network reachability and readiness of the sandbox.
+    #[must_use]
+    pub fn ports(&self) -> crate::Ports {
+        crate::Ports::attached(self.ctx.clone(), self.id.clone())
+    }
+
+    /// Subscribe to this sandbox's lifecycle events (keepalive frames
+    /// filtered). The subscription is dialled on the first
+    /// [`next`](EventStream::next); the stream ends when the daemon
+    /// ends it. Events cannot be replayed, so re-subscribing after an
+    /// error is the caller's decision.
+    #[must_use]
+    pub fn events(&self) -> EventStream {
+        EventStream {
+            ctx: self.ctx.clone(),
+            sandbox_id: self.id.clone(),
+            stream: None,
+            done: false,
+        }
+    }
+
+    /// Checkpoint this sandbox into a reusable snapshot: paused,
+    /// snapshotted, then resumed, automatically — the sandbox keeps
+    /// running under the same id. Requires a quiescent sandbox (READY —
+    /// no running command). Restore the returned snapshot into fresh
+    /// sandboxes with [`ArcBox::restore`].
+    ///
+    /// # Errors
+    ///
+    /// [`ErrorKind::SandboxState`] when the sandbox is not quiescent;
+    /// otherwise any RPC failure.
+    pub async fn checkpoint(&self, options: CheckpointOptions) -> Result<Snapshot> {
+        let name = options.name.unwrap_or_default();
+        // No client-side deadline: checkpointing takes as long as it
+        // takes.
+        let response =
+            SandboxSnapshotServiceClient::new(self.ctx.transport.clone(), self.ctx.config.clone())
+                .checkpoint(pb::CheckpointRequest {
+                    sandbox_id: self.id.clone(),
+                    name: name.clone(),
+                    labels: options.labels.clone().into_iter().collect(),
+                    ..Default::default()
+                })
+                .await
+                .map_err(|error| Error::from_connect(error, "sandbox.checkpoint"))?
+                .into_owned();
+        // The response carries only id + creation time; name and labels
+        // echo the request, which is exactly what the catalog recorded.
+        Ok(Snapshot {
+            id: response.snapshot_id,
+            sandbox_id: self.id.clone(),
+            name,
+            labels: options.labels,
+            created_at: time_from_wire(response.created_at.as_option()),
+        })
+    }
+
     /// Fetch the sandbox's current state — always fresh, never cached.
     ///
     /// # Errors
@@ -615,6 +808,63 @@ impl Sandbox {
             .await
             .map_err(|error| Error::from_connect(error, "sandbox.set_lifecycle"))?;
         Ok(())
+    }
+}
+
+/// A sandbox's lifecycle events, read one at a time with
+/// [`next`](Self::next). The subscription is dialled on the first call.
+pub struct EventStream {
+    ctx: ClientContext,
+    sandbox_id: String,
+    stream: Option<EventWireStream>,
+    done: bool,
+}
+
+impl EventStream {
+    /// The next event, or `None` when the daemon ended the stream.
+    ///
+    /// # Errors
+    ///
+    /// Any RPC failure, mapped onto [`Error`].
+    pub async fn next(&mut self) -> Result<Option<SandboxEvent>> {
+        if self.done {
+            return Ok(None);
+        }
+        if self.stream.is_none() {
+            let stream =
+                SandboxServiceClient::new(self.ctx.transport.clone(), self.ctx.config.clone())
+                    .events(pb::SandboxEventsRequest {
+                        sandbox_id: self.sandbox_id.clone(),
+                        ..Default::default()
+                    })
+                    .await
+                    .map_err(|error| {
+                        self.done = true;
+                        Error::from_connect(error, "sandbox.events")
+                    })?;
+            self.stream = Some(stream);
+        }
+        let stream = self.stream.as_mut().expect("stream attached above");
+        loop {
+            match stream.message::<pb::WatchEventsResponse>().await {
+                Ok(Some(frame)) => {
+                    if let Some(watch_events_response::Payload::Event(event)) =
+                        frame.to_owned_message().payload
+                    {
+                        return Ok(Some(sandbox_event_from_wire(*event)));
+                    }
+                    // Keepalives prove liveness but carry no event.
+                }
+                Ok(None) => {
+                    self.done = true;
+                    return Ok(None);
+                }
+                Err(error) => {
+                    self.done = true;
+                    return Err(Error::from_connect(error, "sandbox.events"));
+                }
+            }
+        }
     }
 }
 

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -104,6 +104,53 @@ pub struct Capabilities {
     pub nested_virt: NestedVirtCapability,
 }
 
+/// One checkpointed sandbox image in the snapshot catalog.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct Snapshot {
+    pub id: String,
+    /// The sandbox this snapshot was checkpointed from.
+    pub sandbox_id: String,
+    /// Human-readable name recorded at checkpoint time.
+    pub name: String,
+    /// Labels recorded at checkpoint time, filterable in listings.
+    pub labels: BTreeMap<String, String>,
+    pub created_at: Option<SystemTime>,
+}
+
+/// Kind of a sandbox lifecycle event. `Unknown` covers wire values
+/// this SDK predates. `Idle` fires when an execution exits and the
+/// sandbox returns to ready.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SandboxEventKind {
+    Created,
+    Ready,
+    Running,
+    Idle,
+    Stopping,
+    Stopped,
+    Failed,
+    Removed,
+    Pausing,
+    Paused,
+    Resumed,
+    Unknown,
+}
+
+/// One sandbox lifecycle event, as delivered by `Sandbox::events`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SandboxEvent {
+    pub sandbox_id: String,
+    pub kind: SandboxEventKind,
+    /// When it happened (daemon clock).
+    pub time: Option<SystemTime>,
+    /// Per-kind context: `exit_code`/`signal` on `Idle`, `error` on
+    /// `Failed`, `reason` on `Pausing`/`Resumed`.
+    pub attributes: BTreeMap<String, String>,
+}
+
 /// One knob of a lifecycle update: leave it, clear it to the daemon
 /// default, or set a value. [`Update::Unchanged`] is the `Default`, so
 /// struct-update syntax touches only the knobs it names.
@@ -185,7 +232,7 @@ pub fn seconds_to_wire(duration: Option<Duration>) -> u32 {
     }
 }
 
-fn time_from_wire(timestamp: Option<&Timestamp>) -> Option<SystemTime> {
+pub fn time_from_wire(timestamp: Option<&Timestamp>) -> Option<SystemTime> {
     let timestamp = timestamp?;
     let seconds = u64::try_from(timestamp.seconds).ok()?;
     UNIX_EPOCH.checked_add(Duration::new(seconds, timestamp.nanos.try_into().ok()?))
@@ -256,6 +303,42 @@ pub fn capabilities_from_wire(response: pb::GetCapabilitiesResponse) -> Capabili
                 .map(|nested| nested.reason.clone())
                 .filter(|reason| !reason.is_empty()),
         },
+    }
+}
+
+/// Map one ListSnapshots row to the public DTO.
+pub fn snapshot_from_wire(summary: pb::SnapshotSummary) -> Snapshot {
+    Snapshot {
+        id: summary.id,
+        sandbox_id: summary.sandbox_id,
+        name: summary.name,
+        labels: summary.labels.into_iter().collect(),
+        created_at: time_from_wire(summary.created_at.as_option()),
+    }
+}
+
+/// Map one Events frame to the public DTO.
+pub fn sandbox_event_from_wire(event: pb::SandboxEvent) -> SandboxEvent {
+    use pb::SandboxEventKind as Kind;
+    let kind = match event.kind.as_known() {
+        Some(Kind::SANDBOX_EVENT_KIND_CREATED) => SandboxEventKind::Created,
+        Some(Kind::SANDBOX_EVENT_KIND_READY) => SandboxEventKind::Ready,
+        Some(Kind::SANDBOX_EVENT_KIND_RUNNING) => SandboxEventKind::Running,
+        Some(Kind::SANDBOX_EVENT_KIND_IDLE) => SandboxEventKind::Idle,
+        Some(Kind::SANDBOX_EVENT_KIND_STOPPING) => SandboxEventKind::Stopping,
+        Some(Kind::SANDBOX_EVENT_KIND_STOPPED) => SandboxEventKind::Stopped,
+        Some(Kind::SANDBOX_EVENT_KIND_FAILED) => SandboxEventKind::Failed,
+        Some(Kind::SANDBOX_EVENT_KIND_REMOVED) => SandboxEventKind::Removed,
+        Some(Kind::SANDBOX_EVENT_KIND_PAUSING) => SandboxEventKind::Pausing,
+        Some(Kind::SANDBOX_EVENT_KIND_PAUSED) => SandboxEventKind::Paused,
+        Some(Kind::SANDBOX_EVENT_KIND_RESUMED) => SandboxEventKind::Resumed,
+        _ => SandboxEventKind::Unknown,
+    };
+    SandboxEvent {
+        sandbox_id: event.sandbox_id,
+        kind,
+        time: time_from_wire(event.time.as_option()),
+        attributes: event.attributes.into_iter().collect(),
     }
 }
 

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -306,39 +306,41 @@ pub fn capabilities_from_wire(response: pb::GetCapabilitiesResponse) -> Capabili
     }
 }
 
-/// Map one ListSnapshots row to the public DTO.
-pub fn snapshot_from_wire(summary: pb::SnapshotSummary) -> Snapshot {
-    Snapshot {
-        id: summary.id,
-        sandbox_id: summary.sandbox_id,
-        name: summary.name,
-        labels: summary.labels.into_iter().collect(),
-        created_at: time_from_wire(summary.created_at.as_option()),
+impl From<pb::SnapshotSummary> for Snapshot {
+    fn from(summary: pb::SnapshotSummary) -> Self {
+        Self {
+            id: summary.id,
+            sandbox_id: summary.sandbox_id,
+            name: summary.name,
+            labels: summary.labels.into_iter().collect(),
+            created_at: time_from_wire(summary.created_at.as_option()),
+        }
     }
 }
 
-/// Map one Events frame to the public DTO.
-pub fn sandbox_event_from_wire(event: pb::SandboxEvent) -> SandboxEvent {
-    use pb::SandboxEventKind as Kind;
-    let kind = match event.kind.as_known() {
-        Some(Kind::SANDBOX_EVENT_KIND_CREATED) => SandboxEventKind::Created,
-        Some(Kind::SANDBOX_EVENT_KIND_READY) => SandboxEventKind::Ready,
-        Some(Kind::SANDBOX_EVENT_KIND_RUNNING) => SandboxEventKind::Running,
-        Some(Kind::SANDBOX_EVENT_KIND_IDLE) => SandboxEventKind::Idle,
-        Some(Kind::SANDBOX_EVENT_KIND_STOPPING) => SandboxEventKind::Stopping,
-        Some(Kind::SANDBOX_EVENT_KIND_STOPPED) => SandboxEventKind::Stopped,
-        Some(Kind::SANDBOX_EVENT_KIND_FAILED) => SandboxEventKind::Failed,
-        Some(Kind::SANDBOX_EVENT_KIND_REMOVED) => SandboxEventKind::Removed,
-        Some(Kind::SANDBOX_EVENT_KIND_PAUSING) => SandboxEventKind::Pausing,
-        Some(Kind::SANDBOX_EVENT_KIND_PAUSED) => SandboxEventKind::Paused,
-        Some(Kind::SANDBOX_EVENT_KIND_RESUMED) => SandboxEventKind::Resumed,
-        _ => SandboxEventKind::Unknown,
-    };
-    SandboxEvent {
-        sandbox_id: event.sandbox_id,
-        kind,
-        time: time_from_wire(event.time.as_option()),
-        attributes: event.attributes.into_iter().collect(),
+impl From<pb::SandboxEvent> for SandboxEvent {
+    fn from(event: pb::SandboxEvent) -> Self {
+        use pb::SandboxEventKind as Kind;
+        let kind = match event.kind.as_known() {
+            Some(Kind::SANDBOX_EVENT_KIND_CREATED) => SandboxEventKind::Created,
+            Some(Kind::SANDBOX_EVENT_KIND_READY) => SandboxEventKind::Ready,
+            Some(Kind::SANDBOX_EVENT_KIND_RUNNING) => SandboxEventKind::Running,
+            Some(Kind::SANDBOX_EVENT_KIND_IDLE) => SandboxEventKind::Idle,
+            Some(Kind::SANDBOX_EVENT_KIND_STOPPING) => SandboxEventKind::Stopping,
+            Some(Kind::SANDBOX_EVENT_KIND_STOPPED) => SandboxEventKind::Stopped,
+            Some(Kind::SANDBOX_EVENT_KIND_FAILED) => SandboxEventKind::Failed,
+            Some(Kind::SANDBOX_EVENT_KIND_REMOVED) => SandboxEventKind::Removed,
+            Some(Kind::SANDBOX_EVENT_KIND_PAUSING) => SandboxEventKind::Pausing,
+            Some(Kind::SANDBOX_EVENT_KIND_PAUSED) => SandboxEventKind::Paused,
+            Some(Kind::SANDBOX_EVENT_KIND_RESUMED) => SandboxEventKind::Resumed,
+            _ => SandboxEventKind::Unknown,
+        };
+        Self {
+            sandbox_id: event.sandbox_id,
+            kind,
+            time: time_from_wire(event.time.as_option()),
+            attributes: event.attributes.into_iter().collect(),
+        }
     }
 }
 

--- a/sdk/rust/tests/data_plane.rs
+++ b/sdk/rust/tests/data_plane.rs
@@ -555,6 +555,26 @@ async fn read_collects_chunks_until_done() {
 }
 
 #[tokio::test]
+async fn a_read_stream_that_ends_without_done_is_an_error() {
+    let mock = Arc::new(MockDaemon::default());
+    // A prefix without the done marker: the transfer was cut short.
+    *mock.read_chunks.lock().unwrap() = vec![pb::FileChunk {
+        data: b"hel".to_vec(),
+        ..Default::default()
+    }];
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let error = sandbox_for(&path)
+        .await
+        .files()
+        .read("/tmp/hello.txt")
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind(), arcbox::ErrorKind::ConnectionLost);
+}
+
+#[tokio::test]
 async fn path_verbs_carry_their_shapes_and_stat_maps() {
     let mock = Arc::new(MockDaemon::default());
     let (_dir, path) = serve(mock.clone()).await;
@@ -643,6 +663,10 @@ async fn expose_and_list_map_the_port_shapes() {
 
     let mapping = ports.expose(8080, ExposeOptions::default()).await.unwrap();
     assert_eq!(mapping.host_port, 49152);
+    // The mapping's identity is the caller's sandbox port — the
+    // response's guest_port (61000 here) is the DNAT relay, never the
+    // sandbox port.
+    assert_eq!(mapping.sandbox_port, 8080);
     assert_eq!(mapping.protocol, Protocol::Tcp);
     // The wire never carries UNSPECIFIED outbound.
     assert_eq!(

--- a/sdk/rust/tests/data_plane.rs
+++ b/sdk/rust/tests/data_plane.rs
@@ -1,0 +1,775 @@
+//! Files, ports, snapshots and events against a mock daemon on a real
+//! Unix socket.
+//!
+//! The contracts under test: the write protocol (open + chunks + done,
+//! mode defaulted), read collection, path-verb request shapes and stat
+//! mapping, watch keepalive filtering and clean end, wait_for_port's
+//! timeout naming, expose/list port mapping, the checkpoint echo row,
+//! restore's minted id + leak cleanup, snapshot pagination, and event
+//! mapping.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use arcbox::{
+    ArcBox, CheckpointOptions, ConnectOptions, Connection, ExposeOptions, FileKind, FsEventKind,
+    ListSnapshotsOptions, MkdirOptions, Protocol, RemoveOptions, RestoreOptions, SandboxEventKind,
+    WatchOptions, WriteOptions,
+};
+use arcbox_connect::sandbox_v1 as pb;
+use arcbox_connect::sandbox_v1::{watch_dir_response, watch_events_response, write_file_request};
+use connectrpc::{ConnectError, RequestContext, Response, ServiceRequest, ServiceResult};
+
+type Frames<T> = Vec<Result<T, ConnectError>>;
+type BoxStream<T> =
+    std::pin::Pin<Box<dyn futures_core::Stream<Item = Result<T, ConnectError>> + Send>>;
+
+fn empty() -> buffa_types::google::protobuf::Empty {
+    buffa_types::google::protobuf::Empty::default()
+}
+
+#[derive(Default)]
+struct MockDaemon {
+    // Filesystem.
+    write_frames: Mutex<Vec<pb::WriteFileRequest>>,
+    read_chunks: Mutex<Vec<pb::FileChunk>>,
+    stats: Mutex<Vec<pb::StatFileRequest>>,
+    removes: Mutex<Vec<pb::RemoveEntryRequest>>,
+    moves: Mutex<Vec<pb::MoveEntryRequest>>,
+    mkdirs: Mutex<Vec<pb::MakeDirRequest>>,
+    watch_frames: Mutex<Frames<pb::WatchDirResponse>>,
+    // Ports.
+    wait_ports: Mutex<Vec<pb::WaitForPortRequest>>,
+    fail_wait_port: Mutex<Option<ConnectError>>,
+    exposes: Mutex<Vec<pb::ExposePortRequest>>,
+    // Snapshots.
+    checkpoints: Mutex<Vec<pb::CheckpointRequest>>,
+    restores: Mutex<Vec<pb::RestoreRequest>>,
+    fail_restore: Mutex<Option<ConnectError>>,
+    snapshot_removes: Mutex<Vec<pb::RemoveSandboxRequest>>,
+    deletes: Mutex<Vec<pb::DeleteSnapshotRequest>>,
+    // Events.
+    event_frames: Mutex<Frames<pb::WatchEventsResponse>>,
+}
+
+#[allow(
+    refining_impl_trait,
+    reason = "the trait returns `impl Encodable<M>`; naming the concrete body \
+              type is strictly more informative and this mock is registered on a \
+              Router rather than named by callers"
+)]
+impl pb::SandboxFilesystemService for MockDaemon {
+    async fn read_file(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ReadFileRequest>,
+    ) -> ServiceResult<BoxStream<pb::FileChunk>> {
+        let frames: Frames<pb::FileChunk> = self
+            .read_chunks
+            .lock()
+            .unwrap()
+            .iter()
+            .cloned()
+            .map(Ok)
+            .collect();
+        Response::ok(Box::pin(tokio_stream::iter(frames)))
+    }
+
+    async fn write_file(
+        &self,
+        _ctx: RequestContext,
+        mut requests: connectrpc::InboundStream<pb::WriteFileRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        use tokio_stream::StreamExt as _;
+        while let Some(frame) = requests.next().await {
+            self.write_frames
+                .lock()
+                .unwrap()
+                .push(frame?.to_owned_message());
+        }
+        Response::ok(empty())
+    }
+
+    async fn stat(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::StatFileRequest>,
+    ) -> ServiceResult<pb::FileStat> {
+        self.stats.lock().unwrap().push(request.to_owned_message());
+        Response::ok(pb::FileStat {
+            name: "hello.txt".into(),
+            kind: pb::FileKind::FILE_KIND_FILE.into(),
+            size: 5,
+            mode: 0o644,
+            uid: 1000,
+            gid: 1000,
+            ..Default::default()
+        })
+    }
+
+    async fn list_dir(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ListDirRequest>,
+    ) -> ServiceResult<pb::ListDirResponse> {
+        Response::ok(pb::ListDirResponse {
+            entries: vec![
+                pb::FileStat {
+                    name: "a.txt".into(),
+                    kind: pb::FileKind::FILE_KIND_FILE.into(),
+                    size: 3,
+                    ..Default::default()
+                },
+                pb::FileStat {
+                    name: "link".into(),
+                    kind: pb::FileKind::FILE_KIND_SYMLINK.into(),
+                    symlink_target: "/etc/hosts".into(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        })
+    }
+
+    async fn make_dir(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::MakeDirRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        self.mkdirs.lock().unwrap().push(request.to_owned_message());
+        Response::ok(empty())
+    }
+
+    async fn remove(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::RemoveEntryRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        self.removes
+            .lock()
+            .unwrap()
+            .push(request.to_owned_message());
+        Response::ok(empty())
+    }
+
+    async fn r#move(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::MoveEntryRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        self.moves.lock().unwrap().push(request.to_owned_message());
+        Response::ok(empty())
+    }
+
+    async fn watch_dir(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::WatchDirRequest>,
+    ) -> ServiceResult<BoxStream<pb::WatchDirResponse>> {
+        let frames = std::mem::take(&mut *self.watch_frames.lock().unwrap());
+        Response::ok(Box::pin(tokio_stream::iter(frames)))
+    }
+}
+
+#[allow(
+    refining_impl_trait,
+    reason = "the trait returns `impl Encodable<M>`; naming the concrete body \
+              type is strictly more informative and this mock is registered on a \
+              Router rather than named by callers"
+)]
+impl pb::SandboxSnapshotService for MockDaemon {
+    async fn checkpoint(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::CheckpointRequest>,
+    ) -> ServiceResult<pb::CheckpointResponse> {
+        self.checkpoints
+            .lock()
+            .unwrap()
+            .push(request.to_owned_message());
+        Response::ok(pb::CheckpointResponse {
+            snapshot_id: "snap-1".into(),
+            ..Default::default()
+        })
+    }
+
+    async fn restore(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::RestoreRequest>,
+    ) -> ServiceResult<pb::RestoreResponse> {
+        let request = request.to_owned_message();
+        self.restores.lock().unwrap().push(request.clone());
+        let failure = self.fail_restore.lock().unwrap().take();
+        if let Some(error) = failure {
+            return Err(error);
+        }
+        Response::ok(pb::RestoreResponse {
+            id: request.id,
+            ip_address: "192.168.64.7".into(),
+            ..Default::default()
+        })
+    }
+
+    async fn list_snapshots(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::ListSnapshotsRequest>,
+    ) -> ServiceResult<pb::ListSnapshotsResponse> {
+        let token = request.to_owned_message().page_token;
+        if token.is_empty() {
+            Response::ok(pb::ListSnapshotsResponse {
+                snapshots: vec![pb::SnapshotSummary {
+                    id: "snap-1".into(),
+                    sandbox_id: "sb-1".into(),
+                    name: "warm-base".into(),
+                    ..Default::default()
+                }],
+                next_page_token: "page-2".into(),
+                ..Default::default()
+            })
+        } else {
+            Response::ok(pb::ListSnapshotsResponse {
+                snapshots: vec![pb::SnapshotSummary {
+                    id: "snap-2".into(),
+                    sandbox_id: "sb-2".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            })
+        }
+    }
+
+    async fn delete_snapshot(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::DeleteSnapshotRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        self.deletes
+            .lock()
+            .unwrap()
+            .push(request.to_owned_message());
+        Response::ok(empty())
+    }
+}
+
+#[allow(
+    refining_impl_trait,
+    reason = "the trait returns `impl Encodable<M>`; naming the concrete body \
+              type is strictly more informative and this mock is registered on a \
+              Router rather than named by callers"
+)]
+impl pb::SandboxProcessService for MockDaemon {
+    async fn start_execution(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::StartExecutionRequest>,
+    ) -> ServiceResult<pb::Execution> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn attach_execution(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::AttachExecutionRequest>,
+    ) -> ServiceResult<BoxStream<pb::ExecutionEvent>> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn write_stdin(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::WriteStdinRequest>,
+    ) -> ServiceResult<pb::StdinStatus> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn stream_stdin(
+        &self,
+        _ctx: RequestContext,
+        _requests: connectrpc::InboundStream<pb::WriteStdinRequest>,
+    ) -> ServiceResult<pb::StdinStatus> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn get_stdin_status(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::GetStdinStatusRequest>,
+    ) -> ServiceResult<pb::StdinStatus> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn signal_execution(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::SignalExecutionRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn resize_execution_tty(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ResizeExecutionTtyRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn wait_execution(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::WaitExecutionRequest>,
+    ) -> ServiceResult<pb::Execution> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn list_executions(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ListExecutionsRequest>,
+    ) -> ServiceResult<pb::ListExecutionsResponse> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn wait_for_port(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::WaitForPortRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        self.wait_ports
+            .lock()
+            .unwrap()
+            .push(request.to_owned_message());
+        let failure = self.fail_wait_port.lock().unwrap().take();
+        if let Some(error) = failure {
+            return Err(error);
+        }
+        Response::ok(empty())
+    }
+}
+
+#[allow(
+    refining_impl_trait,
+    reason = "the trait returns `impl Encodable<M>`; naming the concrete body \
+              type is strictly more informative and this mock is registered on a \
+              Router rather than named by callers"
+)]
+impl pb::SandboxService for MockDaemon {
+    async fn create(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::CreateSandboxRequest>,
+    ) -> ServiceResult<pb::CreateSandboxResponse> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn stop(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::StopSandboxRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn remove(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::RemoveSandboxRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        self.snapshot_removes
+            .lock()
+            .unwrap()
+            .push(request.to_owned_message());
+        Response::ok(empty())
+    }
+    async fn pause(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::PauseSandboxRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn resume(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ResumeSandboxRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn set_lifecycle(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::SetLifecycleRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn get_capabilities(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::GetCapabilitiesRequest>,
+    ) -> ServiceResult<pb::GetCapabilitiesResponse> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn inspect(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::InspectSandboxRequest>,
+    ) -> ServiceResult<pb::SandboxInfo> {
+        Response::ok(pb::SandboxInfo {
+            id: request.to_owned_message().id,
+            state: pb::SandboxState::SANDBOX_STATE_READY.into(),
+            ..Default::default()
+        })
+    }
+    async fn list(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ListSandboxesRequest>,
+    ) -> ServiceResult<pb::ListSandboxesResponse> {
+        Err(ConnectError::unimplemented("mock"))
+    }
+    async fn events(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::SandboxEventsRequest>,
+    ) -> ServiceResult<BoxStream<pb::WatchEventsResponse>> {
+        let frames = std::mem::take(&mut *self.event_frames.lock().unwrap());
+        Response::ok(Box::pin(tokio_stream::iter(frames)))
+    }
+    async fn expose_port(
+        &self,
+        _ctx: RequestContext,
+        request: ServiceRequest<'_, pb::ExposePortRequest>,
+    ) -> ServiceResult<pb::ExposePortResponse> {
+        self.exposes
+            .lock()
+            .unwrap()
+            .push(request.to_owned_message());
+        Response::ok(pb::ExposePortResponse {
+            host_port: 49152,
+            guest_port: 61000,
+            ..Default::default()
+        })
+    }
+    async fn unexpose_port(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::UnexposePortRequest>,
+    ) -> ServiceResult<buffa_types::google::protobuf::Empty> {
+        Response::ok(empty())
+    }
+    async fn list_exposed_ports(
+        &self,
+        _ctx: RequestContext,
+        _request: ServiceRequest<'_, pb::ListExposedPortsRequest>,
+    ) -> ServiceResult<pb::ListExposedPortsResponse> {
+        Response::ok(pb::ListExposedPortsResponse {
+            ports: vec![
+                pb::ExposedPort {
+                    sandbox_port: 8080,
+                    host_port: 49152,
+                    protocol: pb::PortProtocol::PORT_PROTOCOL_TCP.into(),
+                    ..Default::default()
+                },
+                // UNSPECIFIED decodes as tcp.
+                pb::ExposedPort {
+                    sandbox_port: 9000,
+                    host_port: 49153,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        })
+    }
+}
+
+async fn serve(mock: Arc<MockDaemon>) -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("daemon.sock");
+    let listener = tokio::net::UnixListener::bind(&path).unwrap();
+    let app = connectrpc::Router::new()
+        .add_service::<_, pb::SandboxServiceRegisterMarker>(mock.clone())
+        .add_service::<_, pb::SandboxProcessServiceRegisterMarker>(mock.clone())
+        .add_service::<_, pb::SandboxFilesystemServiceRegisterMarker>(mock.clone())
+        .add_service::<_, pb::SandboxSnapshotServiceRegisterMarker>(mock)
+        .into_axum_router();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (dir, path)
+}
+
+async fn sandbox_for(path: &PathBuf) -> arcbox::Sandbox {
+    ArcBox::with_connection(&Connection::new().socket_path(path))
+        .unwrap()
+        .connect("sb-1", ConnectOptions::default())
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn write_streams_open_chunks_done_with_the_default_mode() {
+    let mock = Arc::new(MockDaemon::default());
+    let (_dir, path) = serve(mock.clone()).await;
+
+    sandbox_for(&path)
+        .await
+        .files()
+        .write("/tmp/hello.txt", "hello", WriteOptions::default())
+        .await
+        .unwrap();
+
+    let frames = mock.write_frames.lock().unwrap();
+    let Some(write_file_request::Payload::Open(open)) = &frames[0].payload else {
+        panic!("first frame must be the open");
+    };
+    assert_eq!(open.path, "/tmp/hello.txt");
+    assert_eq!(open.mode, 0o644);
+    let Some(write_file_request::Payload::Chunk(chunk)) = &frames[1].payload else {
+        panic!("second frame must be data");
+    };
+    assert_eq!(chunk.data, b"hello");
+    assert!(!chunk.done);
+    let Some(write_file_request::Payload::Chunk(last)) = &frames[2].payload else {
+        panic!("last frame must be the done marker");
+    };
+    assert!(last.done);
+}
+
+#[tokio::test]
+async fn read_collects_chunks_until_done() {
+    let mock = Arc::new(MockDaemon::default());
+    *mock.read_chunks.lock().unwrap() = vec![
+        pb::FileChunk {
+            data: b"hel".to_vec(),
+            ..Default::default()
+        },
+        pb::FileChunk {
+            data: b"lo".to_vec(),
+            done: true,
+            ..Default::default()
+        },
+    ];
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let content = sandbox_for(&path)
+        .await
+        .files()
+        .read("/tmp/hello.txt")
+        .await
+        .unwrap();
+
+    assert_eq!(content, b"hello");
+}
+
+#[tokio::test]
+async fn path_verbs_carry_their_shapes_and_stat_maps() {
+    let mock = Arc::new(MockDaemon::default());
+    let (_dir, path) = serve(mock.clone()).await;
+    let files = sandbox_for(&path).await.files();
+
+    let stat = files.stat("/tmp/hello.txt").await.unwrap();
+    assert_eq!(stat.kind, FileKind::File);
+    assert_eq!(stat.size, 5);
+    assert_eq!(stat.symlink_target, None);
+
+    let entries = files.list("/tmp").await.unwrap();
+    assert_eq!(entries[1].kind, FileKind::Symlink);
+    assert_eq!(entries[1].symlink_target.as_deref(), Some("/etc/hosts"));
+
+    files
+        .mkdir("/tmp/sub", MkdirOptions { mode: Some(0o700) })
+        .await
+        .unwrap();
+    files
+        .remove("/tmp/sub", RemoveOptions { recursive: true })
+        .await
+        .unwrap();
+    files.rename("/tmp/a", "/tmp/b").await.unwrap();
+
+    assert_eq!(mock.mkdirs.lock().unwrap()[0].mode, 0o700);
+    assert!(mock.removes.lock().unwrap()[0].recursive);
+    let moves = mock.moves.lock().unwrap();
+    assert_eq!(moves[0].from_path, "/tmp/a");
+    assert_eq!(moves[0].to_path, "/tmp/b");
+}
+
+#[tokio::test]
+async fn watch_filters_keepalives_and_ends_cleanly() {
+    let mock = Arc::new(MockDaemon::default());
+    *mock.watch_frames.lock().unwrap() = vec![
+        Ok(pb::WatchDirResponse {
+            payload: Some(watch_dir_response::Payload::from(pb::KeepAlive::default())),
+            ..Default::default()
+        }),
+        Ok(pb::WatchDirResponse {
+            payload: Some(watch_dir_response::Payload::from(pb::FsEvent {
+                kind: pb::FsEventKind::FS_EVENT_KIND_RENAMED.into(),
+                path: "/w/old".into(),
+                renamed_to: "/w/new".into(),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }),
+    ];
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let files = sandbox_for(&path).await.files();
+    let mut watch = files.watch("/w", WatchOptions { recursive: true });
+    let event = watch.next().await.unwrap().unwrap();
+    assert_eq!(event.kind, FsEventKind::Renamed);
+    assert_eq!(event.path, "/w/old");
+    assert_eq!(event.renamed_to.as_deref(), Some("/w/new"));
+    // The daemon ending the stream is the clean end (sandbox stopped).
+    assert!(watch.next().await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn wait_for_port_names_its_own_timeout() {
+    let mock = Arc::new(MockDaemon::default());
+    *mock.fail_wait_port.lock().unwrap() = Some(ConnectError::deadline_exceeded(
+        "no listener on port 8080 within 10s",
+    ));
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let ports = sandbox_for(&path).await.ports();
+    let error = ports
+        .wait_for_port(8080, Some(Duration::from_secs(10)))
+        .await
+        .unwrap_err();
+
+    assert_eq!(error.kind(), arcbox::ErrorKind::Timeout);
+    assert!(error.to_string().contains("wait_for_port(timeout)"));
+    assert_eq!(mock.wait_ports.lock().unwrap()[0].timeout_seconds, 10);
+}
+
+#[tokio::test]
+async fn expose_and_list_map_the_port_shapes() {
+    let mock = Arc::new(MockDaemon::default());
+    let (_dir, path) = serve(mock.clone()).await;
+    let ports = sandbox_for(&path).await.ports();
+
+    let mapping = ports.expose(8080, ExposeOptions::default()).await.unwrap();
+    assert_eq!(mapping.host_port, 49152);
+    assert_eq!(mapping.protocol, Protocol::Tcp);
+    // The wire never carries UNSPECIFIED outbound.
+    assert_eq!(
+        mock.exposes.lock().unwrap()[0].protocol.as_known(),
+        Some(pb::PortProtocol::PORT_PROTOCOL_TCP)
+    );
+
+    let listed = ports.list().await.unwrap();
+    assert_eq!(listed.len(), 2);
+    // Inbound UNSPECIFIED decodes as tcp.
+    assert_eq!(listed[1].protocol, Protocol::Tcp);
+    assert_eq!(listed[1].sandbox_port, 9000);
+}
+
+#[tokio::test]
+async fn checkpoint_returns_the_echoed_catalog_row() {
+    let mock = Arc::new(MockDaemon::default());
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let snapshot = sandbox_for(&path)
+        .await
+        .checkpoint(CheckpointOptions {
+            name: Some("warm-base".into()),
+            labels: [("tier".to_owned(), "warm".to_owned())].into(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.id, "snap-1");
+    assert_eq!(snapshot.sandbox_id, "sb-1");
+    assert_eq!(snapshot.name, "warm-base");
+    assert_eq!(
+        snapshot.labels.get("tier").map(String::as_str),
+        Some("warm")
+    );
+    let requests = mock.checkpoints.lock().unwrap();
+    assert_eq!(requests[0].name, "warm-base");
+}
+
+#[tokio::test]
+async fn restore_mints_the_id_and_cleans_up_on_failure() {
+    let mock = Arc::new(MockDaemon::default());
+    let (_dir, path) = serve(mock.clone()).await;
+    let client = ArcBox::with_connection(&Connection::new().socket_path(&path)).unwrap();
+
+    let sandbox = client
+        .restore(
+            "snap-1",
+            RestoreOptions {
+                ttl: Some(Duration::from_millis(90_500)),
+                fresh_network: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    {
+        let requests = mock.restores.lock().unwrap();
+        assert_eq!(requests[0].snapshot_id, "snap-1");
+        assert!(requests[0].network_override);
+        // Milliseconds round UP to whole wire seconds.
+        assert_eq!(requests[0].ttl_seconds, 91);
+        // The handle's identity is the client-minted UUID the wire saw.
+        assert_eq!(sandbox.id(), requests[0].id);
+        uuid::Uuid::parse_str(sandbox.id()).unwrap();
+    }
+
+    // A failed restore force-removes the minted id — the create() rule.
+    *mock.fail_restore.lock().unwrap() = Some(ConnectError::not_found("snapshot gone"));
+    let error = client
+        .restore("snap-9", RestoreOptions::default())
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), arcbox::ErrorKind::NotFound);
+    let removes = mock.snapshot_removes.lock().unwrap();
+    assert_eq!(removes.len(), 1);
+    assert!(removes[0].force);
+    assert_eq!(removes[0].id, mock.restores.lock().unwrap()[1].id);
+}
+
+#[tokio::test]
+async fn snapshot_listing_paginates_and_delete_names_the_snapshot() {
+    let mock = Arc::new(MockDaemon::default());
+    let (_dir, path) = serve(mock.clone()).await;
+    let client = ArcBox::with_connection(&Connection::new().socket_path(&path)).unwrap();
+
+    let rows = client
+        .list_snapshots(ListSnapshotsOptions::default())
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].name, "warm-base");
+    assert_eq!(rows[1].id, "snap-2");
+
+    client.delete_snapshot("snap-1").await.unwrap();
+    assert_eq!(mock.deletes.lock().unwrap()[0].snapshot_id, "snap-1");
+}
+
+#[tokio::test]
+async fn events_map_kinds_and_filter_keepalives() {
+    let mock = Arc::new(MockDaemon::default());
+    *mock.event_frames.lock().unwrap() = vec![
+        Ok(pb::WatchEventsResponse {
+            payload: Some(watch_events_response::Payload::from(
+                pb::KeepAlive::default(),
+            )),
+            ..Default::default()
+        }),
+        Ok(pb::WatchEventsResponse {
+            payload: Some(watch_events_response::Payload::from(pb::SandboxEvent {
+                sandbox_id: "sb-1".into(),
+                kind: pb::SandboxEventKind::SANDBOX_EVENT_KIND_IDLE.into(),
+                attributes: std::iter::once(("exit_code".to_owned(), "0".to_owned())).collect(),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }),
+    ];
+    let (_dir, path) = serve(mock.clone()).await;
+
+    let sandbox = sandbox_for(&path).await;
+    let mut events = sandbox.events();
+    let event = events.next().await.unwrap().unwrap();
+    assert_eq!(event.kind, SandboxEventKind::Idle);
+    assert_eq!(
+        event.attributes.get("exit_code").map(String::as_str),
+        Some("0")
+    );
+    assert!(events.next().await.unwrap().is_none());
+}


### PR DESCRIPTION
## What

Phase 3 of the Rust SDK (`sdk/rust`, follows #603 and #606): the data plane, completing the surface the TypeScript/Python SDKs carry.

- **`files()`** — streamed `read`/`write` over the Connect chunk protocol (open + chunks + done marker, mode defaulted to `0o644`, the 256 MiB per-file cap checked client-side before any byte is sent); the path verbs with a typed `FileStat` (symlinks reported, never followed; `mkdir -p` semantics; `rename` — the `std::fs` name); and `watch` — a typed `FsEvent` stream, keepalives filtered, ending cleanly when the sandbox stops. Content is bytes end to end: `write` takes `impl AsRef<[u8]>` so `&str` works directly, and text decoding stays the caller's one-liner instead of a lossy SDK guess.
- **`ports()`** — `wait_for_port` (guest listen-table wait; a deadline expiry is re-typed to name *this* knob, the sibling SDKs' discipline), `expose`/`unexpose`/`list` over the CORE-102 authoritative listener table. Ports are `u16` at the boundary — the wire's `u32` never leaks.
- **snapshots** — `Sandbox::checkpoint` (echoes the catalog row: response id + creation time, request-echoed name/labels), `ArcBox::restore` (fresh client-minted id; a failed restore force-removes it — the same no-leak rule create() carries), auto-paginating `list_snapshots`, `delete_snapshot`. No client-side deadline on checkpoint/restore: they take as long as they take.
- **`events()`** — typed lifecycle events with per-kind attributes, keepalives filtered, lazy-dialled on first `next()`.

## Testing

10 new mock tests; the mock implements all four generated services on one struct, registered on a single router via the per-service `RegisterMarker`s, served on a temp Unix socket. Pinned contracts: the write frame sequence, read chunk collection, path-verb shapes + stat mapping, watch keepalive filtering + clean end, `wait_for_port` timeout naming, outbound-never-UNSPECIFIED / inbound-UNSPECIFIED-is-tcp protocol mapping, the checkpoint echo row, restore minted-id + leak cleanup, snapshot pagination, event kind/attribute mapping.

Full crate: 37 tests, clippy `--all-targets -D warnings` clean.

## Still deferred (README states it)

`wait_for_log` (filter `output()` directly), the remote tier (CORE-63), and Template statics — the same tail the sibling SDKs carry.