### PR TITLE
test(splicetcp): size the partial-take tests against the granted socket buffer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,23 +125,14 @@ jobs:
   # `lib test` target and type-checks it.
   #
   # The test step covers the two things `--all-targets` still cannot: it
-  # RUNS the tests (a Linux/macOS behavioral difference type-checks fine —
-  # see the splicetcp note below), and it compiles DOCTESTS, which no
-  # `cargo check` invocation ever does. That second gap was not theoretical:
-  # `LinuxTap`'s doctest had been calling a trait method without importing
-  # the trait since the Linux arm was revived, and only this step caught it.
-  # Every KVM-touching test in `arcbox-hypervisor` is already `#[ignore]`d
-  # ("Requires /dev/kvm", not available on this runner); the netlink/tap
-  # tests in `arcbox-net` self-skip at runtime when not root. `splicetcp` is
-  # the one crate checked but not tested: two of its tcp_bridge tests
-  # calibrate a 4 KiB socket buffer to force a partial-take, and Linux
-  # doubles a `SO_SNDBUF` request and enforces a floor, so the buffer
-  # swallows the whole payload and the tests' own "this must exercise the
-  # partial-take path" guards fire. The guards are right — they refuse to
-  # pass vacuously — but the constant is macOS-calibrated; sizing the
-  # payload against the *granted* buffer would let them run here too. That
-  # pair is also the reason the test step exists at all: it type-checks
-  # identically on both platforms and only diverges when run.
+  # RUNS the tests (a Linux/macOS behavioral difference type-checks fine),
+  # and it compiles DOCTESTS, which no `cargo check` invocation ever does.
+  # That second gap was not theoretical: `LinuxTap`'s doctest had been
+  # calling a trait method without importing the trait since the Linux arm
+  # was revived, and only this step caught it. Every KVM-touching test in
+  # `arcbox-hypervisor` is already `#[ignore]`d ("Requires /dev/kvm", not
+  # available on this runner); the netlink/tap tests in `arcbox-net`
+  # self-skip at runtime when not root.
   #
   # A second step repeats the *check* (not the tests — a musl-arm64 test
   # binary can't run on this x86_64 runner) on aarch64-unknown-linux-musl
@@ -203,7 +194,7 @@ jobs:
       # than stopping at the first, which otherwise hides later failures
       # behind a fix-and-rerun loop.
       - name: Test engine-layer crates on Linux
-        run: cargo test --no-fail-fast -p arcbox-image -p arcbox-net -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-engine -p arcbox-computer
+        run: cargo test --no-fail-fast -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-engine -p arcbox-computer
 
       - name: Check engine-layer crates on aarch64-unknown-linux-musl
         run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm

--- a/common/splicetcp/src/tcp_bridge/tests.rs
+++ b/common/splicetcp/src/tcp_bridge/tests.rs
@@ -1324,6 +1324,28 @@ async fn upload_ooo_reassembly_across_seq_wraparound() {
     assert!(got[100..].iter().all(|&b| b == 0xBB));
 }
 
+/// A byte count that safely exceeds the combined one-shot capacity of a
+/// shrunken sender's `SO_SNDBUF` and receiver's `SO_RCVBUF` — derived from
+/// what the OS actually granted (`granted_send`/`granted_recv`), not from
+/// what a test requested. Linux doubles a `SO_SNDBUF`/`SO_RCVBUF` request
+/// and enforces its own floor (`net.core.wmem_min`/`rmem_min`), so a 4 KiB
+/// request can yield well more than 4 KiB back; macOS mostly honors the
+/// request as-is. On a loopback socket a single non-blocking write can be
+/// satisfied out of BOTH buffers — the receiver's kernel can accept and ACK
+/// bytes within the same syscall, before user space ever calls `read` — so
+/// `granted_send + granted_recv` is the real one-shot ceiling a
+/// partial-take test must outrun, on any platform. Capped well under the
+/// 65,495-byte payload a synthetic frame's u16 IP total-length field allows.
+fn guaranteed_oversized(granted_send: usize, granted_recv: usize) -> usize {
+    let capacity = granted_send + granted_recv;
+    let oversized = (capacity * 3).min(60_000);
+    assert!(
+        oversized > capacity,
+        "granted socket buffers ({capacity} bytes) leave no margin under the frame-size cap"
+    );
+    oversized
+}
+
 /// Property: draining parked segments obeys the same contract as in-order
 /// writes — the ACK never covers bytes the host socket did not take, and
 /// retransmitting from the cursor eventually delivers every byte exactly
