### PR TITLE
fix(hypervisor): make the KVM backend compile on Linux again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,10 +163,10 @@ jobs:
             ${{ runner.os }}-cargo-linux-engine-
 
       - name: Check engine-layer crates on Linux
-        run: cargo check --all-targets -p arcbox-image -p arcbox-net -p splicetcp
+        run: cargo check --all-targets -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net
 
       - name: Check net stack on aarch64-unknown-linux-musl
-        run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-net -p splicetcp
+        run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net
 
   # Pure proto-contract analysis — no Rust toolchain, no build. Runs in
   # parallel with `ci` on a cheap Linux runner. The desktop and agent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,10 @@ jobs:
   # see root CLAUDE.md "Guest Agent Cross-Compilation") because gnu/musl and
   # x86_64/aarch64 each pick different concrete types for a few libc
   # primitives (e.g. `c_char`'s signedness is arch-, not libc-, driven) that
-  # the gnu-only first step can't exercise; scoped to arcbox-net + splicetcp
-  # only — arcbox-image's TLS deps pull in `ring`, whose build script needs a
-  # musl C cross-compiler this runner doesn't have. Scoped to the crates that
+  # the gnu-only first step can't exercise; scoped to arcbox-net + splicetcp +
+  # arcbox-hypervisor + arcbox-virtio-net — arcbox-image is the one exclusion,
+  # since its TLS deps pull in `ring`, whose build script needs a musl C
+  # cross-compiler this runner doesn't have. Scoped to the crates that
   # make the platform-neutrality promise — the workspace as a whole still
   # contains macOS-only crates (arcbox-vz, arcbox-vmnet). Extend the -p list
   # as engine/computer crates land.
@@ -165,7 +166,7 @@ jobs:
       - name: Check engine-layer crates on Linux
         run: cargo check --all-targets -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net
 
-      - name: Check net stack on aarch64-unknown-linux-musl
+      - name: Check engine-layer crates on aarch64-unknown-linux-musl
         run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net
 
   # Pure proto-contract analysis — no Rust toolchain, no build. Runs in

