### PR TITLE
docs(agents): sync AGENTS.md with the shipped template catalog (CORE-107)

### DIFF
--- a/guest/AGENTS.md
+++ b/guest/AGENTS.md
@@ -132,6 +132,15 @@ generated file, the guest handler (4), and the host caller (5): the
 `MessageType` variant (2) and the `rpc.rs` parse/`message_type`/`encode_payload`
 arms (3) already exist — do not duplicate them.
 
+**EXCEPTION — the sandbox family (`Sandbox*`/`Template*` message types)**
+replaces steps 1, 3, and 4: its messages live in the `arcbox/sandbox/v1`
+protos, and `MessageType::is_sandbox_request()` routes the whole family to
+`handle_sandbox_message` (`agent/linux/sandbox.rs`) *before* the `rpc.rs`
+codec — do not add `rpc.rs` arms for it. A new sandbox-family message
+needs: the proto (all three build-script arrays, see `rpc/AGENTS.md`), the
+`MessageType` variant + `is_sandbox_request()` arm, a
+`handle_sandbox_message` dispatch arm, and the `AgentClient` method.
+
 Then run the `buf` breaking check, decide whether the change alters existing
 message *meaning* (if so, bump `AGENT_PROTOCOL_VERSION`), and add a test on the
 real request path — not just a leaf helper.

--- a/guest/AGENTS.md
+++ b/guest/AGENTS.md
@@ -132,14 +132,23 @@ generated file, the guest handler (4), and the host caller (5): the
 `MessageType` variant (2) and the `rpc.rs` parse/`message_type`/`encode_payload`
 arms (3) already exist — do not duplicate them.
 
-**EXCEPTION — the sandbox family (`Sandbox*`/`Template*` message types)**
-replaces steps 1, 3, and 4: its messages live in the `arcbox/sandbox/v1`
-protos, and `MessageType::is_sandbox_request()` routes the whole family to
-`handle_sandbox_message` (`agent/linux/sandbox.rs`) *before* the `rpc.rs`
-codec — do not add `rpc.rs` arms for it. A new sandbox-family message
-needs: the proto (all three build-script arrays, see `rpc/AGENTS.md`), the
-`MessageType` variant + `is_sandbox_request()` arm, a
-`handle_sandbox_message` dispatch arm, and the `AgentClient` method.
+**EXCEPTION — the sandbox family (every `MessageType` for which
+`is_sandbox_request()` is true: the `Sandbox*` types incl. the
+`SandboxTemplate*` catalog types, plus `WatchSandboxCleanupRequest`)**
+replaces steps 3 and 4: `MessageType::is_sandbox_request()` routes the
+whole family to `handle_sandbox_message` (`agent/linux/sandbox.rs`)
+*before* the `rpc.rs` codec — do not add `rpc.rs` arms for it. Step 1's
+proto file splits by audience: public sandbox API messages live in the
+`arcbox/sandbox/v1` protos (all three build-script arrays, see
+`rpc/AGENTS.md`); host↔guest-internal control frames
+(`SandboxPortForwardRequest`, `SandboxCleanupTicket`,
+`SandboxResumeCommand`, …) stay in `agent.proto` — never expose an
+internal frame through the public schema. A new sandbox-family message
+needs: the proto (in the right file per that split), the `MessageType`
+variant + `is_sandbox_request()` arm, a `handle_sandbox_message` dispatch
+arm, and the `AgentClient` method. `MachineExecRequest` bypasses the
+codec the same way (streaming multi-frame handler dispatched before
+`parse_request`, `agent/linux/rpc.rs`) — it has no `rpc.rs` arms either.
 
 Then run the `buf` breaking check, decide whether the change alters existing
 message *meaning* (if so, bump `AGENT_PROTOCOL_VERSION`), and add a test on the

--- a/guest/AGENTS.md
+++ b/guest/AGENTS.md
@@ -146,9 +146,12 @@ proto file splits by audience: public sandbox API messages live in the
 internal frame through the public schema. A new sandbox-family message
 needs: the proto (in the right file per that split), the `MessageType`
 variant + `is_sandbox_request()` arm, a `handle_sandbox_message` dispatch