@@ -1340,13 +1362,19 @@ async fn upload_ooo_drain_respects_host_writable() {
     let connect = tokio::net::TcpStream::connect(addr);
     let (client, accepted) = tokio::join!(connect, listener.accept());
     let std_client = client.unwrap().into_std().unwrap();
-    socket2::SockRef::from(&std_client)
-        .set_send_buffer_size(4096)
-        .unwrap();
+    // The requested size is not what lands: Linux doubles it and applies
+    // its own floor, so read back what the OS actually granted below.
+    let granted_send = {
+        let sock = socket2::SockRef::from(&std_client);
+        sock.set_send_buffer_size(4096).unwrap();
+        sock.send_buffer_size().unwrap()
+    };
     let (accepted, _) = accepted.unwrap();
-    socket2::SockRef::from(&accepted)
-        .set_recv_buffer_size(4096)
-        .unwrap();
+    let granted_recv = {
+        let sock = socket2::SockRef::from(&accepted);
+        sock.set_recv_buffer_size(4096).unwrap();
+        sock.recv_buffer_size().unwrap()
+    };
 
     let dst_ip = Ipv4Addr::new(198, 18, 30, 103);
     let key = SynFlowKey {
@@ -1366,9 +1394,11 @@ async fn upload_ooo_drain_respects_host_writable() {
     // Position-dependent pattern (251 is prime, so no aliasing if a chunk
     // were duplicated or skipped).
     const HOLE: usize = 100;
-    const PARKED: usize = 16 * 1024;
-    const TOTAL: usize = HOLE + PARKED;
-    let payload: Vec<u8> = (0..TOTAL).map(|i| (i % 251) as u8).collect();
+    // The parked segment must outrun what the OS actually granted above —
+    // see `guaranteed_oversized`.
+    let parked_len = guaranteed_oversized(granted_send, granted_recv);
+    let total = HOLE + parked_len;
+    let payload: Vec<u8> = (0..total).map(|i| (i % 251) as u8).collect();
     let base: u32 = 2000;
 
     // Park far more than the shrunken socket can take, then fill the hole:
@@ -1402,9 +1432,9 @@ async fn upload_ooo_drain_respects_host_writable() {
         "the in-order fill itself must be ACKed"
     );
     assert!(
-        first_advance < TOTAL,
-        "4 KiB socket buffers cannot take all {TOTAL} bytes at once — \
-         the test must exercise the drain's partial-take stop"
+        first_advance < total,
+        "granted socket buffers ({granted_send}+{granted_recv} bytes) cannot take all \
+         {total} bytes at once — the test must exercise the drain's partial-take stop"
     );
 
     // Retransmit from the cursor (the guest's recovery) until everything
@@ -1430,23 +1460,23 @@ async fn upload_ooo_drain_respects_host_writable() {
             }
         }
         let offset = cursor.wrapping_sub(base) as usize;
-        if offset >= TOTAL {
+        if offset >= total {
             break;
         }
-        let chunk = &payload[offset..(offset + 8 * 1024).min(TOTAL)];
+        let chunk = &payload[offset..(offset + 8 * 1024).min(total)];
         let seg = make_guest_segment((40035, dst_ip, 443), cursor, 1000, 65535, 0x18, chunk);
         let reply = bridge.try_fast_path_intercept(&seg).expect("intercepted");
         let acked = tcp_ack_of(&reply);
         // The ACK may leap past this chunk (the drain flushes parked bytes
         // behind it) but never past bytes that were never offered.
         assert!(
-            acked.wrapping_sub(base) as usize <= TOTAL,
+            acked.wrapping_sub(base) as usize <= total,
             "ACK beyond the offered bytes"
         );
         cursor = acked;
     }
-    assert_eq!(cursor.wrapping_sub(base) as usize, TOTAL);
-    assert_eq!(server_received, TOTAL);
+    assert_eq!(cursor.wrapping_sub(base) as usize, total);
+    assert_eq!(server_received, total);
 }
 
 /// A FIN whose sequence position lies beyond the cursor (its stream still
@@ -1666,14 +1696,19 @@ async fn upload_ack_never_exceeds_host_writable() {
     let (client, accepted) = tokio::join!(connect, listener.accept());
     let std_client = client.unwrap().into_std().unwrap();
     // Shrink both socket buffers so segments outrun what the kernel will
-    // take and the write path must report partial/zero takes.
-    socket2::SockRef::from(&std_client)
-        .set_send_buffer_size(4096)
-        .unwrap();
+    // take and the write path must report partial/zero takes. The
+    // requested size is not what lands: read back the actual grant below.
+    let granted_send = {
+        let sock = socket2::SockRef::from(&std_client);
+        sock.set_send_buffer_size(4096).unwrap();
+        sock.send_buffer_size().unwrap()
+    };
     let (accepted, _) = accepted.unwrap();
-    socket2::SockRef::from(&accepted)
-        .set_recv_buffer_size(4096)
-        .unwrap();
+    let granted_recv = {
+        let sock = socket2::SockRef::from(&accepted);
+        sock.set_recv_buffer_size(4096).unwrap();
+        sock.recv_buffer_size().unwrap()
+    };
 
     let dst_ip = Ipv4Addr::new(198, 18, 30, 98);
     let key = SynFlowKey {
@@ -1690,10 +1725,12 @@ async fn upload_ack_never_exceeds_host_writable() {
         .set_read_timeout(Some(std::time::Duration::from_millis(500)))
         .unwrap();
 
-    // Segments stay MTU-plausible (an IP packet's total length is u16);
-    // the volume, not the segment size, is what outruns the buffers.
-    const SEGMENT: usize = 8 * 1024;
-    let payload = vec![0xCC; 256 * 1024];
+    // Segments stay MTU-plausible (an IP packet's total length is u16) and
+    // safely outrun whatever the OS actually granted above — see
+    // `guaranteed_oversized`. The payload is a generous multiple of that so
+    // the loop below exercises many iterations, not just one.
+    let chunk_size = guaranteed_oversized(granted_send, granted_recv);
+    let payload = vec![0xCC; chunk_size * 8];
     let base: u32 = 2000;
     let mut cursor: u32 = base;
     let mut server_received = 0usize;
@@ -1705,7 +1742,7 @@ async fn upload_ack_never_exceeds_host_writable() {
         if offset >= payload.len() {
             break;
         }
-        let chunk = &payload[offset..(offset + SEGMENT).min(payload.len())];
+        let chunk = &payload[offset..(offset + chunk_size).min(payload.len())];
         let segment = make_guest_segment((40023, dst_ip, 443), cursor, 1000, 65535, 0x18, chunk);
         let reply = bridge
             .try_fast_path_intercept(&segment)
@@ -1740,7 +1777,8 @@ async fn upload_ack_never_exceeds_host_writable() {
     assert_eq!(server_received, payload.len());
     assert!(
         short_takes > 0,
-        "test must actually exercise the partial-take path (send buffer 4 KiB, payload 64 KiB)"
+        "test must actually exercise the partial-take path (granted buffers \
+         {granted_send}+{granted_recv} bytes, segment {chunk_size} bytes)"
     );
 }
 


### PR DESCRIPTION
## Problem

`upload_ack_never_exceeds_host_writable` and `upload_ooo_drain_respects_host_writable` (`common/splicetcp/src/tcp_bridge/tests.rs`) each request a 4 KiB `SO_SNDBUF`/`SO_RCVBUF` via `socket2::SockRef` and then hardcode a payload size chosen to outrun *that requested size*, relying on the socket being too small to swallow the whole payload so the partial-take code path in `fast_path.rs` (`conn.stream.write(...)` returning fewer bytes than offered, and `drain_parked_segments`'s mid-segment short write) actually gets exercised.

That assumption holds on macOS, where a 4 KiB request is honored close to as-is. It does not hold on Linux: the kernel doubles a `SO_SNDBUF`/`SO_RCVBUF` request and enforces its own floor (`net.core.wmem_min`/`rmem_min`), so a 4 KiB ask yields ≥8 KiB back — and on a loopback socket a single non-blocking write can additionally be satisfied out of *both* the sender's send buffer and the receiver's already-ACKed receive buffer before the reader ever calls `read()`, so the effective one-shot capacity is close to their sum. With the old constants that's enough to swallow the whole test payload in one shot, so the tests' own anti-vacuous-pass guards correctly fire:
- `assert!(short_takes > 0, ...)`
- `assert!(first_advance < TOTAL, ...)`

The guards are right — they exist so these tests cannot pass vacuously. The bug is the hardcoded, macOS-calibrated constant.

## Fix

Both tests now call `send_buffer_size()`/`recv_buffer_size()` after setting the buffers to read back what the OS actually granted, and derive the payload from that measurement (`guaranteed_oversized`: `(granted_send + granted_recv) * 3`, capped under the 65,495-byte payload ceiling a synthetic frame's u16 IP total-length field allows, with an explicit assertion that the margin holds). This makes the partial-take path guaranteed by construction on any platform instead of tuned to today's macOS buffer-sizing policy — nobody has to re-derive a constant if a kernel ever changes how it doubles/floors these buffers.

The `TOTAL`/`PARKED`/`SEGMENT` constants become runtime `let` bindings since the granted size is only known at runtime; everything downstream (offsets, holes, the retransmit-from-cursor loop) is otherwise unchanged — the tests still verify exactly what they did before (the ACK never covers unwritten bytes, drain stops at the socket's capacity, retransmit-from-cursor eventually delivers every byte exactly once).

## CI

Re-enables `splicetcp` in the "Test engine-layer crates on Linux" step's `-p` list (it was already present on the *check* step, deliberately absent from *test*) and removes the comment paragraph in `.github/workflows/ci.yml` that documented the exclusion — added in #625, which is also where the exclusion's rationale (this exact doubling/floor behavior) was first written up.

## Verification

- macOS (this host): `cargo test -p splicetcp` — 91 passed, including both fixed tests. `cargo clippy -p splicetcp --all-targets -- -D warnings` clean. `cargo fmt --all -- --check` clean.
- `cargo check --target aarch64-unknown-linux-musl -p splicetcp --all-targets` — compiles clean.
- Linux *behavior* (the actual bug) can only be observed in CI — this host's toolchain has no linux-gnu std to run a linux-gnu test binary locally. Watching `gh pr checks` on this PR for the `linux-engine` job's "Test engine-layer crates on Linux" step is the real verification.

## Test plan

- [x] `cargo test -p splicetcp` green on macOS
- [x] `cargo clippy -p splicetcp --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check --target aarch64-unknown-linux-musl -p splicetcp --all-targets` clean
- [ ] CI `linux-engine` / "Test engine-layer crates on Linux" green (splicetcp now included)