### PR TITLE
fix(net): make the Linux half of the net stack compile again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,15 +115,23 @@ jobs:
         run: ./target/debug/arcbox-helper --help
 
   # The engine layer and the net stack under it promise platform
-  # neutrality (architecture charter, company repo): this compile gate
-  # keeps darwin-only deps target-gated so a Linux host build never rots
-  # again. `--tests` is load-bearing: a plain `cargo check` skips test
-  # targets, so a macOS-only symbol reintroduced into a `#[cfg(test)]`
-  # module (as happened once already) would pass the gate while still
-  # breaking `cargo test` on Linux. Scoped to the crates that make the
-  # platform-neutrality promise — the workspace as a whole still contains
-  # macOS-only crates (arcbox-vz, arcbox-vmnet). Extend the -p list as
-  # engine/computer crates land.
+  # neutrality (architecture charter, company repo; engine/AGENTS.md: "every
+  # crate must compile and pass unit tests on Linux as well as macOS"): this
+  # compile gate keeps darwin-only deps target-gated so a Linux host build
+  # never rots again. `--all-targets` is load-bearing: a plain `cargo check`
+  # skips test/example/bench targets, so a macOS-only symbol reintroduced
+  # into a `#[cfg(test)]` module (as happened once already) would pass the
+  # gate while still breaking `cargo test` on Linux. A second step repeats
+  # the check on aarch64-unknown-linux-musl (the real cross-compile target,
+  # see root CLAUDE.md "Guest Agent Cross-Compilation") because gnu/musl and
+  # x86_64/aarch64 each pick different concrete types for a few libc
+  # primitives (e.g. `c_char`'s signedness is arch-, not libc-, driven) that
+  # the gnu-only first step can't exercise; scoped to arcbox-net + splicetcp
+  # only — arcbox-image's TLS deps pull in `ring`, whose build script needs a
+  # musl C cross-compiler this runner doesn't have. Scoped to the crates that
+  # make the platform-neutrality promise — the workspace as a whole still
+  # contains macOS-only crates (arcbox-vz, arcbox-vmnet). Extend the -p list
+  # as engine/computer crates land.
   linux-engine:
     name: Linux engine-layer check
     runs-on: ubuntu-latest
@@ -139,6 +147,7 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
         with:
           toolchain: stable
+          targets: aarch64-unknown-linux-musl
 
       - name: Cache cargo
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -154,7 +163,10 @@ jobs:
             ${{ runner.os }}-cargo-linux-engine-
 
       - name: Check engine-layer crates on Linux
-        run: cargo check --tests -p arcbox-image -p arcbox-net -p splicetcp
+        run: cargo check --all-targets -p arcbox-image -p arcbox-net -p splicetcp
+
+      - name: Check net stack on aarch64-unknown-linux-musl
+        run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-net -p splicetcp
 
   # Pure proto-contract analysis — no Rust toolchain, no build. Runs in
   # parallel with `ci` on a cheap Linux runner. The desktop and agent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,13 @@ jobs:
   # The engine layer and the net stack under it promise platform
   # neutrality (architecture charter, company repo): this compile gate
   # keeps darwin-only deps target-gated so a Linux host build never rots
-  # again. Scoped to the crates that make that promise — the workspace as
-  # a whole still contains macOS-only crates (arcbox-vz, arcbox-vmnet).
-  # Extend the -p list as engine/computer crates land.
+  # again. `--tests` is load-bearing: a plain `cargo check` skips test
+  # targets, so a macOS-only symbol reintroduced into a `#[cfg(test)]`
+  # module (as happened once already) would pass the gate while still
+  # breaking `cargo test` on Linux. Scoped to the crates that make the
+  # platform-neutrality promise — the workspace as a whole still contains
+  # macOS-only crates (arcbox-vz, arcbox-vmnet). Extend the -p list as
+  # engine/computer crates land.
   linux-engine:
     name: Linux engine-layer check
     runs-on: ubuntu-latest
@@ -150,7 +154,7 @@ jobs:
             ${{ runner.os }}-cargo-linux-engine-
 
       - name: Check engine-layer crates on Linux
