### PR TITLE
chore(tools): bump buildx to 0.36.1 and compose to 5.4.0

### DIFF
--- a/assets.lock
+++ b/assets.lock
@@ -28,16 +28,16 @@ arch.x86_64.sha256 = "9a72a1c1a331885aadf7948e3da8e3c5c88c5e813474bb82dce7cc7245
 [[tools]]
 name = "docker-buildx"
 group = "docker"
-version = "0.35.0"
-arch.arm64.sha256 = "fedbcbd488dcdb46414c6119920d8186d406531a1157ceede4e857e25af77ff1"
-arch.x86_64.sha256 = "7d53fd11deca2d4caebc5436c9eebece5c81c8bbc6d4b539cf30be5c133c38c7"
+version = "0.36.1"
+arch.arm64.sha256 = "214cdc36788602862dbc82b523d58648b4585c7b0ff95218b0817c44db5573d7"
+arch.x86_64.sha256 = "52a39ee4012d18f83373656712102ebda55656121dcdabbbb1ccfbd41b7debe8"
 
 [[tools]]
 name = "docker-compose"
 group = "docker"
-version = "5.3.1"
-arch.arm64.sha256 = "32691ba1196d819fa68cbdc0aad9a5569e730a35ae40c6fdd8458110ecd69488"
-arch.x86_64.sha256 = "56620a2e87e789147b9b1cc5d37eeecec2332e2cdf5c2d58a68f999f2dc416ca"
+version = "5.4.0"
+arch.arm64.sha256 = "bc3d1fd4c01e3af9b481fc5ea153ea7c006c77eb39be78e9af3e2e8ebecc0d61"
+arch.x86_64.sha256 = "59fc378c6832c7c8d628d4d38a4e2bebcad579b21d1d380e9b8872961fe3da83"
 
 [[tools]]
 name = "docker-credential-osxkeychain"


### PR DESCRIPTION
The generated bump (#634) proposes three tools; two of them can land now and one cannot.

| tool | from | to | lands here |
| --- | --- | --- | --- |
| docker-buildx | 0.35.0 | 0.36.1 | yes |
| docker-compose | 5.3.1 | 5.4.0 | yes |
| docker | 29.6.2 | 29.7.2 | **no** |

`assets.lock`'s header asks the `docker` tool to track the boot bundle's dockerd and to diverge only "for the short window between a bundle release and the `[boot]` bump". Bundle `0.8.4` ships dockerd **29.6.1** (`upstream.toml` at tag v0.8.4 in the boot-assets repo), so the host CLI already sits a patch ahead and 29.7.2 would make it a minor. That half belongs in a two-repo change: boot-assets tags a bundle with dockerd 29.7.2, then `[boot] version` + `manifest_sha256` move here in the same PR as the tool bump.

buildx and compose have no guest-side twin and no such constraint, so there is no reason for them to wait.

Checksums are the generator's, computed by downloading each binary — and corroborated by two independent runs a week apart: #587 (2026-08-10) and #634 (today) produced identical digests for both tools.

#634 stays open for the docker half; the weekly job now maintains exactly one such PR (#632), and once buildx and compose are current it will propose docker alone.