### PR TITLE
fix(vmm): repair the Linux arm, and gate engine/computer on it (restructure phase 5 debt)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,8 +189,11 @@ jobs:
       - name: Check engine-layer crates on Linux
         run: cargo check --all-targets -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-engine -p arcbox-computer
 
+      # `--no-fail-fast` so one red run reports every broken crate rather
+      # than stopping at the first, which otherwise hides later failures
+      # behind a fix-and-rerun loop.
       - name: Test engine-layer crates on Linux
-        run: cargo test -p arcbox-image -p arcbox-net -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-engine -p arcbox-computer
+        run: cargo test --no-fail-fast -p arcbox-image -p arcbox-net -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-engine -p arcbox-computer
 
       - name: Check engine-layer crates on aarch64-unknown-linux-musl
         run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,11 +118,19 @@ jobs:
   # neutrality (architecture charter, company repo; engine/AGENTS.md: "every
   # crate must compile and pass unit tests on Linux as well as macOS"): this
   # job keeps darwin-only deps target-gated so a Linux host build never rots
-  # again, and actually runs the crates' unit tests rather than stopping at
-  # `cargo check` — a macOS-only symbol reintroduced into a `#[cfg(test)]`
-  # module compiles clean under `check --all-targets` and only breaks at
-  # `cargo test`, which is exactly the gap this job exists to close. Every
-  # KVM-touching test in `arcbox-hypervisor` is already `#[ignore]`d
+  # again. `--all-targets` on the check step is load-bearing: a plain
+  # `cargo check` skips test targets, so a macOS-only symbol reintroduced
+  # into a `#[cfg(test)]` module (as happened once already) would pass while
+  # still breaking `cargo test` on Linux — `--all-targets` builds the
+  # `lib test` target and type-checks it.
+  #
+  # The test step covers the two things `--all-targets` still cannot: it
+  # RUNS the tests (a Linux/macOS behavioral difference type-checks fine —
+  # see the splicetcp note below), and it compiles DOCTESTS, which no
+  # `cargo check` invocation ever does. That second gap was not theoretical:
+  # `LinuxTap`'s doctest had been calling a trait method without importing
+  # the trait since the Linux arm was revived, and only this step caught it.
+  # Every KVM-touching test in `arcbox-hypervisor` is already `#[ignore]`d
   # ("Requires /dev/kvm", not available on this runner); the netlink/tap
   # tests in `arcbox-net` self-skip at runtime when not root. `splicetcp` is
   # the one crate checked but not tested: two of its tcp_bridge tests
@@ -131,10 +139,12 @@ jobs:
   # swallows the whole payload and the tests' own "this must exercise the
   # partial-take path" guards fire. The guards are right — they refuse to
   # pass vacuously — but the constant is macOS-calibrated; sizing the
-  # payload against the *granted* buffer would let them run here too. A
-  # second step
-  # repeats the *check* (not the tests — a musl-arm64 test binary can't run
-  # on this x86_64 runner without emulation) on aarch64-unknown-linux-musl
+  # payload against the *granted* buffer would let them run here too. That
+  # pair is also the reason the test step exists at all: it type-checks
+  # identically on both platforms and only diverges when run.
+  #
+  # A second step repeats the *check* (not the tests — a musl-arm64 test
+  # binary can't run on this x86_64 runner) on aarch64-unknown-linux-musl
   # (the real cross-compile target, see root CLAUDE.md "Guest Agent
   # Cross-Compilation") because gnu/musl and x86_64/aarch64 each pick
   # different concrete types for a few libc primitives (e.g. `c_char`'s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,22 +117,27 @@ jobs:
   # The engine layer and the net stack under it promise platform
   # neutrality (architecture charter, company repo; engine/AGENTS.md: "every
   # crate must compile and pass unit tests on Linux as well as macOS"): this