-arm, and the `AgentClient` method. `MachineExecRequest` bypasses the
-codec the same way (streaming multi-frame handler dispatched before
-`parse_request`, `agent/linux/rpc.rs`) — it has no `rpc.rs` arms either.
+arm, and the `AgentClient` method. `MachineExecRequest` is the one other
+codec bypass: dispatched by name before `parse_request`
+(`agent/linux/rpc.rs`), so it has no `rpc.rs` arms either. Streaming
+alone does not waive step 3 — `WatchReadiness`/`WatchStats`/
+`WatchMemoryPressure` stream too and keep their codec arms (step 4's
+`handle_watch_readiness` pattern).
 
 Then run the `buf` breaking check, decide whether the change alters existing
 message *meaning* (if so, bump `AGENT_PROTOCOL_VERSION`), and add a test on the

--- a/rpc/AGENTS.md
+++ b/rpc/AGENTS.md
@@ -150,15 +150,25 @@ This file is only the non-obvious operational knowledge.
 4. Add a method on `AgentClient` (`app/arcbox-core/src/agent_client.rs`) that
    buffa-encodes and frames the message via `rpc_call`.
 
-**EXCEPTION — the sandbox family (`Sandbox*`/`Template*` message types)**
-skips steps 1 and 3's codec half: its messages live in the
-`arcbox/sandbox/v1` protos (not `agent.proto`), and
-`MessageType::is_sandbox_request()` routes the whole family to
-`handle_sandbox_message` (`guest/arcbox-agent/src/agent/linux/sandbox.rs`)
-*before* the `rpc.rs` codec, which therefore has no arms for it. A new
-sandbox-family message needs: the proto (all three build-script arrays),
-the `MessageType` variant + `is_sandbox_request()` arm, a
+**EXCEPTION — the sandbox family (every `MessageType` for which
+`is_sandbox_request()` is true: the `Sandbox*` types incl. the
+`SandboxTemplate*` catalog types, plus `WatchSandboxCleanupRequest`)**
+skips step 3's codec half: `MessageType::is_sandbox_request()` routes the
+whole family to `handle_sandbox_message`
+(`guest/arcbox-agent/src/agent/linux/sandbox.rs`) *before* the `rpc.rs`
+codec, which therefore has no arms for it. Step 1's proto file splits by
+audience: messages of the public sandbox API live in the
+`arcbox/sandbox/v1` protos (all three build-script arrays), while
+host↔guest-internal control frames (`SandboxPortForwardRequest`,
+`SandboxCleanupTicket`, `SandboxResumeCommand`, …) stay in `agent.proto` —
+never expose an internal frame through the public schema. A new
+sandbox-family message needs: the proto (in the right file per that
+split), the `MessageType` variant + `is_sandbox_request()` arm, a
 `handle_sandbox_message` dispatch arm, and the `AgentClient` method.
