### PR TITLE
ci(release): make release runs mean something

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,14 +323,37 @@ jobs:
         with:
           persist-credentials: false
 
-      # A real restore, not a lookup: on an exact hit the steps below all skip,
-      # and on a miss the prefix key still lands a recent `target/` so the
-      # build is incremental rather than ~300 crates from scratch on a runner
-      # that bills at 10x. That miss is the common case, not the rare one —
-      # the release PR runs `cargo update --workspace`, so every release moves
-      # Cargo.lock and with it the exact key.
-      - name: Restore the release cache
+      # Two steps, because the two cases want opposite things.
+      #
+      # Nothing moved: this must cost nothing. `lookup-only` answers "is the
+      # exact entry there?" without downloading it, and every step below skips
+      # — the usual master push stays a ~30-second no-op on a runner billed at
+      # 10x.
+      #
+      # Cargo.lock moved: a cold build is ~300 crates. The prefix restore below
+      # lands the nearest previous entry so the build is incremental instead.
+      # That case is not rare — the release PR runs `cargo update --workspace`,
+      # so every release moves the lockfile and the exact key with it, and the
+      # release build is precisely the one this exists to warm.
+      #
+      # The union of an old target/ and a new build does grow the saved entry,
+      # since cargo prunes nothing. Confining the restore to the miss path is
+      # what bounds it: a run that changed nothing neither downloads nor saves.
+      - name: Look for an exact entry
         id: probe
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          lookup-only: true
+
+      - name: Restore the nearest entry
+        id: restore
+        if: steps.probe.outputs.cache-hit != 'true'
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
@@ -356,8 +379,10 @@ jobs:
       # graph in the cache is exactly the one it needs.
       - name: Build release binaries
         if: steps.probe.outputs.cache-hit != 'true'
+        env:
+          MATCHED: ${{ steps.restore.outputs.cache-matched-key }}
         run: |
-          echo "Restored from: ${{ steps.probe.outputs.cache-matched-key }}"
+          echo "Restored from: ${MATCHED:-nothing (cold build)}"
           cargo build --release --locked -p arcbox-cli -p arcbox-daemon -p arcbox-helper
 
       # Paths and key repeated verbatim from the probe above: workflow files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,3 +292,84 @@ jobs:
 
       - name: Build
         run: uv build
+
+  # ==========================================================================
+  # Warm the release-profile cache that Release Build restores.
+  #
+  # The release job runs on a tag, and a tag can only read caches from its own
+  # ref or the default branch — never another tag's. So no matter how many
+  # releases run, none of them can warm the next one; the cache has to be
+  # written from master. Until it was, every release compiled ~300 dependency
+  # crates from scratch (the `macOS-cargo-` fallback it landed on is CI's debug
+  # cache above, which shares only the registry download with a release build).
+  # That is what timed out on v0.6.4 and published a release with no assets.
+  #
+  # Keyed on Cargo.lock alone, so this does real work only when dependencies
+  # move: the probe below turns every other master push into a ~30-second
+  # no-op. macOS runners bill at 10x, and a per-commit key would also thrash
+  # the repo's 10 GB cache budget — these entries run to several GB. The cost
+  # is that workspace members are not in the cache and still compile at
+  # release time; the release step's timeout accounts for that.
+  # ==========================================================================
+  warm-release-cache:
+    name: Warm release cache
+    if: github.event_name == 'push' && github.ref_name == 'master'
+    runs-on: macos-26
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      # A real restore, not a lookup: on an exact hit the steps below all skip,
+      # and on a miss the prefix key still lands a recent `target/` so the
+      # build is incremental rather than ~300 crates from scratch on a runner
+      # that bills at 10x. That miss is the common case, not the rare one —
+      # the release PR runs `cargo update --workspace`, so every release moves
+      # Cargo.lock and with it the exact key.
+      - name: Restore the release cache
+        id: probe
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-
+
+      - name: Setup Rust
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+        with:
+          toolchain: stable
+
+      - name: Install Protobuf compiler
+        if: steps.probe.outputs.cache-hit != 'true'
+        run: brew install protobuf
+
+      # The same three packages Release Build compiles, so the dependency
+      # graph in the cache is exactly the one it needs.
+      - name: Build release binaries
+        if: steps.probe.outputs.cache-hit != 'true'
+        run: |
+          echo "Restored from: ${{ steps.probe.outputs.cache-matched-key }}"
+          cargo build --release --locked -p arcbox-cli -p arcbox-daemon -p arcbox-helper
+
+      # Paths and key repeated verbatim from the probe above: workflow files
+      # cannot factor them out, and cache/save must agree with cache/restore
+      # exactly or the release job matches nothing.
+      - name: Save release build cache
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,10 +9,6 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -81,37 +77,7 @@ jobs:
             echo "::endgroup::"
           done
 
