### PR TITLE
fix(runtime): close multi-dev isolation gaps

### DIFF
--- a/app/arcbox-cli/README.md
+++ b/app/arcbox-cli/README.md
@@ -43,7 +43,8 @@ abctl docker disable            # Reset to default context
 
 # Native Kubernetes integration
 abctl k8s start                  # Start the ArcBox Kubernetes cluster
-abctl k8s enable                 # Install kubectl + activate ArcBox kube context
+abctl k8s enable                 # Install kubectl + add the ArcBox kube context
+# Development contexts are not activated globally; select one with kubectl config use-context.
 kubectl get nodes
 
 # Run containers through Docker CLI

--- a/app/arcbox-cli/src/commands/kubernetes.rs
+++ b/app/arcbox-cli/src/commands/kubernetes.rs
@@ -306,11 +306,12 @@ async fn refresh_if_enabled(home: &Path) -> Result<()> {
     }
 
     let current_context = current_context(home).await?;
-    let restore_managed_context = should_restore_managed_context(
-        current_context.as_deref(),
-        state.managed_context.as_deref(),
-        managed_context_name(),
-    );
+    let restore_managed_context = owns_global_current_context(ArcboxProfile::from_env_or_default())
+        && should_restore_managed_context(
+            current_context.as_deref(),
+            state.managed_context.as_deref(),
+            managed_context_name(),
+        );
     let managed_context = refresh_managed_kubeconfig(home).await?;
     delete_context_entries(home, &managed_context).await?;
     merge_managed_kubeconfig(home).await?;
@@ -326,6 +327,10 @@ async fn refresh_if_enabled(home: &Path) -> Result<()> {
     )
     .await?;
     Ok(())
+}
+
+fn owns_global_current_context(profile: ArcboxProfile) -> bool {
+    profile == ArcboxProfile::Production
 }
 
 fn should_restore_managed_context(
@@ -448,11 +453,18 @@ async fn execute_enable() -> Result<()> {
     let home = home_dir()?;
     install_kubernetes_tools(&home).await?;
 
-    let previous_context = current_context(&home).await?;
+    let owns_current_context = owns_global_current_context(ArcboxProfile::from_env_or_default());
+    let previous_context = if owns_current_context {
+        current_context(&home).await?
+    } else {
+        None
+    };
     let managed_context = refresh_managed_kubeconfig(&home).await?;
     delete_context_entries(&home, &managed_context).await?;
     merge_managed_kubeconfig(&home).await?;
-    set_current_context(&home, &managed_context).await?;
+    if owns_current_context {
+        set_current_context(&home, &managed_context).await?;
+    }
 
     save_state(
         &home,
@@ -465,7 +477,12 @@ async fn execute_enable() -> Result<()> {
     .await?;
 
     println!("Kubernetes integration enabled.");
-    println!("Current context: {managed_context}");
+    if owns_current_context {
+        println!("Current context: {managed_context}");
+    } else {
+        println!("Context added: {managed_context}");
+        println!("Select it explicitly with 'kubectl config use-context {managed_context}'.");
+    }
     println!("kubectl installed to {}", kubectl_bin(&home).display());
     Ok(())
 }
@@ -513,7 +530,10 @@ async fn execute_kubeconfig() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_managed_context_name, should_restore_managed_context};
+    use super::{
+        owns_global_current_context, resolve_managed_context_name, should_restore_managed_context,
+    };
+    use arcbox_constants::paths::ArcboxProfile;
 
     #[test]
     fn context_name_uses_old_daemon_fallback_only_when_missing() {
@@ -549,5 +569,11 @@ mod tests {
             Some("arcbox-dev-a"),
             "arcbox-dev"
         ));
+    }
+
+    #[test]
+    fn only_production_owns_the_global_current_context() {
+        assert!(owns_global_current_context(ArcboxProfile::Production));
+        assert!(!owns_global_current_context(ArcboxProfile::Development));
     }
 }

--- a/app/arcbox-core/src/route_reconciler.rs
+++ b/app/arcbox-core/src/route_reconciler.rs
@@ -330,7 +330,18 @@ async fn reconcile_with_snapshot(
                 if routes.network != ContainerNetwork::default() {
                     // Close the useful part of the check/add race. Route changes
                     // after this point are caught by the daemon route watcher.
-                    inspect_routes(bridge_name, routes).await?;
+                    if let Err(error) = inspect_routes(bridge_name, routes).await {
+                        let cleanup = client
+                            .route_remove_if_owned(&routes.preferred.to_string(), bridge_name)
+                            .await;
+                        if let Err(cleanup) = cleanup {
+                            return Err(RouteError::RouteFailed(format!(
+                                "{error}; failed to roll back added route {}: {cleanup}",
+                                routes.preferred
+                            )));
+                        }
+                        return Err(error);
+                    }
                 }
                 return Ok(RouteMode::Preferred);
             }
