### PR TITLE
fix(sandbox): PATH-resolve the TAP-delete ip binary; prove caller-less cleanup releases host resources (CORE-19/20)

### DIFF
--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -1684,18 +1684,32 @@ async fn expose_cleanup_scenario(sandboxes: &mut SandboxServiceClient<Channel>) 
         .context("Create smoke-cleanup failed")?;
     wait_for_state(sandboxes, ID, SandboxState::Ready, SANDBOX_READY_TIMEOUT).await?;
 
-    // Ephemeral host port (host_port: 0) per the e2e isolation rules.
+    // Reserve a genuinely ephemeral host port: with host_port omitted the
+    // daemon reuses the guest relay port, and every System VM allocates
+    // those from the same 40000+ pool — two concurrent isolated smoke runs
+    // would deterministically collide on the host loopback (the fixed-port
+    // isolation rule in tests/e2e/AGENTS.md). Bind-then-drop yields a port
+    // unique host-wide; the reuse race in the gap is negligible here.
+    let host_port = std::net::TcpListener::bind(("127.0.0.1", 0))
+        .and_then(|probe| probe.local_addr())
+        .context("reserving an ephemeral host port")?
+        .port();
     let exposed = sandboxes
         .expose_port(with_machine(ExposePortRequest {
             id: ID.into(),
             sandbox_port: 8080,
+            host_port: u32::from(host_port),
             ..Default::default()
         }))
         .await
         .context("ExposePort failed")?
         .into_inner();
-    let host_port = u16::try_from(exposed.host_port)
-        .with_context(|| format!("host port out of range: {}", exposed.host_port))?;
+    if exposed.host_port != u32::from(host_port) {
+        bail!(
+            "ExposePort bound {} instead of the requested {host_port}",
+            exposed.host_port
+        );
+    }
 
     // The daemon's loopback listener accepts (the guest side needs no
     // workload behind it for the TCP handshake — accept happens host-side).
@@ -1726,14 +1740,14 @@ async fn expose_cleanup_scenario(sandboxes: &mut SandboxServiceClient<Channel>) 
         .context("SetLifecycle (ttl) failed")?;
 
     // The guest reaps the sandbox first...