-  # Bump the daemon arcbox-desktop embeds when a new release is created.
-  #
-  # This job only announces the tag. Writing arcbox.version is half a bump —
-  # the generated Swift gRPC client is pinned to the same ref and desktop CI
-  # rejects a PR where the two disagree — and regenerating that client needs
-  # macOS and Xcode. So arcbox-desktop owns the bump in its own `Bump ArcBox`
-  # workflow and this dispatches it. Dispatch is fire-and-forget: a failure
-  # there surfaces in that repo's Actions tab, not in this release run.
-  update-desktop:
-    name: Update arcbox-desktop
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.BOT_APP_ID }}
-          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-          repositories: arcbox-desktop
-          # The bump workflow mints its own token for the branch and the PR;
-          # this one only has to start it.
-          permission-actions: write
-
-      - name: Dispatch the arcbox-desktop bump
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TAG: ${{ needs.release-please.outputs.tag_name }}
-        run: |
-          gh workflow run bump-arcbox.yml \
-            --repo arcboxlabs/arcbox-desktop \
-            --ref master \
-            --field version="$TAG"
+  # The arcbox-desktop bump used to be dispatched from here, on release_created.
+  # It now lives in Release Build's `update-desktop`, which waits for the
+  # binaries to be attached — a tag alone is not something desktop can build
+  # against. See that job for why.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,11 +482,22 @@ jobs:
           # this one only has to start it.
           permission-actions: write
 
+      # The tag is free-form on the workflow_dispatch path and flows straight
+      # into the bump, so recovering a superseded tag would propose moving
+      # desktop's arcbox.version *backwards*. A redundant bump is cheap; a
+      # downgrade is not. Only the newest release announces itself.
       - name: Dispatch the arcbox-desktop bump
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.version.outputs.version }}
         run: |
+          set -euo pipefail
+          latest=$(gh release view --json tagName --jq .tagName)
+          if [ "$TAG" != "$latest" ]; then
+            echo "::notice::$TAG is superseded by $latest; not bumping desktop backwards"
+            exit 0
+          fi
           gh workflow run bump-arcbox.yml \
             --repo arcboxlabs/arcbox-desktop \
             --ref master \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
   build-macos-arm64:
     name: Build macOS ARM64
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - name: Checkout
@@ -164,11 +164,22 @@ jobs:
         timeout-minutes: 5
         run: brew install protobuf
 
-      - name: Cache cargo
-        uses: actions/cache@v4
+      # Restore only. A cache saved here lands in this tag's scope, and GitHub
+      # does not let one tag read another tag's caches — every release would
+      # save a few GB that nothing can ever read. The entry this restores is
+      # written by ci.yml's `warm-release-cache` job on master, which is a
+      # scope tags *can* read.
+      #
+      # No `${{ runner.os }}-cargo-` fallback: that key belongs to CI's debug
+      # cache, and a debug `target/` shares nothing with a release build beyond
+      # the registry download. Matching it made the build look cached while it
+      # recompiled the whole dependency graph — which is how v0.6.4 hit the
+      # old 15-minute step timeout and shipped a release with no assets.
+      - name: Restore release build cache
+        id: cargo_cache
+        uses: actions/cache/restore@v4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -176,7 +187,11 @@ jobs:
           key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-release-
