### PR TITLE
docs(rpc): the template catalog is served, not contract-only

### DIFF
--- a/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/template.proto
+++ b/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/template.proto
@@ -23,10 +23,11 @@ import "google/protobuf/timestamp.proto";
 
 // TemplateService manages the template catalog. Control plane.
 //
-// Contract-only in CORE-58 phase 1: the daemon answers UNIMPLEMENTED
-// until the catalog lands with CORE-21. Build additionally depends on the
-// rootfs pipeline (CORE-5) and, for pre-warmed snapshots, FC 1.16
-// network overrides (CORE-16).
+// Served as of CORE-107: every RPC below is implemented, all three Build
+// sources work, and `CreateSandboxRequest.template` resolves
+// `name[:version]` against the catalog. Clients that also talk to older
+// daemons feature-detect on the `templates` flag in `SANDBOX_FEATURES`
+// rather than on this service existing.
 service TemplateService {
     // Build a template from a source and register it in the catalog.
     // Blocks until the build completes; a streaming progress variant can
@@ -141,8 +142,8 @@ message BuildTemplateRequest {
     // Labels for the template.
     map<string, string> labels = 6;
     // Also boot the built rootfs once and checkpoint it at READY, so the
-    // template carries a warm snapshot (requires CORE-16; ignored for
-    // `snapshot_id` sources, which are warm by construction).
+    // template carries a warm snapshot (ignored for `snapshot_id` sources,
+    // which are warm by construction).
     bool prewarm = 7;
 }
 

--- a/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/template.proto
+++ b/rpc/arcbox-protocol/proto/arcbox/sandbox/v1/template.proto
@@ -26,8 +26,9 @@ import "google/protobuf/timestamp.proto";
 // Served as of CORE-107: every RPC below is implemented, all three Build
 // sources work, and `CreateSandboxRequest.template` resolves
 // `name[:version]` against the catalog. Clients that also talk to older
-// daemons feature-detect on the `templates` flag in `SANDBOX_FEATURES`
-// rather than on this service existing.
+// daemons detect it with the `templates` flag in
+// `GetCapabilitiesResponse.features` rather than on this service
+// existing.
 service TemplateService {
     // Build a template from a source and register it in the catalog.
     // Blocks until the build completes; a streaming progress variant can

--- a/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
+++ b/rpc/arcbox-protocol/src/generated/arcbox.sandbox.v1.rs
@@ -1613,8 +1613,8 @@ pub struct BuildTemplateRequest {
     pub labels:
         ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     /// Also boot the built rootfs once and checkpoint it at READY, so the
-    /// template carries a warm snapshot (requires CORE-16; ignored for
-    /// `snapshot_id` sources, which are warm by construction).
+    /// template carries a warm snapshot (ignored for `snapshot_id` sources,
+    /// which are warm by construction).
     #[prost(bool, tag = "7")]
     pub prewarm: bool,
     /// What to build the rootfs from.

--- a/sdk/typescript/src/gen/arcbox/sandbox/v1/template_pb.ts
+++ b/sdk/typescript/src/gen/arcbox/sandbox/v1/template_pb.ts
@@ -297,8 +297,8 @@ export type BuildTemplateRequest = Message<"arcbox.sandbox.v1.BuildTemplateReque
 
   /**
    * Also boot the built rootfs once and checkpoint it at READY, so the
-   * template carries a warm snapshot (requires CORE-16; ignored for
-   * `snapshot_id` sources, which are warm by construction).
+   * template carries a warm snapshot (ignored for `snapshot_id` sources,
+   * which are warm by construction).
    *
    * @generated from field: bool prewarm = 7;
    */
@@ -451,10 +451,12 @@ export const DeleteTemplateRequestSchema: GenMessage<DeleteTemplateRequest> = /*
 /**
  * TemplateService manages the template catalog. Control plane.
  *
- * Contract-only in CORE-58 phase 1: the daemon answers UNIMPLEMENTED
- * until the catalog lands with CORE-21. Build additionally depends on the
- * rootfs pipeline (CORE-5) and, for pre-warmed snapshots, FC 1.16
- * network overrides (CORE-16).
+ * Served as of CORE-107: every RPC below is implemented, all three Build
+ * sources work, and `CreateSandboxRequest.template` resolves
+ * `name[:version]` against the catalog. Clients that also talk to older
+ * daemons detect it with the `templates` flag in
+ * `GetCapabilitiesResponse.features` rather than on this service
+ * existing.
  *
  * @generated from service arcbox.sandbox.v1.TemplateService
  */


### PR DESCRIPTION
`TemplateService`'s doc comment still says the catalog is contract-only and that "the daemon answers UNIMPLEMENTED until the catalog lands". CORE-107 landed it:

- `app/arcbox-api/src/connect/template.rs` forwards all five RPCs to the guest agent — no `unimplemented!`, no feature gate.
- `guest/arcbox-agent/src/sandbox/templates.rs` implements all three Build sources (`docker_ref`, `dockerfile`, `snapshot_id`).
- `CreateSandboxRequest.template` resolves `name[:version]` against the catalog.
- `SANDBOX_FEATURES` already advertises `templates` and `ready_probe`.

This is not an internal-only comment. protoc copies it into generated clients, so it shipped in the public SDKs and sits in arcbox-desktop's checked-in Swift client — `template.grpc.swift` repeats it six times — telling every reader the service does not work. It is the reason the desktop client went unwritten until now: the proto says don't bother.

The replacement points at the `templates` feature flag, which is what a client spanning daemon versions should actually test, rather than at the service's existence.

`prewarm` loses its "requires CORE-16" caveat for the same reason. The dependency is satisfied, and the e2e `smoke-prewarm` phase asserts a prewarm build records a warm snapshot and then creates two sandboxes from it concurrently — the case that needs the network override.

Comments only; `buf breaking` against master passes.