-    let deadline = Instant::now() + Duration::from_secs(60);
+    let reap_deadline = Instant::now() + Duration::from_secs(60);
     loop {
         match sandboxes
             .inspect(with_machine(InspectSandboxRequest { id: ID.into() }))
             .await
         {
             Err(status) if status.code() == tonic::Code::NotFound => break,
-            Ok(_) | Err(_) if Instant::now() < deadline => {
+            Ok(_) | Err(_) if Instant::now() < reap_deadline => {
                 tokio::time::sleep(Duration::from_millis(500)).await;
             }
             Ok(info) => bail!(
@@ -1745,11 +1759,13 @@ async fn expose_cleanup_scenario(sandboxes: &mut SandboxServiceClient<Channel>) 
     }
     // ...then the cleanup ticket must release the host listener. Re-binding
     // the port from this process is the strongest observable: a closed but
-    // still-bound listener fails it, and so does any leaked forwarder.
+    // still-bound listener fails it, and so does any leaked forwarder. A
+    // fresh budget — the reap wait above must not eat the cleanup window.
+    let release_deadline = Instant::now() + Duration::from_secs(60);
     loop {
         match std::net::TcpListener::bind(("127.0.0.1", host_port)) {
             Ok(_) => break,
-            Err(_) if Instant::now() < deadline => {
+            Err(_) if Instant::now() < release_deadline => {
                 tokio::time::sleep(Duration::from_millis(500)).await;
             }
             Err(error) => {

--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -24,17 +24,17 @@ use arcbox_grpc::sandbox_v1::template_service_client::TemplateServiceClient;
 use arcbox_protocol::sandbox_v1::{
     AttachExecutionRequest, BuildTemplateRequest, CheckpointRequest, CommandProbe,
     CreateSandboxRequest, DeleteSnapshotRequest, DeleteTemplateRequest, Execution, ExecutionEvent,
-    ExecutionState, FileChunk, FileKind, FsEventKind, GetCapabilitiesRequest,
+    ExecutionState, ExposePortRequest, FileChunk, FileKind, FsEventKind, GetCapabilitiesRequest,
     GetStdinStatusRequest, GetTemplateRequest, IdleAction, InspectSandboxRequest, ListDirRequest,
-    ListExecutionsRequest, ListSandboxesRequest, ListSnapshotsRequest, ListTemplatesRequest,
-    MakeDirRequest, MoveEntryRequest, PauseSandboxRequest, PublishTemplateRequest, ReadFileRequest,
-    ReadyProbe, RemoveEntryRequest, RemoveSandboxRequest, ResourceLimits, RestoreRequest,
-    ResumeSandboxRequest, SandboxEventKind, SandboxEventsRequest, SandboxState,
-    SetLifecycleRequest, Signal, SignalExecutionRequest, StartExecutionRequest, StatFileRequest,
-    StdioChannel, StopSandboxRequest, TemplateDefaults, WaitExecutionRequest, WaitForPortRequest,
-    WatchDirRequest, WatchEventsResponse, WriteFileOpen, WriteFileRequest, WriteStdinRequest,
-    build_template_request, execution_event, exit_status, ready_probe, watch_dir_response,
-    watch_events_response, write_file_request,
+    ListExecutionsRequest, ListExposedPortsRequest, ListSandboxesRequest, ListSnapshotsRequest,
+    ListTemplatesRequest, MakeDirRequest, MoveEntryRequest, PauseSandboxRequest,
+    PublishTemplateRequest, ReadFileRequest, ReadyProbe, RemoveEntryRequest, RemoveSandboxRequest,
+    ResourceLimits, RestoreRequest, ResumeSandboxRequest, SandboxEventKind, SandboxEventsRequest,
+    SandboxState, SetLifecycleRequest, Signal, SignalExecutionRequest, StartExecutionRequest,
+    StatFileRequest, StdioChannel, StopSandboxRequest, TemplateDefaults, WaitExecutionRequest,
+    WaitForPortRequest, WatchDirRequest, WatchEventsResponse, WriteFileOpen, WriteFileRequest,
+    WriteStdinRequest, build_template_request, execution_event, exit_status, ready_probe,
+    watch_dir_response, watch_events_response, write_file_request,
 };
 use tonic::transport::Channel;
 use tracing::{info, warn};
@@ -446,6 +446,14 @@ async fn drive_sandboxes(
     metrics.record(
         "sandbox_idle_lifecycle",
         lifecycle_started.elapsed().as_secs_f64(),
+    );
+
+    // -- CORE-19/20: caller-less teardown releases host resources ----------
+    let cleanup_started = Instant::now();
+    expose_cleanup_scenario(&mut sandboxes).await?;
+    metrics.record(
+        "sandbox_expose_cleanup",
+        cleanup_started.elapsed().as_secs_f64(),
     );
 
     // -- Checkpoint / Restore --------------------------------------------
@@ -1648,6 +1656,108 @@ async fn idle_lifecycle_scenario(
         }))
         .await
         .context("Remove smoke-idle failed")?;
+    Ok(())
+}
+
+/// CORE-19/20 acceptance: host resources a sandbox owns are released by the
+/// daemon's cleanup watcher when the guest reaps the sandbox with no
+/// daemon-side caller involved. TTL expiry is deliberately the trigger —
+/// it is the teardown path where nobody is around to clean up: the reap
+/// happens inside the guest, the cleanup ticket rides the always-open
+/// `WatchSandboxCleanup` stream, and the daemon must drop its expose
+/// listener on its own. DNS deregistration rides the same ticket arm
+/// (`connect/sandbox_cleanup.rs::complete`) and is covered by runtime unit
+/// tests; the host listener is the half observable from outside the daemon.
+async fn expose_cleanup_scenario(sandboxes: &mut SandboxServiceClient<Channel>) -> Result<()> {
+    const ID: &str = "smoke-cleanup";
+
+    sandboxes
+        .create(with_machine(CreateSandboxRequest {
+            id: ID.into(),
+            limits: Some(ResourceLimits {
+                vcpus: 1,
+                memory_mib: 256,
+            }),
+            ..Default::default()
+        }))
+        .await
+        .context("Create smoke-cleanup failed")?;
+    wait_for_state(sandboxes, ID, SandboxState::Ready, SANDBOX_READY_TIMEOUT).await?;
+
+    // Ephemeral host port (host_port: 0) per the e2e isolation rules.
+    let exposed = sandboxes
+        .expose_port(with_machine(ExposePortRequest {
+            id: ID.into(),
+            sandbox_port: 8080,
+            ..Default::default()
+        }))
+        .await
+        .context("ExposePort failed")?
+        .into_inner();
+    let host_port = u16::try_from(exposed.host_port)
+        .with_context(|| format!("host port out of range: {}", exposed.host_port))?;
+
+    // The daemon's loopback listener accepts (the guest side needs no
+    // workload behind it for the TCP handshake — accept happens host-side).
+    tokio::net::TcpStream::connect(("127.0.0.1", host_port))
+        .await
+        .with_context(|| format!("host listener 127.0.0.1:{host_port} not accepting"))?;
+    let listed = sandboxes
+        .list_exposed_ports(with_machine(ListExposedPortsRequest { id: ID.into() }))
+        .await
+        .context("ListExposedPorts failed")?
+        .into_inner();
+    if !listed
+        .ports
+        .iter()
+        .any(|p| p.sandbox_port == 8080 && p.host_port == u32::from(host_port))
+    {
+        bail!("exposed mapping missing from ListExposedPorts: {listed:?}");
+    }
+    info!(host_port, "expose listener live on loopback");
+
+    sandboxes
+        .set_lifecycle(with_machine(SetLifecycleRequest {
+            id: ID.into(),
+            ttl_seconds: Some(1),
+            ..Default::default()
+        }))
+        .await
+        .context("SetLifecycle (ttl) failed")?;
+
+    // The guest reaps the sandbox first...
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        match sandboxes
+            .inspect(with_machine(InspectSandboxRequest { id: ID.into() }))
+            .await
+        {
+            Err(status) if status.code() == tonic::Code::NotFound => break,
+            Ok(_) | Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            Ok(info) => bail!(
+                "sandbox never TTL-reaped (state: {:?})",
+                info.into_inner().state()
+            ),
+            Err(status) => bail!("Inspect failed while waiting for the TTL reap: {status}"),
+        }
+    }
+    // ...then the cleanup ticket must release the host listener. Re-binding
+    // the port from this process is the strongest observable: a closed but
+    // still-bound listener fails it, and so does any leaked forwarder.
+    loop {
+        match std::net::TcpListener::bind(("127.0.0.1", host_port)) {
+            Ok(_) => break,
+            Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            Err(error) => {
+                bail!("host port {host_port} never released after the TTL reap: {error}")
+            }
+        }
+    }
+    info!(host_port, "TTL reap released the host listener");
     Ok(())
 }
 

--- a/virt/arcbox-vm/src/network.rs
+++ b/virt/arcbox-vm/src/network.rs
@@ -735,10 +735,17 @@ fn destroy_tap_checked(tap_name: &str) -> Result<()> {
     // ("can't find device 'x'", exit 2) while a dev host has iproute2
     // ("Cannot find device \"x\"", exit 1), so any wording test would pass
     // CI and still fail in production.
+    //
+    // PATH lookup, not an absolute path: the System VM rootfs installs the
+    // busybox `ip` applet at /bin/ip (BUSYBOX_SYMLINKS in boot-assets
+    // rootfs.rs) while Linux hosts carry iproute2 in /sbin or /usr/sbin —
+    // no single absolute path exists in both environments, and the old
+    // hardcoded /usr/sbin/ip made every create that lost the sysfs race
+    // above fail with ENOENT inside the guest.
     let sysfs = format!("/sys/class/net/{tap_name}");
     let mut delete_error = None;
     if std::path::Path::new(&sysfs).exists() {
-        let output = std::process::Command::new("/usr/sbin/ip")
+        let output = std::process::Command::new("ip")
             .args(["link", "delete", tap_name])
             .output()
             .map_err(|error| {


### PR DESCRIPTION
## What

Two commits:

1. **`fix(sandbox)`: resolve the TAP-delete fallback's `ip` binary via PATH.**
   `destroy_tap_checked` hardcoded `/usr/sbin/ip` — a path that has never
   existed in the System VM rootfs (busybox installs the `ip` applet at
   `/bin/ip`; see `BUSYBOX_SYMLINKS` in boot-assets `rootfs.rs`). The
   fallback only runs when the kernel's async TAP removal loses the sysfs
   race in `create_tap`'s stale-TAP sweep, so every sandbox create carried
   a timing-dependent ENOENT failure — the first e2e run of this branch hit
   it on its very first `Create`:
   `network error: run ip link delete vmtap0-2: No such file or directory`.
   The path dates back to the original arcbox-vm import. PATH lookup finds
   busybox `/bin/ip` in the guest (busybox init's default PATH includes
   `/bin`) and iproute2 in `/sbin`/`/usr/sbin` on Linux hosts.

2. **`test(e2e)`: `sandbox_expose_cleanup` phase (CORE-19/20 acceptance).**
   The smoke never called `ExposePort`, so the daemon's cleanup watcher
   (`sandbox_cleanup::spawn` + the `WatchSandboxCleanup` ticket protocol)
   had no regression proving host resources are released on a teardown with
   no daemon-side caller. The new phase: expose an ephemeral host port on a
   ready sandbox → assert the loopback listener accepts and
   `ListExposedPorts` agrees → `SetLifecycle{ttl_seconds: 1}` so the guest
   TTL-reaps it on its own → poll `Inspect` to NotFound → assert the host
   listener is truly gone by **re-binding the port from the test process**
   (fails for any leaked forwarder). DNS deregistration rides the same
   ticket arm (`connect/sandbox_cleanup.rs::complete`) and stays covered by
   runtime unit tests.

## Verification

- Full sandbox e2e green on hardware (VZ, M5 Max, 179s):
  `expose listener live on loopback host_port=40000` →
  `TTL reap released the host listener host_port=40000` (~1.5s after reap).
  First run (pre-fix) failed the first Create with the ENOENT above — the
  fix is validated by the same scenario that exposed the bug.
- `cargo clippy --workspace --exclude arcbox-agent -- -D warnings`,
  `cargo clippy -p arcbox-vm --target aarch64-unknown-linux-musl`,
  `cargo fmt --all --check`, `cargo test -p arcbox-vm` (237 passed) all green.