-            ${{ runner.os }}-cargo-
+
+      - name: Report cache state
+        run: |
+          echo "Exact release-cache hit: ${{ steps.cargo_cache.outputs.cache-hit }}"
+          echo "Restored from: ${{ steps.cargo_cache.outputs.cache-matched-key }}"
 
       - name: Import signing certificate
         env:
@@ -217,8 +232,13 @@ jobs:
           echo "$APPLE_PROVISIONING_PROFILE" | base64 --decode \
             > "$PROFILE_DIR/arcbox-daemon.provisionprofile"
 
+      # 40 minutes, not 15. The warm cache carries the dependency graph but is
+      # keyed on Cargo.lock alone, so every workspace member still compiles
+      # here — and those are not cheap (arcbox-api alone ran past six minutes
+      # on v0.6.4). A release must not fail for being slow; it is the timeout
+      # of last resort, not a budget.
       - name: Build arcbox binaries (release)
-        timeout-minutes: 15
+        timeout-minutes: 40
         run: cargo build --release --locked -p arcbox-cli -p arcbox-daemon -p arcbox-helper
 
       - name: Codesign arcbox-daemon
@@ -333,10 +353,33 @@ jobs:
     name: Package & Upload Release
     needs: [version, build-macos-arm64, build-agent]
     runs-on: ubuntu-latest
+    # contents: read is for the checkout below. The releases API is spoken to
+    # with the app token instead — see the token step.
     permissions:
-      contents: write
+      contents: read
 
     steps:
+      # release-please cuts the release as a draft (see release-please-config
+      # .json) and does it as this app. GITHUB_TOKEN cannot modify another
+      # integration's draft — arcbox-desktop learned that the hard way on
+      # v1.34.5, taking a 403 on the update after finding the draft fine. So
+      # publish as the app that owns it.
+      #
+      # Narrowed to this repository and to contents, because the job around it
+      # was just dropped to `contents: read` — which makes this the only
+      # elevated credential in scope, and an un-narrowed installation token
+      # carries every permission the app holds in every repo it is installed
+      # on. Flipping a draft to published needs contents: write here, nothing
+      # else.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          repositories: arcbox
+          permission-contents: write
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -358,10 +401,16 @@ jobs:
       - name: Create desktop tarball
         run: cargo xtask release package-tarball --version "${{ needs.version.outputs.version }}"
 
-      - name: Upload assets to GitHub Release
+      # `draft: false` is what publishes it: the action uploads the tarball into
+      # the draft first and flips it afterwards. A build that fails before this
+      # point therefore leaves a draft, not the assetless release v0.6.4 left
+      # sitting at the top of the releases page for eight hours.
+      - name: Publish GitHub Release with assets
         uses: softprops/action-gh-release@v2
         with:
+          token: ${{ steps.app-token.outputs.token }}
           tag_name: ${{ needs.version.outputs.version }}
+          draft: false
           files: |
             *.tar.gz
             *.tar.gz.sha256
@@ -393,3 +442,52 @@ jobs:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           version: ${{ needs.version.outputs.version }}
           links: https://github.com/${{ github.repository }}/releases/tag/${{ needs.version.outputs.version }}
+
+  # ==========================================================================
+  # Bump the daemon arcbox-desktop embeds, once this release is installable.
+  #
+  # This used to fire from Release Please the moment a tag was cut, which meant
+  # desktop was told about a version whose binaries did not exist yet. v0.6.4
+  # is what that costs: the macOS build timed out, desktop was bumped anyway,
+  # and its DMG build then failed on a release with no assets. Gating on
+  # package-and-release makes the announcement mean "downloadable".
+  #
+  # This job only announces the tag. Writing arcbox.version is half a bump —
+  # the generated Swift gRPC client is pinned to the same ref and desktop CI
+  # rejects a PR where the two disagree — and regenerating that client needs
+  # macOS and Xcode. So arcbox-desktop owns the bump in its own `Bump ArcBox`
+  # workflow and this dispatches it. Dispatch is fire-and-forget: a failure
+  # there surfaces in that repo's Actions tab, not in this release run.
+  # ==========================================================================
+  update-desktop:
+    name: Update arcbox-desktop
+    needs: [version, package-and-release]
+    # Deliberately not gated on the trigger. workflow_dispatch is how a release
+    # that died mid-way gets recovered — the v0.6.4 case this job exists for —
+    # and gating on `push` would re-attach the assets on that path and then
+    # leave desktop un-bumped, silently. `needs: package-and-release` already
+    # means the binaries are attached, which is the condition that matters. A
+    # redundant bump PR is cheap; a missing one is what cost us a release.
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          repositories: arcbox-desktop
+          # The bump workflow mints its own token for the branch and the PR;
+          # this one only has to start it.
+          permission-actions: write
+
+      - name: Dispatch the arcbox-desktop bump
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ needs.version.outputs.version }}
+        run: |
+          gh workflow run bump-arcbox.yml \
+            --repo arcboxlabs/arcbox-desktop \
+            --ref master \
+            --field version="$TAG"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,12 @@ without the others reintroduces a failure already paid for.
 - **`update-desktop` waits for the assets and is not gated on the trigger.**
   `workflow_dispatch` is how a half-finished release is recovered, which is the
   case that job exists for; gating on `push` would re-attach assets there and
