### PR TITLE
fix(net): stop an aged-out FDB entry from tearing down a healthy container route

### DIFF
--- a/app/arcbox-daemon/src/services.rs
+++ b/app/arcbox-daemon/src/services.rs
@@ -362,27 +362,34 @@ async fn container_route_guard(
         }
 
         let runtime_for_bridge = Arc::clone(&runtime);
-        let bridge = match tokio::task::spawn_blocking(move || {
+        let resolution = match tokio::task::spawn_blocking(move || {
             resolve_container_bridge(&runtime_for_bridge)
         })
         .await
         {
-            Ok(bridge) => bridge,
+            Ok(resolution) => resolution,
             Err(error) => {
                 tracing::warn!(%error, "container bridge resolution task failed");
-                None
+                BridgeResolution::Inconclusive
             }
         };
-        let Some(bridge) = bridge else {
-            if active.take().is_some()
-                && let Some(lease) = container_network_lease.get()
-                && let Err(error) = lease.cleanup_route().await
-            {
-                tracing::warn!(%error, "failed to remove stopped VM container route");
+        let bridge = match resolution {
+            BridgeResolution::Found(bridge) => bridge,
+            BridgeResolution::Absent => {
+                if active.take().is_some()
+                    && let Some(lease) = container_network_lease.get()
+                    && let Err(error) = lease.cleanup_route().await
+                {
+                    tracing::warn!(%error, "failed to remove stopped VM container route");
+                }
+                setup_state.set_route_installed(false);
+                consecutive_failures = 0;
+                continue;
             }
-            setup_state.set_route_installed(false);
-            consecutive_failures = 0;
-            continue;
+            BridgeResolution::Inconclusive => {
+                tracing::debug!("container bridge discovery inconclusive; keeping route state");
+                continue;
+            }
         };
 
         let current_mode = active
@@ -590,8 +597,9 @@ async fn ensure_isolated_container_route(
     )
     .await
     .with_context(|| format!("failed to install isolated container route {container_network}"))?;
-    let bridge = resolve_container_bridge(runtime)
-        .with_context(|| format!("container bridge is not ready for {container_network}"))?;
+    let BridgeResolution::Found(bridge) = resolve_container_bridge(runtime) else {
+        anyhow::bail!("container bridge is not ready for {container_network}");
+    };
     container_network_lease
         .get()
         .context("isolated container network lease is missing")?
@@ -600,48 +608,82 @@ async fn ensure_isolated_container_route(
     Ok(())
 }
 
-#[cfg(all(target_os = "macos", feature = "vmnet"))]
-fn resolve_container_bridge(runtime: &Runtime) -> Option<String> {
-    let machine = runtime
-        .machine_manager()
-        .get(arcbox_core::DEFAULT_MACHINE_NAME)?;
-    if !matches!(
-        machine.state,
-        arcbox_core::machine::MachineState::Starting | arcbox_core::machine::MachineState::Running
-    ) {
-        return None;
-    }
-    use arcbox_core::bridge_discovery::MachineBridgeExt as _;
-    if let Some(bridge) = runtime
-        .machine_manager()
-        .vmnet_bridge_name(arcbox_core::DEFAULT_MACHINE_NAME)
-    {
-        return Some(bridge);
-    }
+/// What one bridge-resolution attempt established.
+///
+/// The distinction the route guard turns on: only the machine record can say
+/// authoritatively that no container route should exist. Discovery itself
+/// cannot, because it finds the bridge by looking the guest MAC up in each
+/// bridge's forwarding table (`ifbridge::find_bridge_by_mac` → `list_fdb`),
+/// and FDB entries age out when the guest goes quiet (20 min by default on
+/// macOS). Reading that silence as "the bridge is gone" tears down a healthy
+/// route on an idle VM.
+#[cfg(target_os = "macos")]
+#[derive(Debug, PartialEq, Eq)]
+enum BridgeResolution {
+    /// The bridge the container route must target.
+    Found(String),
+    /// No System VM is running, so no container route should exist.
+    Absent,
+    /// Discovery could not answer. Keep whatever route state is in place.
+    Inconclusive,
+}
 
-    // The binary may include vmnet support while this signed daemon is using
-    // VZ NAT (notably development builds without com.apple.vm.networking).
-    let mac = runtime
+/// Classifies a bridge lookup against the machine's own state.
+///
+/// `discover` is lazy so a stopped VM costs no forwarding-table walk.
+#[cfg(target_os = "macos")]
+fn classify_bridge(
+    machine_state: Option<arcbox_core::machine::MachineState>,
+    discover: impl FnOnce() -> Option<String>,
+) -> BridgeResolution {
+    let running = matches!(
+        machine_state,
+        Some(
+            arcbox_core::machine::MachineState::Starting
+                | arcbox_core::machine::MachineState::Running
+        )
+    );
+    if !running {
+        return BridgeResolution::Absent;
+    }
+    discover().map_or(BridgeResolution::Inconclusive, BridgeResolution::Found)
+}
+
+#[cfg(target_os = "macos")]
+fn system_vm_state(runtime: &Runtime) -> Option<arcbox_core::machine::MachineState> {
+    runtime
         .machine_manager()
-        .bridge_mac(arcbox_core::DEFAULT_MACHINE_NAME)?;
-    arcbox_core::bridge_discovery::resolve_bridge_by_mac(&mac).map(|bridge| bridge.name)
+        .get(arcbox_core::DEFAULT_MACHINE_NAME)
+        .map(|machine| machine.state)
+}
+
+#[cfg(all(target_os = "macos", feature = "vmnet"))]
+fn resolve_container_bridge(runtime: &Runtime) -> BridgeResolution {
+    classify_bridge(system_vm_state(runtime), || {
+        use arcbox_core::bridge_discovery::MachineBridgeExt as _;
+        runtime
+            .machine_manager()
+            .vmnet_bridge_name(arcbox_core::DEFAULT_MACHINE_NAME)
+            .or_else(|| {
+                // The binary may include vmnet support while this signed daemon
+                // is using VZ NAT (notably development builds without
+                // com.apple.vm.networking).
+                let mac = runtime
+                    .machine_manager()
+                    .bridge_mac(arcbox_core::DEFAULT_MACHINE_NAME)?;
+                arcbox_core::bridge_discovery::resolve_bridge_by_mac(&mac).map(|bridge| bridge.name)
+            })
+    })
 }
 
 #[cfg(all(target_os = "macos", not(feature = "vmnet")))]
-fn resolve_container_bridge(runtime: &Runtime) -> Option<String> {
-    let machine = runtime
-        .machine_manager()
-        .get(arcbox_core::DEFAULT_MACHINE_NAME)?;
-    if !matches!(
-        machine.state,
-        arcbox_core::machine::MachineState::Starting | arcbox_core::machine::MachineState::Running
-    ) {
-        return None;
-    }
-    let mac = runtime
-        .machine_manager()
-        .bridge_mac(arcbox_core::DEFAULT_MACHINE_NAME)?;
-    arcbox_core::bridge_discovery::resolve_bridge_by_mac(&mac).map(|bridge| bridge.name)
+fn resolve_container_bridge(runtime: &Runtime) -> BridgeResolution {
+    classify_bridge(system_vm_state(runtime), || {
+        let mac = runtime
+            .machine_manager()
+            .bridge_mac(arcbox_core::DEFAULT_MACHINE_NAME)?;
+        arcbox_core::bridge_discovery::resolve_bridge_by_mac(&mac).map(|bridge| bridge.name)
+    })
 }
 
 #[cfg(target_os = "macos")]
@@ -696,6 +738,59 @@ mod tests {
     use arcbox_core::event::{Event, EventBus};
 
     use super::*;
+
+    /// The regression this enum exists for: the bridge is found by looking the
+    /// guest MAC up in bridge forwarding tables, which forget an idle guest
+    /// after ~20 minutes. A running VM plus a silent FDB must not read as
+    /// "no route should exist" — that tears down a healthy route and drops
+    /// `route_installed`, sending the desktop back to localhost.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_running_vm_with_no_fdb_entry_is_inconclusive_not_absent() {
+        use arcbox_core::machine::MachineState;
+
+        for state in [MachineState::Starting, MachineState::Running] {
+            assert_eq!(
+                classify_bridge(Some(state), || None),
+                BridgeResolution::Inconclusive,
+                "{state:?} with a silent FDB"
+            );
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn only_the_machine_record_can_say_no_bridge_should_exist() {
+        use arcbox_core::machine::MachineState;
+
+        // No machine record, and a stopped one, are both authoritative — even
+        // if a stale FDB entry still names a bridge.
+        assert_eq!(
+            classify_bridge(None, || Some("bridge100".to_string())),
+            BridgeResolution::Absent
+        );
+        assert_eq!(
+            classify_bridge(Some(MachineState::Stopped), || Some(
+                "bridge100".to_string()
+            )),
+            BridgeResolution::Absent
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_stopped_vm_costs_no_forwarding_table_walk() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use arcbox_core::machine::MachineState;
+
+        let walks = AtomicUsize::new(0);
+        let _ = classify_bridge(Some(MachineState::Stopped), || {
+            walks.fetch_add(1, Ordering::Relaxed);
+            None
+        });
+        assert_eq!(walks.load(Ordering::Relaxed), 0);
+    }
 
     #[cfg(target_os = "macos")]
     #[test]

--- a/app/arcbox-daemon/src/services.rs
+++ b/app/arcbox-daemon/src/services.rs
@@ -373,9 +373,12 @@ async fn container_route_guard(
                 BridgeResolution::Inconclusive
             }
         };
-        let bridge = match resolution {
-            BridgeResolution::Found(bridge) => bridge,
-            BridgeResolution::Absent => {
+        let bridge = match route_action(
+            resolution,
+            active.as_ref().map(|(bridge, _)| bridge.as_str()),
+        ) {
+            RouteAction::Reconcile(bridge) => bridge,
+            RouteAction::TearDown => {
                 if active.take().is_some()
                     && let Some(lease) = container_network_lease.get()
                     && let Err(error) = lease.cleanup_route().await
@@ -386,7 +389,7 @@ async fn container_route_guard(
                 consecutive_failures = 0;
                 continue;
             }
-            BridgeResolution::Inconclusive => {
+            RouteAction::Wait => {
                 tracing::debug!("container bridge discovery inconclusive; keeping route state");
                 continue;
             }
@@ -628,6 +631,37 @@ enum BridgeResolution {
     Inconclusive,
 }
 
+/// What the route guard does with one resolution attempt.
+#[cfg(target_os = "macos")]
+#[derive(Debug, PartialEq, Eq)]
+enum RouteAction {
+    /// Reconcile the container route against this bridge.
+    Reconcile(String),
+    /// Remove the route and report it uninstalled.
+    TearDown,
+    /// Leave the route and its reported state alone until the next attempt.
+    Wait,
+}
+
+/// Decides the guard's move from a resolution and the bridge it last acted on.
+///
+/// An inconclusive lookup falls back to the remembered bridge rather than
+/// skipping the tick: this loop is woken by managed-route events, so the case
+/// where discovery is stale is *also* the case where a route may have just been
+/// deleted. Skipping there would leave the route unrepaired while
+/// `route_installed` still reported `true`. With no bridge ever resolved there
+/// is nothing to reconcile against, and waiting is all that is left.
+#[cfg(target_os = "macos")]
+fn route_action(resolution: BridgeResolution, active: Option<&str>) -> RouteAction {
+    match resolution {
+        BridgeResolution::Found(bridge) => RouteAction::Reconcile(bridge),
+        BridgeResolution::Absent => RouteAction::TearDown,
+        BridgeResolution::Inconclusive => active.map_or(RouteAction::Wait, |bridge| {
+            RouteAction::Reconcile(bridge.to_string())
+        }),
+    }
+}
+
 /// Classifies a bridge lookup against the machine's own state.
 ///
 /// `discover` is lazy so a stopped VM costs no forwarding-table walk.
@@ -774,6 +808,35 @@ mod tests {
                 "bridge100".to_string()
             )),
             BridgeResolution::Absent
+        );
+    }
+
+    /// The loop is woken by managed-route events, so "discovery is stale" and
+    /// "a route was just deleted" are the same tick. Falling back to the
+    /// remembered bridge is what repairs it; skipping would leave the route
+    /// gone while `route_installed` still said true.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn an_inconclusive_lookup_still_reconciles_the_remembered_bridge() {
+        assert_eq!(
+            route_action(BridgeResolution::Inconclusive, Some("bridge100")),
+            RouteAction::Reconcile("bridge100".to_string())
+        );
+        // Nothing resolved yet: there is no bridge to reconcile against.
+        assert_eq!(
+            route_action(BridgeResolution::Inconclusive, None),
+            RouteAction::Wait
+        );
+    }
+
+    /// A stopped VM tears the route down even if the guard still remembers the
+    /// bridge it last used — that memory must not outlive the machine.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn an_absent_machine_tears_down_despite_a_remembered_bridge() {
+        assert_eq!(
+            route_action(BridgeResolution::Absent, Some("bridge100")),
+            RouteAction::TearDown
         );
     }
 


### PR DESCRIPTION
The narrow fix that #552 identified and then buried under 32 files. Closing that
PR; this lands its root cause.

## The bug

`container_route_guard` re-resolves the container bridge every 30 s. Resolution
walks each bridge's **forwarding table** looking for the guest MAC —
`vmnet_bridge_name` -> `resolve_bridge_by_mac` -> `ifbridge::find_bridge_by_mac`
-> `list_fdb` — and a miss was indistinguishable from "no VM is running":

```rust
let Some(bridge) = bridge else {
    ... lease.cleanup_route().await ...
    setup_state.set_route_installed(false);
    continue;
};
```

FDB entries age out when the guest goes quiet (20 min by default on macOS). So a
VM that is up and healthy but idle eventually loses its entry, and the next tick
**removes its container route** and reports `route_installed = false` — which is
what sends the desktop back to localhost instead of `*.arcbox.local`.

This is not confined to unsigned dev builds. The signed release path resolves
through the same FDB walk; the MAC fallback below it is just a second walk.

## The fix

Only the machine record can say authoritatively that no route should exist.
`resolve_container_bridge` now returns that distinction instead of an `Option`:

| resolution | meaning | guard's move |
|---|---|---|
| `Found(name)` | discovery answered | reconcile as before |
| `Absent` | no machine record, or not `Starting`/`Running` | tear down + `route_installed = false` |
| `Inconclusive` | discovery could not answer | keep current route state |

A panicked resolution task is `Inconclusive` too — a `JoinError` says nothing
about the bridge. Discovery stays lazy behind the state check, so a stopped VM
still costs no forwarding-table walk.

Keeping on `Inconclusive` is safe in the other direction: the route reconciler is
idempotent, a genuinely replaced interface reappears as a different `Found(name)`
once the FDB relearns it, and VM stop is observed through the machine record
rather than through discovery.

## Validation

`cargo test -p arcbox-daemon --bins` — 52 passed, including three new:
`a_running_vm_with_no_fdb_entry_is_inconclusive_not_absent`,
`only_the_machine_record_can_say_no_bridge_should_exist`,
`a_stopped_vm_costs_no_forwarding_table_walk`. `cargo clippy -p arcbox-daemon
--all-targets` clean, `cargo fmt` clean.

Refs ABX-510.