-  # compile gate keeps darwin-only deps target-gated so a Linux host build
-  # never rots again. `--all-targets` is load-bearing: a plain `cargo check`
-  # skips test/example/bench targets, so a macOS-only symbol reintroduced
-  # into a `#[cfg(test)]` module (as happened once already) would pass the
-  # gate while still breaking `cargo test` on Linux. A second step repeats
-  # the check on aarch64-unknown-linux-musl (the real cross-compile target,
-  # see root CLAUDE.md "Guest Agent Cross-Compilation") because gnu/musl and
-  # x86_64/aarch64 each pick different concrete types for a few libc
-  # primitives (e.g. `c_char`'s signedness is arch-, not libc-, driven) that
-  # the gnu-only first step can't exercise. The musl step drops every crate
-  # whose graph reaches `ring` — arcbox-image, plus arcbox-engine and
-  # arcbox-computer above it — because ring's build script needs a musl C
-  # cross-compiler this runner doesn't have. Scoped to the crates that
-  # make the platform-neutrality promise — the workspace as a whole still
-  # contains macOS-only crates (arcbox-vz, arcbox-vmnet). Extend both -p
-  # lists as further engine/computer crates land.
+  # job keeps darwin-only deps target-gated so a Linux host build never rots
+  # again, and actually runs the crates' unit tests rather than stopping at
+  # `cargo check` — a macOS-only symbol reintroduced into a `#[cfg(test)]`
+  # module compiles clean under `check --all-targets` and only breaks at
+  # `cargo test`, which is exactly the gap this job exists to close. Every
+  # KVM-touching test in `arcbox-hypervisor` is already `#[ignore]`d
+  # ("Requires /dev/kvm", not available on this runner); the netlink/tap
+  # tests in `arcbox-net` self-skip at runtime when not root. A second step
+  # repeats the *check* (not the tests — a musl-arm64 test binary can't run
+  # on this x86_64 runner without emulation) on aarch64-unknown-linux-musl
+  # (the real cross-compile target, see root CLAUDE.md "Guest Agent
+  # Cross-Compilation") because gnu/musl and x86_64/aarch64 each pick
+  # different concrete types for a few libc primitives (e.g. `c_char`'s
+  # signedness is arch-, not libc-, driven) that the gnu-only steps can't
+  # exercise. The musl step drops every crate whose graph reaches `ring` —
+  # arcbox-image, plus arcbox-engine and arcbox-computer above it — because
+  # ring's build script needs a musl C cross-compiler this runner doesn't
+  # have. Scoped to the crates that make the platform-neutrality promise —
+  # the workspace as a whole still contains macOS-only crates (arcbox-vz,
+  # arcbox-vmnet). Extend all three -p lists as further engine/computer
+  # crates land.
   linux-engine:
     name: Linux engine-layer check
     runs-on: ubuntu-latest
@@ -175,6 +180,9 @@ jobs:
 
       - name: Check engine-layer crates on Linux
         run: cargo check --all-targets -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-engine -p arcbox-computer
+
+      - name: Test engine-layer crates on Linux
+        run: cargo test -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-engine -p arcbox-computer
 
       - name: Check engine-layer crates on aarch64-unknown-linux-musl
         run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,16 @@ jobs:
           toolchain: stable
           targets: aarch64-unknown-linux-musl
 
+      # arcbox-engine and arcbox-computer depend on arcbox-connect, whose
+      # build.rs shells out to `protoc` directly (rpc/arcbox-connect/build.rs)
+      # rather than a vendored binary. The musl step below never touches
+      # those two crates, so this only gates the gnu step, but installing it
+      # once up front is simpler than conditioning on the target.
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: Cache cargo
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,15 @@ jobs:
   # `cargo test`, which is exactly the gap this job exists to close. Every
   # KVM-touching test in `arcbox-hypervisor` is already `#[ignore]`d
   # ("Requires /dev/kvm", not available on this runner); the netlink/tap
