### PR TITLE
fix(ci): unbreak the crates.io publish, and make the Rust SDK publishable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,12 +356,12 @@ jobs:
         with:
           toolchain: stable
 
-      # arcbox-hv and arcbox-helper keep their own release cadences and the
-      # release excludes them; mirror it so the two commands stay one command.
+      # arcbox-hv keeps its own release cadence and the release excludes it;
+      # mirror the exclusion so the two commands stay one command.
       - name: Dry-run the coordinated workspace publish
         run: |
           cargo publish --workspace \
-            --exclude arcbox-hv --exclude arcbox-helper \
+            --exclude arcbox-hv \
             --no-verify --locked --dry-run
 
   # ==========================================================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,47 @@ jobs:
         run: uv build
 
   # ==========================================================================
+  # Prove the workspace still packages for crates.io.
+  #
+  # `Release Build`'s publish step is the only other place this runs, and it
+  # runs after the tag is cut — so a member whose manifest cannot package
+  # doesn't fail a PR, it fails a release, and the whole coordinated publish
+  # aborts before uploading anything. That is how v0.6.5 and v0.6.6 shipped
+  # binaries with not one crate reaching the registry: sdk/rust joined the
+  # workspace carrying a path dependency with no version, and the job had been
+  # red ever since.
+  #
+  # Same command as the release, minus the upload. --no-verify because four
+  # crates embed files from outside their own package directory (see the
+  # publish step for the list); --locked because the release publishes locked
+  # and a lockfile behind the manifests fails there too. No compilation, no
+  # token, ~1 minute.
+  # ==========================================================================
+  publish-dry-run:
+    name: crates.io packaging check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable branch
+        with:
+          toolchain: stable
+
+      # arcbox-hv and arcbox-helper keep their own release cadences and the
+      # release excludes them; mirror it so the two commands stay one command.
+      - name: Dry-run the coordinated workspace publish
+        run: |
+          cargo publish --workspace \
+            --exclude arcbox-hv --exclude arcbox-helper \
+            --no-verify --locked --dry-run
+
+  # ==========================================================================
   # Warm the release-profile cache that Release Build restores.
   #
   # The release job runs on a tag, and a tag can only read caches from its own

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,16 @@ jobs:
   # green by the CI build job, so the per-crate verify build is redundant safety
   # here, not new coverage. cargo still resolves the dependency graph and uploads
   # in dependency order via a local temp registry, so unpublished inter-deps
-  # resolve. arcbox-hv and arcbox-helper have their own release cadences and may
-  # already exist at their pinned versions, so exclude them from the coordinated
-  # workspace publish. Platform-agnostic (no compilation happens), so it runs on
+  # resolve. arcbox-hv is excluded: it releases on its own cadence, usually
+  # already exists at its pinned version, and depends on no workspace crate, so
+  # it can always be published by itself. arcbox-helper is NOT excluded even
+  # though its cadence is equally manual — it depends on arcbox-constants /
+  # -logging / -route at the workspace version, so a standalone publish of it
+  # cannot resolve until those are on the registry, and those go up in this
+  # pass. Excluding it deadlocked the publish the moment its pin moved ahead of
+  # crates.io (#613 bumped it to 1.1.0): arcbox-core requires `arcbox-helper
+  # ^1.1.0`, which then existed in neither the registry nor the temp one.
+  # Platform-agnostic (no compilation happens), so it runs on
   # ubuntu. Manual binary rebuilds only republish when explicitly requested.
   publish-crates:
     name: Publish crates to crates.io
@@ -107,7 +114,7 @@ jobs:
         # list before resuming. Only rate limits are retried; other errors fail
         # immediately.
         run: |
-          excludes=(--exclude arcbox-hv --exclude arcbox-helper)
+          excludes=(--exclude arcbox-hv)
           rate_limit_attempts=0
 
           while true; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "arcbox"
