### PR TITLE
docs(docker): correct two stale compatibility claims

### DIFF
--- a/app/arcbox-docker-tools/src/lockfile.rs
+++ b/app/arcbox-docker-tools/src/lockfile.rs
@@ -1,9 +1,18 @@
 //! Parser for the `[[tools]]` section of `assets.lock`.
 //!
-//! These tool entries pin both the **host-side CLI** binaries (installed to
-//! `~/.arcbox/runtime/bin/`) and the **guest-side daemon** binaries (exposed
-//! via VirtioFS to the VM). A single lockfile ensures the Docker CLI and guest
-//! dockerd are always at the same version — no version-skew concerns on upgrade.
+//! These entries pin **host-side macOS binaries only**, installed to
+//! `~/.arcbox/runtime/bin/`. Every URL in [`crate::registry`] resolves to a
+//! darwin artifact (`download.docker.com/mac/...`, `*.darwin-arm64`,
+//! `bin/darwin/...`), so nothing here can run in the Linux guest.
+//!
+//! The guest's `dockerd`/`containerd`/`runc` come from the boot manifest
+//! pinned under `[boot]`, which the daemon stages into the generation-scoped
+//! `<data_dir>/runtime/<boot version>/bin`. **The host CLI and the guest
+//! daemon are therefore two independent pins and can skew**: bumping the
+//! `docker` tool here does not move guest dockerd, and vice versa. The Docker
+//! CLI negotiates down to an older daemon's API, so a skew is tolerable, but
+//! it is neither prevented nor detected — keep the two in step by hand when
+//! bumping either (`assets.lock`'s own header says the same).
 
 use std::collections::HashMap;
 

--- a/app/arcbox-docker/README.md
+++ b/app/arcbox-docker/README.md
@@ -203,7 +203,10 @@ This keeps the ownership boundary clear:
 
 ## API Version
 
-- **Host route compatibility:** `/v1.24` through `/v1.43` plus unversioned routes
+- **Host route compatibility:** any `/v{major}.{minor}` prefix, plus unversioned
+  routes. `strip_api_version_prefix` removes the prefix before route matching
+  and forwards the original URI, so there is no supported range to maintain
+  here — guest `dockerd` does the negotiating. The bundled CLI sends `v1.52`.
 - **Version payload source:** `/version` and related system metadata are reported by guest `dockerd`
 
 ## Testing

--- a/app/arcbox-docker/src/lib.rs
+++ b/app/arcbox-docker/src/lib.rs
@@ -7,9 +7,14 @@
 //!
 //! ## Compatibility
 //!
-//! Host routing supports Docker Engine API compatibility paths `v1.24..v1.43`
-//! (plus unversioned endpoints). Request handling is split between local
-//! `ArcBox` handlers and pass-through proxying to guest `dockerd`.
+//! Host routing accepts **any** `/v{major}.{minor}` path prefix (plus
+//! unversioned endpoints): [`api::strip_api_version_prefix`] removes the
+//! prefix before route matching and stashes the original URI so proxy
+//! handlers forward it verbatim, which leaves version negotiation to guest
+//! `dockerd`. There is no supported-range check here, so no list to keep in
+//! step with the Docker version in `assets.lock` — the CLI bundled today
+//! speaks `v1.52`. Request handling is split between local `ArcBox` handlers
+//! and pass-through proxying to guest `dockerd`.
 //!
 //! Supported operation groups include:
 //!

--- a/app/arcbox-docker/tests/api_versioned.rs
+++ b/app/arcbox-docker/tests/api_versioned.rs
@@ -10,7 +10,8 @@ async fn test_versioned_api() {
     let (runtime, connector, _tmp) = create_test_runtime().await;
     let app = create_router(runtime, connector);
 
-    // Test v1.43 (current)
+    // Any /v{major}.{minor} prefix is accepted; this one is an arbitrary
+    // sample, not a supported ceiling.
     let response = app
         .oneshot(
             Request::builder()
@@ -29,7 +30,7 @@ async fn test_older_api_version() {
     let (runtime, connector, _tmp) = create_test_runtime().await;
     let app = create_router(runtime, connector);
 
-    // Test v1.24 (minimum supported)
+    // A far older prefix, to show the parser has no floor either.
     let response = app
         .oneshot(
             Request::builder()


### PR DESCRIPTION
Found while checking what the Docker 29.7.2 bump (#634) needs from us. Both comments assert the opposite of what the code does, and both are exactly the comments someone reads *before* bumping a Docker pin.

**1. `arcbox-docker-tools::lockfile` said `[[tools]]` pins the guest daemon binaries too**, and concluded "A single lockfile ensures the Docker CLI and guest dockerd are always at the same version — no version-skew concerns on upgrade."

Every URL in `registry.rs` is a darwin artifact — `download.docker.com/mac/static/...`, `buildx-v{version}.darwin-arm64`, `bin/darwin/{arch}/kubectl` — so nothing in `[[tools]]` can execute in a Linux guest. Guest `dockerd`/`containerd`/`runc` come from the `[boot]` manifest and are staged into a *different*, generation-scoped directory (`<data_dir>/runtime/<boot version>/bin`; `tests/e2e/src/boot_assets.rs` calls the two destinations out explicitly as "not interchangeable").

The two pins are independent and do skew — right now the host CLI is `29.6.2` and guest dockerd is `29.6.1`. That is fine (the CLI negotiates the API down), but it is neither prevented nor detected, which is why `assets.lock`'s own header asks for them to be kept in step by hand. The comment claimed the guarantee that header exists to say we don't have.

**2. `arcbox-docker` said host routing supports `v1.24..v1.43`.**

There is no range check anywhere. `strip_api_version_prefix` accepts any `/v{digits}.{digits}` prefix, saves the original URI, and forwards it verbatim, leaving negotiation to guest dockerd. The stated ceiling was also nine minor versions below what the bundled CLI actually sends — `system_disk_usage.rs` already hardcodes `/v1.52/system/df`, and the crate's own tests exercise `/v1.51`.

Comments only; no behavior change.