-  leave desktop un-bumped in silence.
+  leave desktop un-bumped in silence. The guard that replaces it is a
+  *newest-release* check, not a trigger check: the dispatch `tag` is free-form
+  and flows straight into the bump, so recovering a superseded tag would
+  propose moving desktop's `arcbox.version` **backwards**. A redundant bump is
+  cheap; a downgrade is not. Do not remove that check believing the worst case
+  is a no-op.
 - **The release cache is written from master, never from a tag.** A tag cannot
   read another tag's caches, so no release can warm the next one. `ci.yml`
   writes `macOS-cargo-release-*`; `Release Build` restores only, and must not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,42 @@ When asked to plan, the plan must be fully resolved before implementation begins
 - PR merges are squash-only (merge commits are disabled on the repo). For stacked PRs, merge the base PR first — and expect GitHub to close the stacked PR when the base branch is deleted; recovery is: re-push the old base ref, reopen the PR, retarget it to master, delete the ref again, then close/reopen once more to trigger CI (pushes made while a PR is closed fire no events).
 - Review-bot findings (pullfrog/Codex/Greptile) get verified against the code first, then either fixed with a reply + thread resolution, or refuted with evidence in the reply. Never resolve a thread silently.
 
+## Releasing (the ordering is the contract)
+
+A release runs: merge the release PR → release-please creates the tag **and a
+draft GitHub release** → the tag push starts `Release Build` →
+`package-and-release` attaches the tarball and *then* publishes → the
+arcbox-desktop bump is announced. Each arrow is load-bearing; changing one
+without the others reintroduces a failure already paid for.
+
+- **The release stays a draft until its assets exist.** `release-please-config.json`
+  sets `draft` + `force-tag-creation`. v0.6.4 published the moment its tag was
+  cut, its macOS build then timed out, and the assetless release sat at the top
+  of the releases page — and told arcbox-desktop to bump to it, whose DMG build
+  failed eight hours later on a missing protoc, three layers from the cause.
+- **`force-tag-creation` is not optional alongside `draft`.** GitHub withholds
+  the git tag for a draft release, and `Release Build` triggers on tag pushes;
+  without it nothing builds at all.
+- **`draft` belongs on the root package only.** `fleet`, `sdk/typescript` and
+  `sdk/python` publish from other workflows and would sit as drafts forever.
+  Their tags carry component prefixes, so they never trigger `Release Build`.
+- **Publishing uses the app token, not `GITHUB_TOKEN`.** A draft created by one
+  integration cannot be modified by another — arcbox-desktop spent a release
+  cycle discovering that as a 403 on the update, *after* finding the draft.
+  Keep that token narrowed to this repo and to contents.
+- **`update-desktop` waits for the assets and is not gated on the trigger.**
+  `workflow_dispatch` is how a half-finished release is recovered, which is the
+  case that job exists for; gating on `push` would re-attach assets there and
+  leave desktop un-bumped in silence.
+- **The release cache is written from master, never from a tag.** A tag cannot
+  read another tag's caches, so no release can warm the next one. `ci.yml`
+  writes `macOS-cargo-release-*`; `Release Build` restores only, and must not
+  fall back to CI's `macOS-cargo-` debug cache — that fallback made the build
+  look cached while it recompiled the whole graph.
+- **A red release run is not evidence of a missing artifact, and green is not
+  evidence of a present one.** Check `gh release view <tag> --json assets`
+  before concluding anything about a release.
+
 ## Licensing
 
 - All crates: MIT OR Apache-2.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,7 +27,9 @@
         }
       ],
       "changelog-path": "CHANGELOG.md",