@@ -499,11 +510,11 @@ pub fn system_vm_route_hook(
     machine_manager: &std::sync::Arc<crate::machine::MachineManager>,
     event_bus: &crate::event::EventBus,
     machine_name: &str,
+    network: ContainerNetwork,
 ) -> crate::vm_lifecycle::RouteHook {
     let mm = std::sync::Arc::clone(machine_manager);
     let bus = event_bus.clone();
     let machine_name = machine_name.to_string();
-    let network = ContainerNetwork::default();
     crate::vm_lifecycle::RouteHook::new(std::sync::Arc::new(move || {
         #[cfg(feature = "vmnet")]
         {

--- a/app/arcbox-core/src/runtime.rs
+++ b/app/arcbox-core/src/runtime.rs
@@ -235,6 +235,7 @@ impl Runtime {
                 &machine_manager,
                 &event_bus,
                 crate::vm_lifecycle::DEFAULT_MACHINE_NAME,
+                config.container.cidr,
             ));
         }
 

--- a/app/arcbox-daemon/src/services.rs
+++ b/app/arcbox-daemon/src/services.rs
@@ -307,26 +307,35 @@ async fn container_route_guard(
     let mut ticker = tokio::time::interval(ROUTE_POLL_INTERVAL);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut watcher = open_route_watcher();
+    // Custom routes stay daemon-owned for lease cleanup, so VM arrival edges
+    // trigger the same retrying route setup instead of a detached core hook.
+    let mut vm_state = runtime.subscribe_system_vm_state();
     let mut active: Option<(String, RouteMode)> = None;
     let mut consecutive_failures = 0u32;
 
     loop {
-        let route_event = tokio::select! {
+        let (route_event, vm_became_ready) = tokio::select! {
             () = shutdown.cancelled() => break,
-            _ = ticker.tick() => false,
+            _ = ticker.tick() => (false, false),
+            changed = vm_state.changed() => {
+                if changed.is_err() {
+                    break;
+                }
+                (false, vm_state.borrow().is_ready())
+            }
             event = next_managed_route_event(watcher.as_ref(), container_network) => {
                 match event {
-                    Ok(()) => true,
+                    Ok(()) => (true, false),
                     Err(error) if error.raw_os_error() == Some(libc::ENOBUFS) => {
                         tracing::debug!(
                             "route event queue overflowed; reconciling current state"
                         );
-                        true
+                        (true, false)
                     }
                     Err(error) => {
                         tracing::warn!(%error, "route event watcher failed; polling remains active");
                         watcher = None;
-                        false
+                        (false, false)
                     }
                 }
             }
@@ -342,6 +351,14 @@ async fn container_route_guard(
             }
         } else if watcher.is_none() {
             watcher = open_route_watcher();
+        }
+
+        if vm_became_ready
+            && let Err(error) =
+                ensure_isolated_container_route(&runtime, &setup_state, &container_network_lease)
+                    .await
+        {
+            tracing::debug!(%error, "container route was not ready on the VM arrival edge");
         }
 
         let runtime_for_bridge = Arc::clone(&runtime);
@@ -411,7 +428,7 @@ async fn container_route_guard(
                     );
                 }
             }
-            Err(error) if is_route_ownership_conflict(&error) => {
+            Err(error) if is_route_ownership_conflict(&error, container_network) => {
                 if let Some(lease) = container_network_lease.get()
                     && let Err(cleanup_error) = lease.cleanup_route().await
                 {
@@ -441,12 +458,16 @@ async fn container_route_guard(
 }
 
 #[cfg(target_os = "macos")]
-fn is_route_ownership_conflict(error: &arcbox_core::route_reconciler::RouteError) -> bool {
-    matches!(
-        error,
-        arcbox_core::route_reconciler::RouteError::RouteConflict { .. }
-            | arcbox_core::route_reconciler::RouteError::RouteOverlap { .. }
-    )
+fn is_route_ownership_conflict(
+    error: &arcbox_core::route_reconciler::RouteError,
+    network: ContainerNetwork,
+) -> bool {
+    network != ContainerNetwork::default()
+        && matches!(
+            error,
+            arcbox_core::route_reconciler::RouteError::RouteConflict { .. }
+                | arcbox_core::route_reconciler::RouteError::RouteOverlap { .. }
+        )
 }
 
 #[cfg(target_os = "macos")]
@@ -695,17 +716,28 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn every_route_ownership_conflict_is_fatal() {
+    fn only_isolated_route_ownership_conflicts_are_fatal() {
         use arcbox_core::route_reconciler::RouteError;
 
-        assert!(is_route_ownership_conflict(&RouteError::RouteConflict {
-            subnet: "10.64.32.0/20".into(),
-        }));
-        assert!(is_route_ownership_conflict(&RouteError::RouteOverlap {
-            network: "10.64.32.0/20".parse().unwrap(),
+        let isolated: ContainerNetwork = "10.64.32.0/20".parse().unwrap();
+        let conflict = RouteError::RouteConflict {
+            subnet: isolated.to_string(),
+        };
+        let overlap = RouteError::RouteOverlap {
+            network: isolated,
             route: "10.64.0.0/16".parse().unwrap(),
-        }));
-        assert!(!is_route_ownership_conflict(&RouteError::BridgeNotReady));
+        };
+
+        assert!(is_route_ownership_conflict(&conflict, isolated));
+        assert!(is_route_ownership_conflict(&overlap, isolated));
+        assert!(!is_route_ownership_conflict(
+            &conflict,
+            ContainerNetwork::default()
+        ));
+        assert!(!is_route_ownership_conflict(
+            &RouteError::BridgeNotReady,
+            isolated
+        ));
     }
 
     /// Polls until `route_installed` matches `want` or times out.

--- a/app/arcbox-daemon/src/startup/mod.rs
+++ b/app/arcbox-daemon/src/startup/mod.rs
@@ -51,6 +51,9 @@ async fn init_early(args: DaemonArgs, handles: StartupHandles) -> Result<EarlyCo
         layout.grpc_socket = grpc;
     }
 
+    let dns_domain = dns_domain(args.dns_domain)?;
+    validate_explicit_dns_resolver(profile, args.install_dns_resolver, &dns_domain)?;
+
     std::fs::create_dir_all(&layout.data_dir).context("Failed to create data directory")?;
     std::fs::create_dir_all(&layout.run_dir).context("Failed to create run directory")?;
     // The gRPC/Docker sockets live in run_dir and are the daemon's only access
@@ -66,7 +69,6 @@ async fn init_early(args: DaemonArgs, handles: StartupHandles) -> Result<EarlyCo
     std::fs::create_dir_all(&layout.data_subdir)
         .context("Failed to create persistent data directory")?;
 
-    let dns_domain = dns_domain(args.dns_domain)?;
     let dns_port = dns_port(args.dns_port);
     let kubernetes_context = kubernetes_context(profile, args.kubernetes_context)?;
 
@@ -93,6 +95,18 @@ async fn init_early(args: DaemonArgs, handles: StartupHandles) -> Result<EarlyCo
             no_linux_vm: args.no_linux_vm,
         },
     })
+}
+
+fn validate_explicit_dns_resolver(
+    profile: ArcboxProfile,
+    enabled: bool,
+    domain: &str,
+) -> Result<()> {
+    anyhow::ensure!(
+        profile == ArcboxProfile::Production || !enabled || domain != DEFAULT_DNS_DOMAIN,
+        "development --install-dns-resolver requires a non-canonical --dns-domain"
+    );
+    Ok(())
 }
 
 /// Acquire the daemon lock, consuming the [`EarlyContext`].
@@ -371,7 +385,7 @@ fn kubernetes_context(profile: ArcboxProfile, requested: Option<String>) -> Resu
 
 #[cfg(test)]
 mod tests {
-    use super::kubernetes_context;
+    use super::{DEFAULT_DNS_DOMAIN, kubernetes_context, validate_explicit_dns_resolver};
     use arcbox_constants::paths::ArcboxProfile;
 
     #[test]
@@ -390,6 +404,26 @@ mod tests {
         );
         assert!(
             kubernetes_context(ArcboxProfile::Development, Some("bad: value".to_owned())).is_err()
+        );
+    }
+
+    #[test]
+    fn development_cannot_claim_the_production_resolver_domain() {
+        assert!(
+            validate_explicit_dns_resolver(ArcboxProfile::Development, true, DEFAULT_DNS_DOMAIN)
+                .is_err()
+        );
+        assert!(
+            validate_explicit_dns_resolver(
+                ArcboxProfile::Development,
+                true,
+                "worktree.dev.arcbox.local"
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_explicit_dns_resolver(ArcboxProfile::Production, true, DEFAULT_DNS_DOMAIN)
+                .is_ok()
         );
     }
 }


### PR DESCRIPTION
## Summary

- reject development daemons that try to claim the production DNS resolver domain
- reconcile isolated routes on VM arrival, roll back failed post-add verification, and keep production route conflicts non-fatal
- add development kubeconfig entries without changing the host-global current context
- pass the selected network into the VM route hook instead of hiding a default-CIDR assumption

## Root cause

Post-merge review of #613 found that several host-global ownership boundaries were incomplete: development could still mutate the production resolver and kubeconfig selection, while route recovery mixed production best-effort semantics with isolated-instance fail-fast semantics.

The helper compatibility comment does not need another installer: ArcBox Desktop compares the installed helper with the bundled helper and requests an authenticated upgrade before daemon startup. A source audit also found no ArcBox Desktop references to the removed route constants.

## Validation

- `cargo test -p arcbox-daemon --bin arcbox-daemon` — 49 passed
- `cargo test -p arcbox-core --lib` — 91 passed
- `cargo test -p arcbox-cli --lib --bins` — 132 passed
- `cargo clippy -p arcbox-daemon -p arcbox-core -p arcbox-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Follow-up to #613 and ABX-515.