-version = "0.1.0"
+version = "0.6.6"
 dependencies = [
  "arcbox-connect",
  "arcbox-connectrpc",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "arcbox"
 description = "ArcBox Sandbox SDK for Rust — run isolated microVM sandboxes on your Mac"
-version = "0.1.0"
+# The workspace version, not a cadence of its own: crates.io already carries
+# `arcbox` 0.6.3 from the runtime facade this SDK replaced, so any version
+# below that publishes fine and is then never selected by `cargo add arcbox`.
+# Riding the workspace also keeps the SDK in the one coordinated
+# `cargo publish --workspace` that ships arcbox-connect, its own dependency.
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
-# Still unpublishable, but no longer because of connectrpc: that now resolves
-# from the registry as arcbox-connectrpc. What `cargo publish` stops on is
-# `arcbox-connect` below — a path dependency with no version, which cannot get
-# one until arcbox-connect 0.6.5 is on crates.io.
 
 [dependencies]
-arcbox-connect = { path = "../../rpc/arcbox-connect" }
+arcbox-connect.workspace = true
 base64 = "0.22.1"
 buffa = { version = "0.9.1", features = ["json"] }
 buffa-types = { version = "0.9.1", features = ["json"] }

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -65,8 +65,8 @@ path dependency this crate resolves against.
 Versions **0.6.3 and below on crates.io are not this crate**: they are
 the `arcbox` runtime facade — a re-export shell over `arcbox-core` and
 the VM crates — which this SDK replaced by taking the name. The API
-changes completely at 0.6.6, inside a version line semver says it
-shouldn't. The facade had no dependents on the registry and its
+changes completely at the first release that carries this SDK, inside
+a version line semver says it shouldn't. The facade had no dependents on the registry and its
 re-exports were commented out, so nothing can be broken by it, but a
 `arcbox = "0.6"` requirement written against the old crate does need
 rewriting rather than merely re-resolving.

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -66,10 +66,10 @@ Versions **0.6.3 and below on crates.io are not this crate**: they are
 the `arcbox` runtime facade — a re-export shell over `arcbox-core` and
 the VM crates — which this SDK replaced by taking the name. The API
 changes completely at the first release that carries this SDK, inside
-a version line semver says it shouldn't. The facade had no dependents on the registry and its
-re-exports were commented out, so nothing can be broken by it, but a
-`arcbox = "0.6"` requirement written against the old crate does need
-rewriting rather than merely re-resolving.
+a version line semver says it shouldn't. The facade had no dependents
+on the registry and its re-exports were commented out, so nothing can
+be broken by it, but an `arcbox = "0.6"` requirement written against
+the old crate does need rewriting rather than merely re-resolving.
 
 ## Status
 

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -62,6 +62,15 @@ carries `arcbox` 0.6.3 from the runtime facade this SDK replaced, so a
 `cargo add arcbox`; and the same run publishes `arcbox-connect`, the
 path dependency this crate resolves against.
 
+Versions **0.6.3 and below on crates.io are not this crate**: they are
+the `arcbox` runtime facade — a re-export shell over `arcbox-core` and
+the VM crates — which this SDK replaced by taking the name. The API
+changes completely at 0.6.6, inside a version line semver says it
+shouldn't. The facade had no dependents on the registry and its
+re-exports were commented out, so nothing can be broken by it, but a
+`arcbox = "0.6"` requirement written against the old crate does need
+rewriting rather than merely re-resolving.
+
 ## Status
 
 Shipped: connection resolution, the registry-derived error type, the

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -53,13 +53,14 @@ daemon speaks.
 
 ## Publishing
 
-Not on crates.io yet: the SDK speaks Connect through the `connectrpc`
-crate, which the workspace pins to a git revision until its 0.9 release
-reaches the registry. `cargo publish` fails loudly on the git
-dependency, so an accidental publish cannot ship a broken manifest.
-When `connectrpc` (and `arcbox-connect`) are on the registry, this
-crate publishes as `arcbox` on its own release-please cadence like the
-TypeScript and Python SDKs.
+Published as `arcbox` by the release tag's coordinated
+`cargo publish --workspace`, on the workspace version — not on a
+cadence of its own like the TypeScript and Python SDKs, which live in
+other registries. Two reasons it rides the workspace: crates.io already
+carries `arcbox` 0.6.3 from the runtime facade this SDK replaced, so a
+0.1.x line would publish and then never be selected by
+`cargo add arcbox`; and the same run publishes `arcbox-connect`, the
+path dependency this crate resolves against.
 
 ## Status
 


### PR DESCRIPTION
`arcbox-connectrpc` reaching the registry removed the last external blocker on publishing the Rust SDK — but the SDK was not the only thing stuck behind it. There turned out to be **two independent breaks** in the workspace publish; the second was found by the guard added here, on its first run.

## Break 1 — the SDK's own manifest

`sdk/rust` declared `arcbox-connect` as a bare path dependency. Cargo refuses to package a manifest with a versionless dependency, and the release's `cargo publish --workspace` packages **every** member before uploading **any**:

```
error: failed to verify manifest at `sdk/rust/Cargo.toml`
  all dependencies must have a version requirement specified when publishing.
  dependency `arcbox-connect` does not specify a version
```

So the whole coordinated publish aborted on this one manifest. **v0.6.5 and v0.6.6 both shipped binaries with not a single crate reaching crates.io** — `arcbox-connect` is still at 0.6.4 there, published 2026-08-10. The job was red both times; nothing else was.

Fixed by pointing it at the workspace entry every other member already uses (`arcbox-connect.workspace = true`).

The package version moves to the workspace version rather than its own 0.1.x line. crates.io already carries `arcbox` 0.6.3 from the runtime facade this SDK replaced, so a 0.1.0 upload would publish successfully and then never be what `cargo add arcbox` resolves. Riding the workspace also keeps the SDK in the same coordinated publish as `arcbox-connect`, which is what lets an as-yet-unpublished 0.6.6 resolve at upload time. The discontinuity — same name, different crate, inside one version line — is documented in the SDK README rather than left silent.

The alternative, a `sdk/rust` release-please package on its own 0.1.x cadence matching the TypeScript and Python SDKs, needs the four facade versions yanked first plus new release plumbing. Those SDKs are separate because they publish to other registries; this one is a workspace crate published by the workspace's own job.

## Break 2 — arcbox-helper's exclusion

#613 bumped `arcbox-helper` to 1.1.0 without publishing it, and the release excluded that crate from the workspace publish. `arcbox-core` requires `arcbox-helper ^1.1.0`, which then existed in neither the registry (1.0.2 is newest) nor cargo's temp registry of crates being published:

```
error: failed to prepare local package for uploading
  failed to select a version for the requirement `arcbox-helper = "^1.1.0"`
  candidate versions found which didn't match: 1.0.2, 1.0.1, 1.0.0, ...
  required by package `arcbox-core v0.6.6`
```

Publishing arcbox-helper by hand does not resolve it: helper depends on `arcbox-constants`/`-logging`/`-route` at the workspace version, which are themselves not on the registry — and go up in the very pass its exclusion breaks. The two cadences were never independent.

So only `arcbox-hv` stays excluded: it depends on no workspace crate and can always be published by itself. When helper's version has not moved, the loop's existing `already exists on crates.io index` arm excludes it and resumes — which is what the static exclusion was hand-rolling.

## The guard

The publish step only runs on a tag, so an unpublishable manifest fails a release rather than a PR. The new `crates.io packaging check` job runs the same command on every PR with the upload removed: no compilation (`--no-verify`), no token (`--dry-run`), 27 seconds. `--locked` also covers the release's other packaging failure mode, a lockfile behind the manifests.

## Verification

`cargo publish --workspace --exclude arcbox-hv --no-verify --locked --dry-run` resolves all 54 crates and exits 0, with `arcbox v0.6.6`, `arcbox-helper v1.1.0` and `arcbox-snapshot v0.6.6` among them. On master it exits 101 at `sdk/rust`; with break 1 fixed alone it exits 101 at `arcbox-core`.