-      "exclude-paths": ["fleet", "sdk/typescript", "sdk/python"]
+      "exclude-paths": ["fleet", "sdk/typescript", "sdk/python"],
+      "draft": true,
+      "force-tag-creation": true
     },
     "fleet": {
       "component": "fleet-agent",


### PR DESCRIPTION
Release runs have been red on every tag since v0.6.1, for reasons unrelated to whether the release actually shipped. v0.6.4 is what that costs: the macOS build timed out, `Package & Upload Release` was skipped, and the v0.6.4 GitHub release was published with **zero assets** — which arcbox-desktop was then told to bump to. Its DMG build failed eight hours later on `failed to invoke protoc`, three layers from the cause.

Three separate causes, addressed here. The fourth — the `CARGO_REGISTRY_TOKEN` 403 on `splicetcp`, which is what made every run red and hid the rest — has already been fixed out-of-band by rotating the secret.

### 1. The release build was structurally cold

Its cache key is `macOS-cargo-release-*`, but the job only runs on tags, and [GitHub does not let one tag read another tag's caches](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching):

> Workflow runs also cannot restore caches created for different tag names.

Nothing on master ever wrote that key, so no release could warm the next one. What it *did* match was the third fallback `macOS-cargo-` — CI's **debug** cache. A debug `target/` shares nothing with a release build beyond the registry download, so every release recompiled the whole dependency graph while the log said "Cache restored". Confirmed: the repo has no `*-cargo-release-*` entry at all.

- `ci.yml` gains `warm-release-cache`, which writes that key from master — a scope tags *can* read (proven in arcbox-desktop, whose tag builds hit caches saved by `pr.yml` on master).
- It probes for its own key first, so most master pushes are a ~30-second no-op. Keyed on `Cargo.lock` alone: macOS minutes bill at 10x, and a per-commit key would thrash the 10 GB budget at several GB per entry.
- The release job switches to restore-only (saving into a tag's scope is unreadable by anything) and drops the debug fallback, so a miss reports itself as a miss.
- `~/.cargo/bin/` leaves the cached paths — caching installed binaries can shadow toolchain updates.

### 2. The release published before its assets existed

Root release is now a draft (`draft` + `force-tag-creation`, the pairing release-please's own schema documents), and `package-and-release` publishes it once the tarball is attached. A build that fails leaves a draft instead of a broken release.

`draft` is on the **root package only** — `fleet`, `sdk/typescript`, and `sdk/python` publish from elsewhere and would otherwise sit as drafts forever. Their tags carry component prefixes, so they never trigger this workflow either.

Publishing uses the app token: `GITHUB_TOKEN` cannot modify a draft owned by another integration, and release-please creates it as `arcbox-labs[bot]`. arcbox-desktop spent a release cycle discovering that — a 403 on the update, *after* finding the draft fine.

### 3. The desktop bump fired on the tag, not on the binaries

`update-desktop` moves out of `release-please.yml` into `release.yml`, gated on `package-and-release`. Announcing a version to desktop now means it is downloadable. As a bonus, a re-run of a failed release re-dispatches naturally, which the old placement could not.

### 4. Timeouts

15 → 40 minutes on the build step, 30 → 60 on the job. Margin, not a budget: the warm cache omits workspace members, and those are not cheap (`arcbox-api` alone ran past six minutes on v0.6.4).

---

**What this PR cannot verify.** `warm-release-cache` only runs on master pushes, and everything else only runs on a tag. The first real exercise is the next release. The first master push after merge will do one cold release build (~25–40 min of macOS time) to seed the cache.