-        run: cargo check -p arcbox-image -p arcbox-net -p splicetcp
+        run: cargo check --tests -p arcbox-image -p arcbox-net -p splicetcp
 
   # Pure proto-contract analysis — no Rust toolchain, no build. Runs in
   # parallel with `ci` on a cheap Linux runner. The desktop and agent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,44 @@ jobs:
       - name: Smoke test arcbox helper
         run: ./target/debug/arcbox-helper --help
 
+  # The engine layer and the net stack under it promise platform
+  # neutrality (architecture charter, company repo): this compile gate
+  # keeps darwin-only deps target-gated so a Linux host build never rots
+  # again. Scoped to the crates that make that promise — the workspace as
+  # a whole still contains macOS-only crates (arcbox-vz, arcbox-vmnet).
+  # Extend the -p list as engine/computer crates land.
+  linux-engine:
+    name: Linux engine-layer check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-linux-engine-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-linux-engine-
+
+      - name: Check engine-layer crates on Linux
+        run: cargo check -p arcbox-image -p arcbox-net -p splicetcp
+
   # Pure proto-contract analysis — no Rust toolchain, no build. Runs in
   # parallel with `ci` on a cheap Linux runner. The desktop and agent
   # ship/self-update independently, so the control-plane wire contract must

--- a/common/splicetcp/Cargo.toml
+++ b/common/splicetcp/Cargo.toml
@@ -14,7 +14,6 @@ arcbox-datapath = { workspace = true }
 arcbox-fakeip = { workspace = true }
 arcbox-packet = { workspace = true }
 arcbox-proxy = { workspace = true }
-arcbox-xnu-net.workspace = true
 crossbeam-channel = "0.5"
 libc = { workspace = true }
 socket2 = "0.6"
@@ -30,3 +29,6 @@ tokio-frame-sink = []
 
 [lints]
 workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+arcbox-xnu-net.workspace = true