--- a/virt/arcbox-fs/src/passthrough/file_handles.rs
+++ b/virt/arcbox-fs/src/passthrough/file_handles.rs
@@ -171,6 +171,8 @@ impl PassthroughFs {
     /// - [`FsError::InvalidHandle`] if the handle is invalid
     #[cfg(target_os = "linux")]
     pub fn fallocate(&self, handle: u64, mode: u32, offset: u64, length: u64) -> Result<()> {
+        use std::os::unix::io::AsRawFd;
+
         let handles = self
             .handles
             .read()

--- a/virt/arcbox-hypervisor/src/linux/ffi.rs
+++ b/virt/arcbox-hypervisor/src/linux/ffi.rs
@@ -36,6 +36,7 @@ macro_rules! kvm_iow {
     };
 }
 
+#[cfg(target_arch = "x86_64")]
 macro_rules! kvm_iowr {
     ($nr:expr, $ty:ty) => {
         nix::request_code_readwrite!(KVMIO, $nr, std::mem::size_of::<$ty>())
@@ -71,7 +72,9 @@ pub const KVM_GET_REGS: nix::sys::ioctl::ioctl_num_type = kvm_ior!(0x81, KvmRegs
 pub const KVM_SET_REGS: nix::sys::ioctl::ioctl_num_type = kvm_iow!(0x82, KvmRegs);
 pub const KVM_GET_SREGS: nix::sys::ioctl::ioctl_num_type = kvm_ior!(0x83, KvmSregs);
 pub const KVM_SET_SREGS: nix::sys::ioctl::ioctl_num_type = kvm_iow!(0x84, KvmSregs);
+#[cfg(target_arch = "x86_64")]
 pub const KVM_SET_CPUID2: nix::sys::ioctl::ioctl_num_type = kvm_iow!(0x90, KvmCpuid2);
+#[cfg(target_arch = "x86_64")]
 pub const KVM_GET_CPUID2: nix::sys::ioctl::ioctl_num_type = kvm_iowr!(0x91, KvmCpuid2);
 
 // ARM64-specific ioctls

--- a/virt/arcbox-hypervisor/src/linux/vm/tests.rs
+++ b/virt/arcbox-hypervisor/src/linux/vm/tests.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod tests {
-    use super::virtio::{VIRTIO_MMIO_BASE, VIRTIO_MMIO_GAP, VIRTIO_MMIO_SIZE};
-    use super::*;
+    use super::super::virtio::{VIRTIO_MMIO_BASE, VIRTIO_MMIO_GAP, VIRTIO_MMIO_SIZE};
+    use super::super::*;
     use crate::memory::PAGE_SIZE;
-    use crate::traits::VirtualMachine;
-    use crate::types::CpuArch;
+    use crate::traits::{Vcpu, VirtualMachine};
+    use crate::types::{CpuArch, VirtioDeviceConfig, VirtioDeviceType};
     use std::sync::Arc;
 
     #[test]
@@ -119,7 +119,7 @@ mod tests {
         assert!(devices[0].notify_fd >= 0);
 
         // Add a network device.
-        let net_config = VirtioDeviceConfig::net();
+        let net_config = VirtioDeviceConfig::network_with_mac("02:00:00:00:00:01");
         vm.add_virtio_device(net_config).unwrap();
 
         // Verify second device.
@@ -133,7 +133,7 @@ mod tests {
 
         // Cannot add device after VM starts.
         vm.start().unwrap();
-        let fs_config = VirtioDeviceConfig::filesystem("/share", "share");
+        let fs_config = VirtioDeviceConfig::filesystem("/share", "share", false);
         let result = vm.add_virtio_device(fs_config);
         assert!(result.is_err());
     }

--- a/virt/arcbox-hypervisor/src/linux/vm/virtual_machine.rs
+++ b/virt/arcbox-hypervisor/src/linux/vm/virtual_machine.rs
@@ -7,7 +7,8 @@ use crate::{
 };
 
 use super::virtio::{VIRTIO_MMIO_SIZE, bincode_serialize_device_config};
-use super::{KvmMemory, KvmVcpu, KvmVm, VirtioDeviceInfo, VmState};
+use super::{KvmMemory, KvmVm, VirtioDeviceInfo, VmState};
+use crate::linux::KvmVcpu;
 
 impl VirtualMachine for KvmVm {
     type Vcpu = KvmVcpu;

--- a/virt/arcbox-hypervisor/tests/vcpu_e2e_test.rs
+++ b/virt/arcbox-hypervisor/tests/vcpu_e2e_test.rs
@@ -6,6 +6,8 @@
 //! Note: Some tests require a valid kernel to run. They will be skipped
 //! if the kernel is not available.
 
+// Darwin vCPU execution end-to-end: nothing here can run off macOS.
+#![cfg(target_os = "macos")]
 #![allow(clippy::expect_fun_call)]
 #![allow(clippy::field_reassign_with_default)]
 #![allow(clippy::unnecessary_cast)]

--- a/virt/arcbox-virtio-net/src/tap.rs
+++ b/virt/arcbox-virtio-net/src/tap.rs
@@ -10,8 +10,8 @@ use crate::header::NetPacket;
 // Linux kernel `TUNSETOFFLOAD` / `TUNSETVNETHDRSZ` ioctl numbers and the
 // `TUN_F_*` flag bits. See `<linux/if_tun.h>` — we encode them inline rather
 // than pulling in another crate because only the TAP backend needs them.
-const TUNSETOFFLOAD: libc::c_ulong = 0x400454d0;
-const TUNSETVNETHDRSZ: libc::c_ulong = 0x400454d8;
+const TUNSETOFFLOAD: libc::Ioctl = 0x400454d0;
+const TUNSETVNETHDRSZ: libc::Ioctl = 0x400454d8;
 
 const TUN_F_CSUM: u32 = 0x01;
 const TUN_F_TSO4: u32 = 0x02;
@@ -71,7 +71,7 @@ impl TapBackend {
         }
 
         // Create TAP device
-        const TUNSETIFF: libc::c_ulong = 0x400454ca;
+        const TUNSETIFF: libc::Ioctl = 0x400454ca;
         // SAFETY: ioctl reads `&ifr` for the duration of the call; on failure
         // we close the fd we just opened.
         let ret = unsafe { libc::ioctl(fd, TUNSETIFF, &ifr) };


### PR DESCRIPTION
Follow-up from #622/#623 (charter P3→P5 seam): extending the `linux-engine` gate to the engine crates surfaced that the in-process KVM backend had never been compiled in CI. This PR fixes the compile-rot that is *shallow* and honestly scopes out what is not:

**Fixed** (all verified with `cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-hypervisor -p arcbox-virtio-net` locally, plus macOS fmt/clippy/tests):
- `arcbox-hypervisor`: x86-only `KvmCpuid2` ioctl constants + `kvm_iowr` macro gain their `target_arch` gate; `vm/virtual_machine.rs` imports `KvmVcpu` from `crate::linux` (the `vm` module never carried it); the nested test module's `super::` paths resolved one level short; the bit-rotted KVM tests are updated to the current `VirtioDeviceConfig`/`Vcpu`-trait API (still `#[ignore]`d behind /dev/kvm, now compiling); the darwin-only `vcpu_e2e_test` is crate-gated to macOS.
- `arcbox-virtio-net`: `TUNSET*` ioctl constants switch from `libc::c_ulong` to `libc::Ioctl` (same fix class as #622).
- `arcbox-fs`: the Linux `fallocate` path gains its missing `AsRawFd` import.
- CI: `linux-engine`'s GNU and musl steps grow `-p arcbox-hypervisor -p arcbox-virtio-net`.

**Deliberately NOT fixed here**: `arcbox-vmm`'s Linux arm has 17 deeper errors (dax module hard-wired to `arcbox_hv`, missing Gsi/IrqTriggerCallback types, `net_rx_worker` module references, `Vmm` struct field drift) — that is the charter's P5 in-process-KVM-backend work, tracked there. Until it lands, `arcbox-engine`/`arcbox-computer` stay out of the `linux-engine` `-p` list (their Linux compile is blocked solely by arcbox-vmm).