### PR TITLE
refactor(computer): open the computer layer — sandbox protocols behind the SandboxHost seam (restructure phase 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ The project is in **alpha**. Breaking changes (internal or user-facing) are acce
 - `virt/` — Virtualization.framework bindings, cross-platform hypervisor traits, VMM, VirtIO devices, VirtioFS, networking (NAT/DHCP/DNS)
 - `rpc/` — protobuf definitions, gRPC services, vsock/unix transport
 - `runtime/` — container state, OCI image/runtime
-- `engine/` — embeddable, daemon-free engine library (boot assets, machine images; growing per the architecture charter in the company repo)
+- `engine/` — embeddable, daemon-free engine library (boot assets, machine images, VM/machine lifecycle, agent client; growing per the architecture charter in the company repo)
+- `computer/` — agent-computer domain layer: transport-free sandbox protocols behind the `SandboxHost` seam
 - `app/` — core orchestration, API server, Docker Engine API compat, thin CLI (`abctl`, not `arcbox`), daemon binary (`arcbox-daemon`), facade crate
 - `guest/` — in-VM agent (cross-compiled for Linux)
 - `tests/` — test resources and fixture build scripts
@@ -57,6 +58,7 @@ govern, and are imported here:
 @virt/arcbox-vz/AGENTS.md
 @virt/arcbox-virtio-blk/AGENTS.md
 @engine/AGENTS.md
+@computer/AGENTS.md
 @app/AGENTS.md
 @guest/AGENTS.md
 @rpc/AGENTS.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,6 @@ version = "0.6.5"
 dependencies = [
  "anyhow",
  "arcbox-api",
- "arcbox-computer",
  "arcbox-connect",
  "arcbox-constants",
  "arcbox-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ dependencies = [
 name = "arcbox-api"
 version = "0.6.5"
 dependencies = [
+ "arcbox-computer",
  "arcbox-connect",
  "arcbox-constants",
  "arcbox-core",
@@ -344,6 +345,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcbox-computer"
+version = "0.6.5"
+dependencies = [
+ "arcbox-connect",
+ "arcbox-engine",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "arcbox-connect"
 version = "0.6.5"
 dependencies = [
@@ -388,6 +399,7 @@ dependencies = [
 name = "arcbox-core"
 version = "0.6.5"
 dependencies = [
+ "arcbox-computer",
  "arcbox-connect",
  "arcbox-constants",
  "arcbox-dns",
@@ -436,6 +448,7 @@ version = "0.6.5"
 dependencies = [
  "anyhow",
  "arcbox-api",
+ "arcbox-computer",
  "arcbox-connect",
  "arcbox-constants",
  "arcbox-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,12 @@ members = [
     "engine/arcbox-engine",
 
     # ============================================
-    # L7: Application (MIT OR Apache-2.0)
+    # L7: Computer (MIT OR Apache-2.0)
+    # ============================================
+    "computer/arcbox-computer",
+
+    # ============================================
+    # L8: Application (MIT OR Apache-2.0)
     # ============================================
     "app/arcbox-core",
     "app/arcbox-api",
@@ -275,6 +280,7 @@ arcbox-docker = { version = "0.6.5", path = "app/arcbox-docker" } # x-release-pl
 arcbox-helper = { version = "1.0.2", path = "app/arcbox-helper" }
 arcbox-image = { version = "0.6.5", path = "engine/arcbox-image" } # x-release-please-version
 arcbox-engine = { version = "0.6.5", path = "engine/arcbox-engine" } # x-release-please-version
+arcbox-computer = { version = "0.6.5", path = "computer/arcbox-computer" } # x-release-please-version
 arcbox-core = { version = "0.6.5", path = "app/arcbox-core" } # x-release-please-version
 arcbox-api = { version = "0.6.5", path = "app/arcbox-api" } # x-release-please-version
 arcbox-migration = { version = "0.6.5", path = "app/arcbox-migration" } # x-release-please-version

--- a/app/arcbox-api/Cargo.toml
+++ b/app/arcbox-api/Cargo.toml
@@ -30,6 +30,7 @@ buffa-types = { version = "0.9.1", features = ["json"] }
 arcbox-transport.workspace = true
 arcbox-image.workspace = true
 arcbox-engine.workspace = true
+arcbox-computer.workspace = true
 
 [dev-dependencies]
 base64 = "0.22.1"

--- a/app/arcbox-api/src/connect/control.rs
+++ b/app/arcbox-api/src/connect/control.rs
@@ -18,10 +18,10 @@ use super::SharedRuntime;
 use crate::ApiError;
 
 use super::exposed_port;
-use super::sandbox_cleanup;
-use super::sandbox_locks::SandboxOperationLocks;
 use super::sandbox_resume;
 use super::{ConnectRuntimeExt as _, ContextExt as _, protocol_key, wire_protocol, with_keepalive};
+use arcbox_computer::cleanup as sandbox_cleanup;
+use arcbox_computer::locks::SandboxOperationLocks;
 
 /// Sandbox lifecycle service implementation.
 ///

--- a/app/arcbox-api/src/connect/control.rs
+++ b/app/arcbox-api/src/connect/control.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use arcbox_connect::sandbox_v1 as pb;
 use arcbox_connect::sandbox_v1::{KeepAlive, WatchEventsResponse, watch_events_response};
-use arcbox_connect::v1::{SandboxPortForwardRemoveRequest, SandboxPortForwardRequest};
 use buffa_types::google::protobuf::Empty;
 use connectrpc::{
     ConnectError, RequestContext, Response, ServiceRequest, ServiceResult, ServiceStream,
@@ -12,16 +11,15 @@ use connectrpc::{
 use tokio_stream::StreamExt as _;
 use tokio_stream::wrappers::ReceiverStream;
 
-use arcbox_core::SandboxPortExposure;
-
 use super::SharedRuntime;
 use crate::ApiError;
 
 use super::exposed_port;
 use super::sandbox_resume;
-use super::{ConnectRuntimeExt as _, ContextExt as _, protocol_key, wire_protocol, with_keepalive};
+use super::{ConnectRuntimeExt as _, ContextExt as _, port_protocol, with_keepalive};
 use arcbox_computer::cleanup as sandbox_cleanup;
 use arcbox_computer::locks::SandboxOperationLocks;
+use arcbox_computer::ports;
 
 /// Sandbox lifecycle service implementation.
 ///
@@ -78,16 +76,10 @@ impl pb::SandboxService for SandboxServiceImpl {
                 tracing::warn!(machine = %machine, sandbox_id = %sandbox_id, %error, "sandbox create failed");
             })
             .map_err(ApiError::from)?;
-        let _host_state = runtime.lock_sandbox_host_state().await;
-
-        // Register sandbox DNS so the host can resolve sandbox-id.arcbox.local.
-        // Replays retain the original result even after Stop, so always
-        // confirm that the exact sandbox and IP are still live.
-        if let Ok(ip) = resp.ip_address.parse()
-            && sandbox_cleanup::live_sandbox_matches(runtime, &machine, &resp.id, ip).await
-        {
-            runtime.register_sandbox_dns(&resp.id, ip).await;
-        }
+        // Register sandbox DNS so the host can resolve sandbox-id.arcbox.local
+        // (shared live-match discipline; see register_live_sandbox_dns).
+        sandbox_cleanup::register_live_sandbox_dns(runtime, &machine, &resp.id, &resp.ip_address)
+            .await;
 
         Response::ok(resp)
     }
@@ -300,76 +292,28 @@ impl pb::SandboxService for SandboxServiceImpl {
             .ok_or_else(|| ConnectError::invalid_argument("sandbox_port must be 1-65535"))?;
         let host_port = u16::try_from(req.host_port)
             .map_err(|_| ConnectError::invalid_argument("host_port must be 0-65535"))?;
-        let requested = req.protocol.as_known().unwrap_or_default();
-        let protocol = protocol_key(requested).to_owned();
-        let wire = wire_protocol(requested);
+        let protocol = port_protocol(req.protocol.as_known().unwrap_or_default());
         let runtime = self.runtime.ready()?;
-        let host_generation = runtime.sandbox_host_state_generation().await;
 
-        // Guest half: allocate the reserved relay port and install the DNAT.
-        let mut agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
-        let forwarded = agent
-            .sandbox_port_forward(SandboxPortForwardRequest {
-                id: req.id.clone(),
-                sandbox_port: u32::from(sandbox_port),
-                protocol: wire.into(),
-                ..Default::default()
-            })
-            .await
-            .map_err(ApiError::from)?;
-        let guest_port = u16::try_from(forwarded.guest_port)
-            .map_err(|_| ConnectError::internal("agent returned an invalid guest port"))?;
-        let rollback_request = || SandboxPortForwardRemoveRequest {
-            id: req.id.clone(),
-            sandbox_port: u32::from(sandbox_port),
-            protocol: wire.into(),
-            ..Default::default()
-        };
-        let host_state = runtime.lock_sandbox_host_state().await;
-        if *host_state != host_generation {
-            let primary = ConnectError::unavailable(
-                "sandbox host cleanup raced port exposure; retry to confirm the result",
-            );
-            if let Err(rollback) = agent.sandbox_port_forward_remove(rollback_request()).await {
-                tracing::warn!(
-                    sandbox_id = %req.id,
-                    error = %rollback,
-                    "failed to roll back guest DNAT after host cleanup race"
-                );
-            }
-            return Err(primary);
-        }
-
-        // Host half: bind the listener; default the host port to the relay
-        // port for a stable, collision-free mapping.
-        let host_port = if host_port == 0 {
-            guest_port
-        } else {
-            host_port
-        };
-        let exposure = SandboxPortExposure {
-            sandbox_id: req.id.clone(),
+        let exposed = ports::expose(
+            runtime,
+            &machine,
+            &req.id,
             sandbox_port,
-            protocol: protocol.clone(),
             host_port,
-            guest_port,
-        };
-        if let Err(e) = runtime.expose_sandbox_port(&machine, &exposure).await {
-            // Roll back the guest DNAT so a failed bind leaves no half rule.
-            let primary = ConnectError::from(ApiError::from(e));
-            if let Err(rollback) = agent.sandbox_port_forward_remove(rollback_request()).await {
-                tracing::warn!(
-                    sandbox_id = %req.id,
-                    error = %rollback,
-                    "failed to roll back guest DNAT after host bind failure"
-                );
-            }
-            return Err(primary);
-        }
+            protocol,
+        )
+        .await
+        .map_err(|error| match error {
+            ports::ExposePortError::Raced => ConnectError::unavailable(
+                "sandbox host cleanup raced port exposure; retry to confirm the result",
+            ),
+            ports::ExposePortError::Engine(e) => ConnectError::from(ApiError::from(e)),
+        })?;
 
         let resp = pb::ExposePortResponse {
-            host_port: u32::from(host_port),
-            guest_port: u32::from(guest_port),
+            host_port: u32::from(exposed.host_port),
+            guest_port: u32::from(exposed.guest_port),
             ..Default::default()
         };
         Response::ok(resp)
@@ -384,42 +328,25 @@ impl pb::SandboxService for SandboxServiceImpl {
         let req = request.to_owned_message();
         let _operation = self.operations.lock(&machine, &req.id).await;
         let runtime = self.runtime.ready()?;
-        let mut agent = runtime.get_agent(&machine).map_err(|error| {
-            ConnectError::unavailable(format!("sandbox state unavailable: {error}"))
-        })?;
-        // A retry turns a concurrent TTL/idle deletion into the existing 404
-        // boundary without holding host state across the guest RPC.
-        for _ in 0..2 {
-            let host_generation = runtime.sandbox_host_state_generation().await;
-            agent
-                .sandbox_inspect(pb::InspectSandboxRequest {
-                    id: req.id.clone(),
-                    ..Default::default()
-                })
+        let mappings =
+            ports::list(runtime, &machine, &req.id)
                 .await
                 .map_err(|error| match error {
-                    error @ arcbox_engine::EngineError::Agent { code: 404, .. } => {
-                        ConnectError::from(ApiError::from(error))
+                    ports::ListExposedPortsError::Sandbox(e) => {
+                        ConnectError::from(ApiError::from(e))
                     }
-                    error => {
-                        ConnectError::unavailable(format!("sandbox state unavailable: {error}"))
+                    ports::ListExposedPortsError::Unavailable(e) => {
+                        ConnectError::unavailable(format!("sandbox state unavailable: {e}"))
                     }
+                    ports::ListExposedPortsError::Unstable => ConnectError::unavailable(
+                        "sandbox cleanup prevented a stable exposed-port snapshot; retry",
+                    ),
                 })?;
-
-            if let Some(mappings) = runtime
-                .sandbox_port_mappings_if_unchanged(&req.id, host_generation)
-                .await
-            {
-                let ports = mappings.into_iter().map(exposed_port).collect();
-                return Response::ok(pb::ListExposedPortsResponse {
-                    ports,
-                    ..Default::default()
-                });
-            }
-        }
-        Err(ConnectError::unavailable(
-            "sandbox cleanup prevented a stable exposed-port snapshot; retry",
-        ))
+        let listed = mappings.into_iter().map(exposed_port).collect();
+        Response::ok(pb::ListExposedPortsResponse {
+            ports: listed,
+            ..Default::default()
+        })
     }
 
     async fn unexpose_port(
@@ -434,26 +361,9 @@ impl pb::SandboxService for SandboxServiceImpl {
             .ok()
             .filter(|p| *p != 0)
             .ok_or_else(|| ConnectError::invalid_argument("sandbox_port must be 1-65535"))?;
-        let requested = req.protocol.as_known().unwrap_or_default();
-        let protocol = protocol_key(requested);
-        let wire = wire_protocol(requested);
-
+        let protocol = port_protocol(req.protocol.as_known().unwrap_or_default());
         let runtime = self.runtime.ready()?;
-        // Close the host listener before freeing the guest relay port. If the
-        // guest delete fails, the safe half is already closed and a retry can
-        // finish it without a cross-sandbox forwarding window.
-        runtime
-            .unexpose_sandbox_port(&req.id, sandbox_port, protocol)
-            .await;
-
-        let mut agent = runtime.get_agent(&machine).map_err(ApiError::from)?;
-        agent
-            .sandbox_port_forward_remove(SandboxPortForwardRemoveRequest {
-                id: req.id.clone(),
-                sandbox_port: u32::from(sandbox_port),
-                protocol: wire.into(),
-                ..Default::default()
-            })
+        ports::unexpose(runtime, &machine, &req.id, sandbox_port, protocol)
             .await
             .map_err(ApiError::from)?;
 

--- a/app/arcbox-api/src/connect/filesystem.rs
+++ b/app/arcbox-api/src/connect/filesystem.rs
@@ -17,9 +17,9 @@ use arcbox_core::WriteFileChunk;
 use super::SharedRuntime;
 use crate::ApiError;
 
-use super::sandbox_locks::SandboxOperationLocks;
 use super::sandbox_resume;
 use super::{ConnectRuntimeExt as _, ContextExt as _, with_keepalive};
+use arcbox_computer::locks::SandboxOperationLocks;
 
 /// Filesystem service implementation.
 ///

--- a/app/arcbox-api/src/connect/filesystem.rs
+++ b/app/arcbox-api/src/connect/filesystem.rs
@@ -19,6 +19,7 @@ use crate::ApiError;
 
 use super::sandbox_resume;
 use super::{ConnectRuntimeExt as _, ContextExt as _, with_keepalive};
+use arcbox_computer::SandboxHost as _;
 use arcbox_computer::locks::SandboxOperationLocks;
 
 /// Filesystem service implementation.
@@ -184,7 +185,7 @@ impl pb::SandboxFilesystemService for SandboxFilesystemServiceImpl {
             || {
                 let req = req.clone();
                 async {
-                    let mut agent = sandbox_resume::engine_agent(runtime, &machine)?;
+                    let mut agent = runtime.agent(&machine)?;
                     agent.sandbox_stat(req).await
                 }
             },
@@ -210,7 +211,7 @@ impl pb::SandboxFilesystemService for SandboxFilesystemServiceImpl {
             || {
                 let req = req.clone();
                 async {
-                    let mut agent = sandbox_resume::engine_agent(runtime, &machine)?;
+                    let mut agent = runtime.agent(&machine)?;
                     agent.sandbox_list_dir(req).await
                 }
             },
@@ -236,7 +237,7 @@ impl pb::SandboxFilesystemService for SandboxFilesystemServiceImpl {
             || {
                 let req = req.clone();
                 async {
-                    let mut agent = sandbox_resume::engine_agent(runtime, &machine)?;
+                    let mut agent = runtime.agent(&machine)?;
                     agent.sandbox_make_dir(req).await
                 }
             },
@@ -262,7 +263,7 @@ impl pb::SandboxFilesystemService for SandboxFilesystemServiceImpl {
             || {
                 let req = req.clone();
                 async {
-                    let mut agent = sandbox_resume::engine_agent(runtime, &machine)?;
+                    let mut agent = runtime.agent(&machine)?;
                     agent.sandbox_remove_entry(req).await
                 }
             },
@@ -288,7 +289,7 @@ impl pb::SandboxFilesystemService for SandboxFilesystemServiceImpl {
             || {
                 let req = req.clone();
                 async {
-                    let mut agent = sandbox_resume::engine_agent(runtime, &machine)?;
+                    let mut agent = runtime.agent(&machine)?;
                     agent.sandbox_move_entry(req).await
                 }
             },

--- a/app/arcbox-api/src/connect/mod.rs
+++ b/app/arcbox-api/src/connect/mod.rs
@@ -31,9 +31,7 @@ mod machine;
 mod macos;
 mod migration;
 mod process;
-mod sandbox_cleanup;
 mod sandbox_errors;
-mod sandbox_locks;
 mod sandbox_resume;
 mod snapshot;
 mod stats;
@@ -50,6 +48,9 @@ use arcbox_core::vm_lifecycle::DEFAULT_MACHINE_NAME;
 use connectrpc::{ConnectError, RequestContext};
 use tokio_stream::{Stream, StreamExt as _};
 
+pub use arcbox_computer::cleanup::{
+    initialize as initialize_sandbox_cleanup, spawn as spawn_sandbox_cleanup,
+};
 pub use control::SandboxServiceImpl;
 pub use filesystem::SandboxFilesystemServiceImpl;
 pub use icon::IconServiceImpl;
@@ -59,9 +60,6 @@ pub use machine::MachineServiceImpl;
 pub use macos::MacosServiceImpl;
 pub use migration::MigrationServiceImpl;
 pub use process::SandboxProcessServiceImpl;
-pub use sandbox_cleanup::{
-    initialize as initialize_sandbox_cleanup, spawn as spawn_sandbox_cleanup,
-};
 pub use snapshot::SandboxSnapshotServiceImpl;
 pub use stats::StatsServiceImpl;
 pub use system::{SetupState, SystemServiceImpl};
@@ -229,7 +227,7 @@ fn exposed_port(
 #[must_use]
 pub fn router(runtime: SharedRuntime) -> connectrpc::Router {
     let clone = || Arc::clone(&runtime);
-    let sandbox_operations = Arc::new(sandbox_locks::SandboxOperationLocks::default());
+    let sandbox_operations = Arc::new(arcbox_computer::locks::SandboxOperationLocks::default());
     let router = connectrpc::Router::new()
         .add_service(Arc::new(SandboxServiceImpl::new(
             clone(),

--- a/app/arcbox-api/src/connect/mod.rs
+++ b/app/arcbox-api/src/connect/mod.rs
@@ -176,27 +176,14 @@ impl ContextExt for RequestContext {
     }
 }
 
-/// Map the public port protocol onto the host-side exposure key
-/// (`UNSPECIFIED` defaults to TCP).
-fn protocol_key(protocol: arcbox_connect::sandbox_v1::PortProtocol) -> &'static str {
-    use arcbox_connect::sandbox_v1::PortProtocol;
-    match protocol {
-        PortProtocol::Udp => "udp",
-        _ => "tcp",
-    }
-}
-
-/// Map the public port protocol onto the host↔guest wire enum.
-///
-/// The vsock payloads carry their own protocol enum so the published
-/// contract is never imported by the internal wire (CORE-57).
-fn wire_protocol(
+/// Map the public port protocol onto the computer layer's enum.
+fn port_protocol(
     protocol: arcbox_connect::sandbox_v1::PortProtocol,
-) -> arcbox_connect::v1::SandboxPortProtocol {
-    use arcbox_connect::sandbox_v1::PortProtocol;
+) -> arcbox_computer::ports::SandboxPortProtocol {
+    use arcbox_computer::ports::SandboxPortProtocol;
     match protocol {
-        PortProtocol::Udp => arcbox_connect::v1::SandboxPortProtocol::Udp,
-        _ => arcbox_connect::v1::SandboxPortProtocol::Tcp,
+        arcbox_connect::sandbox_v1::PortProtocol::Udp => SandboxPortProtocol::Udp,
+        _ => SandboxPortProtocol::Tcp,
     }
 }
 

--- a/app/arcbox-api/src/connect/process.rs
+++ b/app/arcbox-api/src/connect/process.rs
@@ -17,6 +17,7 @@ use crate::ApiError;
 
 use super::sandbox_resume;
 use super::{ConnectRuntimeExt as _, ContextExt as _, with_keepalive};
+use arcbox_computer::SandboxHost as _;
 use arcbox_computer::locks::SandboxOperationLocks;
 
 /// Wait budget applied when `WaitForPortRequest.timeout_seconds` is 0, as
@@ -92,7 +93,7 @@ impl pb::SandboxProcessService for SandboxProcessServiceImpl {
             || {
                 let req = req.clone();
                 async {
-                    let mut agent = sandbox_resume::engine_agent(runtime, &machine)?;
+                    let mut agent = runtime.agent(&machine)?;
                     agent.sandbox_exec_start(req).await
                 }
             },
@@ -142,7 +143,7 @@ impl pb::SandboxProcessService for SandboxProcessServiceImpl {
             || {
                 let req = req.clone();
                 async {
-                    let mut agent = sandbox_resume::engine_agent(runtime, &machine)?;
+                    let mut agent = runtime.agent(&machine)?;
                     agent.sandbox_stdin_write(req).await
                 }
             },
@@ -174,7 +175,7 @@ impl pb::SandboxProcessService for SandboxProcessServiceImpl {
                 || {
                     let req = req.clone();
                     async {
-                        let mut agent = sandbox_resume::engine_agent(runtime, &machine)?;
+                        let mut agent = runtime.agent(&machine)?;
                         agent.sandbox_stdin_write(req).await
                     }
                 },
@@ -300,7 +301,7 @@ impl pb::SandboxProcessService for SandboxProcessServiceImpl {
             || {
                 let req = req.clone();
                 async {
-                    let mut agent = sandbox_resume::engine_agent(runtime, &machine)?;
+                    let mut agent = runtime.agent(&machine)?;
                     agent.sandbox_wait_for_port(req).await
                 }
             },

--- a/app/arcbox-api/src/connect/process.rs
+++ b/app/arcbox-api/src/connect/process.rs
@@ -15,9 +15,9 @@ use tokio_stream::wrappers::ReceiverStream;
 use super::SharedRuntime;
 use crate::ApiError;
 
-use super::sandbox_locks::SandboxOperationLocks;
 use super::sandbox_resume;
 use super::{ConnectRuntimeExt as _, ContextExt as _, with_keepalive};
+use arcbox_computer::locks::SandboxOperationLocks;
 
 /// Wait budget applied when `WaitForPortRequest.timeout_seconds` is 0, as
 /// documented on the proto field ("0 = daemon default of 30 s").

--- a/app/arcbox-api/src/connect/sandbox_resume.rs
+++ b/app/arcbox-api/src/connect/sandbox_resume.rs
@@ -19,9 +19,9 @@ use arcbox_core::Runtime;
 use arcbox_engine::EngineError;
 use connectrpc::{ConnectError, RequestContext};
 
-use super::sandbox_cleanup;
-use super::sandbox_locks::SandboxOperationLocks;
 use crate::ApiError;
+use arcbox_computer::cleanup as sandbox_cleanup;
+use arcbox_computer::locks::SandboxOperationLocks;
 
 /// Reserved request header opting out of transparent resume.
 pub(super) const NO_AUTO_RESUME_HEADER: &str = "x-arcbox-no-auto-resume";

--- a/app/arcbox-api/src/connect/sandbox_resume.rs
+++ b/app/arcbox-api/src/connect/sandbox_resume.rs
@@ -1,67 +1,23 @@
-//! Daemon-side transparent resume for paused sandboxes (CORE-21).
+//! Connect adapter for transparent sandbox resume (CORE-21).
 //!
-//! Data-plane RPCs (executions, files) targeting a PAUSED sandbox resume it
-//! before proceeding, so clients see a latency blip instead of an error.
-//! The guest signals "paused" with the dedicated wire code 423
-//! (`SandboxError::SandboxPaused`); callers opt out with the reserved
-//! `x-arcbox-no-auto-resume` request header and receive the honest
-//! `FAILED_PRECONDITION` carrying the `SANDBOX_PAUSED` `ErrorInfo` detail.
-//! `Inspect`/`List` never resume.
-//!
-//! Concurrent auto-resumes share one resume by construction: the per-sandbox
-//! operation lock serializes them and the guest's Resume is idempotent, so
-//! every follower no-ops against the already-resumed sandbox.
+//! The resume protocol itself (retry budget, DNS re-registration, paused
+//! detection) lives in `arcbox_computer::resume`; this module owns the
+//! wire-side halves: the `x-arcbox-no-auto-resume` opt-out header and the
+//! `EngineError` → `ConnectError` mapping.
 
 use std::sync::Arc;
 
-use arcbox_connect::v1::SandboxResumeCommand;
 use arcbox_core::Runtime;
 use arcbox_engine::EngineError;
 use connectrpc::{ConnectError, RequestContext};
 
 use crate::ApiError;
-use arcbox_computer::cleanup as sandbox_cleanup;
 use arcbox_computer::locks::SandboxOperationLocks;
+
+pub(super) use arcbox_computer::resume::{REASON_AUTO_RESUME, REASON_RESUME, is_sandbox_paused};
 
 /// Reserved request header opting out of transparent resume.
 pub(super) const NO_AUTO_RESUME_HEADER: &str = "x-arcbox-no-auto-resume";
-
-/// Wire code the guest agent answers for a paused sandbox
-/// (`SandboxError::SandboxPaused`; see `guest/arcbox-agent/src/error.rs`).
-pub(super) const SANDBOX_PAUSED_WIRE_CODE: i32 = 423;
-
-/// Resume reasons, surfaced verbatim as the RESUMED event's "reason"
-/// attribute. The value vocabulary is defined on `SandboxResumeCommand`
-/// (`agent.proto`).
-pub(super) const REASON_RESUME: &str = "resume";
-pub(super) const REASON_AUTO_RESUME: &str = "auto_resume";
-
-/// Connects to a machine's agent in the engine error vocabulary the
-/// sandbox call paths speak.
-///
-/// `MachineManager::connect_agent` already returns `EngineError` natively
-/// — there is nothing to convert here. (`Runtime::get_agent` is the
-/// app-layer wrapper that maps the same call through `CoreError` for
-/// callers that want the full app-error vocabulary instead; going
-/// through it and back would be a lossy round trip, since `CoreError`
-/// carries variants `EngineError` has no counterpart for.)
-pub(super) fn engine_agent(
-    runtime: &Runtime,
-    machine: &str,
-) -> Result<arcbox_core::AgentClient, EngineError> {
-    runtime.machine_manager().connect_agent(machine)
-}
-
-/// True when this agent error means "the sandbox is paused".
-pub(super) fn is_sandbox_paused(error: &EngineError) -> bool {
-    matches!(
-        error,
-        EngineError::Agent {
-            code: SANDBOX_PAUSED_WIRE_CODE,
-            ..
-        }
-    )
-}
 
 /// True when the caller opted out of transparent resume.
 ///
@@ -74,12 +30,8 @@ pub(super) fn auto_resume_opted_out(ctx: &RequestContext) -> bool {
         .is_some_and(|value| !matches!(value, "" | "0" | "false"))
 }
 
-/// Resume `sandbox_id` on `machine` and re-register its host DNS entry.
-///
-/// Shared by the explicit `SandboxService.Resume` handler and the
-/// data-plane auto-resume; only `reason` differs. Mirrors Create's DNS
-/// discipline: the fresh IP is registered only after confirming it still
-/// names the live sandbox under the host-state lock.
+/// Resume `sandbox_id` on `machine`, mapping the protocol error onto the
+/// wire. See [`arcbox_computer::resume::resume`].
 pub(super) async fn resume(
     runtime: &Arc<Runtime>,
     operations: &SandboxOperationLocks,
@@ -87,60 +39,9 @@ pub(super) async fn resume(
     sandbox_id: &str,
     reason: &str,
 ) -> Result<(), ConnectError> {
-    let _operation = operations.lock(machine, sandbox_id).await;
-    let mut agent = runtime
-        .get_agent(machine)
-        .map_err(|e| ConnectError::from(ApiError::from(e)))?;
-    // A resume can race the host finalization of the pause's network
-    // quarantine (guest-initiated pauses — the idle detector — publish
-    // their cleanup ticket through the async watch stream). The guest
-    // answers 503 for that transient, so retry within a bounded budget
-    // while the daemon's cleanup watcher completes the ticket; resume is
-    // idempotent, and the guest lock is released between attempts.
-    let resumed = {
-        const RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(8);
-        const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(250);
-        let deadline = tokio::time::Instant::now() + RETRY_BUDGET;
-        loop {
-            let attempt = agent
-                .sandbox_resume(SandboxResumeCommand {
-                    id: sandbox_id.to_owned(),
-                    reason: reason.to_owned(),
-                    ..Default::default()
-                })
-                .await;
-            match attempt {
-                Ok(resumed) => break resumed,
-                Err(EngineError::Agent { code: 503, message })
-                    if tokio::time::Instant::now() < deadline =>
-                {
-                    tracing::debug!(
-                        sandbox_id,
-                        message,
-                        "sandbox resume hit a retryable condition; retrying"
-                    );
-                    tokio::time::sleep(RETRY_DELAY).await;
-                }
-                Err(error) => {
-                    // Same reason as create/stop/remove/pause: a failed
-                    // lifecycle mutation must reach the daemon log on its own
-                    // (CORE-82). It matters more here — an auto-resume has no
-                    // caller expecting a Resume RPC, so the failure would
-                    // otherwise surface only as the data-plane error.
-                    tracing::warn!(machine, sandbox_id, reason, %error, "sandbox resume failed");
-                    return Err(ConnectError::from(ApiError::from(error)));
-                }
-            }
-        }
-    };
-
-    let _host_state = runtime.lock_sandbox_host_state().await;
-    if let Ok(ip) = resumed.ip_address.parse()
-        && sandbox_cleanup::live_sandbox_matches(runtime, machine, sandbox_id, ip).await
-    {
-        runtime.register_sandbox_dns(sandbox_id, ip).await;
-    }
-    Ok(())
+    arcbox_computer::resume::resume(runtime, operations, machine, sandbox_id, reason)
+        .await
+        .map_err(|e| ConnectError::from(ApiError::from(e)))
 }
 
 /// Run a data-plane call, transparently resuming a paused sandbox once.
@@ -174,13 +75,8 @@ where
     }
 }
 
-/// Pre-flight for client-streaming writes.
-///
-/// `WriteFile` consumes its input stream before the guest's verdict comes
-/// back, so a paused sandbox cannot be handled by retrying the call — the
-/// bytes are gone. Instead the sandbox's state is checked up front and a
-/// paused one is resumed (or refused, honoring the opt-out header) before
-/// any chunk is bridged.
+/// Pre-flight for client-streaming writes; honors the opt-out header.
+/// See [`arcbox_computer::resume::ensure_resumed_for_write`].
 pub(super) async fn ensure_resumed_for_write(
     runtime: &Arc<Runtime>,
     operations: &SandboxOperationLocks,
@@ -188,33 +84,15 @@ pub(super) async fn ensure_resumed_for_write(
     machine: &str,
     sandbox_id: &str,
 ) -> Result<(), ConnectError> {
-    use arcbox_connect::sandbox_v1::{InspectSandboxRequest, SandboxState};
-
-    let mut agent = runtime
-        .get_agent(machine)
-        .map_err(|e| ConnectError::from(ApiError::from(e)))?;
-    let info = agent
-        .sandbox_inspect(InspectSandboxRequest {
-            id: sandbox_id.to_owned(),
-            ..Default::default()
-        })
-        .await
-        .map_err(|e| ConnectError::from(ApiError::from(e)))?;
-    // Pausing counts too: the guest serializes on its per-sandbox operation
-    // lock, so the resume below simply waits for the pause to finish.
-    if matches!(
-        info.state.as_known(),
-        Some(SandboxState::Paused | SandboxState::Pausing)
-    ) {
-        if auto_resume_opted_out(ctx) {
-            return Err(ConnectError::from(ApiError::from(EngineError::Agent {
-                code: SANDBOX_PAUSED_WIRE_CODE,
-                message: format!("sandbox '{sandbox_id}' is paused"),
-            })));
-        }
-        resume(runtime, operations, machine, sandbox_id, REASON_AUTO_RESUME).await?;
-    }
-    Ok(())
+    arcbox_computer::resume::ensure_resumed_for_write(
+        runtime,
+        operations,
+        machine,
+        sandbox_id,
+        !auto_resume_opted_out(ctx),
+    )
+    .await
+    .map_err(|e| ConnectError::from(ApiError::from(e)))
 }
 
 #[cfg(test)]
@@ -227,23 +105,6 @@ mod tests {
             headers.insert(NO_AUTO_RESUME_HEADER, value.parse().unwrap());
         }
         RequestContext::new(headers)
-    }
-
-    #[test]
-    fn only_the_paused_wire_code_triggers_auto_resume() {
-        assert!(is_sandbox_paused(&EngineError::Agent {
-            code: 423,
-            message: "sandbox 'box' is paused".into(),
-        }));
-        for code in [400, 404, 409, 412, 416, 500, 503] {
-            assert!(!is_sandbox_paused(&EngineError::Agent {
-                code,
-                message: "other".into(),
-            }));
-        }
-        assert!(!is_sandbox_paused(&EngineError::Machine(
-            "dead vsock".into()
-        )));
     }
 
     #[test]

--- a/app/arcbox-api/src/connect/snapshot.rs
+++ b/app/arcbox-api/src/connect/snapshot.rs
@@ -9,9 +9,9 @@ use std::sync::Arc;
 use super::SharedRuntime;
 use crate::ApiError;
 
-use super::sandbox_cleanup;
-use super::sandbox_locks::SandboxOperationLocks;
 use super::{ConnectRuntimeExt as _, ContextExt as _};
+use arcbox_computer::cleanup as sandbox_cleanup;
+use arcbox_computer::locks::SandboxOperationLocks;
 
 /// Sandbox snapshot service implementation.
 pub struct SandboxSnapshotServiceImpl {

--- a/app/arcbox-api/src/connect/snapshot.rs
+++ b/app/arcbox-api/src/connect/snapshot.rs
@@ -81,16 +81,10 @@ impl pb::SandboxSnapshotService for SandboxSnapshotServiceImpl {
                 tracing::warn!(machine = %machine, sandbox_id = %sandbox_id, %error, "sandbox restore failed");
             })
             .map_err(ApiError::from)?;
-        let _host_state = runtime.lock_sandbox_host_state().await;
-
-        // Register restored sandbox DNS.
-        // Replays retain the original result even after Stop, so always
-        // confirm that the exact sandbox and IP are still live.
-        if let Ok(ip) = resp.ip_address.parse()
-            && sandbox_cleanup::live_sandbox_matches(runtime, &machine, &resp.id, ip).await
-        {
-            runtime.register_sandbox_dns(&resp.id, ip).await;
-        }
+        // Register restored sandbox DNS (shared live-match discipline;
+        // see register_live_sandbox_dns).
+        sandbox_cleanup::register_live_sandbox_dns(runtime, &machine, &resp.id, &resp.ip_address)
+            .await;
 
         Response::ok(resp)
     }

--- a/app/arcbox-core/Cargo.toml
+++ b/app/arcbox-core/Cargo.toml
@@ -45,6 +45,7 @@ arcbox-connect.workspace = true
 buffa = "0.9.1"
 arcbox-image.workspace = true
 arcbox-engine.workspace = true
+arcbox-computer.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 arcbox-route.workspace = true

--- a/app/arcbox-core/src/error.rs
+++ b/app/arcbox-core/src/error.rs
@@ -152,6 +152,7 @@ impl From<arcbox_engine::EngineError> for CoreError {
             E::Machine(msg) => Self::Machine(msg),
             E::Agent { code, message } => Self::Agent { code, message },
             E::Transport { context, source } => Self::Transport { context, source },
+            E::Net(e) => Self::Net(e),
             E::Image(img) => Self::from(img),
             E::Persistence(e) => Self::Persistence(e),
             E::LockPoisoned => Self::LockPoisoned,

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -150,42 +150,10 @@ pub struct Runtime {
     >,
 }
 
-/// Parameters of one sandbox port exposure (the host listener half).
-///
-/// The guest half — DNAT from `guest_port` to the sandbox — is installed by
-/// the guest agent before this is applied.
-pub struct SandboxPortExposure {
-    /// Sandbox that owns the mapping.
-    pub sandbox_id: String,
-    /// Port the workload listens on inside the sandbox.
-    pub sandbox_port: u16,
-    /// `"tcp"` or `"udp"`.
-    pub protocol: String,
-    /// Host port to bind (loopback-reachable).
-    pub host_port: u16,
-    /// Reserved-range guest relay port the agent allocated.
-    pub guest_port: u16,
-}
-
-/// One sandbox mapping currently backed by a host listener.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SandboxPortMapping {
-    /// Port the workload listens on inside the sandbox.
-    pub sandbox_port: u16,
-    /// Loopback host port where the service is reachable.
-    pub host_port: u16,
-    /// Transport protocol.
-    pub protocol: SandboxPortProtocol,
-}
-
-/// Transport protocol of an exposed sandbox port.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum SandboxPortProtocol {
-    /// TCP.
-    Tcp,
-    /// UDP.
-    Udp,
-}
+// The port value types moved to the computer layer with the exposure
+// protocols; re-exported so `arcbox_core::SandboxPortExposure` paths keep
+// resolving during the migration.
+pub use arcbox_computer::ports::{SandboxPortExposure, SandboxPortMapping, SandboxPortProtocol};
 
 impl Runtime {
     /// Creates a new runtime with the given configuration.

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -3,6 +3,7 @@
 mod assets;
 mod kubeconfig;
 mod progress;
+mod sandbox_host;
 
 #[cfg(test)]
 mod tests;

--- a/app/arcbox-core/src/runtime/sandbox_host.rs
+++ b/app/arcbox-core/src/runtime/sandbox_host.rs
@@ -27,6 +27,10 @@ impl SandboxHost for Runtime {
         self.deregister_sandbox_dns(sandbox_id).await;
     }
 
+    async fn register_dns(&self, sandbox_id: &str, ip: std::net::IpAddr) {
+        self.register_sandbox_dns(sandbox_id, ip).await;
+    }
+
     fn agent(&self, machine: &str) -> arcbox_engine::Result<AgentClient> {
         self.machine_manager().connect_agent(machine)
     }

--- a/app/arcbox-core/src/runtime/sandbox_host.rs
+++ b/app/arcbox-core/src/runtime/sandbox_host.rs
@@ -44,9 +44,14 @@ impl SandboxHost for Runtime {
         self.expose_sandbox_port(machine, exposure)
             .await
             .map_err(|e| match e {
-                // Listener binding fails with I/O-flavored (Common) or
-                // net-stack errors; anything else cannot originate from
-                // this path and is carried as text.
+                // Common/Net cover the non-macOS fallback (PortForwarder's
+                // direct TCP/UDP connect can fail with either). On P0
+                // macOS, `start_port_forwarding_macos` only ever
+                // constructs `CoreError::Machine` — Common/Net are
+                // unreachable there, and `other` is the sole arm that
+                // fires. Kept as a match on the full error type, not a
+                // cfg'd one, so a future macOS error path lands here
+                // losslessly without a second edit site.
                 CoreError::Common(c) => arcbox_engine::EngineError::Common(c),
                 CoreError::Net(n) => arcbox_engine::EngineError::Net(n),
                 other => arcbox_engine::EngineError::Machine(other.to_string()),

--- a/app/arcbox-core/src/runtime/sandbox_host.rs
+++ b/app/arcbox-core/src/runtime/sandbox_host.rs
@@ -1,0 +1,33 @@
+//! `Runtime`'s implementation of the computer layer's [`SandboxHost`]
+//! seam: the sandbox protocols sequence host state through this trait,
+//! and the daemon-side ownership of listeners, DNS, and the generation
+//! fence stays here.
+
+use arcbox_computer::SandboxHost;
+use arcbox_engine::agent_client::AgentClient;
+
+use super::Runtime;
+
+impl SandboxHost for Runtime {
+    type StateGuard<'a> = tokio::sync::MutexGuard<'a, u64>;
+
+    async fn lock_host_state(&self) -> Self::StateGuard<'_> {
+        self.lock_sandbox_host_state().await
+    }
+
+    async fn clear_host_state(&self) {
+        self.clear_sandbox_host_state().await;
+    }
+
+    async fn remove_ports(&self, sandbox_id: &str) {
+        self.remove_sandbox_ports(sandbox_id).await;
+    }
+
+    async fn deregister_dns(&self, sandbox_id: &str) {
+        self.deregister_sandbox_dns(sandbox_id).await;
+    }
+
+    fn agent(&self, machine: &str) -> arcbox_engine::Result<AgentClient> {
+        self.machine_manager().connect_agent(machine)
+    }
+}

--- a/app/arcbox-core/src/runtime/sandbox_host.rs
+++ b/app/arcbox-core/src/runtime/sandbox_host.rs
@@ -31,6 +31,42 @@ impl SandboxHost for Runtime {
         self.register_sandbox_dns(sandbox_id, ip).await;
     }
 
+    async fn host_state_generation(&self) -> u64 {
+        self.sandbox_host_state_generation().await
+    }
+
+    async fn expose_port(
+        &self,
+        machine: &str,
+        exposure: &arcbox_computer::ports::SandboxPortExposure,
+    ) -> arcbox_engine::Result<()> {
+        use crate::error::CoreError;
+        self.expose_sandbox_port(machine, exposure)
+            .await
+            .map_err(|e| match e {
+                // Listener binding fails with I/O-flavored (Common) or
+                // net-stack errors; anything else cannot originate from
+                // this path and is carried as text.
+                CoreError::Common(c) => arcbox_engine::EngineError::Common(c),
+                CoreError::Net(n) => arcbox_engine::EngineError::Net(n),
+                other => arcbox_engine::EngineError::Machine(other.to_string()),
+            })
+    }
+
+    async fn unexpose_port(&self, sandbox_id: &str, sandbox_port: u16, protocol_key: &str) {
+        self.unexpose_sandbox_port(sandbox_id, sandbox_port, protocol_key)
+            .await;
+    }
+
+    async fn port_mappings_if_unchanged(
+        &self,
+        sandbox_id: &str,
+        expected_generation: u64,
+    ) -> Option<Vec<arcbox_computer::ports::SandboxPortMapping>> {
+        self.sandbox_port_mappings_if_unchanged(sandbox_id, expected_generation)
+            .await
+    }
+
     fn agent(&self, machine: &str) -> arcbox_engine::Result<AgentClient> {
         self.machine_manager().connect_agent(machine)
     }

--- a/app/arcbox-daemon/Cargo.toml
+++ b/app/arcbox-daemon/Cargo.toml
@@ -42,7 +42,6 @@ hyper-util = { version = "0.1.20", features = ["server", "server-auto", "server-
 hyper = { workspace = true, features = ["server", "http1", "http2"] }
 connectrpc-reflection = { git = "https://github.com/connectrpc/connect-rust", rev = "c5c1a6faa5d7f4d681662731db61e1fbe7796eec", version = "0.8.0" }
 arcbox-connect.workspace = true
-arcbox-computer.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 arcbox-route.workspace = true

--- a/app/arcbox-daemon/Cargo.toml
+++ b/app/arcbox-daemon/Cargo.toml
@@ -42,6 +42,7 @@ hyper-util = { version = "0.1.20", features = ["server", "server-auto", "server-
 hyper = { workspace = true, features = ["server", "http1", "http2"] }
 connectrpc-reflection = { git = "https://github.com/connectrpc/connect-rust", rev = "c5c1a6faa5d7f4d681662731db61e1fbe7796eec", version = "0.8.0" }
 arcbox-connect.workspace = true
+arcbox-computer.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 arcbox-route.workspace = true

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -256,7 +256,7 @@ async fn init_runtime(ctx: &DaemonContext) -> Result<Arc<Runtime>> {
     }
 
     let sandbox_cleanup_supported = if runtime.config().vm.autostart {
-        arcbox_api::initialize_sandbox_cleanup(&runtime)
+        arcbox_api::initialize_sandbox_cleanup(runtime.as_ref())
             .await
             .context("Failed to initialize sandbox cleanup")?
     } else {

--- a/computer/AGENTS.md
+++ b/computer/AGENTS.md
@@ -26,6 +26,13 @@ and its locked decisions live in the company repo:
 
 - `arcbox-computer` — `cleanup` (durable cleanup-ticket protocol: the
   generation fence bump, startup-vs-targeted teardown, obsolete-ticket
-  swallowing), `locks` (weak-map per-`(machine, sandbox)` operation
-  locks), `host` (the `SandboxHost` seam + Arc blanket impl). Later cuts
-  add the resume and port-exposure protocols per the charter.
+  swallowing, and `register_live_sandbox_dns`, the shared
+  Create/Restore/Resume DNS discipline), `resume` (transparent-resume
+  protocol: 503 retry budget, paused wire code 423, write pre-flight),
+  `ports` (exposure protocols and the port value types: guest-DNAT-then-
+  host-bind with compensating rollbacks, the generation-fenced list
+  snapshot, host-half-first unexpose), `locks` (weak-map per-`(machine,
+  sandbox)` operation locks), `host` (the `SandboxHost` seam + Arc
+  blanket impl). Domain errors are modeled, not stringified
+  (`ExposePortError::Raced`, `ListExposedPortsError::Unstable`) — the
+  arcbox-api adapters map them onto Connect codes.

--- a/computer/AGENTS.md
+++ b/computer/AGENTS.md
@@ -1,0 +1,31 @@
+# computer/ — Agent-Computer Domain Layer Agent Guidance
+
+The transport-free sandbox/agent-computer protocols. The restructure plan
+and its locked decisions live in the company repo:
+`engineering/arcbox/architecture-charter.md`.
+
+## Layer rules
+
+- **Never import `connectrpc`.** Wire *message* types (`arcbox-connect`)
+  are the domain vocabulary and are allowed; the transport (ConnectError,
+  RequestContext, routers) belongs to `arcbox-api`, which adapts these
+  protocols onto the wire.
+- **No `app/` dependency**: the composing runtime reaches this layer
+  through the [`SandboxHost`] seam (`src/host.rs`), implemented by
+  `arcbox_core::Runtime` (`app/arcbox-core/src/runtime/sandbox_host.rs`).
+  Protocol code is generic over the trait — do not add a concrete
+  `Runtime` type anywhere here.
+- **Platform-neutral**: must compile and pass unit tests on Linux as well
+  as macOS (the `linux-engine` CI job gates it).
+- Errors speak `arcbox_engine::EngineError`; predicates like
+  `EngineError::Agent { code }` carry the agent's HTTP-style wire codes
+  (404/412 obsolete-ticket, 423 paused, 503 retry) — those codes are
+  protocol contract, mirrored guest-side.
+
+## Crates
+
+- `arcbox-computer` — `cleanup` (durable cleanup-ticket protocol: the
+  generation fence bump, startup-vs-targeted teardown, obsolete-ticket
+  swallowing), `locks` (weak-map per-`(machine, sandbox)` operation
+  locks), `host` (the `SandboxHost` seam + Arc blanket impl). Later cuts
+  add the resume and port-exposure protocols per the charter.

--- a/computer/arcbox-computer/Cargo.toml
+++ b/computer/arcbox-computer/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "arcbox-computer"
+description = "Agent-computer domain layer for ArcBox: transport-free sandbox protocols"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+arcbox-connect = { workspace = true }
+arcbox-engine = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/computer/arcbox-computer/src/cleanup.rs
+++ b/computer/arcbox-computer/src/cleanup.rs
@@ -61,6 +61,26 @@ pub async fn live_sandbox_matches<H: SandboxHost>(
     live_sandbox_info_matches(&info, ip)
 }
 
+/// Register `sandbox_id`'s DNS at `ip_address` only if that address still
+/// names the live sandbox, under the host-state lock.
+///
+/// The shared DNS discipline of Create, Restore, and Resume: replays
+/// retain the original result even after Stop, so the liveness of the
+/// exact (sandbox, IP) pair is always re-confirmed before registering.
+pub async fn register_live_sandbox_dns<H: SandboxHost>(
+    host: &H,
+    machine: &str,
+    sandbox_id: &str,
+    ip_address: &str,
+) {
+    let _host_state = host.lock_host_state().await;
+    if let Ok(ip) = ip_address.parse()
+        && live_sandbox_matches(host, machine, sandbox_id, ip).await
+    {
+        host.register_dns(sandbox_id, ip).await;
+    }
+}
+
 fn live_sandbox_info_matches(info: &SandboxInfo, ip: std::net::IpAddr) -> bool {
     let live = matches!(
         info.state.as_known(),

--- a/computer/arcbox-computer/src/cleanup.rs
+++ b/computer/arcbox-computer/src/cleanup.rs
@@ -5,18 +5,20 @@ use std::time::Duration;
 
 use arcbox_connect::sandbox_v1::{InspectSandboxRequest, SandboxInfo, SandboxState};
 use arcbox_connect::v1::SandboxCleanupTicket;
-use arcbox_core::vm_lifecycle::DEFAULT_MACHINE_NAME;
-use arcbox_core::{AgentClient, CoreError, Runtime};
 use arcbox_engine::EngineError;
+use arcbox_engine::agent_client::AgentClient;
+use arcbox_engine::machine::DEFAULT_MACHINE_NAME;
+
+use crate::host::SandboxHost;
 
 /// Validate a cleanup generation, remove host-owned state, then let the guest
 /// recycle its DNAT relay and quarantined IP.
-pub(super) async fn complete(
-    runtime: &Runtime,
+pub async fn complete<H: SandboxHost>(
+    host: &H,
     agent: &mut AgentClient,
     ticket: &SandboxCleanupTicket,
 ) -> arcbox_engine::Result<()> {
-    let mut host_generation = runtime.lock_sandbox_host_state().await;
+    let mut host_generation = host.lock_host_state().await;
     if let Err(error) = agent.sandbox_cleanup_prepare(ticket).await {
         return if obsolete_ticket(&error) {
             Ok(())
@@ -26,10 +28,10 @@ pub(super) async fn complete(
     }
     *host_generation = (*host_generation).wrapping_add(1);
     if ticket.startup {
-        runtime.clear_sandbox_host_state().await;
+        host.clear_host_state().await;
     } else {
-        runtime.remove_sandbox_ports(&ticket.id).await;
-        runtime.deregister_sandbox_dns(&ticket.id).await;
+        host.remove_ports(&ticket.id).await;
+        host.deregister_dns(&ticket.id).await;
     }
     match agent.sandbox_cleanup_finalize(ticket).await {
         Err(error) if obsolete_ticket(&error) => Ok(()),
@@ -38,13 +40,13 @@ pub(super) async fn complete(
 }
 
 /// Confirm that a cleanup-raced result still names the live guest sandbox.
-pub(super) async fn live_sandbox_matches(
-    runtime: &Runtime,
+pub async fn live_sandbox_matches<H: SandboxHost>(
+    host: &H,
     machine: &str,
     sandbox_id: &str,
     ip: std::net::IpAddr,
 ) -> bool {
-    let Ok(mut agent) = runtime.get_agent(machine) else {
+    let Ok(mut agent) = host.agent(machine) else {
         return false;
     };
     let Ok(info) = agent
@@ -73,23 +75,28 @@ fn live_sandbox_info_matches(info: &SandboxInfo, ip: std::net::IpAddr) -> bool {
 
 /// Complete the initial cleanup replay before the daemon publishes its runtime.
 /// Returns `false` when nested sandbox virtualization is unavailable.
-pub async fn initialize(runtime: &Runtime) -> arcbox_core::Result<bool> {
-    let watcher = runtime.get_agent(DEFAULT_MACHINE_NAME)?;
+///
+/// # Errors
+///
+/// Returns an error if the agent is unreachable or the watch stream ends
+/// before the startup cleanup completes.
+pub async fn initialize<H: SandboxHost>(host: &H) -> arcbox_engine::Result<bool> {
+    let watcher = host.agent(DEFAULT_MACHINE_NAME)?;
     let mut events = watcher.sandbox_cleanup_events().await?;
     while let Some(event) = events.recv().await {
         let ticket = match event {
             Ok(ticket) => ticket,
             Err(error) if sandbox_unavailable(&error) => return Ok(false),
-            Err(error) => return Err(error.into()),
+            Err(error) => return Err(error),
         };
         let startup = ticket.startup;
-        let mut agent = runtime.get_agent(DEFAULT_MACHINE_NAME)?;
-        complete(runtime, &mut agent, &ticket).await?;
+        let mut agent = host.agent(DEFAULT_MACHINE_NAME)?;
+        complete(host, &mut agent, &ticket).await?;
         if startup {
             return Ok(true);
         }
     }
-    Err(CoreError::Machine(
+    Err(EngineError::Machine(
         "sandbox cleanup watch ended before startup cleanup completed".into(),
     ))
 }
@@ -97,10 +104,10 @@ pub async fn initialize(runtime: &Runtime) -> arcbox_core::Result<bool> {
 /// Keep the System VM's durable cleanup stream connected.
 ///
 /// Reconnects replay every unfinalized marker.
-pub fn spawn(runtime: Arc<Runtime>) {
+pub fn spawn<H: SandboxHost + 'static>(host: Arc<H>) {
     tokio::spawn(async move {
         loop {
-            if let Err(error) = watch_once(&runtime).await {
+            if let Err(error) = watch_once(host.as_ref()).await {
                 tracing::warn!(error = %error, "sandbox cleanup watch disconnected");
             }
             tokio::time::sleep(Duration::from_secs(1)).await;
@@ -108,15 +115,15 @@ pub fn spawn(runtime: Arc<Runtime>) {
     });
 }
 
-async fn watch_once(runtime: &Runtime) -> arcbox_core::Result<()> {
-    let watcher = runtime.get_agent(DEFAULT_MACHINE_NAME)?;
+async fn watch_once<H: SandboxHost>(host: &H) -> arcbox_engine::Result<()> {
+    let watcher = host.agent(DEFAULT_MACHINE_NAME)?;
     let mut events = watcher.sandbox_cleanup_events().await?;
     while let Some(event) = events.recv().await {
         let ticket = event?;
-        let mut agent = runtime.get_agent(DEFAULT_MACHINE_NAME)?;
-        complete(runtime, &mut agent, &ticket).await?;
+        let mut agent = host.agent(DEFAULT_MACHINE_NAME)?;
+        complete(host, &mut agent, &ticket).await?;
     }
-    Err(CoreError::Machine(
+    Err(EngineError::Machine(
         "sandbox cleanup watch ended before reconnect".into(),
     ))
 }

--- a/computer/arcbox-computer/src/host.rs
+++ b/computer/arcbox-computer/src/host.rs
@@ -42,6 +42,36 @@ pub trait SandboxHost: Send + Sync {
         ip: std::net::IpAddr,
     ) -> impl Future<Output = ()> + Send;
 
+    /// Reads the host-state generation without locking it.
+    fn host_state_generation(&self) -> impl Future<Output = u64> + Send;
+
+    /// Binds the host listener half of one port exposure.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the host listener cannot be bound.
+    fn expose_port(
+        &self,
+        machine: &str,
+        exposure: &crate::ports::SandboxPortExposure,
+    ) -> impl Future<Output = arcbox_engine::Result<()>> + Send;
+
+    /// Closes the host listener half of one exposure (idempotent).
+    fn unexpose_port(
+        &self,
+        sandbox_id: &str,
+        sandbox_port: u16,
+        protocol_key: &str,
+    ) -> impl Future<Output = ()> + Send;
+
+    /// Snapshots one sandbox's mappings, or `None` if the host-state
+    /// generation moved past `expected_generation`.
+    fn port_mappings_if_unchanged(
+        &self,
+        sandbox_id: &str,
+        expected_generation: u64,
+    ) -> impl Future<Output = Option<Vec<crate::ports::SandboxPortMapping>>> + Send;
+
     /// Connects to a machine's guest agent, in the engine vocabulary.
     ///
     /// # Errors
@@ -77,6 +107,34 @@ impl<H: SandboxHost> SandboxHost for std::sync::Arc<H> {
 
     async fn register_dns(&self, sandbox_id: &str, ip: std::net::IpAddr) {
         (**self).register_dns(sandbox_id, ip).await;
+    }
+
+    async fn host_state_generation(&self) -> u64 {
+        (**self).host_state_generation().await
+    }
+
+    async fn expose_port(
+        &self,
+        machine: &str,
+        exposure: &crate::ports::SandboxPortExposure,
+    ) -> arcbox_engine::Result<()> {
+        (**self).expose_port(machine, exposure).await
+    }
+
+    async fn unexpose_port(&self, sandbox_id: &str, sandbox_port: u16, protocol_key: &str) {
+        (**self)
+            .unexpose_port(sandbox_id, sandbox_port, protocol_key)
+            .await;
+    }
+
+    async fn port_mappings_if_unchanged(
+        &self,
+        sandbox_id: &str,
+        expected_generation: u64,
+    ) -> Option<Vec<crate::ports::SandboxPortMapping>> {
+        (**self)
+            .port_mappings_if_unchanged(sandbox_id, expected_generation)
+            .await
     }
 
     fn agent(&self, machine: &str) -> arcbox_engine::Result<AgentClient> {

--- a/computer/arcbox-computer/src/host.rs
+++ b/computer/arcbox-computer/src/host.rs
@@ -1,0 +1,74 @@
+//! The seam between sandbox protocols and the composing runtime.
+
+use std::ops::DerefMut;
+
+use arcbox_engine::agent_client::AgentClient;
+
+/// Host-side services the sandbox protocols need from whatever composes
+/// them (in production, `arcbox_core::Runtime`).
+///
+/// The trait exists so protocol code stays daemon-free and
+/// platform-neutral: host port bookkeeping, DNS registration, and the
+/// host-state generation fence are owned by the composer; the protocols
+/// only sequence them. Consumption is generic (`impl SandboxHost`), so
+/// implementations keep their concrete guard types.
+pub trait SandboxHost: Send + Sync {
+    /// Guard over the sandbox host-state generation counter.
+    ///
+    /// Holding it serializes every host-state mutation (port exposure,
+    /// cleanup, resume re-registration); bumping the value fences
+    /// concurrent snapshots of derived state.
+    type StateGuard<'a>: DerefMut<Target = u64> + Send
+    where
+        Self: 'a;
+
+    /// Locks the sandbox host-state generation fence.
+    fn lock_host_state(&self) -> impl Future<Output = Self::StateGuard<'_>> + Send;
+
+    /// Drops every sandbox-owned host resource (listeners, DNS): the
+    /// agent-startup handshake, when the guest has no sandboxes left.
+    fn clear_host_state(&self) -> impl Future<Output = ()> + Send;
+
+    /// Removes the host port listeners owned by one sandbox.
+    fn remove_ports(&self, sandbox_id: &str) -> impl Future<Output = ()> + Send;
+
+    /// Deregisters one sandbox's DNS records.
+    fn deregister_dns(&self, sandbox_id: &str) -> impl Future<Output = ()> + Send;
+
+    /// Connects to a machine's guest agent, in the engine vocabulary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the machine is not running or the agent is
+    /// unreachable.
+    fn agent(&self, machine: &str) -> arcbox_engine::Result<AgentClient>;
+}
+
+// Handlers hold the runtime behind an Arc; delegate so generic protocol
+// functions accept it without a deref at every call site.
+impl<H: SandboxHost> SandboxHost for std::sync::Arc<H> {
+    type StateGuard<'a>
+        = H::StateGuard<'a>
+    where
+        Self: 'a;
+
+    async fn lock_host_state(&self) -> Self::StateGuard<'_> {
+        (**self).lock_host_state().await
+    }
+
+    async fn clear_host_state(&self) {
+        (**self).clear_host_state().await;
+    }
+
+    async fn remove_ports(&self, sandbox_id: &str) {
+        (**self).remove_ports(sandbox_id).await;
+    }
+
+    async fn deregister_dns(&self, sandbox_id: &str) {
+        (**self).deregister_dns(sandbox_id).await;
+    }
+
+    fn agent(&self, machine: &str) -> arcbox_engine::Result<AgentClient> {
+        (**self).agent(machine)
+    }
+}

--- a/computer/arcbox-computer/src/host.rs
+++ b/computer/arcbox-computer/src/host.rs
@@ -35,6 +35,13 @@ pub trait SandboxHost: Send + Sync {
     /// Deregisters one sandbox's DNS records.
     fn deregister_dns(&self, sandbox_id: &str) -> impl Future<Output = ()> + Send;
 
+    /// Registers a sandbox's DNS records at `ip`.
+    fn register_dns(
+        &self,
+        sandbox_id: &str,
+        ip: std::net::IpAddr,
+    ) -> impl Future<Output = ()> + Send;
+
     /// Connects to a machine's guest agent, in the engine vocabulary.
     ///
     /// # Errors
@@ -66,6 +73,10 @@ impl<H: SandboxHost> SandboxHost for std::sync::Arc<H> {
 
     async fn deregister_dns(&self, sandbox_id: &str) {
         (**self).deregister_dns(sandbox_id).await;
+    }
+
+    async fn register_dns(&self, sandbox_id: &str, ip: std::net::IpAddr) {
+        (**self).register_dns(sandbox_id, ip).await;
     }
 
     fn agent(&self, machine: &str) -> arcbox_engine::Result<AgentClient> {

--- a/computer/arcbox-computer/src/lib.rs
+++ b/computer/arcbox-computer/src/lib.rs
@@ -2,9 +2,8 @@
 //!
 //! The agent-computer domain layer for `ArcBox`: the transport-free
 //! sandbox protocols (durable cleanup tickets, per-sandbox operation
-//! locks, and — in later cuts — the resume and port-exposure
-//! protocols), written against the [`SandboxHost`] seam the composing
-//! runtime implements.
+//! locks, transparent resume, and port exposure), written against the
+//! [`SandboxHost`] seam the composing runtime implements.
 //!
 //! Layer rules: this crate speaks the wire *message* vocabulary
 //! (`arcbox-connect` types) but never the transport — no `connectrpc`

--- a/computer/arcbox-computer/src/lib.rs
+++ b/computer/arcbox-computer/src/lib.rs
@@ -1,0 +1,18 @@
+//! # arcbox-computer
+//!
+//! The agent-computer domain layer for `ArcBox`: the transport-free
+//! sandbox protocols (durable cleanup tickets, per-sandbox operation
+//! locks, and — in later cuts — the resume and port-exposure
+//! protocols), written against the [`SandboxHost`] seam the composing
+//! runtime implements.
+//!
+//! Layer rules: this crate speaks the wire *message* vocabulary
+//! (`arcbox-connect` types) but never the transport — no `connectrpc`
+//! import, ever — and it must compile and pass unit tests on Linux as
+//! well as macOS.
+
+pub mod cleanup;
+pub mod host;
+pub mod locks;
+
+pub use host::SandboxHost;

--- a/computer/arcbox-computer/src/lib.rs
+++ b/computer/arcbox-computer/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod cleanup;
 pub mod host;
 pub mod locks;
+pub mod ports;
 pub mod resume;
 
 pub use host::SandboxHost;

--- a/computer/arcbox-computer/src/lib.rs
+++ b/computer/arcbox-computer/src/lib.rs
@@ -14,5 +14,6 @@
 pub mod cleanup;
 pub mod host;
 pub mod locks;
+pub mod resume;
 
 pub use host::SandboxHost;

--- a/computer/arcbox-computer/src/locks.rs
+++ b/computer/arcbox-computer/src/locks.rs
@@ -1,3 +1,5 @@
+//! Per-sandbox operation serialization.
+
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, Weak};
 
@@ -6,17 +8,19 @@ use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 type OperationKey = (String, String);
 type OperationMap = HashMap<OperationKey, Weak<AsyncMutex<()>>>;
 
+/// Per-`(machine, sandbox)` async operation locks.
+///
+/// A weak map: entries are garbage-collected on lookup once no
+/// operation holds them, so the map never grows with dead sandboxes.
 #[derive(Default)]
-pub(super) struct SandboxOperationLocks {
+pub struct SandboxOperationLocks {
     entries: Mutex<OperationMap>,
 }
 
 impl SandboxOperationLocks {
-    pub(super) async fn lock(
-        &self,
-        machine: &str,
-        sandbox_id: &str,
-    ) -> Option<OwnedMutexGuard<()>> {
+    /// Locks operations for one sandbox; `None` when `sandbox_id` is
+    /// empty (nothing to serialize against).
+    pub async fn lock(&self, machine: &str, sandbox_id: &str) -> Option<OwnedMutexGuard<()>> {
         if sandbox_id.is_empty() {
             return None;
         }

--- a/computer/arcbox-computer/src/ports.rs
+++ b/computer/arcbox-computer/src/ports.rs
@@ -1,0 +1,270 @@
+//! Sandbox port-exposure protocols, host half.
+//!
+//! An exposure has two halves installed in order: the guest agent
+//! allocates a reserved relay port and installs the DNAT, then the host
+//! binds a loopback listener. The protocols here keep the two halves
+//! consistent against concurrent cleanup (the host-state generation
+//! fence) and roll back the guest half when the host half cannot be
+//! applied.
+
+use arcbox_connect::sandbox_v1::InspectSandboxRequest;
+use arcbox_connect::v1::{SandboxPortForwardRemoveRequest, SandboxPortForwardRequest};
+use arcbox_engine::EngineError;
+
+use crate::host::SandboxHost;
+
+/// Parameters of one sandbox port exposure (the host listener half).
+///
+/// The guest half — DNAT from `guest_port` to the sandbox — is installed by
+/// the guest agent before this is applied.
+pub struct SandboxPortExposure {
+    /// Sandbox that owns the mapping.
+    pub sandbox_id: String,
+    /// Port the workload listens on inside the sandbox.
+    pub sandbox_port: u16,
+    /// `"tcp"` or `"udp"`.
+    pub protocol: String,
+    /// Host port to bind (loopback-reachable).
+    pub host_port: u16,
+    /// Reserved-range guest relay port the agent allocated.
+    pub guest_port: u16,
+}
+
+/// One sandbox mapping currently backed by a host listener.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SandboxPortMapping {
+    /// Port the workload listens on inside the sandbox.
+    pub sandbox_port: u16,
+    /// Loopback host port where the service is reachable.
+    pub host_port: u16,
+    /// Transport protocol.
+    pub protocol: SandboxPortProtocol,
+}
+
+/// Transport protocol of an exposed sandbox port.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SandboxPortProtocol {
+    /// TCP.
+    Tcp,
+    /// UDP.
+    Udp,
+}
+
+impl SandboxPortProtocol {
+    /// The listener-registry key form (`"tcp"` / `"udp"`).
+    #[must_use]
+    pub const fn key(self) -> &'static str {
+        match self {
+            Self::Tcp => "tcp",
+            Self::Udp => "udp",
+        }
+    }
+
+    /// The host↔guest wire enum form.
+    ///
+    /// The vsock payloads carry their own protocol enum so the published
+    /// contract is never imported by the internal wire (CORE-57).
+    #[must_use]
+    const fn wire(self) -> arcbox_connect::v1::SandboxPortProtocol {
+        match self {
+            Self::Tcp => arcbox_connect::v1::SandboxPortProtocol::Tcp,
+            Self::Udp => arcbox_connect::v1::SandboxPortProtocol::Udp,
+        }
+    }
+}
+
+/// The two ports an exposure resolved to.
+pub struct ExposedPortPair {
+    /// Loopback host port where the service is reachable.
+    pub host_port: u16,
+    /// Reserved-range guest relay port the agent allocated.
+    pub guest_port: u16,
+}
+
+/// Why an exposure did not happen.
+#[derive(Debug)]
+pub enum ExposePortError {
+    /// Host cleanup raced the exposure; the guest DNAT was rolled back.
+    /// Retryable: the caller should retry to confirm the result.
+    Raced,
+    /// The guest or host half failed with the engine's own error.
+    Engine(EngineError),
+}
+
+impl From<EngineError> for ExposePortError {
+    fn from(err: EngineError) -> Self {
+        Self::Engine(err)
+    }
+}
+
+/// Expose `sandbox_port` of `sandbox_id` on the host.
+///
+/// Guest half first (reserved relay port + DNAT), then the host listener,
+/// fenced by the host-state generation: if a cleanup slips between the
+/// two halves, or the host bind fails, the guest DNAT is rolled back so
+/// no half rule survives. A `requested_host_port` of 0 defaults to the
+/// relay port for a stable, collision-free mapping.
+///
+/// # Errors
+///
+/// [`ExposePortError::Raced`] when cleanup raced the exposure (guest half
+/// rolled back); [`ExposePortError::Engine`] when either half failed.
+pub async fn expose<H: SandboxHost>(
+    host: &H,
+    machine: &str,
+    sandbox_id: &str,
+    sandbox_port: u16,
+    requested_host_port: u16,
+    protocol: SandboxPortProtocol,
+) -> Result<ExposedPortPair, ExposePortError> {
+    let host_generation = host.host_state_generation().await;
+
+    // Guest half: allocate the reserved relay port and install the DNAT.
+    let mut agent = host.agent(machine)?;
+    let forwarded = agent
+        .sandbox_port_forward(SandboxPortForwardRequest {
+            id: sandbox_id.to_owned(),
+            sandbox_port: u32::from(sandbox_port),
+            protocol: protocol.wire().into(),
+            ..Default::default()
+        })
+        .await?;
+    let guest_port = u16::try_from(forwarded.guest_port).map_err(|_| {
+        ExposePortError::Engine(EngineError::Machine(
+            "agent returned an invalid guest port".into(),
+        ))
+    })?;
+    let rollback_request = || SandboxPortForwardRemoveRequest {
+        id: sandbox_id.to_owned(),
+        sandbox_port: u32::from(sandbox_port),
+        protocol: protocol.wire().into(),
+        ..Default::default()
+    };
+    let host_state = host.lock_host_state().await;
+    if *host_state != host_generation {
+        if let Err(rollback) = agent.sandbox_port_forward_remove(rollback_request()).await {
+            tracing::warn!(
+                sandbox_id,
+                error = %rollback,
+                "failed to roll back guest DNAT after host cleanup race"
+            );
+        }
+        return Err(ExposePortError::Raced);
+    }
+
+    // Host half: bind the listener; default the host port to the relay
+    // port for a stable, collision-free mapping.
+    let host_port = if requested_host_port == 0 {
+        guest_port
+    } else {
+        requested_host_port
+    };
+    let exposure = SandboxPortExposure {
+        sandbox_id: sandbox_id.to_owned(),
+        sandbox_port,
+        protocol: protocol.key().to_owned(),
+        host_port,
+        guest_port,
+    };
+    if let Err(primary) = host.expose_port(machine, &exposure).await {
+        // Roll back the guest DNAT so a failed bind leaves no half rule.
+        if let Err(rollback) = agent.sandbox_port_forward_remove(rollback_request()).await {
+            tracing::warn!(
+                sandbox_id,
+                error = %rollback,
+                "failed to roll back guest DNAT after host bind failure"
+            );
+        }
+        return Err(ExposePortError::Engine(primary));
+    }
+
+    Ok(ExposedPortPair {
+        host_port,
+        guest_port,
+    })
+}
+
+/// Why a stable exposed-port snapshot could not be taken.
+#[derive(Debug)]
+pub enum ListExposedPortsError {
+    /// The sandbox lookup itself failed with the agent's own error (the
+    /// 404 boundary for a deleted sandbox).
+    Sandbox(EngineError),
+    /// The guest state was unreachable — retryable.
+    Unavailable(EngineError),
+    /// Concurrent cleanup kept invalidating the snapshot — retryable.
+    Unstable,
+}
+
+/// Snapshot the host listeners backing `sandbox_id`, fenced against
+/// concurrent cleanup.
+///
+/// A retry turns a concurrent TTL/idle deletion into the existing 404
+/// boundary without holding host state across the guest RPC.
+///
+/// # Errors
+///
+/// See [`ListExposedPortsError`].
+pub async fn list<H: SandboxHost>(
+    host: &H,
+    machine: &str,
+    sandbox_id: &str,
+) -> Result<Vec<SandboxPortMapping>, ListExposedPortsError> {
+    let mut agent = host
+        .agent(machine)
+        .map_err(ListExposedPortsError::Unavailable)?;
+    for _ in 0..2 {
+        let host_generation = host.host_state_generation().await;
+        agent
+            .sandbox_inspect(InspectSandboxRequest {
+                id: sandbox_id.to_owned(),
+                ..Default::default()
+            })
+            .await
+            .map_err(|error| match error {
+                error @ EngineError::Agent { code: 404, .. } => {
+                    ListExposedPortsError::Sandbox(error)
+                }
+                error => ListExposedPortsError::Unavailable(error),
+            })?;
+
+        if let Some(mappings) = host
+            .port_mappings_if_unchanged(sandbox_id, host_generation)
+            .await
+        {
+            return Ok(mappings);
+        }
+    }
+    Err(ListExposedPortsError::Unstable)
+}
+
+/// Withdraw one exposure, host half first.
+///
+/// Close the host listener before freeing the guest relay port. If the
+/// guest delete fails, the safe half is already closed and a retry can
+/// finish it without a cross-sandbox forwarding window.
+///
+/// # Errors
+///
+/// Returns the agent's error when the guest half could not be removed.
+pub async fn unexpose<H: SandboxHost>(
+    host: &H,
+    machine: &str,
+    sandbox_id: &str,
+    sandbox_port: u16,
+    protocol: SandboxPortProtocol,
+) -> arcbox_engine::Result<()> {
+    host.unexpose_port(sandbox_id, sandbox_port, protocol.key())
+        .await;
+
+    let mut agent = host.agent(machine)?;
+    agent
+        .sandbox_port_forward_remove(SandboxPortForwardRemoveRequest {
+            id: sandbox_id.to_owned(),
+            sandbox_port: u32::from(sandbox_port),
+            protocol: protocol.wire().into(),
+            ..Default::default()
+        })
+        .await?;
+    Ok(())
+}

--- a/computer/arcbox-computer/src/resume.rs
+++ b/computer/arcbox-computer/src/resume.rs
@@ -107,12 +107,7 @@ pub async fn resume<H: SandboxHost>(
         }
     };
 
-    let _host_state = host.lock_host_state().await;
-    if let Ok(ip) = resumed.ip_address.parse()
-        && cleanup::live_sandbox_matches(host, machine, sandbox_id, ip).await
-    {
-        host.register_dns(sandbox_id, ip).await;
-    }
+    cleanup::register_live_sandbox_dns(host, machine, sandbox_id, &resumed.ip_address).await;
     Ok(())
 }
 

--- a/computer/arcbox-computer/src/resume.rs
+++ b/computer/arcbox-computer/src/resume.rs
@@ -1,0 +1,183 @@
+//! Transparent resume for paused sandboxes (CORE-21), host half.
+//!
+//! Data-plane RPCs (executions, files) targeting a PAUSED sandbox resume
+//! it before proceeding, so clients see a latency blip instead of an
+//! error. The guest signals "paused" with the dedicated wire code 423
+//! (`SandboxError::SandboxPaused`); `Inspect`/`List` never resume. The
+//! caller-facing opt-out (a request header) lives in the transport
+//! adapter — this module receives the already-made decision.
+//!
+//! Concurrent auto-resumes share one resume by construction: the
+//! per-sandbox operation lock serializes them and the guest's Resume is
+//! idempotent, so every follower no-ops against the already-resumed
+//! sandbox.
+
+use arcbox_connect::sandbox_v1::{InspectSandboxRequest, SandboxState};
+use arcbox_connect::v1::SandboxResumeCommand;
+use arcbox_engine::EngineError;
+
+use crate::cleanup;
+use crate::host::SandboxHost;
+use crate::locks::SandboxOperationLocks;
+
+/// Wire code the guest agent answers for a paused sandbox
+/// (`SandboxError::SandboxPaused`; see `guest/arcbox-agent/src/error.rs`).
+pub const SANDBOX_PAUSED_WIRE_CODE: i32 = 423;
+
+/// Resume reason for an explicit `SandboxService.Resume` call, surfaced
+/// verbatim as the RESUMED event's "reason" attribute. The value
+/// vocabulary is defined on `SandboxResumeCommand` (`agent.proto`).
+pub const REASON_RESUME: &str = "resume";
+
+/// Resume reason for a data-plane transparent resume.
+pub const REASON_AUTO_RESUME: &str = "auto_resume";
+
+/// True when this agent error means "the sandbox is paused".
+#[must_use]
+pub fn is_sandbox_paused(error: &EngineError) -> bool {
+    matches!(
+        error,
+        EngineError::Agent {
+            code: SANDBOX_PAUSED_WIRE_CODE,
+            ..
+        }
+    )
+}
+
+/// Resume `sandbox_id` on `machine` and re-register its host DNS entry.
+///
+/// Shared by the explicit `SandboxService.Resume` handler and the
+/// data-plane auto-resume; only `reason` differs. Mirrors Create's DNS
+/// discipline: the fresh IP is registered only after confirming it still
+/// names the live sandbox under the host-state lock.
+///
+/// # Errors
+///
+/// Returns the agent's error when the resume fails (or keeps failing past
+/// the transient-retry budget).
+pub async fn resume<H: SandboxHost>(
+    host: &H,
+    operations: &SandboxOperationLocks,
+    machine: &str,
+    sandbox_id: &str,
+    reason: &str,
+) -> arcbox_engine::Result<()> {
+    let _operation = operations.lock(machine, sandbox_id).await;
+    let mut agent = host.agent(machine)?;
+    // A resume can race the host finalization of the pause's network
+    // quarantine (guest-initiated pauses — the idle detector — publish
+    // their cleanup ticket through the async watch stream). The guest
+    // answers 503 for that transient, so retry within a bounded budget
+    // while the daemon's cleanup watcher completes the ticket; resume is
+    // idempotent, and the guest lock is released between attempts.
+    let resumed = {
+        const RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(8);
+        const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(250);
+        let deadline = tokio::time::Instant::now() + RETRY_BUDGET;
+        loop {
+            let attempt = agent
+                .sandbox_resume(SandboxResumeCommand {
+                    id: sandbox_id.to_owned(),
+                    reason: reason.to_owned(),
+                    ..Default::default()
+                })
+                .await;
+            match attempt {
+                Ok(resumed) => break resumed,
+                Err(EngineError::Agent { code: 503, message })
+                    if tokio::time::Instant::now() < deadline =>
+                {
+                    tracing::debug!(
+                        sandbox_id,
+                        message,
+                        "sandbox resume hit a retryable condition; retrying"
+                    );
+                    tokio::time::sleep(RETRY_DELAY).await;
+                }
+                Err(error) => {
+                    // Same reason as create/stop/remove/pause: a failed
+                    // lifecycle mutation must reach the daemon log on its own
+                    // (CORE-82). It matters more here — an auto-resume has no
+                    // caller expecting a Resume RPC, so the failure would
+                    // otherwise surface only as the data-plane error.
+                    tracing::warn!(machine, sandbox_id, reason, %error, "sandbox resume failed");
+                    return Err(error);
+                }
+            }
+        }
+    };
+
+    let _host_state = host.lock_host_state().await;
+    if let Ok(ip) = resumed.ip_address.parse()
+        && cleanup::live_sandbox_matches(host, machine, sandbox_id, ip).await
+    {
+        host.register_dns(sandbox_id, ip).await;
+    }
+    Ok(())
+}
+
+/// Pre-flight for client-streaming writes.
+///
+/// `WriteFile` consumes its input stream before the guest's verdict comes
+/// back, so a paused sandbox cannot be handled by retrying the call — the
+/// bytes are gone. Instead the sandbox's state is checked up front and a
+/// paused one is resumed before any chunk is bridged; with `auto_resume`
+/// off (the caller opted out) a paused sandbox is refused with the
+/// paused wire code instead.
+///
+/// # Errors
+///
+/// Returns the agent's error when the inspect or resume fails, or the
+/// paused wire error when the sandbox is paused and `auto_resume` is off.
+pub async fn ensure_resumed_for_write<H: SandboxHost>(
+    host: &H,
+    operations: &SandboxOperationLocks,
+    machine: &str,
+    sandbox_id: &str,
+    auto_resume: bool,
+) -> arcbox_engine::Result<()> {
+    let mut agent = host.agent(machine)?;
+    let info = agent
+        .sandbox_inspect(InspectSandboxRequest {
+            id: sandbox_id.to_owned(),
+            ..Default::default()
+        })
+        .await?;
+    // Pausing counts too: the guest serializes on its per-sandbox operation
+    // lock, so the resume below simply waits for the pause to finish.
+    if matches!(
+        info.state.as_known(),
+        Some(SandboxState::Paused | SandboxState::Pausing)
+    ) {
+        if !auto_resume {
+            return Err(EngineError::Agent {
+                code: SANDBOX_PAUSED_WIRE_CODE,
+                message: format!("sandbox '{sandbox_id}' is paused"),
+            });
+        }
+        resume(host, operations, machine, sandbox_id, REASON_AUTO_RESUME).await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_the_paused_wire_code_triggers_auto_resume() {
+        assert!(is_sandbox_paused(&EngineError::Agent {
+            code: 423,
+            message: "sandbox 'box' is paused".into(),
+        }));
+        for code in [400, 404, 409, 412, 416, 500, 503] {
+            assert!(!is_sandbox_paused(&EngineError::Agent {
+                code,
+                message: "other".into(),
+            }));
+        }
+        assert!(!is_sandbox_paused(&EngineError::Machine(
+            "dead vsock".into()
+        )));
+    }
+}

--- a/engine/arcbox-engine/src/error.rs
+++ b/engine/arcbox-engine/src/error.rs
@@ -56,6 +56,10 @@ pub enum EngineError {
         source: arcbox_transport::error::TransportError,
     },
 
+    /// Network error (host listeners, forwarding).
+    #[error("network error: {0}")]
+    Net(#[from] arcbox_net::NetError),
+
     /// Image-layer error (boot assets, machine images).
     #[error(transparent)]
     Image(#[from] arcbox_image::ImageError),


### PR DESCRIPTION
Phase 3 of the engine/computer restructure (charter: company repo, `engineering/arcbox/architecture-charter.md`; P1 = #620 merged, P2 = #621 merged). Rebased onto `master` after #621 merged and deleted `refactor/engine-core` (GitHub auto-retargeted this PR; rebase applied with zero conflicts, content-identical). The new `computer/arcbox-computer` crate holds the transport-free sandbox protocols; the arcbox-api Connect handlers shrink to validation + wire mapping.

Three atomic cuts, each workspace-green:
1. **Scaffold + cleanup + locks** — the two files that already had zero connectrpc imports move verbatim; the hexagonal seam is the **`SandboxHost` trait** (GAT state guard, RPITIT async methods, Arc blanket impl), implemented by `Runtime` in `app/arcbox-core/src/runtime/sandbox_host.rs` (L4 → L3 dependency, no cycle).
2. **Resume protocol** — 503 retry budget, paused wire code 423, write pre-flight move to `computer::resume`; the opt-out header and ConnectError mapping stay api-side; the `engine_agent` bridge retires (`SandboxHost::agent` speaks EngineError natively — same direction as the #621 review fix).
3. **Port-exposure protocols** — expose (guest-DNAT-then-host-bind with both compensating rollbacks), generation-fenced list, host-half-first unexpose, plus the port value types (runtime re-exports for compat). Domain outcomes are modeled (`ExposePortError::Raced`, `ListExposedPortsError::Unstable`) instead of pre-baked wire strings. The Create/Restore/Resume DNS live-match discipline, previously duplicated verbatim ×3, is now one `cleanup::register_live_sandbox_dns`. `EngineError` gains `Net` so bind failures cross the seam losslessly.

**Deviation from the charter note**: `nested_virt_for_backend` (sandbox_capability) stays in arcbox-core for now — moving it needs the VZ hardware probe rehomed behind the vmm layer to keep computer free of macOS deps; deferred with a charter follow-up.

**Validation**: workspace check clean; unit tests green (computer 19+4+4 incl. moved protocol tests, core 88, api, daemon 39); clippy `-D warnings` --all-targets + fmt clean.

**linux-engine CI job extension — deferred, not in this PR**: after rebasing, the Linux musl check of arcbox-computer's own code passes, but extending the `linux-engine` job's `-p` list to `arcbox-engine`/`arcbox-computer` is blocked on a pre-existing, unrelated issue: `arcbox-engine` unconditionally depends on `arcbox-hypervisor`/`arcbox-vmm` (not target-gated), and `arcbox-hypervisor`'s Linux/KVM backend currently fails to compile (unresolved `KvmVcpu` import, undefined `KvmCpuid2` type) with an additional musl-only `libc::ioctl` signature mismatch in `arcbox-virtio-net`. Neither predates this restructuring nor is in scope here — nothing in the current `linux-engine` job's `-p` list (arcbox-image/arcbox-net/splicetcp) ever pulled in arcbox-hypervisor before, so this is the first time it would be checked. A follow-up PR fixes both and carries the `-p arcbox-engine -p arcbox-computer` extension.

Docs: `computer/AGENTS.md` added (+ CLAUDE.md structure/import lines — flagged for human approval per repo rules).
