### PR TITLE
ci(release): give release-please a manual trigger

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,10 +53,17 @@ jobs:
       - name: Update lockfiles on release PRs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           git config --global user.name "arcbox-labs[bot]"
           git config --global user.email "254083426+arcbox-labs[bot]@users.noreply.github.com"
-          gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls?base=${GITHUB_REF_NAME}&state=open&per_page=100" |
+          # Filter on the default branch, not the ref this run started from.
+          # release-please takes no `target-branch`, so it always builds its
+          # PRs against the default branch — but a `workflow_dispatch` can run
+          # from any ref, and `GITHUB_REF_NAME` would then match no PR at all.
+          # The step would find nothing, skip silently, and leave the release
+          # PR with a stale lockfile that fails --locked at tag time.
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls?base=${DEFAULT_BRANCH}&state=open&per_page=100" |
           jq -c '.[]
             | select(any(.labels[]; .name == "autorelease: pending"))
             | {number, headRefName: .head.ref}' |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches:
       - master
+  # A release PR that goes stale has no other way back. release-please only
+  # rewrites a component's PR when that component gets new commits, so one
+  # release PR merging can leave a sibling conflicted on
+  # `.release-please-manifest.json` with nothing to un-stick it — the fix is
+  # to close the stale PR and have release-please rebuild it, which without
+  # this needs an unrelated push to master to happen first. `release.yml`
+  # carries the same escape hatch for the same reason.
+  workflow_dispatch:
 
 jobs:
   release-please:


### PR DESCRIPTION
## What went wrong

release-please rewrites a component's release PR only when that component gets new commits. Merging #615 (sdk-typescript 0.1.3) changed `.release-please-manifest.json`, which put #501 (fleet-agent 0.1.4) into `CONFLICTING/DIRTY` — and it stayed there through four later merges to master (#492, #495, #467, #635, #633), because none of them was a `fleet/` commit. The bot had no reason to look at it, and nothing else could.

The standard recovery is to close the stale PR and let release-please rebuild it. But `release-please.yml` only ran `on: push`, so even that had to wait for an unrelated commit to land first.

## Fix

Add `workflow_dispatch`. `release.yml` already carries the same escape hatch, for the same class of problem — CLAUDE.md's release section calls it out as how a half-finished release is recovered.

With this in place the sequence is: close the stale PR → dispatch → release-please opens a clean one.