### PR TITLE
refactor(snapshot): put block-device tooling behind a BlockTools seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,6 +1041,7 @@ dependencies = [
  "arcbox-atomic-file",
  "arcbox-error",
  "chrono",
+ "nix 0.29.0",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -45,6 +45,14 @@ The restructure plan and its locked decisions live in the company repo:
   - The device-mapper paths only *do* anything on Linux (`dmsetup`, thin
     pools) but compile everywhere, which is what lets the layer above
     keep its own platform-neutrality promise.
+  - Loop-device tooling is a seam, not an assumption: `CowManager` takes
+    `CowOptions { block_tools: Arc<dyn BlockTools>, dmsetup_candidates, .. }`
+    (`snapshot_cow/block_tools.rs`). `BusyboxBlockTools` is the reference
+    (the System VM's `/bin/busybox` applets); a consumer on a stock distro
+    supplies its own — `util-linux` binaries or the loop ioctls — without
+    forking the module. `stat`/`mknod` are syscalls, not applets, so they
+    have no seam. Adding a new host operation means adding a trait method,
+    never a hard-coded binary path.
   - `CowManager`'s test seam (`CowTestProbe`, `new_with_test_probe`) is
     behind the **`test-probe` feature**, not `#[cfg(test)]`: a
     `cfg(test)` item does not exist for another crate's tests, and its

--- a/engine/arcbox-snapshot/Cargo.toml
+++ b/engine/arcbox-snapshot/Cargo.toml
@@ -12,6 +12,7 @@ authors.workspace = true
 arcbox-atomic-file.workspace = true
 arcbox-error = { workspace = true }
 chrono = { workspace = true }
+nix = { workspace = true, features = ["fs"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/engine/arcbox-snapshot/src/snapshot_cow.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow.rs
@@ -227,15 +227,15 @@ impl CowManager {
         // talk to the driver (unprivileged dev host, CI runner) can never have
         // created dm snapshots either, so it degrades to the same copy-mode
         // fallback as a missing binary instead of failing every dm command.
-        let dmsetup_bin = dmsetup_candidates
-            .into_iter()
-            .find(|p| p.exists())
-            .filter(|bin| {
-                Command::new(bin)
+        // Every candidate gets the same test: an existing-but-broken entry
+        // earlier in the list must not shadow a working one later.
+        let dmsetup_bin = dmsetup_candidates.into_iter().find(|bin| {
+            bin.exists()
+                && Command::new(bin)
                     .arg("version")
                     .output()
                     .is_ok_and(|out| out.status.success())
-            });
+        });
 
         if dmsetup_bin.is_none() {
             warn!("dmsetup not found or unusable; dm-snapshot CoW will be unavailable");

--- a/engine/arcbox-snapshot/src/snapshot_cow.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow.rs
@@ -5,28 +5,29 @@
 //! The template image is shared read-only across all sandboxes that
 //! use the same rootfs; only written blocks consume disk space.
 //!
-//! Requires `CONFIG_DM_SNAPSHOT=y` in the guest kernel and the `dmsetup`
-//! binary at one of `DMSETUP_CANDIDATES` (private).  `PATH` is not searched — the
-//! guest does not have a meaningful one.
+//! Requires `CONFIG_DM_SNAPSHOT=y` in the kernel, a `dmsetup` binary at one
+//! of [`CowOptions::dmsetup_candidates`], and loop-device tooling supplied
+//! through the [`BlockTools`] seam ([`BusyboxBlockTools`] is the reference:
+//! the System VM's busybox applets). `PATH` is never searched — the guest
+//! does not have a meaningful one.
 
 use std::collections::HashMap;
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Mutex;
 #[cfg(any(test, feature = "test-probe"))]
-use std::sync::{
-    Arc,
-    atomic::{AtomicUsize, Ordering},
-};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::{debug, info, warn};
 
 use crate::error::{Result, SnapshotError};
 
+mod block_tools;
 mod persistence;
 
+pub use block_tools::{BlockTools, BusyboxBlockTools, device_major_minor, mknod_blkdev};
 use persistence::{
     SetupOrphan, clear_owner_marker, loop_backs_path, loop_devices_for_backing_sync,
     remove_file_durable,
@@ -36,13 +37,10 @@ use persistence::{
 // Constants
 // ---------------------------------------------------------------------------
 
-/// Busybox binary (used for `losetup` and `blockdev` applets).
-const BUSYBOX: &str = "/bin/busybox";
-
-/// Candidate paths for the `dmsetup` binary.  The first existing entry
-/// wins.  `/sbin/dmsetup` covers stock Debian/Alpine; `/usr/sbin/dmsetup`
-/// covers usrmerged distros; `/arcbox/bin/dmsetup` is the guest's bundled
-/// copy.
+/// Reference search list for the `dmsetup` binary.  The first existing,
+/// working entry wins.  `/sbin/dmsetup` covers stock Debian/Alpine;
+/// `/usr/sbin/dmsetup` covers usrmerged distros; `/arcbox/bin/dmsetup` is
+/// the System VM's bundled copy.
 const DMSETUP_CANDIDATES: &[&str] = &["/arcbox/bin/dmsetup", "/usr/sbin/dmsetup", "/sbin/dmsetup"];
 
 /// dm-snapshot chunk size in 512-byte sectors (4096 bytes = 8 sectors).
@@ -156,6 +154,34 @@ impl CowTestProbe {
     }
 }
 
+/// What a [`CowManager`] needs from its environment.
+///
+/// [`CowOptions::new`] fills in the reference environment — the System
+/// VM's userland — so today's callers pass a data directory and nothing
+/// else; a composer on a different userland overrides the fields it owns.
+pub struct CowOptions {
+    /// Data directory; COW files live under `{data_dir}/cow/`.
+    pub data_dir: PathBuf,
+    /// Loop-device and block-size operations.
+    pub block_tools: Arc<dyn BlockTools>,
+    /// Where to look for `dmsetup`. The first entry that exists and answers
+    /// `dmsetup version` is used; none usable degrades the manager to
+    /// copy-mode fallback (every setup fails with an actionable error).
+    pub dmsetup_candidates: Vec<PathBuf>,
+}
+
+impl CowOptions {
+    /// The reference environment: busybox at [`BusyboxBlockTools::DEFAULT_PATH`]
+    /// and the System VM's `dmsetup` search list.
+    pub fn new(data_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            data_dir: data_dir.into(),
+            block_tools: Arc::new(BusyboxBlockTools::default()),
+            dmsetup_candidates: DMSETUP_CANDIDATES.iter().map(PathBuf::from).collect(),
+        }
+    }
+}
+
 /// Manages template loop devices and per-sandbox dm-snapshot lifecycle.
 pub struct CowManager {
     templates: Mutex<HashMap<PathBuf, TemplateEntry>>,
@@ -167,7 +193,8 @@ pub struct CowManager {
     /// the kernel via `losetup --show`.)
     losetup_lock: AsyncMutex<()>,
     cow_dir: PathBuf,
-    dmsetup_bin: Option<String>,
+    tools: Arc<dyn BlockTools>,
+    dmsetup_bin: Option<PathBuf>,
     #[cfg(any(test, feature = "test-probe"))]
     test_probe: Option<Arc<CowTestProbe>>,
 }
@@ -177,11 +204,14 @@ pub struct CowManager {
 // ---------------------------------------------------------------------------
 
 impl CowManager {
-    /// Create a new manager.  `data_dir` is the Firecracker data directory
-    /// (e.g. `/var/lib/firecracker-vmm`); COW files are stored under
+    /// Create a new manager over `options`; COW files are stored under
     /// `{data_dir}/cow/`.
-    pub fn new(data_dir: &str) -> Result<Self> {
-        let data_dir = PathBuf::from(data_dir);
+    pub fn new(options: CowOptions) -> Result<Self> {
+        let CowOptions {
+            data_dir,
+            block_tools,
+            dmsetup_candidates,
+        } = options;
         let cow_dir = data_dir.join("cow");
         let marker_dir = cow_dir.join(TEMPLATE_LOOP_DIR);
         std::fs::create_dir_all(&marker_dir)?;
@@ -197,10 +227,9 @@ impl CowManager {
         // talk to the driver (unprivileged dev host, CI runner) can never have
         // created dm snapshots either, so it degrades to the same copy-mode
         // fallback as a missing binary instead of failing every dm command.
-        let dmsetup_bin = DMSETUP_CANDIDATES
-            .iter()
-            .find(|p| Path::new(p).exists())
-            .map(|s| (*s).to_string())
+        let dmsetup_bin = dmsetup_candidates
+            .into_iter()
+            .find(|p| p.exists())
             .filter(|bin| {
                 Command::new(bin)
                     .arg("version")
@@ -217,6 +246,7 @@ impl CowManager {
             setup_orphans: Mutex::new(HashMap::new()),
             losetup_lock: AsyncMutex::new(()),
             cow_dir,
+            tools: block_tools,
             dmsetup_bin,
             #[cfg(any(test, feature = "test-probe"))]
             test_probe: None,
@@ -224,10 +254,31 @@ impl CowManager {
     }
 
     #[cfg(any(test, feature = "test-probe"))]
-    pub fn new_with_test_probe(data_dir: &str, probe: Arc<CowTestProbe>) -> Result<Self> {
-        let mut manager = Self::new(data_dir)?;
+    pub fn new_with_test_probe(options: CowOptions, probe: Arc<CowTestProbe>) -> Result<Self> {
+        let mut manager = Self::new(options)?;
         manager.test_probe = Some(probe);
         Ok(manager)
+    }
+
+    /// [`BlockTools::attach_loop`] on a blocking thread.
+    pub(super) async fn attach_loop(&self, backing: &Path, read_only: bool) -> Result<String> {
+        let tools = Arc::clone(&self.tools);
+        let backing = backing.to_path_buf();
+        run_blocking(move || tools.attach_loop(&backing, read_only)).await
+    }
+
+    /// [`BlockTools::detach_loop`] on a blocking thread.
+    pub(super) async fn detach_loop(&self, device: &str) -> Result<()> {
+        let tools = Arc::clone(&self.tools);
+        let device = device.to_owned();
+        run_blocking(move || tools.detach_loop(&device)).await
+    }
+
+    /// [`BlockTools::device_sectors`] on a blocking thread.
+    pub(super) async fn device_sectors(&self, device: &str) -> Result<u64> {
+        let tools = Arc::clone(&self.tools);
+        let device = device.to_owned();
+        run_blocking(move || tools.device_sectors(&device)).await
     }
 
     /// Create a dm-snapshot for `sandbox_id` using `rootfs_path` as template.
@@ -337,7 +388,7 @@ impl CowManager {
             // Genuinely first to attach — do the work and publish the entry
             // before releasing the lock.
             let pending = self.write_template_pending(sandbox_id, &template)?;
-            let loop_dev = match losetup_attach(BUSYBOX, Path::new(rootfs_path), true).await {
+            let loop_dev = match self.attach_loop(Path::new(rootfs_path), true).await {
                 Ok(loop_dev) => loop_dev,
                 Err(error) => {
                     return Err(self
@@ -359,7 +410,7 @@ impl CowManager {
                     )
                     .await);
             }
-            let sectors = match blockdev_getsz(BUSYBOX, &loop_dev).await {
+            let sectors = match self.device_sectors(&loop_dev).await {
                 Ok(sectors) => sectors,
                 Err(error) => {
                     return Err(self
@@ -453,7 +504,7 @@ impl CowManager {
         // --- 3. Attach COW file as a loop device ----------------------------
         let cow_loop_result = {
             let losetup_guard = self.losetup_lock.lock().await;
-            let result = losetup_attach(BUSYBOX, &cow_file, false).await;
+            let result = self.attach_loop(&cow_file, false).await;
             drop(losetup_guard);
             result
         };
@@ -538,7 +589,7 @@ impl CowManager {
 
         // 2. Detach COW loop device.
         let loop_detached = if loop_backs_path(&handle.cow_loop, &handle.cow_file)? {
-            match losetup_detach(BUSYBOX, &handle.cow_loop).await {
+            match self.detach_loop(&handle.cow_loop).await {
                 Ok(()) => true,
                 Err(error) => {
                     failures.push(format!("detach {}: {error}", handle.cow_loop));
@@ -614,7 +665,7 @@ impl CowManager {
         }
         if failures.is_empty()
             && loop_backs_path(&handle.cow_loop, &handle.cow_file)?
-            && let Err(error) = losetup_detach(BUSYBOX, &handle.cow_loop).await
+            && let Err(error) = self.detach_loop(&handle.cow_loop).await
         {
             failures.push(format!("detach {}: {error}", handle.cow_loop));
         }
@@ -639,7 +690,7 @@ impl CowManager {
             return Ok(());
         }
         for loop_device in loop_devices_for_backing_sync(&cow_file)? {
-            losetup_detach(BUSYBOX, &loop_device).await?;
+            self.detach_loop(&loop_device).await?;
         }
         remove_file_durable(&cow_file)?;
         Ok(())
@@ -649,6 +700,15 @@ impl CowManager {
 // ---------------------------------------------------------------------------
 // Shell helpers
 // ---------------------------------------------------------------------------
+
+/// Run a blocking block-tools operation on a blocking thread.
+async fn run_blocking<T: Send + 'static>(
+    op: impl FnOnce() -> Result<T> + Send + 'static,
+) -> Result<T> {
+    tokio::task::spawn_blocking(op)
+        .await
+        .map_err(|e| SnapshotError::DeviceMapper(format!("spawn_blocking join: {e}")))?
+}
 
 /// Run a synchronous [`Command`] on a blocking thread.
 ///
@@ -663,79 +723,8 @@ async fn run_cmd(mut cmd: Command) -> Result<std::process::Output> {
         .map_err(|e| SnapshotError::DeviceMapper(format!("command spawn: {e}")))
 }
 
-/// Attach a file as a loop device.  Returns the device path (e.g. `/dev/loop0`).
-///
-/// Uses the atomic `losetup -f --show` form so the kernel allocates and
-/// attaches in a single `LOOP_CTL_GET_FREE`+`LOOP_SET_FD` call, avoiding
-/// the TOCTOU window of separate `-f` then `attach` invocations against
-/// other processes that might claim the same slot.  Supported by busybox
-/// >= 1.21 and util-linux >= 2.20.
-async fn losetup_attach(bin: &str, path: &Path, read_only: bool) -> Result<String> {
-    let path_str = path
-        .to_str()
-        .ok_or_else(|| SnapshotError::DeviceMapper("non-UTF-8 path".into()))?;
-
-    let mut cmd = Command::new(bin);
-    if read_only {
-        cmd.args(["losetup", "-r", "-f", "--show", path_str]);
-    } else {
-        cmd.args(["losetup", "-f", "--show", path_str]);
-    }
-    let output = run_cmd(cmd).await?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(SnapshotError::DeviceMapper(format!(
-            "losetup attach {}: {stderr}",
-            path.display()
-        )));
-    }
-    let dev = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if dev.is_empty() {
-        return Err(SnapshotError::DeviceMapper(
-            "losetup --show returned empty device path".into(),
-        ));
-    }
-    Ok(dev)
-}
-
-/// Detach a loop device.
-async fn losetup_detach(bin: &str, dev: &str) -> Result<()> {
-    let mut cmd = Command::new(bin);
-    cmd.args(["losetup", "-d", dev]);
-
-    let output = run_cmd(cmd).await?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(SnapshotError::DeviceMapper(format!(
-            "losetup -d {dev}: {stderr}"
-        )));
-    }
-    Ok(())
-}
-
-/// Get the size of a block device in 512-byte sectors.
-async fn blockdev_getsz(bin: &str, dev: &str) -> Result<u64> {
-    let mut cmd = Command::new(bin);
-    cmd.args(["blockdev", "--getsz", dev]);
-
-    let output = run_cmd(cmd).await?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(SnapshotError::DeviceMapper(format!(
-            "blockdev --getsz {dev}: {stderr}"
-        )));
-    }
-
-    String::from_utf8_lossy(&output.stdout)
-        .trim()
-        .parse::<u64>()
-        .map_err(|e| SnapshotError::DeviceMapper(format!("blockdev parse: {e}")))
-}
-
 /// Create a dm-snapshot device via `dmsetup create`.
-async fn dmsetup_create(bin: &str, name: &str, table: &str) -> Result<()> {
+async fn dmsetup_create(bin: &Path, name: &str, table: &str) -> Result<()> {
     let mut cmd = Command::new(bin);
     cmd.args(["create", name, "--table", table]);
 
@@ -751,7 +740,7 @@ async fn dmsetup_create(bin: &str, name: &str, table: &str) -> Result<()> {
 }
 
 /// Remove a dm device via `dmsetup remove`.
-async fn dmsetup_remove(bin: &str, name: &str) -> Result<()> {
+async fn dmsetup_remove(bin: &Path, name: &str) -> Result<()> {
     let mut cmd = Command::new(bin);
     cmd.args(["remove", name]);
 
@@ -828,58 +817,6 @@ async fn create_sparse_file(
     })?
 }
 
-/// Get the `(major, minor)` device numbers for a block device.
-///
-/// Uses `busybox stat -c '%t %T'` which prints major and minor in hex.
-pub async fn device_major_minor(path: &str) -> Result<(u32, u32)> {
-    let mut cmd = Command::new(BUSYBOX);
-    cmd.args(["stat", "-c", "%t %T", path]);
-    let output = run_cmd(cmd).await?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(SnapshotError::DeviceMapper(format!(
-            "stat {path}: {stderr}"
-        )));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let parts: Vec<&str> = stdout.split_whitespace().collect();
-    if parts.len() != 2 {
-        return Err(SnapshotError::DeviceMapper(format!(
-            "unexpected stat output for {path}: {stdout}"
-        )));
-    }
-    let major = u32::from_str_radix(parts[0], 16)
-        .map_err(|e| SnapshotError::DeviceMapper(format!("parse major: {e}")))?;
-    let minor = u32::from_str_radix(parts[1], 16)
-        .map_err(|e| SnapshotError::DeviceMapper(format!("parse minor: {e}")))?;
-    Ok((major, minor))
-}
-
-/// Create a block device node at `node_path` pointing to `(major, minor)`.
-pub async fn mknod_blkdev(node_path: &Path, major: u32, minor: u32) -> Result<()> {
-    let path_str = node_path
-        .to_str()
-        .ok_or_else(|| SnapshotError::DeviceMapper("non-UTF-8 node path".into()))?;
-    let mut cmd = Command::new(BUSYBOX);
-    cmd.args([
-        "mknod",
-        path_str,
-        "b",
-        &major.to_string(),
-        &minor.to_string(),
-    ]);
-    let output = run_cmd(cmd).await?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(SnapshotError::DeviceMapper(format!(
-            "mknod {path_str}: {stderr}"
-        )));
-    }
-    Ok(())
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -936,6 +873,7 @@ mod tests {
             setup_orphans: Mutex::new(HashMap::new()),
             losetup_lock: AsyncMutex::new(()),
             cow_dir: tmp.path().to_path_buf(),
+            tools: Arc::new(BusyboxBlockTools::default()),
             dmsetup_bin: None,
             test_probe: None,
         };
@@ -966,6 +904,7 @@ mod tests {
             setup_orphans: Mutex::new(HashMap::new()),
             losetup_lock: AsyncMutex::new(()),
             cow_dir: tmp.path().to_path_buf(),
+            tools: Arc::new(BusyboxBlockTools::default()),
             dmsetup_bin: None,
             test_probe: None,
         };
@@ -996,6 +935,7 @@ mod tests {
             setup_orphans: Mutex::new(HashMap::new()),
             losetup_lock: AsyncMutex::new(()),
             cow_dir: tmp.path().to_path_buf(),
+            tools: Arc::new(BusyboxBlockTools::default()),
             dmsetup_bin: None,
             test_probe: None,
         };
@@ -1030,6 +970,7 @@ mod tests {
             setup_orphans: Mutex::new(HashMap::new()),
             losetup_lock: AsyncMutex::new(()),
             cow_dir: tmp.path().to_path_buf(),
+            tools: Arc::new(BusyboxBlockTools::default()),
             dmsetup_bin: Some("/not-used".into()),
             test_probe: None,
         };
@@ -1056,6 +997,7 @@ mod tests {
             setup_orphans: Mutex::new(HashMap::new()),
             losetup_lock: AsyncMutex::new(()),
             cow_dir: PathBuf::from("/tmp"),
+            tools: Arc::new(BusyboxBlockTools::default()),
             dmsetup_bin: None,
             test_probe: None,
         };

--- a/engine/arcbox-snapshot/src/snapshot_cow/block_tools.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow/block_tools.rs
@@ -1,0 +1,238 @@
+//! Block-device operations the CoW manager needs from its environment.
+//!
+//! The manager needs three things it cannot do through the filesystem
+//! alone: attach a file as a loop device, detach one, and read a block
+//! device's size. Which program performs them is an environment fact —
+//! busybox applets in the System VM's EROFS userland, `util-linux` on a
+//! stock distro, or no program at all through the loop-control ioctls —
+//! so [`BlockTools`] names the operations and the composer supplies the
+//! implementation. [`BusyboxBlockTools`] is the reference: the System VM's
+//! behaviour, unchanged.
+//!
+//! Device-node helpers that only need syscalls (`stat`, `mknod`) are plain
+//! functions here rather than trait methods: there is nothing environment
+//! specific about them once they stop shelling out.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::error::{Result, SnapshotError};
+
+/// Loop-device and block-size operations, supplied by the composer.
+///
+/// Every method is synchronous and may block on a subprocess or an ioctl;
+/// [`CowManager`](super::CowManager) calls them from `spawn_blocking`.
+/// Implementations are shared across sandboxes and tasks, hence
+/// `Send + Sync`.
+pub trait BlockTools: Send + Sync {
+    /// Attach `backing` as a loop device and return the device path
+    /// (`/dev/loopN`). Allocation and attach must be one atomic step against
+    /// concurrent callers (`losetup -f --show`, or `LOOP_CONFIGURE`).
+    fn attach_loop(&self, backing: &Path, read_only: bool) -> Result<String>;
+
+    /// Detach a loop device.
+    fn detach_loop(&self, device: &str) -> Result<()>;
+
+    /// Size of a block device in 512-byte sectors.
+    fn device_sectors(&self, device: &str) -> Result<u64>;
+}
+
+/// [`BlockTools`] over busybox applets — the System VM's userland.
+///
+/// Every operation runs `<busybox> <applet> …`; the applets are `losetup`
+/// (busybox ≥ 1.21 for `-f --show`) and `blockdev`.
+#[derive(Debug, Clone)]
+pub struct BusyboxBlockTools {
+    busybox: PathBuf,
+}
+
+impl BusyboxBlockTools {
+    /// Where the System VM's EROFS rootfs installs busybox.
+    pub const DEFAULT_PATH: &'static str = "/bin/busybox";
+
+    /// Use the busybox binary at `busybox`.
+    pub fn new(busybox: impl Into<PathBuf>) -> Self {
+        Self {
+            busybox: busybox.into(),
+        }
+    }
+
+    fn run(&self, applet: &str, args: &[&str]) -> Result<std::process::Output> {
+        Command::new(&self.busybox)
+            .arg(applet)
+            .args(args)
+            .output()
+            .map_err(|e| {
+                SnapshotError::DeviceMapper(format!(
+                    "spawn {} {applet}: {e}",
+                    self.busybox.display()
+                ))
+            })
+    }
+}
+
+impl Default for BusyboxBlockTools {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_PATH)
+    }
+}
+
+impl BlockTools for BusyboxBlockTools {
+    /// Uses the atomic `losetup -f --show` form so the kernel allocates and
+    /// attaches in a single `LOOP_CTL_GET_FREE`+`LOOP_SET_FD` call, avoiding
+    /// the TOCTOU window of separate `-f` then `attach` invocations against
+    /// other processes that might claim the same slot.
+    fn attach_loop(&self, backing: &Path, read_only: bool) -> Result<String> {
+        let backing_str = backing
+            .to_str()
+            .ok_or_else(|| SnapshotError::DeviceMapper("non-UTF-8 path".into()))?;
+        let output = if read_only {
+            self.run("losetup", &["-r", "-f", "--show", backing_str])?
+        } else {
+            self.run("losetup", &["-f", "--show", backing_str])?
+        };
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(SnapshotError::DeviceMapper(format!(
+                "losetup attach {}: {stderr}",
+                backing.display()
+            )));
+        }
+        let dev = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if dev.is_empty() {
+            return Err(SnapshotError::DeviceMapper(
+                "losetup --show returned empty device path".into(),
+            ));
+        }
+        Ok(dev)
+    }
+
+    fn detach_loop(&self, device: &str) -> Result<()> {
+        let output = self.run("losetup", &["-d", device])?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(SnapshotError::DeviceMapper(format!(
+                "losetup -d {device}: {stderr}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn device_sectors(&self, device: &str) -> Result<u64> {
+        let output = self.run("blockdev", &["--getsz", device])?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(SnapshotError::DeviceMapper(format!(
+                "blockdev --getsz {device}: {stderr}"
+            )));
+        }
+        String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse::<u64>()
+            .map_err(|e| SnapshotError::DeviceMapper(format!("blockdev parse: {e}")))
+    }
+}
+
+/// The `(major, minor)` device numbers of the block device at `path`.
+///
+/// Follows symlinks, so `/dev/mapper/<name>` resolves whether device-mapper
+/// created a node there itself (no udev, the System VM) or udev left a
+/// symlink to `/dev/dm-N` (a stock distro).
+#[cfg(target_os = "linux")]
+pub fn device_major_minor(path: &str) -> Result<(u32, u32)> {
+    use std::os::unix::fs::{FileTypeExt as _, MetadataExt as _};
+
+    let metadata = std::fs::metadata(path)
+        .map_err(|e| SnapshotError::DeviceMapper(format!("stat {path}: {e}")))?;
+    if !metadata.file_type().is_block_device() {
+        return Err(SnapshotError::DeviceMapper(format!(
+            "{path} is not a block device"
+        )));
+    }
+    let dev = metadata.rdev();
+    // Linux packs 12-bit majors and 20-bit minors into `dev_t`; nix hands
+    // them back as `u64`, and a value outside `u32` is a corrupt node, not
+    // something to truncate.
+    let narrow = |what: &str, value: u64| {
+        u32::try_from(value).map_err(|_| {
+            SnapshotError::DeviceMapper(format!("{path}: {what} {value} out of range"))
+        })
+    };
+    Ok((
+        narrow("major", nix::sys::stat::major(dev))?,
+        narrow("minor", nix::sys::stat::minor(dev))?,
+    ))
+}
+
+/// Create a block device node at `node_path` for `(major, minor)`, mode 0600.
+///
+/// The caller owns the node's ownership: a jailer chroot `chown`s it to the
+/// jailer uid/gid right after, which is why the mode need not be wider.
+#[cfg(target_os = "linux")]
+pub fn mknod_blkdev(node_path: &Path, major: u32, minor: u32) -> Result<()> {
+    use nix::sys::stat::{Mode, SFlag, makedev, mknod};
+
+    mknod(
+        node_path,
+        SFlag::S_IFBLK,
+        Mode::S_IRUSR | Mode::S_IWUSR,
+        makedev(u64::from(major), u64::from(minor)),
+    )
+    .map_err(|e| SnapshotError::DeviceMapper(format!("mknod {}: {e}", node_path.display())))
+}
+
+/// Block device nodes are a Linux concept; off Linux the crate compiles but
+/// the operation is unavailable.
+#[cfg(not(target_os = "linux"))]
+pub fn device_major_minor(path: &str) -> Result<(u32, u32)> {
+    Err(SnapshotError::Unavailable(format!(
+        "block device numbers for {path}: Linux-only"
+    )))
+}
+
+/// Block device nodes are a Linux concept; off Linux the crate compiles but
+/// the operation is unavailable.
+#[cfg(not(target_os = "linux"))]
+pub fn mknod_blkdev(node_path: &Path, _major: u32, _minor: u32) -> Result<()> {
+    Err(SnapshotError::Unavailable(format!(
+        "mknod {}: Linux-only",
+        node_path.display()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn device_major_minor_rejects_regular_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("plain");
+        std::fs::write(&file, b"x").unwrap();
+        let err = device_major_minor(file.to_str().unwrap()).unwrap_err();
+        assert!(err.to_string().contains("not a block device"), "{err}");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn device_major_minor_reports_missing_paths() {
+        let err = device_major_minor("/nonexistent/arcbox-blkdev").unwrap_err();
+        assert!(err.to_string().contains("stat"), "{err}");
+    }
+
+    #[test]
+    fn busybox_tools_default_to_the_system_vm_path() {
+        assert_eq!(
+            BusyboxBlockTools::default().busybox,
+            PathBuf::from(BusyboxBlockTools::DEFAULT_PATH)
+        );
+    }
+
+    #[test]
+    fn busybox_tools_report_a_missing_binary() {
+        let tools = BusyboxBlockTools::new("/nonexistent/arcbox-busybox");
+        let err = tools.detach_loop("/dev/loop0").unwrap_err();
+        assert!(err.to_string().contains("spawn"), "{err}");
+    }
+}

--- a/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
@@ -6,8 +6,8 @@ use std::process::Command;
 use tracing::{debug, warn};
 
 use super::{
-    BUSYBOX, CowManager, DM_NAME_PREFIX, TEMPLATE_LOOP_DIR, TEMPLATE_MARKER_TEMP_PREFIX,
-    TEMPLATE_PENDING_PREFIX, dmsetup_remove, losetup_detach,
+    CowManager, DM_NAME_PREFIX, TEMPLATE_LOOP_DIR, TEMPLATE_MARKER_TEMP_PREFIX,
+    TEMPLATE_PENDING_PREFIX, dmsetup_remove,
 };
 use crate::error::{Result, SnapshotError};
 
@@ -77,7 +77,7 @@ impl CowManager {
                     continue;
                 }
                 for loop_device in loop_devices_for_backing_sync(&path)? {
-                    run_sync_checked(Command::new(BUSYBOX).args(["losetup", "-d", &loop_device]))?;
+                    self.tools.detach_loop(&loop_device)?;
                 }
                 debug!(file = %path.display(), "removing stale cow file");
                 remove_file_durable(&path)?;
@@ -196,7 +196,7 @@ impl CowManager {
             }
             if loop_basename.starts_with(TEMPLATE_PENDING_PREFIX) {
                 for loop_device in loop_devices_for_backing_sync(Path::new(&expected_backing))? {
-                    run_sync_checked(Command::new(BUSYBOX).args(["losetup", "-d", &loop_device]))?;
+                    self.tools.detach_loop(&loop_device)?;
                 }
                 clear_owner_marker(&marker_path)?;
                 continue;
@@ -212,7 +212,7 @@ impl CowManager {
                 && actual_backing.as_deref() == Some(expected_backing.as_str())
             {
                 debug!(dev = %dev, "detaching stale template loop");
-                run_sync_checked(Command::new(BUSYBOX).args(["losetup", "-d", &dev]))?;
+                self.tools.detach_loop(&dev)?;
             } else {
                 debug!(
                     dev = %dev,
@@ -263,7 +263,7 @@ impl CowManager {
                 orphan.cow_loop = Some(loop_device.to_owned());
                 false
             }
-            (true, Some(loop_device)) => match losetup_detach(BUSYBOX, loop_device).await {
+            (true, Some(loop_device)) => match self.detach_loop(loop_device).await {
                 Ok(()) => true,
                 Err(cleanup) => {
                     failures.push(cleanup.to_string());
@@ -313,7 +313,7 @@ impl CowManager {
         if let (Some(cow_loop), Some(cow_file)) = (&orphan.cow_loop, &orphan.cow_file)
             && loop_backs_path(cow_loop, cow_file)?
         {
-            losetup_detach(BUSYBOX, cow_loop).await?;
+            self.detach_loop(cow_loop).await?;
         }
         if let Some(cow_file) = &orphan.cow_file {
             remove_file_durable(cow_file)?;
@@ -372,7 +372,7 @@ impl CowManager {
     }
 
     async fn detach_template_loop(&self, loop_device: &str) -> Result<()> {
-        losetup_detach(BUSYBOX, loop_device).await?;
+        self.detach_loop(loop_device).await?;
         if let Some(marker) = self.template_marker_path(loop_device)
             && let Err(error) = clear_owner_marker(&marker)
         {

--- a/virt/arcbox-vm/README.md
+++ b/virt/arcbox-vm/README.md
@@ -48,6 +48,17 @@ programmatically; `[firecracker]`, `[network]`, and `[defaults]` are the
 sections that matter, and `[firecracker.jailer]` opts into jailer mode.
 See `config.rs` for the fields.
 
+What the stack needs from its *environment* — the pieces that differ
+between the System VM's busybox userland and a stock distro — is a
+separate input, `SandboxEnvironment`. `SandboxManager::new(config)` uses
+the reference environment (the System VM's); a composer on another host
+overrides the members it owns and calls
+`SandboxManager::with_environment(config, env)`. Today that is the
+loop-device tooling behind `arcbox_snapshot::snapshot_cow::BlockTools`
+(`BusyboxBlockTools` is the reference; a `util-linux` or ioctl
+implementation is a consumer's few dozen lines); the packet-filter and
+path seams follow.
+
 ## Build and test
 
 ```bash

--- a/virt/arcbox-vm/src/environment.rs
+++ b/virt/arcbox-vm/src/environment.rs
@@ -1,0 +1,37 @@
+//! Environment-specific components a composer supplies to the sandbox stack.
+//!
+//! The manager runs in more than one environment — the ArcBox System VM
+//! with its known busybox userland, or a stock distro on a bare-metal
+//! node — and the parts that differ are supplied here rather than assumed
+//! in the code. [`SandboxEnvironment::default`] is the reference
+//! environment, the System VM's, so `SandboxManager::new(config)` behaves
+//! exactly as before; a composer on another userland overrides the members
+//! it owns and calls `SandboxManager::with_environment`.
+
+use std::sync::Arc;
+
+use arcbox_snapshot::snapshot_cow::{BlockTools, BusyboxBlockTools};
+
+/// What differs between hosts of the sandbox stack.
+#[derive(Clone)]
+pub struct SandboxEnvironment {
+    /// Loop-device and block-size operations for the copy-on-write rootfs
+    /// (`arcbox_snapshot::snapshot_cow::BlockTools`).
+    pub block_tools: Arc<dyn BlockTools>,
+}
+
+impl Default for SandboxEnvironment {
+    /// The System VM's userland: busybox applets at
+    /// [`BusyboxBlockTools::DEFAULT_PATH`].
+    fn default() -> Self {
+        Self {
+            block_tools: Arc::new(BusyboxBlockTools::default()),
+        }
+    }
+}
+
+impl std::fmt::Debug for SandboxEnvironment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SandboxEnvironment").finish_non_exhaustive()
+    }
+}

--- a/virt/arcbox-vm/src/lib.rs
+++ b/virt/arcbox-vm/src/lib.rs
@@ -25,6 +25,8 @@
 //! # Public API
 //!
 //! - [`SandboxManager`] — top-level sandbox orchestrator
+//! - [`SandboxEnvironment`] — the environment-specific components a
+//!   composer supplies (block tooling today; more seams follow)
 //! - [`SandboxInstance`] / [`SandboxState`] — per-sandbox runtime state
 //! - [`NetworkManager`] — TAP lifecycle & IP allocation
 //! - [`VmmConfig`] / [`SandboxSpec`] — configuration types
@@ -37,6 +39,7 @@
 
 pub mod boot_proto;
 pub mod config;
+pub mod environment;
 pub mod error;
 pub mod file_io;
 pub mod file_watch;
@@ -54,6 +57,7 @@ pub use arcbox_snapshot::{snapshot, snapshot_cow, template_catalog};
 pub use config::{
     DefaultVmConfig, FirecrackerConfig, GrpcConfig, NetworkConfig, SandboxDatapath, VmmConfig,
 };
+pub use environment::SandboxEnvironment;
 pub use error::{Result, VmmError};
 pub use network::{ExposeTarget, NetworkAllocation, NetworkManager};
 pub use sandbox::pause_reason;

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -27,7 +27,7 @@ use crate::config::VmmConfig;
 use crate::error::{Result, VmmError};
 use crate::network::{NetworkAllocation, NetworkManager};
 use crate::snapshot::{SnapshotCatalog, SnapshotDraft};
-use crate::snapshot_cow::{CowHandle, CowManager};
+use crate::snapshot_cow::{CowHandle, CowManager, CowOptions};
 use crate::spawn::{spawn_direct, spawn_jailer};
 use crate::template_catalog::TemplateCatalog;
 use crate::vsock::{self, ExecInputMsg, ExitStatus, OutputChunk, StartCommand};
@@ -108,7 +108,9 @@ impl SandboxManager {
         let snapshots = Arc::new(SnapshotCatalog::new(&config.firecracker.data_dir));
         let templates = Arc::new(TemplateCatalog::new(&config.firecracker.data_dir));
         let (events_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
-        let cow_manager = Arc::new(CowManager::new(&config.firecracker.data_dir)?);
+        let cow_manager = Arc::new(CowManager::new(CowOptions::new(
+            &config.firecracker.data_dir,
+        ))?);
 
         // Ensure the jailer chroot base directory exists.
         if let Some(ref jc) = config.firecracker.jailer {

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 
 use crate::boot_proto::KernelIpParam;
 use crate::config::VmmConfig;
+use crate::environment::SandboxEnvironment;
 use crate::error::{Result, VmmError};
 use crate::network::{NetworkAllocation, NetworkManager};
 use crate::snapshot::{SnapshotCatalog, SnapshotDraft};
@@ -92,8 +93,15 @@ pub struct SandboxManager {
 }
 
 impl SandboxManager {
-    /// Create a new manager from the given configuration.
+    /// Create a new manager from the given configuration, in the reference
+    /// environment ([`SandboxEnvironment::default`]).
     pub fn new(config: VmmConfig) -> Result<Self> {
+        Self::with_environment(config, SandboxEnvironment::default())
+    }
+
+    /// Create a new manager from the given configuration, with the
+    /// environment-specific components the composer supplies.
+    pub fn with_environment(config: VmmConfig, environment: SandboxEnvironment) -> Result<Self> {
         let records = Arc::new(persistence::SandboxRecordStore::new(Path::new(
             &config.firecracker.data_dir,
         ))?);
@@ -108,9 +116,10 @@ impl SandboxManager {
         let snapshots = Arc::new(SnapshotCatalog::new(&config.firecracker.data_dir));
         let templates = Arc::new(TemplateCatalog::new(&config.firecracker.data_dir));
         let (events_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
-        let cow_manager = Arc::new(CowManager::new(CowOptions::new(
-            &config.firecracker.data_dir,
-        ))?);
+        let cow_manager = Arc::new(CowManager::new(CowOptions {
+            block_tools: environment.block_tools,
+            ..CowOptions::new(&config.firecracker.data_dir)
+        })?);
 
         // Ensure the jailer chroot base directory exists.
         if let Some(ref jc) = config.firecracker.jailer {

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -766,7 +766,7 @@ pub(super) async fn stage_rootfs_device_for_jailer(
     tokio::fs::create_dir_all(chroot_root)
         .await
         .map_err(VmmError::Io)?;
-    let (major, minor) = crate::snapshot_cow::device_major_minor(dm_device).await?;
+    let (major, minor) = crate::snapshot_cow::device_major_minor(dm_device)?;
     let node_path = chroot_root.join("rootfs.ext4");
     // Remove any leftover entry from a previous crash so mknod can succeed
     // (and so we never end up writing into a stale device node).
@@ -775,7 +775,7 @@ pub(super) async fn stage_rootfs_device_for_jailer(
     {
         return Err(VmmError::Io(e));
     }
-    crate::snapshot_cow::mknod_blkdev(&node_path, major, minor).await?;
+    crate::snapshot_cow::mknod_blkdev(&node_path, major, minor)?;
     chown(
         &node_path,
         Some(Uid::from_raw(uid)),

--- a/virt/arcbox-vm/src/sandbox/cleanup.rs
+++ b/virt/arcbox-vm/src/sandbox/cleanup.rs
@@ -431,7 +431,7 @@ pub(super) fn inst_to_info(inst: &SandboxInstance) -> SandboxInfo {
 mod tests {
     use super::*;
     use crate::sandbox::persistence::{ProvisionIntent, SandboxPhase, SandboxProvisionOutcome};
-    use crate::snapshot_cow::CowTestProbe;
+    use crate::snapshot_cow::{CowOptions, CowTestProbe};
     use std::os::unix::fs::PermissionsExt;
 
     fn instance(id: &str) -> Arc<Mutex<SandboxInstance>> {
@@ -522,7 +522,8 @@ mod tests {
                 )
                 .unwrap(),
             );
-            let cow_manager = Arc::new(CowManager::new(&config.firecracker.data_dir).unwrap());
+            let cow_manager =
+                Arc::new(CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap());
             let snapshots = Arc::new(crate::snapshot::SnapshotCatalog::new(
                 &config.firecracker.data_dir,
             ));
@@ -659,7 +660,8 @@ mod tests {
             )
             .unwrap(),
         );
-        let cow_manager = Arc::new(CowManager::new(&config.firecracker.data_dir).unwrap());
+        let cow_manager =
+            Arc::new(CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap());
         let snapshots = Arc::new(crate::snapshot::SnapshotCatalog::new(
             &config.firecracker.data_dir,
         ));
@@ -719,7 +721,7 @@ mod tests {
         let cow_probe = Arc::new(CowTestProbe::default());
         manager.cow_manager = Arc::new(
             CowManager::new_with_test_probe(
-                manager.config.firecracker.data_dir.as_str(),
+                CowOptions::new(&manager.config.firecracker.data_dir),
                 Arc::clone(&cow_probe),
             )
             .unwrap(),
@@ -862,7 +864,8 @@ mod tests {
             )
             .unwrap(),
         );
-        let cow_manager = Arc::new(CowManager::new(&config.firecracker.data_dir).unwrap());
+        let cow_manager =
+            Arc::new(CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap());
 
         release_runtime_resources("job", &arc, &network, &config, &cow_manager)
             .await
@@ -910,7 +913,8 @@ mod tests {
             )
             .unwrap(),
         );
-        let cow_manager = Arc::new(CowManager::new(&config.firecracker.data_dir).unwrap());
+        let cow_manager =
+            Arc::new(CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap());
         let records = Arc::new(SandboxRecordStore::new(data_dir.path()).unwrap());
         let snapshots = Arc::new(crate::snapshot::SnapshotCatalog::new(
             &config.firecracker.data_dir,

--- a/virt/arcbox-vm/tests/integration.rs
+++ b/virt/arcbox-vm/tests/integration.rs
@@ -226,3 +226,76 @@ fn multiple_taps_are_isolated() {
         a1.tap_name
     );
 }
+
+// ---------------------------------------------------------------------------
+// Block device nodes (Linux, root only)
+// ---------------------------------------------------------------------------
+
+/// `device_major_minor` reads the numbers of a real block device and
+/// `mknod_blkdev` recreates a node with the same identity — the syscall pair
+/// the jailer's rootfs staging relies on, exercised against a live loop
+/// device rather than the error paths only. Skips without root or
+/// `losetup`; a failure in production degrades silently to a full rootfs
+/// copy, so this is the loud check.
+#[test]
+#[cfg(target_os = "linux")]
+fn block_device_numbers_round_trip_through_mknod() {
+    use std::os::unix::fs::{FileTypeExt as _, MetadataExt as _};
+
+    use arcbox_vm::snapshot_cow::{device_major_minor, mknod_blkdev};
+
+    if !common::is_root() {
+        eprintln!("SKIP block_device_numbers_round_trip_through_mknod — requires root");
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let backing = dir.path().join("backing.img");
+    std::fs::File::create(&backing)
+        .unwrap()
+        .set_len(4 * 1024 * 1024)
+        .unwrap();
+    let attached = std::process::Command::new("losetup")
+        .args(["-f", "--show"])
+        .arg(&backing)
+        .output();
+    let Ok(output) = attached else {
+        eprintln!("SKIP block_device_numbers_round_trip_through_mknod — no losetup");
+        return;
+    };
+    assert!(
+        output.status.success(),
+        "losetup: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let loop_dev = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    let result = (|| -> Result<(), String> {
+        let (major, minor) = device_major_minor(&loop_dev).map_err(|e| e.to_string())?;
+        let node = dir.path().join("rootfs.node");
+        mknod_blkdev(&node, major, minor).map_err(|e| e.to_string())?;
+        let node_meta = std::fs::metadata(&node).map_err(|e| e.to_string())?;
+        let dev_meta = std::fs::metadata(&loop_dev).map_err(|e| e.to_string())?;
+        if !node_meta.file_type().is_block_device() {
+            return Err("mknod did not create a block device".into());
+        }
+        if node_meta.rdev() != dev_meta.rdev() {
+            return Err(format!(
+                "node rdev {:#x} != loop rdev {:#x}",
+                node_meta.rdev(),
+                dev_meta.rdev()
+            ));
+        }
+        if node_meta.mode() & 0o777 != 0o600 {
+            return Err(format!(
+                "node mode {:o}, want 600",
+                node_meta.mode() & 0o777
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = std::process::Command::new("losetup")
+        .args(["-d", &loop_dev])
+        .status();
+    result.unwrap();
+}


### PR DESCRIPTION
CORE-127, seam 3 (block device tooling) — plus the composer-facing struct the remaining seams will land in. Independent of #649 (both touch `virt/arcbox-vm/src/lib.rs` on adjacent lines; whichever merges second rebases trivially).

**Commit 1 — `arcbox-snapshot`**
- `snapshot_cow/block_tools.rs`: `BlockTools` trait (`attach_loop`, `detach_loop`, `device_sectors`) — the operations the CoW manager needs from a userland; `BusyboxBlockTools` is the reference implementation with today's exact behaviour (`/bin/busybox losetup -f --show`, `blockdev --getsz`). Sync methods; the manager runs them on `spawn_blocking`.
- `CowManager::new(CowOptions { data_dir, block_tools, dmsetup_candidates })`. `CowOptions::new(data_dir)` = the System VM's environment, so `guest/arcbox-agent` is unchanged in behaviour. The `dmsetup` search list is now a field instead of a private constant.
- `device_major_minor` / `mknod_blkdev` are syscalls now (`stat(2)` via std with a block-device type check, `mknod(2)` via nix, Linux-gated with `Unavailable` stubs elsewhere): nothing environment-specific once they stop shelling out, and following symlinks makes `/dev/mapper/<name>` resolve under udev (a stock distro) as well as without it (the System VM, where busybox `stat` on a symlink would have returned `0 0`).
- `persistence.rs` recovery paths call the seam; every `BUSYBOX` reference is gone.

**Commit 2 — `arcbox-vm`**
- `SandboxEnvironment { block_tools }` + `SandboxManager::with_environment(config, env)`; `new(config)` passes `SandboxEnvironment::default()` (the reference). This struct is where the packet-filter and path seams will be added.
- README + `engine/AGENTS.md` note (AGENTS.md edit is the one that needs a human eye per CLAUDE.md).

**Checked**: `cargo clippy -p arcbox-snapshot -p arcbox-vm --all-targets -- -D warnings` on macOS; `cargo clippy -p arcbox-vm -p arcbox-snapshot --target aarch64-unknown-linux-musl -- -D warnings` (the CI shape) and `-p arcbox-snapshot --all-targets` on the musl target; `cargo check -p arcbox-agent --target aarch64-unknown-linux-musl --all-targets`; unit tests `arcbox-snapshot` 44, `arcbox-vm` lib green. `test-vm-linux.yml` (real KVM, root, dmsetup + loop devices) is the suite that proves the busybox reference path still assembles/tears down snapshots — it runs on this PR because `engine/arcbox-snapshot/**` and `virt/arcbox-vm/**` are in its path filter.

**Not here**: the packet-filter seam (`network/invariant.rs`), `rootfs_builder` relocation, path parameterisation (`dmsetup_candidates` is now *settable* but `arcbox-vm` still passes the reference list; wiring it to `VmmConfig` is the paths PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox rootfs CoW assembly, crash recovery, and jailer device-node staging—core VM lifecycle paths—but preserves default busybox behavior and adds clearer dmsetup selection; syscall-based mknod/stat is a deliberate improvement over shell parsing.
> 
> **Overview**
> **CoW block tooling is no longer hard-coded to busybox.** Loop attach/detach and sector sizing go through a new `BlockTools` trait with `BusyboxBlockTools` as the default System VM implementation. `CowManager` is constructed via `CowOptions` (`block_tools`, configurable `dmsetup_candidates` with a working-binary probe) instead of a bare data-dir string; startup recovery in `persistence.rs` uses the same seam.
> 
> **`device_major_minor` and `mknod_blkdev`** no longer shell out to busybox `stat`/`mknod`—they use `stat(2)` metadata and `nix` `mknod` on Linux (with non-Linux `Unavailable` stubs). Jail rootfs staging in `arcbox-vm` calls them synchronously.
> 
> **`arcbox-vm`** adds `SandboxEnvironment { block_tools }` and `SandboxManager::with_environment`; `SandboxManager::new` keeps reference defaults. Docs (`README`, `AGENTS.md`) describe the composer pattern. A root-only integration test round-trips block numbers through a real loop device.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fd30ed29057d72b6ff132dfe86cc5825f3fff57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->