-  # tests in `arcbox-net` self-skip at runtime when not root. A second step
+  # tests in `arcbox-net` self-skip at runtime when not root. `splicetcp` is
+  # the one crate checked but not tested: two of its tcp_bridge tests
+  # calibrate a 4 KiB socket buffer to force a partial-take, and Linux
+  # doubles a `SO_SNDBUF` request and enforces a floor, so the buffer
+  # swallows the whole payload and the tests' own "this must exercise the
+  # partial-take path" guards fire. The guards are right — they refuse to
+  # pass vacuously — but the constant is macOS-calibrated; sizing the
+  # payload against the *granted* buffer would let them run here too. A
+  # second step
   # repeats the *check* (not the tests — a musl-arm64 test binary can't run
   # on this x86_64 runner without emulation) on aarch64-unknown-linux-musl
   # (the real cross-compile target, see root CLAUDE.md "Guest Agent
@@ -182,7 +190,7 @@ jobs:
         run: cargo check --all-targets -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-engine -p arcbox-computer
 
       - name: Test engine-layer crates on Linux
-        run: cargo test -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-engine -p arcbox-computer
+        run: cargo test -p arcbox-image -p arcbox-net -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-engine -p arcbox-computer
 
       - name: Check engine-layer crates on aarch64-unknown-linux-musl
         run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,13 +126,13 @@ jobs:
   # see root CLAUDE.md "Guest Agent Cross-Compilation") because gnu/musl and
   # x86_64/aarch64 each pick different concrete types for a few libc
   # primitives (e.g. `c_char`'s signedness is arch-, not libc-, driven) that
-  # the gnu-only first step can't exercise; scoped to arcbox-net + splicetcp +
-  # arcbox-hypervisor + arcbox-virtio-net — arcbox-image is the one exclusion,
-  # since its TLS deps pull in `ring`, whose build script needs a musl C
+  # the gnu-only first step can't exercise. The musl step drops every crate
+  # whose graph reaches `ring` — arcbox-image, plus arcbox-engine and
+  # arcbox-computer above it — because ring's build script needs a musl C
   # cross-compiler this runner doesn't have. Scoped to the crates that
   # make the platform-neutrality promise — the workspace as a whole still
-  # contains macOS-only crates (arcbox-vz, arcbox-vmnet). Extend the -p list
-  # as engine/computer crates land.
+  # contains macOS-only crates (arcbox-vz, arcbox-vmnet). Extend both -p
+  # lists as further engine/computer crates land.
   linux-engine:
     name: Linux engine-layer check
     runs-on: ubuntu-latest
@@ -164,10 +164,10 @@ jobs:
             ${{ runner.os }}-cargo-linux-engine-
 
       - name: Check engine-layer crates on Linux
-        run: cargo check --all-targets -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net
+        run: cargo check --all-targets -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-engine -p arcbox-computer
 
       - name: Check engine-layer crates on aarch64-unknown-linux-musl
-        run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net
+        run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm
 
   # Pure proto-contract analysis — no Rust toolchain, no build. Runs in
   # parallel with `ci` on a cheap Linux runner. The desktop and agent

--- a/engine/arcbox-engine/src/agent_client.rs
+++ b/engine/arcbox-engine/src/agent_client.rs
@@ -45,7 +45,9 @@ use arcbox_connect::v1::{
 use arcbox_constants::ports::AGENT_PORT;
 use arcbox_constants::wire::MessageType;
 use arcbox_transport::Transport;
-use arcbox_transport::vsock::{BlockingVsockTransport, VsockAddr, VsockTransport};
+#[cfg(target_os = "macos")]
+use arcbox_transport::vsock::BlockingVsockTransport;
+use arcbox_transport::vsock::{VsockAddr, VsockTransport};
 use buffa::Message;
 use bytes::Bytes;
 use std::time::{Duration, Instant};

--- a/engine/arcbox-engine/src/agent_client/transport.rs
+++ b/engine/arcbox-engine/src/agent_client/transport.rs
@@ -12,9 +12,18 @@ use std::time::Duration;
 /// trigger a tokio/kqueue reactor stall when rapidly created and torn down in a
 /// retry loop, causing timer wakeups to stop firing. The blocking transport
 /// uses `libc::poll` + `std::os::unix::net::UnixStream` and never touches the
-/// tokio reactor.
+/// tokio reactor — so it is constructed only on macOS, though its arms stay
+/// compiled everywhere to keep the RPC bodies platform-free.
 pub(super) enum AgentTransport {
     Async(VsockTransport),
+    #[cfg_attr(
+        not(target_os = "macos"),
+        allow(
+            dead_code,
+            reason = "the HV socketpair is macOS-only, so its sole constructor \
+                      `AgentClient::from_fd_blocking` is too"
+        )
+    )]
     Blocking(BlockingVsockTransport),
 }
 

