### PR TITLE
fix(cli): keep a development instance out of the global kube context

### DIFF
--- a/app/arcbox-cli/src/commands/kubernetes.rs
+++ b/app/arcbox-cli/src/commands/kubernetes.rs
@@ -226,6 +226,75 @@ async fn merge_managed_kubeconfig(home: &Path) -> Result<()> {
     Ok(())
 }
 
+/// What the global current-context owes after a kubeconfig merge.
+#[derive(Debug, PartialEq, Eq)]
+enum CurrentContextFix<'a> {
+    /// The merge left the selection where it was.
+    Keep,
+    /// Put back the selection the merge displaced.
+    Restore(&'a str),
+    /// The merge created a selection where the user had none.
+    Clear,
+}
+
+/// Decides [`CurrentContextFix`] for a profile that may not own the selection.
+///
+/// Not writing the current-context is not the same as not changing it.
+/// `merge_managed_kubeconfig` copies the managed kubeconfig verbatim when the
+/// user has none, and that file carries `current-context: <managed>`
+/// (`rewrite_kubeconfig` puts it there); the merge path inherits it too,
+/// because `kubectl config view --flatten` takes the current-context from the
+/// first file that sets one. So a development instance activates its own
+/// context globally just by writing the file — the very thing skipping
+/// `set_current_context` was meant to prevent. Comparing before against after
+/// covers all three shapes (no user kubeconfig, one without a
+/// current-context, one with) and never asks kubectl to unset a key that is
+/// not there.
+fn current_context_restore<'a>(
+    owns_global: bool,
+    before: Option<&'a str>,
+    after: Option<&str>,
+) -> CurrentContextFix<'a> {
+    if owns_global || before == after {
+        CurrentContextFix::Keep
+    } else {
+        before.map_or(CurrentContextFix::Clear, CurrentContextFix::Restore)
+    }
+}
+
+/// Applies [`current_context_restore`] after a merge.
+async fn restore_current_context(home: &Path, before: Option<&str>) -> Result<()> {
+    let after = current_context(home).await?;
+    match current_context_restore(false, before, after.as_deref()) {
+        CurrentContextFix::Keep => Ok(()),
+        CurrentContextFix::Restore(previous) => set_current_context(home, previous).await,
+        CurrentContextFix::Clear => unset_current_context(home).await,
+    }
+}
+
+async fn unset_current_context(home: &Path) -> Result<()> {
+    let kubectl = kubectl_bin(home);
+    let kubeconfig = user_kubeconfig_path(home);
+    let output = tokio::process::Command::new(&kubectl)
+        .arg("config")
+        .arg("unset")
+        .arg("current-context")
+        .arg("--kubeconfig")
+        .arg(&kubeconfig)
+        .output()
+        .await
+        .context("failed to clear the current kube context")?;
+
+    if !output.status.success() {
+        bail!(
+            "kubectl config unset current-context failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    Ok(())
+}
+
 async fn set_current_context(home: &Path, context: &str) -> Result<()> {
     let kubectl = kubectl_bin(home);
     let kubeconfig = user_kubeconfig_path(home);
@@ -306,7 +375,8 @@ async fn refresh_if_enabled(home: &Path) -> Result<()> {
     }
 
     let current_context = current_context(home).await?;
-    let restore_managed_context = owns_global_current_context(ArcboxProfile::from_env_or_default())
+    let owns_current_context = owns_global_current_context(ArcboxProfile::from_env_or_default());
+    let restore_managed_context = owns_current_context
         && should_restore_managed_context(
             current_context.as_deref(),
             state.managed_context.as_deref(),
@@ -317,6 +387,10 @@ async fn refresh_if_enabled(home: &Path) -> Result<()> {
     merge_managed_kubeconfig(home).await?;
     if restore_managed_context {
         set_current_context(home, &managed_context).await?;
+    } else if !owns_current_context {
+        // The refresh merges too, so it can activate the development context
+        // on a host with no user kubeconfig exactly like `enable` can.
+        restore_current_context(home, current_context.as_deref()).await?;
     }
     save_state(
         home,
@@ -454,16 +528,17 @@ async fn execute_enable() -> Result<()> {
     install_kubernetes_tools(&home).await?;
 
     let owns_current_context = owns_global_current_context(ArcboxProfile::from_env_or_default());
-    let previous_context = if owns_current_context {
-        current_context(&home).await?
-    } else {
-        None
-    };
+    // Read unconditionally: a profile that does not own the global
+    // current-context still has to know what it was, to put it back after the
+    // merge writes one (see `current_context_restore`).
+    let previous_context = current_context(&home).await?;
     let managed_context = refresh_managed_kubeconfig(&home).await?;
     delete_context_entries(&home, &managed_context).await?;
     merge_managed_kubeconfig(&home).await?;
     if owns_current_context {
         set_current_context(&home, &managed_context).await?;
+    } else {
+        restore_current_context(&home, previous_context.as_deref()).await?;
     }
 
     save_state(
@@ -531,7 +606,8 @@ async fn execute_kubeconfig() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        owns_global_current_context, resolve_managed_context_name, should_restore_managed_context,
+        CurrentContextFix, current_context_restore, owns_global_current_context,
+        resolve_managed_context_name, should_restore_managed_context,
     };
     use arcbox_constants::paths::ArcboxProfile;
 
@@ -575,5 +651,39 @@ mod tests {
     fn only_production_owns_the_global_current_context() {
         assert!(owns_global_current_context(ArcboxProfile::Production));
         assert!(!owns_global_current_context(ArcboxProfile::Development));
+    }
+
+    /// The merge writes a `current-context` whether or not `enable` asks it
+    /// to — verbatim when the user had no kubeconfig, inherited from the
+    /// managed file when their own set none. A profile that does not own the
+    /// global selection has to put back what was there, including "nothing".
+    #[test]
+    fn a_foreign_profile_puts_the_current_context_back() {
+        // No user kubeconfig: the merge created one pointing at the managed
+        // context, so it has to be cleared rather than left pointing there.
+        assert_eq!(
+            current_context_restore(false, None, Some("arcbox-dev")),
+            CurrentContextFix::Clear
+        );
+        // A user context the merge displaced goes back.
+        assert_eq!(
+            current_context_restore(false, Some("docker-desktop"), Some("arcbox-dev")),
+            CurrentContextFix::Restore("docker-desktop")
+        );
+        // The merge left it alone — including the case where the user had
+        // deliberately selected the managed context themselves.
+        assert_eq!(
+            current_context_restore(false, Some("arcbox-dev"), Some("arcbox-dev")),
+            CurrentContextFix::Keep
+        );
+        assert_eq!(
+            current_context_restore(false, None, None),
+            CurrentContextFix::Keep
+        );
+        // Production owns the selection and sets it explicitly.
+        assert_eq!(
+            current_context_restore(true, None, Some("arcbox")),
+            CurrentContextFix::Keep
+        );
     }
 }

--- a/app/arcbox-cli/src/commands/kubernetes.rs
+++ b/app/arcbox-cli/src/commands/kubernetes.rs
@@ -250,12 +250,21 @@ enum CurrentContextFix<'a> {
 /// covers all three shapes (no user kubeconfig, one without a
 /// current-context, one with) and never asks kubectl to unset a key that is
 /// not there.
+///
+/// It also only ever undoes a selection that landed on `managed`. Nothing
+/// locks `~/.kube/config` — kubectl's own writes are unlocked
+/// read-modify-write — so a `kubectl config use-context` racing this window
+/// would otherwise be read as the merge's doing and reverted. Requiring
+/// `after == managed` leaves any concurrent switch to some other context
+/// alone; the residual race is a switch *to* the managed context during the
+/// window, which is indistinguishable from the merge causing it.
 fn current_context_restore<'a>(
     owns_global: bool,
+    managed: &str,
     before: Option<&'a str>,
     after: Option<&str>,
 ) -> CurrentContextFix<'a> {
-    if owns_global || before == after {
+    if owns_global || before == after || after != Some(managed) {
         CurrentContextFix::Keep
     } else {
         before.map_or(CurrentContextFix::Clear, CurrentContextFix::Restore)
@@ -263,9 +272,9 @@ fn current_context_restore<'a>(
 }
 
 /// Applies [`current_context_restore`] after a merge.
-async fn restore_current_context(home: &Path, before: Option<&str>) -> Result<()> {
+async fn restore_current_context(home: &Path, managed: &str, before: Option<&str>) -> Result<()> {
     let after = current_context(home).await?;
-    match current_context_restore(false, before, after.as_deref()) {
+    match current_context_restore(false, managed, before, after.as_deref()) {
         CurrentContextFix::Keep => Ok(()),
         CurrentContextFix::Restore(previous) => set_current_context(home, previous).await,
         CurrentContextFix::Clear => unset_current_context(home).await,
@@ -390,7 +399,7 @@ async fn refresh_if_enabled(home: &Path) -> Result<()> {
     } else if !owns_current_context {
         // The refresh merges too, so it can activate the development context
         // on a host with no user kubeconfig exactly like `enable` can.
-        restore_current_context(home, current_context.as_deref()).await?;
+        restore_current_context(home, &managed_context, current_context.as_deref()).await?;
     }
     save_state(
         home,
@@ -538,7 +547,7 @@ async fn execute_enable() -> Result<()> {
     if owns_current_context {
         set_current_context(&home, &managed_context).await?;
     } else {
-        restore_current_context(&home, previous_context.as_deref()).await?;
+        restore_current_context(&home, &managed_context, previous_context.as_deref()).await?;
     }
 
     save_state(
@@ -662,27 +671,47 @@ mod tests {
         // No user kubeconfig: the merge created one pointing at the managed
         // context, so it has to be cleared rather than left pointing there.
         assert_eq!(
-            current_context_restore(false, None, Some("arcbox-dev")),
+            current_context_restore(false, "arcbox-dev", None, Some("arcbox-dev")),
             CurrentContextFix::Clear
         );
         // A user context the merge displaced goes back.
         assert_eq!(
-            current_context_restore(false, Some("docker-desktop"), Some("arcbox-dev")),
+            current_context_restore(
+                false,
+                "arcbox-dev",
+                Some("docker-desktop"),
+                Some("arcbox-dev")
+            ),
             CurrentContextFix::Restore("docker-desktop")
         );
         // The merge left it alone — including the case where the user had
         // deliberately selected the managed context themselves.
         assert_eq!(
-            current_context_restore(false, Some("arcbox-dev"), Some("arcbox-dev")),
+            current_context_restore(false, "arcbox-dev", Some("arcbox-dev"), Some("arcbox-dev")),
             CurrentContextFix::Keep
         );
         assert_eq!(
-            current_context_restore(false, None, None),
+            current_context_restore(false, "arcbox-dev", None, None),
             CurrentContextFix::Keep
         );
         // Production owns the selection and sets it explicitly.
         assert_eq!(
-            current_context_restore(true, None, Some("arcbox")),
+            current_context_restore(true, "arcbox", None, Some("arcbox")),
+            CurrentContextFix::Keep
+        );
+    }
+
+    /// Nothing locks `~/.kube/config`, so a `kubectl config use-context`
+    /// landing inside the merge window must not be read as the merge's doing.
+    /// Only a selection that ended up on the managed context is undone.
+    #[test]
+    fn a_concurrent_switch_elsewhere_is_left_alone() {
+        assert_eq!(
+            current_context_restore(false, "arcbox-dev", Some("minikube"), Some("kind-local")),
+            CurrentContextFix::Keep
+        );
+        assert_eq!(
+            current_context_restore(false, "arcbox-dev", None, Some("kind-local")),
             CurrentContextFix::Keep
         );
     }


### PR DESCRIPTION
Follow-up to #631, which merged with this finding open (raised on the enable-path thread, verified against the code before the merge).

## The gap

#631 stopped a development `abctl k8s enable` from calling `set_current_context`. But not writing the current-context is not the same as not changing it — `merge_managed_kubeconfig` copies the managed kubeconfig verbatim when the user has none:

```rust
if !user.exists() {
    let bytes = tokio::fs::read(&managed).await?;
    write_private_file(&user, bytes).await?;
    return Ok(());
}
```

and that file carries the key: `rewrite_kubeconfig` (`app/arcbox-core/src/runtime/kubeconfig.rs`) rewrites `current-context: default` into `current-context: <context_name>`.

So on a host with no `~/.kube/config` — a fresh machine, CI, a container — a development enable creates one whose current context **is** the development context. That is the ownership boundary #631 exists to draw, missed in the case where there is nothing to displace.

One shape further in, the merge path has it too: `kubectl config view --flatten` takes the current-context from the first file that sets one, so a user config that exists but selects nothing inherits the managed selection.

## The fix

Decide the selection *after* the merge rather than only skipping the write. Read it before, read it after, and put back what was there:

| before | after merge | action |
| --- | --- | --- |
| none | managed | clear |
| `docker-desktop` | managed | restore `docker-desktop` |
| `arcbox-dev` | `arcbox-dev` | keep — the user chose it |
| none | none | keep |

Comparing the two also means kubectl is never asked to `unset` a key that is not set. `refresh_if_enabled` merges on the same terms and gets the same treatment; without it a development refresh re-activates the context on every run.

The decision is a pure function (`current_context_restore` → `CurrentContextFix`), so the four shapes above are unit-tested; the kubectl calls stay thin.

## Verification

`cargo test -p arcbox-cli kubernetes` — 4 pass, `cargo clippy -p arcbox-cli --all-targets -- -D warnings` clean.