--- a/common/splicetcp/src/classifier.rs
+++ b/common/splicetcp/src/classifier.rs
@@ -455,10 +455,17 @@ fn learn_guest_mac(mac: [u8; 6], guest_mac: &mut Option<[u8; 6]>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Only `fd_source_drain_reads_and_classifies` below needs raw-fd
+    // plumbing and `FdFrameSource`, which is macOS-only; gate that import
+    // and its helpers with it rather than the whole test module, since
+    // every other test here exercises platform-neutral classifier logic.
+    #[cfg(target_os = "macos")]
     use std::os::fd::{FromRawFd, RawFd};
 
+    #[cfg(target_os = "macos")]
     use crate::frame_source::{FdFrameSource, FrameSource};
 
+    #[cfg(target_os = "macos")]
     fn socketpair() -> (std::os::fd::OwnedFd, std::os::fd::OwnedFd) {
         use std::os::fd::OwnedFd;
         let mut fds: [i32; 2] = [0; 2];
@@ -469,6 +476,7 @@ mod tests {
         unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
     }
 
+    #[cfg(target_os = "macos")]
     fn set_nonblocking(fd: RawFd) {
         // SAFETY: fcntl on a valid fd.
         unsafe {
@@ -478,6 +486,7 @@ mod tests {
     }
 
     /// Writes raw bytes to an FD.
+    #[cfg(target_os = "macos")]
     fn fd_write_raw(fd: RawFd, data: &[u8]) {
         // SAFETY: writing from valid buffer to valid fd.
         unsafe { libc::write(fd, data.as_ptr().cast(), data.len()) };
@@ -815,6 +824,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "macos")]
     fn fd_source_drain_reads_and_classifies() {
         use std::os::fd::AsRawFd;
         let (host_fd, guest_fd) = socketpair();

--- a/common/splicetcp/src/frame_source.rs
+++ b/common/splicetcp/src/frame_source.rs
@@ -6,9 +6,11 @@
 //! Both the VM datapath (over a socketpair) and the host tunnel (over a
 //! `utun`, via the [`shim`](crate::shim)) supply a [`FrameSource`].
 
+#[cfg(target_os = "macos")]
 use std::io;
 use std::os::fd::RawFd;
 
+#[cfg(target_os = "macos")]
 use arcbox_xnu_net::BatchDgram;
 
 /// Largest L2 frame we read from a source in a single `read`.
@@ -16,12 +18,14 @@ use arcbox_xnu_net::BatchDgram;
 /// Also the batch-receive slot size: a datagram that overruns its slot is
 /// truncated silently (see [`BatchDgram::recv_batch_chunked`]), so this must
 /// stay at or above the largest datagram the peer can hand us.
+#[cfg(target_os = "macos")]
 const MAX_FRAME_SIZE: usize = 65535;
 
 /// Frames one `recvmsg_x` collects. The backing buffer is
 /// `RX_BATCH * MAX_FRAME_SIZE` of zeroed — hence lazily faulted — address
 /// space, so the resident cost tracks the frames that actually arrive, not
 /// the reservation.
+#[cfg(target_os = "macos")]
 const RX_BATCH: usize = 32;
 
 /// A source of inbound L2 Ethernet frames.
@@ -50,6 +54,7 @@ pub trait FrameSource {
 /// (A `utun` is L3 and has its own source,
 /// [`UtunFrameSource`](crate::utun::UtunFrameSource), wrapped for the
 /// classifier by the [`shim`](crate::shim).)
+#[cfg(target_os = "macos")]
 pub struct FdFrameSource {
     fd: RawFd,
     /// [`RX_BATCH`] back-to-back [`MAX_FRAME_SIZE`] slots.
@@ -58,6 +63,7 @@ pub struct FdFrameSource {
     batch: BatchDgram,
 }
 
+#[cfg(target_os = "macos")]
 impl FdFrameSource {
     /// Wraps a (non-blocking) raw fd. The fd is not owned — its lifetime is
     /// managed by the caller (typically an `AsyncFd<OwnedFd>` registered for
@@ -72,6 +78,7 @@ impl FdFrameSource {
     }
 }
 
+#[cfg(target_os = "macos")]
 impl FrameSource for FdFrameSource {
     fn as_raw_fd(&self) -> RawFd {
         self.fd

--- a/common/splicetcp/src/frame_source.rs
+++ b/common/splicetcp/src/frame_source.rs
@@ -123,7 +123,9 @@ impl FrameSource for FdFrameSource {
     }
 }
 
-#[cfg(test)]
+// Every test here drives `FdFrameSource` directly (the batched XNU recv
+// path), so the whole module is macOS-only along with the type it tests.
+#[cfg(all(test, target_os = "macos"))]
 mod tests {
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 

--- a/common/splicetcp/src/lib.rs
+++ b/common/splicetcp/src/lib.rs
@@ -34,7 +34,9 @@ pub mod tcp_bridge;
 pub mod utun;
 
 pub use egress::{DefaultEgress, EgressConn, EgressResolver, FlowKey, FlowMeta, FlowObserver};
-pub use frame_source::{FdFrameSource, FrameSource};
+#[cfg(target_os = "macos")]
+pub use frame_source::FdFrameSource;
+pub use frame_source::FrameSource;
 
 // `tcp_bridge` and `classifier` reference `crate::ethernet::*` pervasively;
 // re-export `arcbox-packet`'s ethernet module here so those paths resolve

--- a/virt/arcbox-net/Cargo.toml
+++ b/virt/arcbox-net/Cargo.toml
@@ -36,8 +36,8 @@ splicetcp.workspace = true
 hickory-proto = { version = "0.26.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-arcbox-vmnet = { workspace = true }
 arcbox-xnu-net.workspace = true
+arcbox-vmnet = { workspace = true }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/virt/arcbox-net/src/linux/firewall.rs
+++ b/virt/arcbox-net/src/linux/firewall.rs
@@ -602,17 +602,14 @@ impl LinuxFirewall {
             &rule.out_interface,
         ];
 
+        let snat_target = rule.snat_addr.map(|addr| format!("--to-source {addr}"));
         match rule.nat_type {
             NatType::Masquerade => {
                 args.extend(&["-j", "MASQUERADE"]);
             }
             NatType::Snat => {
-                let target = format!(
-                    "--to-source {}",
-                    rule.snat_addr.expect("SNAT requires snat_addr")
-                );
                 args.extend(&["-j", "SNAT"]);
-                args.push(&target);
+                args.push(snat_target.as_deref().expect("SNAT requires snat_addr"));
             }
         }
 

--- a/virt/arcbox-net/src/linux/netlink.rs
+++ b/virt/arcbox-net/src/linux/netlink.rs
@@ -203,8 +203,8 @@ impl NetlinkHandle {
         }
 
         // Bind to the netlink socket. Zero-init instead of a struct literal:
-        // musl models the padding field as a distinct type, so field-by-field
-        // construction is not portable across libcs.
+        // libc models `nl_pad` as `Padding<c_ushort>` (not an integer), so a
+        // field-by-field literal does not compile on any Linux target.
         // SAFETY: sockaddr_nl is a plain-old-data C struct; all-zeroes is a
         // valid bit pattern for it.
         let mut addr: libc::sockaddr_nl = unsafe { std::mem::zeroed() };
@@ -806,7 +806,8 @@ impl NetlinkHandle {
     ///
     /// Returns an error if the interface is not found.
     pub fn get_ifname(&self, ifindex: u32) -> Result<String> {
-        // c_char is i8 on glibc but u8 on musl; stay libc-agnostic.
+        // c_char signedness is arch-dependent (u8 on aarch64, i8 on x86_64);
+        // annotate the buffer so it types on both.
         let mut buf = [0 as libc::c_char; libc::IF_NAMESIZE];
         let ret = unsafe { libc::if_indextoname(ifindex, buf.as_mut_ptr()) };
         if ret.is_null() {
@@ -821,7 +822,7 @@ impl NetlinkHandle {
             .unwrap_or(libc::IF_NAMESIZE);
         #[allow(
             clippy::unnecessary_cast,
-            reason = "c_char is already u8 on musl but i8 on glibc; the cast keeps both building"
+            reason = "c_char is u8 on aarch64 and i8 on x86_64; the cast keeps both building"
         )]
         let name_bytes: Vec<u8> = buf[..len].iter().map(|&c| c as u8).collect();
         String::from_utf8(name_bytes).map_err(|e| NetError::Netlink(e.to_string()))

--- a/virt/arcbox-net/src/linux/netlink.rs
+++ b/virt/arcbox-net/src/linux/netlink.rs
@@ -202,13 +202,15 @@ impl NetlinkHandle {
             )));
         }
 
-        // Bind to the netlink socket
-        let addr = libc::sockaddr_nl {
-            nl_family: libc::AF_NETLINK as u16,
-            nl_pad: 0,
-            nl_pid: 0, // Let kernel assign
-            nl_groups: 0,
-        };
+        // Bind to the netlink socket. Zero-init instead of a struct literal:
+        // musl models the padding field as a distinct type, so field-by-field
+        // construction is not portable across libcs.
+        // SAFETY: sockaddr_nl is a plain-old-data C struct; all-zeroes is a
+        // valid bit pattern for it.
+        let mut addr: libc::sockaddr_nl = unsafe { std::mem::zeroed() };
+        addr.nl_family = libc::AF_NETLINK as libc::sa_family_t;
+        addr.nl_pid = 0; // Let kernel assign
+        addr.nl_groups = 0;
 
         let ret = unsafe {
             libc::bind(
@@ -804,7 +806,8 @@ impl NetlinkHandle {
     ///
     /// Returns an error if the interface is not found.
     pub fn get_ifname(&self, ifindex: u32) -> Result<String> {
-        let mut buf = [0i8; libc::IF_NAMESIZE];
+        // c_char is i8 on glibc but u8 on musl; stay libc-agnostic.
+        let mut buf = [0 as libc::c_char; libc::IF_NAMESIZE];
         let ret = unsafe { libc::if_indextoname(ifindex, buf.as_mut_ptr()) };
         if ret.is_null() {
             return Err(NetError::Netlink(format!(
@@ -816,6 +819,10 @@ impl NetlinkHandle {
             .iter()
             .position(|&c| c == 0)
             .unwrap_or(libc::IF_NAMESIZE);
+        #[allow(
+            clippy::unnecessary_cast,
+            reason = "c_char is already u8 on musl but i8 on glibc; the cast keeps both building"
+        )]
         let name_bytes: Vec<u8> = buf[..len].iter().map(|&c| c as u8).collect();
         String::from_utf8(name_bytes).map_err(|e| NetError::Netlink(e.to_string()))
     }

--- a/virt/arcbox-net/src/linux/tap.rs
+++ b/virt/arcbox-net/src/linux/tap.rs
@@ -112,10 +112,13 @@ pub struct LinuxTap {
     vnet_hdr: bool,
 }
 
-// ioctl constants
-const TUNSETIFF: libc::c_ulong = 0x400454ca;
-const TUNSETOFFLOAD: libc::c_ulong = 0x400454d0;
-const TUNSETVNETHDRSZ: libc::c_ulong = 0x400454d8;
+// ioctl constants. `libc::Ioctl` is the request type `libc::ioctl` actually
+// takes (`c_ulong` on glibc, `c_int` on musl) — declaring the constants at
+// that type means the call sites need no cast, so a future constant can't
+// silently truncate the way an `as _` on a wider type could.
+const TUNSETIFF: libc::Ioctl = 0x400454ca;
+const TUNSETOFFLOAD: libc::Ioctl = 0x400454d0;
+const TUNSETVNETHDRSZ: libc::Ioctl = 0x400454d8;
 
 // TUN/TAP flags
 const IFF_TAP: libc::c_short = 0x0002;
@@ -179,7 +182,7 @@ impl LinuxTap {
         }
 
         // Create TAP device
-        let ret = unsafe { libc::ioctl(fd, TUNSETIFF as _, &ifr) };
+        let ret = unsafe { libc::ioctl(fd, TUNSETIFF, &ifr) };
         if ret < 0 {
             unsafe { libc::close(fd) };
             return Err(NetError::Tap(format!(
@@ -204,7 +207,7 @@ impl LinuxTap {
         // Set vnet header size if enabled
         if config.vnet_hdr {
             let hdr_sz: i32 = 12; // sizeof(virtio_net_hdr_v1)
-            let ret = unsafe { libc::ioctl(fd.as_raw_fd(), TUNSETVNETHDRSZ as _, &hdr_sz) };
+            let ret = unsafe { libc::ioctl(fd.as_raw_fd(), TUNSETVNETHDRSZ, &hdr_sz) };
             if ret < 0 {
                 return Err(NetError::Tap(format!(
                     "TUNSETVNETHDRSZ failed: {}",
@@ -214,7 +217,7 @@ impl LinuxTap {
 
             // Enable offload features
             let offload = TUN_F_CSUM | TUN_F_TSO4 | TUN_F_TSO6;
-            let ret = unsafe { libc::ioctl(fd.as_raw_fd(), TUNSETOFFLOAD as _, offload) };
+            let ret = unsafe { libc::ioctl(fd.as_raw_fd(), TUNSETOFFLOAD, offload) };
             if ret < 0 {
                 tracing::warn!(
                     "TUNSETOFFLOAD failed (non-fatal): {}",
@@ -292,13 +295,8 @@ impl LinuxTap {
         Ok(())
     }
 
-    /// Returns the TAP device MAC address.
-    #[must_use]
-    pub fn mac(&self) -> [u8; 6] {
-        self.mac
-    }
-
     /// Returns the TAP device name.
+    #[must_use]
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/virt/arcbox-net/src/linux/tap.rs
+++ b/virt/arcbox-net/src/linux/tap.rs
@@ -179,7 +179,7 @@ impl LinuxTap {
         }
 
         // Create TAP device
-        let ret = unsafe { libc::ioctl(fd, TUNSETIFF, &ifr) };
+        let ret = unsafe { libc::ioctl(fd, TUNSETIFF as _, &ifr) };
         if ret < 0 {
             unsafe { libc::close(fd) };
             return Err(NetError::Tap(format!(
@@ -204,7 +204,7 @@ impl LinuxTap {
         // Set vnet header size if enabled
         if config.vnet_hdr {
             let hdr_sz: i32 = 12; // sizeof(virtio_net_hdr_v1)
-            let ret = unsafe { libc::ioctl(fd.as_raw_fd(), TUNSETVNETHDRSZ, &hdr_sz) };
+            let ret = unsafe { libc::ioctl(fd.as_raw_fd(), TUNSETVNETHDRSZ as _, &hdr_sz) };
             if ret < 0 {
                 return Err(NetError::Tap(format!(
                     "TUNSETVNETHDRSZ failed: {}",
@@ -214,7 +214,7 @@ impl LinuxTap {
 
             // Enable offload features
             let offload = TUN_F_CSUM | TUN_F_TSO4 | TUN_F_TSO6;
-            let ret = unsafe { libc::ioctl(fd.as_raw_fd(), TUNSETOFFLOAD, offload) };
+            let ret = unsafe { libc::ioctl(fd.as_raw_fd(), TUNSETOFFLOAD as _, offload) };
             if ret < 0 {
                 tracing::warn!(
                     "TUNSETOFFLOAD failed (non-fatal): {}",
@@ -292,8 +292,13 @@ impl LinuxTap {
         Ok(())
     }
 
-    /// Returns the TAP device name.
+    /// Returns the TAP device MAC address.
     #[must_use]
+    pub fn mac(&self) -> [u8; 6] {
+        self.mac
+    }
+
+    /// Returns the TAP device name.
     pub fn name(&self) -> &str {
         &self.name
     }
@@ -379,7 +384,7 @@ impl LinuxTap {
             if err.kind() == io::ErrorKind::WouldBlock {
                 return Ok(0);
             }
-            return Err(NetError::Io(err));
+            return Err(NetError::Common(err.into()));
         }
 
         Ok(ret as usize)
@@ -400,7 +405,7 @@ impl LinuxTap {
             if err.kind() == io::ErrorKind::WouldBlock {
                 return Ok(0);
             }
-            return Err(NetError::Io(err));
+            return Err(NetError::Common(err.into()));
         }
 
         Ok(ret as usize)
@@ -431,7 +436,7 @@ impl NetworkBackend for LinuxTap {
             if err.kind() == io::ErrorKind::WouldBlock {
                 return Ok(0);
             }
-            return Err(NetError::Io(err));
+            return Err(NetError::Common(err.into()));
         }
 
         Ok(ret as usize)
@@ -445,7 +450,7 @@ impl NetworkBackend for LinuxTap {
             if err.kind() == io::ErrorKind::WouldBlock {
                 return Ok(0);
             }
-            return Err(NetError::Io(err));
+            return Err(NetError::Common(err.into()));
         }
 
         Ok(ret as usize)

--- a/virt/arcbox-net/src/nat.rs
+++ b/virt/arcbox-net/src/nat.rs
@@ -207,6 +207,7 @@ mod linux_impl {
     use std::collections::HashMap;
 
     use super::*;
+    use crate::backend::NetworkBackend;
     use crate::error::NetError;
     use crate::linux::{
         BridgeConfig, LinuxBridge, LinuxFirewall, LinuxTap, NatRule as FirewallNatRule, TapConfig,

--- a/virt/arcbox-net/src/nat.rs
+++ b/virt/arcbox-net/src/nat.rs
@@ -204,7 +204,10 @@ pub struct NatEndpoint {
 // Linux-specific NAT network implementation
 #[cfg(target_os = "linux")]
 mod linux_impl {
+    use std::collections::HashMap;
+
     use super::*;
+    use crate::error::NetError;
     use crate::linux::{
         BridgeConfig, LinuxBridge, LinuxFirewall, LinuxTap, NatRule as FirewallNatRule, TapConfig,
     };


### PR DESCRIPTION
Support work for restructure P3 (charter: company repo, `engineering/arcbox/architecture-charter.md`): the engine layer promises platform neutrality, and this PR makes that checkable.

- `arcbox-xnu-net` (macOS-only XNU batch syscalls) becomes a `[target.'cfg(target_os = "macos")']` dependency of `arcbox-net` and `splicetcp`; `FdFrameSource` is cfg-gated while the `FrameSource` trait stays portable (`shim.rs` needs it cross-platform).
- The never-compiled Linux module of `arcbox-net` had bit-rotted; fixed: missing `HashMap`/`NetError` imports in `nat.rs::linux_impl`, references to the removed `NetError::Io` variant, glibc↔musl libc drift (`sockaddr_nl` padding type → zeroed init, `c_char` signedness, ioctl request width → `as _`), a borrow outliving its match arm in `firewall.rs`, and a missing `LinuxTap::mac()` accessor.
- New scoped ubuntu CI job `linux-engine` runs `cargo check -p arcbox-image -p arcbox-net -p splicetcp` — extend the list as engine/computer crates land (#621 adds `arcbox-engine`).

Validated: `cargo check -p arcbox-net -p arcbox-image --target aarch64-unknown-linux-musl` green locally; macOS side fmt/clippy/tests green (arcbox-net 85+5+2, splicetcp 24+91 tests). Remaining dead-code warnings in the Linux module are pre-existing unused items now visible for the first time; left for the P3 Linux clippy tightening.