--- a/engine/arcbox-engine/src/machine.rs
+++ b/engine/arcbox-engine/src/machine.rs
@@ -6,6 +6,9 @@
 use crate::error::{EngineError, Result};
 use crate::persistence::MachinePersistence;
 use crate::vm::{SharedDirConfig, VmConfig, VmId, VmManager};
+// Only the macOS `connect_agent` dials the agent port — the vsock helper it
+// rides is macOS-only.
+#[cfg(target_os = "macos")]
 use arcbox_constants::ports::AGENT_PORT;
 use arcbox_constants::virtiofs::{MOUNT_PRIVATE, MOUNT_USERS, TAG_ARCBOX, TAG_PRIVATE, TAG_USERS};
 use chrono::{DateTime, Utc};

--- a/engine/arcbox-engine/src/vm.rs
+++ b/engine/arcbox-engine/src/vm.rs
@@ -926,8 +926,9 @@ impl VmManager {
     /// * `target_bytes` - Target memory size in bytes
     ///
     /// # Errors
-    /// Returns an error if the VM is not found, not running, or balloon operation fails.
-    #[cfg(target_os = "macos")]
+    /// Returns an error if the VM is not found, not running, or balloon
+    /// operation fails — including on platforms with no balloon backend,
+    /// where `Vmm::set_balloon_target` reports the gap.
     pub fn set_balloon_target(&self, id: &VmId, target_bytes: u64) -> Result<()> {
         let vms = self.vms.read().map_err(|_| EngineError::LockPoisoned)?;
 

--- a/virt/arcbox-net/src/linux/tap.rs
+++ b/virt/arcbox-net/src/linux/tap.rs
@@ -84,6 +84,8 @@ impl TapConfig {
 /// # Example
 ///
 /// ```no_run
+/// // `recv`/`send` arrive through the backend trait, not inherently.
+/// use arcbox_net::backend::NetworkBackend;
 /// use arcbox_net::linux::{LinuxTap, TapConfig};
 ///
 /// let config = TapConfig::new()

--- a/virt/arcbox-vmm/AGENTS.md
+++ b/virt/arcbox-vmm/AGENTS.md
@@ -162,6 +162,39 @@ coverage: the near-`u64::MAX` ring-address snapshot regression in
   lands (ABX-416). Anything time-sensitive before agent-up sees the kernel
   default epoch — TLS cert validation in particular fails.
 
+## The Linux arm is a CI gate now — keep macOS-only code gated
+
+This crate is the platform seam `engine/arcbox-engine` reaches macOS
+through, so the engine and computer layers compile on Linux only if this
+one does. All three are in CI's `linux-engine` job: the GNU step checks
+`arcbox-vmm`, `arcbox-engine`, `arcbox-computer`; the musl step checks
+`arcbox-vmm` alone, because the other two reach `ring`/`zstd-sys` through
+`arcbox-image` and the runner has no musl C cross-compiler.
+
+Consequences for edits here:
+
+- A new module that touches `arcbox_hv` (or any Hypervisor.framework
+  symbol) needs `#[cfg(target_os = "macos")]` on its `lib.rs` declaration.
+  `arcbox-hv` compiles to an EMPTY crate off macOS/aarch64, so an ungated
+  consumer fails with `cannot find X in arcbox_hv` — not a missing
+  dependency. `dax`, `console_rx_worker`, `net_rx_worker`, and
+  `vsock_rx_worker` are all gated for this reason.
+- A capability only one backend implements gets a `#[cfg(not(...))]`
+  counterpart on `Vmm` that RETURNS `VmmError::Unsupported`, rather than a
+  gate the engine layer has to mirror. `set_balloon_target` is the
+  reference: the platform difference stops here, and `vm_lifecycle`'s
+  balloon controller stays platform-free.
+- Local repro (this host's nix toolchain ships no linux-gnu std, so musl
+  is the only local Linux target):
+  `cargo check --target aarch64-unknown-linux-musl -p arcbox-vmm --all-targets`.
+  Use aarch64, not x86_64 — two errors once lived inside a
+  `#[cfg(target_arch = "aarch64")]` block in `vmm/linux.rs`.
+
+`vmm/linux.rs` names `KvmHypervisor`/`KvmVm` concretely instead of going
+through `arcbox_hypervisor::create_hypervisor()`: it needs `KvmVm`'s
+inherent `virtio_devices()` and stores the VM in `Vmm::linux_vm`, neither
+of which the erased `impl Hypervisor` return type provides.
+
 ## Validation
 
 Follow the ladder in `virt/AGENTS.md`, cheapest first: crate unit tests →

--- a/virt/arcbox-vmm/src/device/net_worker.rs
+++ b/virt/arcbox-vmm/src/device/net_worker.rs
@@ -77,6 +77,10 @@ impl NetRxWorkerSlot {
     }
 
     /// Returns the stored host fd without removing it.
+    ///
+    /// Only the legacy kqueue fallback reads it back, so it exists only
+    /// where that fallback does.
+    #[cfg(target_os = "macos")]
     fn get_host_fd(&self) -> Option<i32> {
         *self
             .host_fd
@@ -116,8 +120,8 @@ impl NetRxWorkerSlot {
     /// Called from the DRIVER_OK handler (which only has `&self`). Returns
     /// immediately if prerequisites are missing or the worker was already
     /// spawned. Prefers the `RxInjectThread` path (channel-based) when
-    /// `rx_inject_channel` is set; falls back to the legacy `net_rx_worker`
-    /// (kqueue on socketpair fd).
+    /// `rx_inject_channel` is set; on macOS falls back to the legacy
+    /// `net_rx_worker` (kqueue on socketpair fd).
     pub fn try_spawn(
         &self,
         mmio_arc: &Arc<RwLock<VirtioMmioState>>,
@@ -256,38 +260,46 @@ impl NetRxWorkerSlot {
             return;
         }
 
-        // Fallback: legacy net_rx_worker (kqueue on socketpair fd).
-        let Some(net_fd) = self.get_host_fd() else {
-            tracing::warn!("net-io: no host fd available for primary VirtioNet");
-            return;
-        };
-
-        let ctx = crate::net_rx_worker::NetRxWorkerContext {
-            net_host_fd: net_fd,
-            guest_mem,
-            rx_queue: queue,
-            event_idx: event_idx_enabled,
-            mmio_state: mmio_arc.clone(),
-            irq_callback,
-            irq,
-            exit_vcpus,
-            running,
-        };
-
-        match std::thread::Builder::new()
-            .name("net-io".to_string())
-            .spawn(move || crate::net_rx_worker::net_rx_worker_loop(ctx))
+        // Fallback: legacy net_rx_worker (kqueue on socketpair fd). kqueue
+        // is a BSD interface, so this flavor exists only on macOS; every
+        // other platform drives RX through the inject channel above.
+        #[cfg(target_os = "macos")]
         {
-            Ok(handle) => {
-                *self
-                    .handle
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(handle);
-                tracing::info!("Spawned net-io worker thread for primary VirtioNet (legacy)");
-            }
-            Err(e) => {
-                tracing::error!("Failed to spawn net-io worker thread: {e}");
+            let Some(net_fd) = self.get_host_fd() else {
+                tracing::warn!("net-io: no host fd available for primary VirtioNet");
+                return;
+            };
+
+            let ctx = crate::net_rx_worker::NetRxWorkerContext {
+                net_host_fd: net_fd,
+                guest_mem,
+                rx_queue: queue,
+                event_idx: event_idx_enabled,
+                mmio_state: mmio_arc.clone(),
+                irq_callback,
+                irq,
+                exit_vcpus,
+                running,
+            };
+
+            match std::thread::Builder::new()
+                .name("net-io".to_string())
+                .spawn(move || crate::net_rx_worker::net_rx_worker_loop(ctx))
+            {
+                Ok(handle) => {
+                    *self
+                        .handle
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(handle);
+                    tracing::info!("Spawned net-io worker thread for primary VirtioNet (legacy)");
+                }
+                Err(e) => {
+                    tracing::error!("Failed to spawn net-io worker thread: {e}");
+                }
             }
         }
+
+        #[cfg(not(target_os = "macos"))]
+        tracing::warn!("net-io: rx_inject_channel unset and no legacy RX worker on this platform");
     }
 }

--- a/virt/arcbox-vmm/src/lib.rs
+++ b/virt/arcbox-vmm/src/lib.rs
@@ -63,10 +63,14 @@
 pub mod blk_worker;
 pub mod boot;
 pub mod builder;
+// Intentionally not `pub` — only used by darwin_hv to spawn the worker.
+#[cfg(target_os = "macos")]
 pub(crate) mod console_rx_worker;
+// DAX windows are mapped through Hypervisor.framework; darwin_hv is the
+// only consumer.
+#[cfg(target_os = "macos")]
 pub mod dax;
 pub mod device;
-// Intentionally not `pub` — only used by darwin_hv to spawn the worker.
 pub mod error;
 pub mod event;
 pub mod fdt;

--- a/virt/arcbox-vmm/src/vmm/linux.rs
+++ b/virt/arcbox-vmm/src/vmm/linux.rs
@@ -5,6 +5,7 @@
 use super::*;
 
 use crate::device::DeviceTreeEntry;
+use crate::irq::{Gsi, IrqTriggerCallback};
 #[cfg(target_arch = "aarch64")]
 use arcbox_hypervisor::GuestAddress;
 use arcbox_hypervisor::VirtioDeviceConfig;
@@ -18,12 +19,15 @@ use crate::fdt::{FdtConfig, generate_fdt};
 impl Vmm {
     /// Linux-specific initialization using KVM.
     pub(super) fn initialize_linux(&mut self) -> Result<()> {
-        use arcbox_hypervisor::linux::KvmVm;
+        use arcbox_hypervisor::linux::{KvmHypervisor, KvmVm};
         use arcbox_hypervisor::traits::{Hypervisor, VirtualMachine};
         use std::sync::Mutex;
 
-        // Create hypervisor and VM
-        let hypervisor = arcbox_hypervisor::create_hypervisor()?;
+        // Named concretely rather than through `create_hypervisor()`: the
+        // code below needs `KvmVm`'s inherent `virtio_devices()` and stores
+        // the VM in `Vmm::linux_vm`, neither of which the erased
+        // `impl Hypervisor` return type can satisfy.
+        let hypervisor = KvmHypervisor::new()?;
         let vm_config = self.config.to_vm_config();
 
         tracing::debug!("Platform capabilities: {:?}", hypervisor.capabilities());

--- a/virt/arcbox-vmm/src/vmm/mod.rs
+++ b/virt/arcbox-vmm/src/vmm/mod.rs
@@ -344,6 +344,7 @@ impl Vmm {
             hv_console_worker: None,
             #[cfg(target_os = "macos")]
             hv_net_fd: None,
+            #[cfg(target_os = "macos")]
             hv_bridge_net_fd: None,
             #[cfg(target_os = "macos")]
             hv_blk_devices: Vec::new(),
@@ -643,6 +644,22 @@ impl Vmm {
     #[must_use]
     pub const fn has_balloon(&self) -> bool {
         self.config.balloon
+    }
+
+    /// Sets the balloon's target memory size.
+    ///
+    /// Only the macOS backends carry a balloon device today (the real
+    /// implementation lives in `darwin.rs`); elsewhere this reports the
+    /// gap rather than pretending the target was applied. Callers drive
+    /// it through the lifecycle balloon controller, whose
+    /// `reclaim_capable` gate keeps it unreached in practice.
+    ///
+    /// # Errors
+    ///
+    /// Always, on platforms with no balloon backend.
+    #[cfg(not(target_os = "macos"))]
+    pub fn set_balloon_target(&self, _target_bytes: u64) -> Result<()> {
+        Err(VmmError::Unsupported("balloon target control".to_string()))
     }
 
     /// Returns a snapshot of DAX counters for the given VirtioFS share


### PR DESCRIPTION
The restructure charter's D4 says the engine and computer layers "must
compile and pass unit tests on Linux", and `linux-engine` is the CI job
that holds them to it. Neither layer was in that job, because
`arcbox-vmm` — the seam they reach macOS through — failed to compile for
Linux with 17 errors. This clears them and extends the gate.

## What was broken

Nine errors were a single missing gate. `arcbox-hv` compiles to an
**empty** crate off macOS/aarch64 (its own `lib.rs` says so), so `dax.rs`
calling `hv_vm_map` unconditionally fails with `cannot find ffi in
arcbox_hv` — which reads like a missing dependency and is not.
`console_rx_worker` had the same shape, and `net_worker.rs`'s legacy
kqueue fallback referenced a module already gated in `lib.rs`. One `Vmm`
initializer had lost the `#[cfg]` its field declaration carries.

The rest was genuine bit rot in `vmm/linux.rs`, predating the
`arcbox-hypervisor` trait refactor: `Gsi`/`IrqTriggerCallback` were never
imported (`use super::*` re-exports only what `vmm/mod.rs` imports), and
`create_hypervisor()` hands back `impl Hypervisor` while the code below
needs `KvmVm`'s inherent `virtio_devices()` and stores the VM in
`Vmm::linux_vm`.

## The one design call

`set_balloon_target` is the only capability with no Linux backend. It now
answers `VmmError::Unsupported` at the `Vmm` seam instead of staying
macOS-gated, so `VmManager::set_balloon_target` and the lifecycle
balloon controller above it stay platform-free. The alternative — mirroring
the `#[cfg]` up into `vm_lifecycle` — would put a platform difference in
the layer the charter says must not have one. No behavior change on
macOS, and `reclaim_capable` is false on every backend regardless.

## Scope of the gate

The GNU step gains `arcbox-vmm`, `arcbox-engine`, `arcbox-computer`. Only
`arcbox-vmm` joins the **musl** step: the other two reach `ring` and
`zstd-sys` through `arcbox-image`, whose build scripts want a musl C
cross-compiler the runner lacks — the exclusion `arcbox-image` already
carries. `arcbox-vmm`'s own musl graph is pure Rust (no `cc`), verified
with `cargo tree`.

## Verification

- `cargo check --target aarch64-unknown-linux-musl --all-targets -p arcbox-vmm -p arcbox-engine -p arcbox-computer` — 0 errors, 0 warnings (was 17 errors)
- `cargo clippy --all-targets -p arcbox-vmm -p arcbox-engine -p arcbox-computer` on macOS — clean
- `cargo test -p arcbox-vmm -p arcbox-engine -p arcbox-computer` — 205 passed

aarch64 is deliberate: two of the 17 errors live inside a
`#[cfg(target_arch = "aarch64")]` block, so an x86_64 check finds only 15.
The linux-gnu half is unverifiable locally (this host's nix toolchain
ships no linux-gnu std) and rides on CI.

No load-bearing invariant is touched — the SplitQueue rules, the
async-worker completion contract, `MAX_VIRTQUEUES`, and the teardown
ordering all live in HV-only paths that Linux never reaches. The crate's
AGENTS.md gains the two rules that keep this from rotting again.