### PR TITLE
test(sdk): template catalog e2e phase in both SDK suites (CORE-107)

### DIFF
--- a/sdk/python/tests/test_e2e.py
+++ b/sdk/python/tests/test_e2e.py
@@ -8,7 +8,8 @@ point the loop at a dev daemon.
 This is the design doc's 20-line hello world plus the phase 2a surface
 (PTY, stdin, re-attach, set_lifecycle, capabilities, events) and the
 phase 2b surface (filesystem path verbs, watch, wait_for_port,
-commands.list, wait_for_log). Still outside scope: Template statics.
+commands.list, wait_for_log) and the template catalog (Template
+statics, snapshot promotion, create-by-name).
 The sync flavor exercises the generated tree end to end — including
 genuinely blocking event-stream reads.
 """
@@ -16,11 +17,12 @@ genuinely blocking event-stream reads.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 
 import pytest
 
-from arcbox import ArcBox, AsyncSandbox, FsEvent, PtySize, Sandbox
+from arcbox import ArcBox, AsyncSandbox, FsEvent, PtySize, Sandbox, Template
 from arcbox.errors import ArcBoxError
 from arcbox.errors import FileNotFoundError as SandboxFileNotFoundError
 from arcbox.errors import TimeoutError as SandboxTimeoutError
@@ -222,6 +224,47 @@ def test_events_observe_the_idle_auto_pause() -> None:
         assert sandbox.info().state == "paused"
     finally:
         sandbox.kill()
+
+
+def test_template_catalog_roundtrip() -> None:
+    # Snapshot-promotion source: no docker image involved, so this runs on
+    # any sandbox-capable host. The strict warm-vs-cold split is the daemon
+    # e2e's job; here the contract is the round trip — the checkpoint's
+    # state must be what a create-by-name boots into.
+    with ArcBox() as box:
+        snapshot_id = ""
+        source = box.create("", ttl=300)
+        try:
+            source.files.write_text("/tmp/tpl-mark", "from-snapshot\n")
+            snapshot_id = source.checkpoint(name="sdk-py-tpl-source").id
+        finally:
+            source.kill()
+        try:
+            # The build handle owns its client; context exit releases it
+            # (the published handle shares it and never closes it).
+            with Template.build("sdk-py-e2e-tpl", snapshot=snapshot_id) as draft:
+                assert draft.version == ""
+                assert draft.digest != ""
+
+                published = draft.publish("1.0")
+                assert published.reference == "sdk-py-e2e-tpl:1.0"
+
+                rows = [row for row in Template.list() if row.name == "sdk-py-e2e-tpl"]
+                assert [row.version for row in rows] == ["1.0"]
+                assert all(row.warm for row in rows)
+
+                sandbox = box.create("sdk-py-e2e-tpl", ttl=300)
+                try:
+                    marked = sandbox.commands.run(["/bin/cat", "/tmp/tpl-mark"])
+                    assert marked.expect().stdout == "from-snapshot\n"
+                finally:
+                    sandbox.kill()
+        finally:
+            with contextlib.suppress(ArcBoxError):
+                Template.delete_reference("sdk-py-e2e-tpl")
+            if snapshot_id:
+                with contextlib.suppress(ArcBoxError):
+                    box.delete_snapshot(snapshot_id)
 
 
 @pytest.mark.anyio

--- a/sdk/typescript/test/e2e.test.ts
+++ b/sdk/typescript/test/e2e.test.ts
@@ -8,7 +8,8 @@
 // This is the design doc's 20-line hello world plus the phase 2a
 // surface (PTY, stdin, re-attach, setLifecycle, capabilities, events)
 // and the phase 2b surface (filesystem path verbs, watch, waitForPort,
-// commands.list, waitForLog). Still outside scope: Template statics.
+// commands.list, waitForLog) and the template catalog (Template statics,
+// snapshot promotion, create-by-name).
 import { noop } from "foxts/noop";
 import { wait } from "foxts/wait";
 import { describe, expect, it } from "vitest";
@@ -19,6 +20,7 @@ import {
   ArcBoxError,
   FileNotFoundError,
   Sandbox,
+  Template,
   TimeoutError,
 } from "../src/index";
 
@@ -258,6 +260,59 @@ describe.skipIf(!enabled)("hello world against a live daemon", () => {
       expect((await sandbox.info()).state).toBe("paused");
     } finally {
       await sandbox.kill();
+    }
+  }, 300000);
+
+  it("drives the template catalog: promote, publish, create by name, delete", async () => {
+    // Snapshot-promotion source: no docker image involved, so this runs
+    // on any sandbox-capable host. The strict warm-vs-cold split is the
+    // daemon e2e's job; here the contract is the round trip — the
+    // checkpoint's state must be what a create-by-name boots into.
+    const box = new ArcBox();
+    let snapshotId = "";
+    const source = await box.create("", { ttlMs: 300000 });
+    try {
+      await source.files.writeText("/tmp/tpl-mark", "from-snapshot\n");
+      snapshotId = (await source.checkpoint({ name: "sdk-ts-tpl-source" })).id;
+    } finally {
+      await source.kill();
+    }
+    try {
+      const draft = await Template.build("sdk-ts-e2e-tpl", {
+        snapshot: snapshotId,
+      });
+      expect(draft.version).toBe("");
+      expect(draft.digest).not.toBe("");
+
+      const published = await draft.publish("1.0");
+      expect(published.reference).toBe("sdk-ts-e2e-tpl:1.0");
+
+      const versions: string[] = [];
+      for await (const row of Template.list()) {
+        if (row.name === "sdk-ts-e2e-tpl") {
+          versions.push(row.version);
+          expect(row.warm).toBe(true);
+        }
+      }
+      expect(versions).toEqual(["1.0"]);
+
+      const sandbox = await Sandbox.create("sdk-ts-e2e-tpl", {
+        ttlMs: 300000,
+      });
+      try {
+        const marked = await sandbox.commands.run([
+          "/bin/cat",
+          "/tmp/tpl-mark",
+        ]);
+        expect(marked.expect().stdout).toBe("from-snapshot\n");
+      } finally {
+        await sandbox.kill();
+      }
+    } finally {
+      await Template.delete("sdk-ts-e2e-tpl").catch(noop);
+      if (snapshotId !== "") {
+        await box.deleteSnapshot(snapshotId).catch(noop);
+      }
     }
   }, 300000);
 });


### PR DESCRIPTION
The last verification piece of the CORE-107 campaign: both SDK e2e suites gain a template-catalog phase.

Snapshot-promotion source, so the phase needs **no docker image** and runs on any sandbox-capable host: create → write a disk marker → checkpoint → `Template.build(snapshot=…)` → publish `1.0` → list shows exactly one (warm) version → create by bare name boots into the checkpoint's state (the marker reads back) → delete the template, then the user checkpoint. The strict warm-vs-cold discriminators stay in the daemon e2e (#607); this pins the SDK-visible round trip.

Both suites' header notes drop the "Template statics outside scope" caveat.

## Testing

- `cargo test -p arcbox-e2e --test sdk_ts -- --ignored`: green on hardware (374 s), template phase included.
- `cargo test -p arcbox-e2e --test sdk_py -- --ignored`: green on hardware (95 s).
- Static gates: tsc/eslint/biome and ruff/pyright clean; unit suites unaffected (126 TS / 191 Py, e2e files skip without `ARCBOX_SDK_E2E`).