+`MachineExecRequest` is the one other codec bypass: streaming multi-frame
+handlers dispatch before `parse_request`
+(`guest/arcbox-agent/src/agent/linux/rpc.rs`), so it has no `rpc.rs` arms
+either.
 
 **Change the wire contract / add a meaning-bearing field:**
 - Bump `AGENT_PROTOCOL_VERSION` (and `MIN_AGENT_PROTOCOL_VERSION` if dropping

--- a/rpc/AGENTS.md
+++ b/rpc/AGENTS.md
@@ -17,7 +17,8 @@ This file is only the non-obvious operational knowledge.
 
 - **Daemon control plane = Connect** (`arcbox-connect` + `connectrpc`),
   served over the Unix socket. Every daemon service — Machine, Kubernetes,
-  Migration, System, Stats, Icon, the four sandbox services, plus Macos on
+  Migration, System, Stats, Icon, the five sandbox services (Sandbox,
+  Template, Process, Filesystem, Snapshot), plus Macos on
   macOS — registers on `arcbox_api::connect::router`, and
   `app/arcbox-daemon/src/control_plane.rs` serves that router directly
   through hyper's protocol-detecting builder (HTTP/1.1 **and** HTTP/2). WHY:
@@ -80,14 +81,13 @@ This file is only the non-obvious operational knowledge.
   comment; diverge and cross-backend frames silently mismatch.
 - **`AgentClient::connect()` is a no-op on the blocking path** — the HV
   transport is connected at creation (`from_fd`); only the async path dials.
-- **`arcbox-protocol/proto/buf.yaml` exempts ONLY the sandbox surface from
-  the CI `buf breaking` gate** — both `arcbox/sandbox/v1` (the package dir)
-  and the flat `sandbox.proto` it replaced, since deleting a file is itself a
-  break. The sandbox surface is pre-release and being redesigned
-  contract-first (CORE-52); every other proto in the dir stays under the
-  default `FILE` breaking rules. Remove the exemption when the
-  sandbox API ships in a public SDK. The fleet protos'
-  `fleet/arcbox-fleet-proto/buf.yaml` is a separate, unrelated gate.
+- **Every proto in the dir is additive-only under the CI `buf breaking`
+  gate — there are NO exemptions.** The historical sandbox carve-out
+  (pre-release CORE-52 redesign) was removed when the template catalog,
+  the surface's last piece, shipped in the public SDKs (CORE-107):
+  `arcbox.sandbox.v1` now breaks the gate like everything else. The fleet
+  protos' `fleet/arcbox-fleet-proto/buf.yaml` is a separate, unrelated
+  gate.
 - **Well-known types map to `pbjson-types`, not `prost-types`**
   (`extern_path(".google.protobuf", "::pbjson_types")` in BOTH
   `arcbox-protocol/build.rs` and `arcbox-grpc/build.rs` — keep them in
@@ -149,6 +149,16 @@ This file is only the non-obvious operational knowledge.
    extending checklist is authoritative for this half.
 4. Add a method on `AgentClient` (`app/arcbox-core/src/agent_client.rs`) that
    buffa-encodes and frames the message via `rpc_call`.
+
+**EXCEPTION — the sandbox family (`Sandbox*`/`Template*` message types)**
+skips steps 1 and 3's codec half: its messages live in the
+`arcbox/sandbox/v1` protos (not `agent.proto`), and
+`MessageType::is_sandbox_request()` routes the whole family to
+`handle_sandbox_message` (`guest/arcbox-agent/src/agent/linux/sandbox.rs`)
+*before* the `rpc.rs` codec, which therefore has no arms for it. A new
+sandbox-family message needs: the proto (all three build-script arrays),
+the `MessageType` variant + `is_sandbox_request()` arm, a
+`handle_sandbox_message` dispatch arm, and the `AgentClient` method.
 
 **Change the wire contract / add a meaning-bearing field:**
 - Bump `AGENT_PROTOCOL_VERSION` (and `MIN_AGENT_PROTOCOL_VERSION` if dropping

--- a/rpc/AGENTS.md
+++ b/rpc/AGENTS.md
@@ -165,10 +165,11 @@ never expose an internal frame through the public schema. A new
 sandbox-family message needs: the proto (in the right file per that
 split), the `MessageType` variant + `is_sandbox_request()` arm, a
 `handle_sandbox_message` dispatch arm, and the `AgentClient` method.
-`MachineExecRequest` is the one other codec bypass: streaming multi-frame
-handlers dispatch before `parse_request`
-(`guest/arcbox-agent/src/agent/linux/rpc.rs`), so it has no `rpc.rs` arms
-either.
+`MachineExecRequest` is the one other codec bypass: it is dispatched by
+name before `parse_request` (`guest/arcbox-agent/src/agent/linux/rpc.rs`),
+so it has no `rpc.rs` arms either. Streaming alone does not waive the
+codec — `WatchReadiness`/`WatchStats`/`WatchMemoryPressure` stream too and
+keep their `rpc.rs` arms.
 
 **Change the wire contract / add a meaning-bearing field:**
 - Bump `AGENT_PROTOCOL_VERSION` (and `MIN_AGENT_PROTOCOL_VERSION` if dropping


### PR DESCRIPTION
User-approved AGENTS.md sync closing out CORE-107's documentation debt. Three claims lagged the code:

- **Five sandbox services** on the Connect router (Template joined Sandbox/Process/Filesystem/Snapshot) — `rpc/AGENTS.md` said four.
- **The sandbox-family dispatch exception** was undocumented in both host↔guest RPC checklists: `MessageType::is_sandbox_request()` routes `Sandbox*`/`Template*` frames to `handle_sandbox_message` (`guest/arcbox-agent/src/agent/linux/rpc.rs:70`) *before* the `rpc.rs` codec, so that family must NOT get `parse_request`/`message_type`/`encode_payload` arms — the checklists (in `rpc/AGENTS.md` and `guest/AGENTS.md`) previously demanded them for every new message type. Flagged by Greptile on #592; wording now matches the shipped dispatch.
- **The buf.yaml invariant** still described the sandbox breaking-gate exemption, which #607 removed — the whole proto dir is additive-only with no exemptions.

Docs-only; no code changes.