### PR TITLE
refactor(vm): put the invariant translation's netfilter rendering behind a PacketFilter seam

### DIFF
--- a/guest/arcbox-agent/src/init.rs
+++ b/guest/arcbox-agent/src/init.rs
@@ -701,7 +701,7 @@ exit 0
     /// before it can be marked or DNAT'd (the per-TAP invariant NAT would
     /// otherwise misattribute it), except toward the pool gateway, which
     /// legacy guests use for DNS. These run at System VM boot, so the
-    /// per-TAP `invariant::translation_rules` (appended with `-A`) always
+    /// per-TAP `packet_filter::translation_rules` (appended with `-A`) always
     /// sit below them. Expose companions (`port_forward.rs`) instead
     /// PREPEND above these — safe because `MARK` is non-terminating, so a
     /// marked packet still falls through to the DROP.

--- a/virt/arcbox-vm/README.md
+++ b/virt/arcbox-vm/README.md
@@ -61,7 +61,11 @@ overrides the members it owns and calls
 `SandboxManager::with_environment(config, env)`. Today that is the
 loop-device tooling behind `arcbox_snapshot::snapshot_cow::BlockTools`
 (`BusyboxBlockTools` is the reference; a `util-linux` or ioctl
-implementation is a consumer's few dozen lines); the packet-filter and
+implementation is a consumer's few dozen lines) and the netfilter
+rendering of the identity-invariant translation behind
+`arcbox_vm::network::PacketFilter` (`IptablesLegacy` is the reference;
+a stock distro on the nft backend supplies an nftables one — legacy and
+nft rulesets are mutually invisible, so this is a seam, not a path); the
 path seams follow.
 
 ## Build and test

--- a/virt/arcbox-vm/src/environment.rs
+++ b/virt/arcbox-vm/src/environment.rs
@@ -12,20 +12,28 @@ use std::sync::Arc;
 
 use arcbox_snapshot::snapshot_cow::{BlockTools, BusyboxBlockTools};
 
+use crate::network::{IptablesLegacy, PacketFilter};
+
 /// What differs between hosts of the sandbox stack.
 #[derive(Clone)]
 pub struct SandboxEnvironment {
     /// Loop-device and block-size operations for the copy-on-write rootfs
     /// (`arcbox_snapshot::snapshot_cow::BlockTools`).
     pub block_tools: Arc<dyn BlockTools>,
+    /// How the identity-invariant translation is expressed in the host's
+    /// netfilter framework ([`crate::network::packet_filter`]) — used by
+    /// the iptables datapath and as the eBPF datapath's fallback.
+    pub packet_filter: Arc<dyn PacketFilter>,
 }
 
 impl Default for SandboxEnvironment {
     /// The System VM's userland: busybox applets at
-    /// [`BusyboxBlockTools::DEFAULT_PATH`].
+    /// [`BusyboxBlockTools::DEFAULT_PATH`], iptables-legacy at
+    /// [`IptablesLegacy::DEFAULT_PATH`].
     fn default() -> Self {
         Self {
             block_tools: Arc::new(BusyboxBlockTools::default()),
+            packet_filter: Arc::new(IptablesLegacy::default()),
         }
     }
 }

--- a/virt/arcbox-vm/src/network.rs
+++ b/virt/arcbox-vm/src/network.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
-use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
@@ -11,6 +11,8 @@ use uuid::Uuid;
 
 use crate::config::SandboxDatapath;
 use crate::error::{Result, VmmError};
+
+pub use packet_filter::{IptablesLegacy, PacketFilter};
 
 #[cfg_attr(
     not(target_os = "linux"),
@@ -28,6 +30,7 @@ mod ebpf;
     )
 )]
 pub mod invariant;
+pub mod packet_filter;
 mod quarantine;
 #[cfg_attr(
     not(target_os = "linux"),
@@ -172,6 +175,16 @@ pub struct NetworkManager {
     /// with that process) or is legacy — both tear down via the tolerant
     /// iptables removal and expose via the fwmark form.
     applied: Mutex<HashMap<String, AppliedDatapath>>,
+    /// How the iptables-datapath translation (and the eBPF fallback) is
+    /// expressed on this host; see [`packet_filter`].
+    #[cfg_attr(
+        not(target_os = "linux"),
+        allow(
+            dead_code,
+            reason = "consulted only by the Linux activation path; other platforms activate nothing"
+        )
+    )]
+    packet_filter: Arc<dyn PacketFilter>,
     /// Lazily loaded eBPF datapath state (CORE-83).
     #[cfg(target_os = "linux")]
     ebpf: Mutex<ebpf::Engine>,
@@ -182,19 +195,35 @@ impl NetworkManager {
     ///
     /// `cidr` must be in `a.b.c.d/n` notation (e.g. `"172.20.0.0/16"`).
     pub fn new(cidr: &str, gateway: &str, dns: Vec<String>) -> Result<Self> {
-        Self::new_inner(cidr, gateway, dns, None, SandboxDatapath::default())
+        Self::new_inner(
+            cidr,
+            gateway,
+            dns,
+            None,
+            SandboxDatapath::default(),
+            Arc::new(IptablesLegacy::default()),
+        )
     }
 
     /// Create a manager that persists inactive allocations until host cleanup
-    /// is finalized, translating invariant TAPs via `datapath`.
+    /// is finalized, translating invariant TAPs via `datapath` and, where
+    /// that means netfilter rules, through `packet_filter`.
     pub(crate) fn with_quarantine_dir(
         cidr: &str,
         gateway: &str,
         dns: Vec<String>,
         quarantine_dir: PathBuf,
         datapath: SandboxDatapath,
+        packet_filter: Arc<dyn PacketFilter>,
     ) -> Result<Self> {
-        Self::new_inner(cidr, gateway, dns, Some(quarantine_dir), datapath)
+        Self::new_inner(
+            cidr,
+            gateway,
+            dns,
+            Some(quarantine_dir),
+            datapath,
+            packet_filter,
+        )
     }
 
     fn new_inner(
@@ -203,6 +232,7 @@ impl NetworkManager {
         dns: Vec<String>,
         quarantine_dir: Option<PathBuf>,
         datapath: SandboxDatapath,
+        packet_filter: Arc<dyn PacketFilter>,
     ) -> Result<Self> {
         let (base, prefix_len) = parse_cidr(cidr)?;
         if !(1..=30).contains(&prefix_len) {
@@ -250,6 +280,7 @@ impl NetworkManager {
             startup_reconciled: AtomicBool::new(!startup_barrier),
             datapath,
             applied: Mutex::new(HashMap::new()),
+            packet_filter,
             #[cfg(target_os = "linux")]
             ebpf: Mutex::new(ebpf::Engine::Unloaded),
         })
@@ -350,14 +381,22 @@ impl NetworkManager {
     fn install_translation(&self, allocation: &NetworkAllocation) -> Result<()> {
         let applied = match self.datapath {
             SandboxDatapath::Iptables => {
-                invariant::install(&allocation.tap_name, allocation.ip_address)?;
+                invariant::install(
+                    &*self.packet_filter,
+                    &allocation.tap_name,
+                    allocation.ip_address,
+                )?;
                 AppliedDatapath::Iptables
             }
             SandboxDatapath::Ebpf => match self.attach_ebpf(allocation) {
                 Ok(ebpf::Attach::Done) => AppliedDatapath::Ebpf,
                 // The load failure already warned once; stay quiet per TAP.
                 Ok(ebpf::Attach::EngineUnavailable) => {
-                    invariant::install(&allocation.tap_name, allocation.ip_address)?;
+                    invariant::install(
+                        &*self.packet_filter,
+                        &allocation.tap_name,
+                        allocation.ip_address,
+                    )?;
                     AppliedDatapath::Iptables
                 }
                 Err(error) => {
@@ -366,7 +405,11 @@ impl NetworkManager {
                         %error,
                         "eBPF TAP attach failed; using iptables NAT for this TAP"
                     );
-                    invariant::install(&allocation.tap_name, allocation.ip_address)?;
+                    invariant::install(
+                        &*self.packet_filter,
+                        &allocation.tap_name,
+                        allocation.ip_address,
+                    )?;
                     AppliedDatapath::Iptables
                 }
             },
@@ -421,7 +464,7 @@ impl NetworkManager {
             }
             return Ok(());
         }
-        invariant::remove(&alloc.tap_name, alloc.ip_address)
+        invariant::remove(&*self.packet_filter, &alloc.tap_name, alloc.ip_address)
     }
 
     /// How expose DNAT must target the sandbox behind `tap_name` (CORE-83).
@@ -1065,6 +1108,7 @@ mod tests {
                 vec![],
                 root.path().join("network-quarantine"),
                 SandboxDatapath::default(),
+                Arc::new(IptablesLegacy::default()),
             )
             .unwrap(),
         );
@@ -1098,6 +1142,7 @@ mod tests {
             vec![],
             quarantine.clone(),
             SandboxDatapath::default(),
+            Arc::new(IptablesLegacy::default()),
         )
         .unwrap();
         manager.mark_reconciled();
@@ -1113,6 +1158,7 @@ mod tests {
             vec![],
             quarantine,
             SandboxDatapath::default(),
+            Arc::new(IptablesLegacy::default()),
         )
         .unwrap();
         restarted.mark_reconciled();
@@ -1177,6 +1223,7 @@ mod tests {
                     vec![],
                     quarantine,
                     SandboxDatapath::default(),
+                    Arc::new(IptablesLegacy::default()),
                 )
                 .is_err()
             );

--- a/virt/arcbox-vm/src/network/invariant.rs
+++ b/virt/arcbox-vm/src/network/invariant.rs
@@ -26,12 +26,15 @@
 //!   the same hook), and a per-sandbox fwmark fib rule routes the rewritten
 //!   destination through a per-sandbox table holding `GUEST_IP dev <tap>`.
 //!
-//! Mechanism choice is grounded in what the System VM actually ships
-//! (2026-08, boot-assets rootfs + arcbox kernel config): static
-//! iptables-legacy and busybox only — no nftables userland, no `tc`, and the
-//! kernel enables neither `NET_ACT_NAT` nor `NETMAP` nor conntrack marks
-//! (`CONNMARK`). What it does enable — `IP_NF_NAT`, `IP_NF_MANGLE`,
-//! `NETFILTER_XT_MARK`, `IP_MULTIPLE_TABLES` — is exactly the rule set below.
+//! The rule set above is the contract; how it is expressed in the host's
+//! netfilter framework is the [`PacketFilter`](super::packet_filter::PacketFilter)
+//! seam. The reference implementation is iptables-legacy, because that is
+//! what the System VM ships (2026-08, boot-assets rootfs + arcbox kernel
+//! config): no nftables userland, no `tc`, and a kernel without
+//! `NET_ACT_NAT` / `NETMAP` / `CONNMARK` — what it does enable (`IP_NF_NAT`,
+//! `IP_NF_MANGLE`, `NETFILTER_XT_MARK`, `IP_MULTIPLE_TABLES`) is exactly
+//! that rule set. The sysctls, the fwmark fib rule, and the per-sandbox
+//! table route are framework-independent and installed here.
 //!
 //! The TAP itself keeps today's point-to-point shape with one change: its
 //! local address is the fixed [`GUEST_GATEWAY`] instead of the pool gateway.
@@ -57,6 +60,8 @@
 use std::net::Ipv4Addr;
 
 #[cfg(target_os = "linux")]
+use super::packet_filter::PacketFilter;
+#[cfg(target_os = "linux")]
 use super::rtnetlink;
 #[cfg(target_os = "linux")]
 use crate::error::Result;
@@ -77,10 +82,6 @@ pub const GUEST_GATEWAY: Ipv4Addr = Ipv4Addr::new(169, 254, 100, 1);
 /// the guest.
 pub const GUEST_NETMASK: Ipv4Addr = Ipv4Addr::new(255, 255, 255, 252);
 
-/// Comment tag on every translation rule, marking them as arcbox-owned for
-/// forensics (`iptables -S`). Deletion goes by exact rule spec, not the tag.
-const RULE_COMMENT: &str = "arcbox-nat";
-
 /// Priority of the per-sandbox fwmark fib rules (before `main`, 32766).
 const FIB_RULE_PRIORITY: u32 = 8000;
 
@@ -100,99 +101,11 @@ pub fn fwmark(pool_ip: Ipv4Addr) -> u32 {
     u32::from(pool_ip)
 }
 
-/// One iptables rule of the per-TAP translation set.
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) struct XtRule {
-    pub table: &'static str,
-    pub chain: &'static str,
-    pub spec: Vec<String>,
-}
-
-/// The complete per-TAP translation rule set, in install order.
-pub(crate) fn translation_rules(tap: &str, pool_ip: Ipv4Addr) -> Vec<XtRule> {
-    let mark = format!("{:#x}", fwmark(pool_ip));
-    let pool = format!("{pool_ip}/32");
-    let comment = |spec: &mut Vec<String>| {
-        spec.extend(["-m", "comment", "--comment", RULE_COMMENT].map(String::from));
-    };
-    let mut rules = Vec::new();
-    let mut rule = |table, chain, head: &[&str], tail: &[&str]| {
-        let mut spec: Vec<String> = head.iter().map(|s| (*s).to_owned()).collect();
-        comment(&mut spec);
-        spec.extend(tail.iter().map(|s| (*s).to_owned()));
-        rules.push(XtRule { table, chain, spec });
-    };
-
-    // Mark sandbox-originated packets so POSTROUTING (which cannot match the
-    // input interface) can select the right source identity.
-    rule(
-        "mangle",
-        "PREROUTING",
-        &["-i", tap],
-        &["-j", "MARK", "--set-mark", &mark],
-    );
-    // Mark to-sandbox packets from their pre-NAT destination; the fwmark fib
-    // rule then routes the DNAT'd destination out this TAP.
-    rule(
-        "mangle",
-        "PREROUTING",
-        &["-d", &pool],
-        &["-j", "MARK", "--set-mark", &mark],
-    );
-    rule(
-        "mangle",
-        "OUTPUT",
-        &["-d", &pool],
-        &["-j", "MARK", "--set-mark", &mark],
-    );
-    // External identity → fixed guest identity, both directions.
-    let guest_ip = GUEST_IP.to_string();
-    rule(
-        "nat",
-        "PREROUTING",
-        &["-d", &pool],
-        &["-j", "DNAT", "--to-destination", &guest_ip],
-    );
-    rule(
-        "nat",
-        "OUTPUT",
-        &["-d", &pool],
-        &["-j", "DNAT", "--to-destination", &guest_ip],
-    );
-    // Local services (DNS, relays) see the pool identity, and their replies
-    // are addressed to it — which is what makes them routable back out the
-    // right TAP (dst-based mark + fwmark table).
-    rule(
-        "nat",
-        "INPUT",
-        &["-i", tap],
-        &["-j", "SNAT", "--to-source", &pool_ip.to_string()],
-    );
-    // Forwarded sandbox-originated traffic. The source match is the
-    // definitive sandbox-origin signature at POSTROUTING (only pre-SNAT
-    // sandbox packets carry the fixed guest source); the mark picks which
-    // sandbox, keeping to-sandbox packets (marked with the same value but
-    // carrying a client source) out of this rewrite.
-    rule(
-        "nat",
-        "POSTROUTING",
-        &[
-            "-s",
-            &format!("{GUEST_IP}/32"),
-            "-m",
-            "mark",
-            "--mark",
-            &mark,
-        ],
-        &["-j", "SNAT", "--to-source", &pool_ip.to_string()],
-    );
-    rules
-}
-
-/// Install the per-TAP translation: sysctls, iptables rules, fwmark fib rule,
-/// and the per-sandbox table route. The TAP must already exist.
+/// Install the per-TAP translation: sysctls, the packet-filter rules, the
+/// fwmark fib rule, and the per-sandbox table route. The TAP must already
+/// exist.
 #[cfg(target_os = "linux")]
-pub(crate) fn install(tap: &str, pool_ip: Ipv4Addr) -> Result<()> {
+pub(crate) fn install(filter: &dyn PacketFilter, tap: &str, pool_ip: Ipv4Addr) -> Result<()> {
     // rp_filter: the reverse lookup for the fixed guest source only resolves
     // through the fwmark table, which strict mode consults solely when
     // src_valid_mark is set. Write both so the invariant link stays up
@@ -200,9 +113,7 @@ pub(crate) fn install(tap: &str, pool_ip: Ipv4Addr) -> Result<()> {
     write_tap_sysctl(tap, "rp_filter", "0")?;
     write_tap_sysctl(tap, "src_valid_mark", "1")?;
 
-    for rule in translation_rules(tap, pool_ip) {
-        run_iptables(&rule, "-A", false)?;
-    }
+    filter.install_translation(tap, pool_ip)?;
 
     let mark = fwmark(pool_ip);
     // EEXIST tolerated: an identical rule surviving a crash is exactly what
@@ -224,12 +135,10 @@ pub(crate) fn install(tap: &str, pool_ip: Ipv4Addr) -> Result<()> {
 /// activated ones, so every miss is a no-op, not an error. The table route
 /// and sysctls die with the TAP device and need no explicit removal.
 #[cfg(target_os = "linux")]
-pub(crate) fn remove(tap: &str, pool_ip: Ipv4Addr) -> Result<()> {
+pub(crate) fn remove(filter: &dyn PacketFilter, tap: &str, pool_ip: Ipv4Addr) -> Result<()> {
     let mut failures = Vec::new();
-    for rule in translation_rules(tap, pool_ip) {
-        if let Err(error) = run_iptables(&rule, "-D", true) {
-            failures.push(error.to_string());
-        }
+    if let Err(error) = filter.remove_translation(tap, pool_ip) {
+        failures.push(error.to_string());
     }
     let mark = fwmark(pool_ip);
     if let Err(error) = rtnetlink::execute(
@@ -271,29 +180,6 @@ pub(super) fn tap_ifindex(tap: &str) -> Result<u32> {
     Ok(index)
 }
 
-/// Run one iptables verb on a rule. `tolerate_missing` treats exit status 1 —
-/// iptables-legacy's "no matching rule" — as success so teardown is
-/// idempotent; other failures (usage errors, the xtables lock timing out)
-/// still propagate.
-#[cfg(target_os = "linux")]
-fn run_iptables(rule: &XtRule, verb: &str, tolerate_missing: bool) -> Result<()> {
-    let output = std::process::Command::new("/sbin/iptables")
-        .args(["-w", "2", "-t", rule.table, verb, rule.chain])
-        .args(&rule.spec)
-        .output()
-        .map_err(|e| crate::error::VmmError::Network(format!("run iptables: {e}")))?;
-    if output.status.success() || (tolerate_missing && output.status.code() == Some(1)) {
-        return Ok(());
-    }
-    Err(crate::error::VmmError::Network(format!(
-        "iptables -t {} {verb} {} {}: {}",
-        rule.table,
-        rule.chain,
-        rule.spec.join(" "),
-        String::from_utf8_lossy(&output.stderr).trim()
-    )))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,42 +203,5 @@ mod tests {
         let b = fwmark("172.20.0.3".parse().unwrap());
         assert_ne!(a, b);
         assert_ne!(a, 0, "a zero mark would match unmarked packets");
-    }
-
-    /// The rule specs are the NAT contract; pin them exactly so drift is loud.
-    #[test]
-    fn translation_rules_pin_the_nat_contract() {
-        let pool: Ipv4Addr = "172.20.0.2".parse().unwrap();
-        let rules = translation_rules("vmtap0-2", pool);
-        let rendered: Vec<String> = rules
-            .iter()
-            .map(|r| format!("-t {} {} {}", r.table, r.chain, r.spec.join(" ")))
-            .collect();
-        assert_eq!(
-            rendered,
-            [
-                "-t mangle PREROUTING -i vmtap0-2 -m comment --comment arcbox-nat -j MARK --set-mark 0xac140002",
-                "-t mangle PREROUTING -d 172.20.0.2/32 -m comment --comment arcbox-nat -j MARK --set-mark 0xac140002",
-                "-t mangle OUTPUT -d 172.20.0.2/32 -m comment --comment arcbox-nat -j MARK --set-mark 0xac140002",
-                "-t nat PREROUTING -d 172.20.0.2/32 -m comment --comment arcbox-nat -j DNAT --to-destination 169.254.100.2",
-                "-t nat OUTPUT -d 172.20.0.2/32 -m comment --comment arcbox-nat -j DNAT --to-destination 169.254.100.2",
-                "-t nat INPUT -i vmtap0-2 -m comment --comment arcbox-nat -j SNAT --to-source 172.20.0.2",
-                "-t nat POSTROUTING -s 169.254.100.2/32 -m mark --mark 0xac140002 -m comment --comment arcbox-nat -j SNAT --to-source 172.20.0.2",
-            ]
-        );
-    }
-
-    #[test]
-    fn snat_selection_never_rewrites_client_sources() {
-        // The POSTROUTING SNAT must be gated on the fixed guest source, not
-        // the mark alone: to-sandbox packets carry the same mark but a client
-        // source, and rewriting those would hide real client IPs from guests.
-        let rules = translation_rules("vmtap0-2", "172.20.0.2".parse().unwrap());
-        let postrouting = rules
-            .iter()
-            .find(|r| r.chain == "POSTROUTING")
-            .expect("POSTROUTING SNAT rule");
-        assert_eq!(postrouting.spec[0], "-s");
-        assert_eq!(postrouting.spec[1], format!("{GUEST_IP}/32"));
     }
 }

--- a/virt/arcbox-vm/src/network/packet_filter.rs
+++ b/virt/arcbox-vm/src/network/packet_filter.rs
@@ -39,6 +39,22 @@ use crate::error::{Result, VmmError};
 ///
 /// Methods are synchronous; the network manager calls them on the
 /// activation and teardown paths, which already run blocking netlink work.
+///
+/// Two obligations every implementation carries, because callers were
+/// built against them:
+///
+/// - **Pipeline placement.** The rules are *appended* to their chains, so
+///   they sit below whatever the composer installed at boot (the reference
+///   guest agent's isolation DROPs) and above nothing; per-sandbox expose
+///   companions are prepended above them by their own code. Rendering the
+///   same rules at another position changes the pipeline even when each
+///   rule is faithful.
+/// - **Failure shape.** `install_translation` fails fast on the first rule
+///   that does not apply, leaving the earlier ones in place — the caller
+///   then calls `remove_translation`, which must attempt every rule,
+///   tolerate ones that are already absent (partial installs, crash
+///   replays, legacy TAPs), and report the failures it could not clear
+///   together rather than stopping at the first.
 pub trait PacketFilter: Send + Sync {
     /// Install the translation for `tap` ↔ `pool_ip`.
     fn install_translation(&self, tap: &str, pool_ip: Ipv4Addr) -> Result<()>;

--- a/virt/arcbox-vm/src/network/packet_filter.rs
+++ b/virt/arcbox-vm/src/network/packet_filter.rs
@@ -86,23 +86,30 @@ impl IptablesLegacy {
     /// Run one iptables verb on a rule. `tolerate_missing` treats exit
     /// status 1 — iptables-legacy's "no matching rule" — as success so
     /// teardown is idempotent; other failures (usage errors, the xtables
-    /// lock timing out) still propagate.
-    fn run(&self, rule: &XtRule, verb: &str, tolerate_missing: bool) -> Result<()> {
+    /// lock timing out) still propagate. The failure is the bare
+    /// diagnostic text: callers wrap it into [`VmmError::Network`] once,
+    /// so a collected teardown report carries one prefix, not one per rule.
+    fn run(
+        &self,
+        rule: &XtRule,
+        verb: &str,
+        tolerate_missing: bool,
+    ) -> std::result::Result<(), String> {
         let output = std::process::Command::new(&self.iptables)
             .args(["-w", "2", "-t", rule.table, verb, rule.chain])
             .args(&rule.spec)
             .output()
-            .map_err(|e| VmmError::Network(format!("run {}: {e}", self.iptables.display())))?;
+            .map_err(|e| format!("run {}: {e}", self.iptables.display()))?;
         if output.status.success() || (tolerate_missing && output.status.code() == Some(1)) {
             return Ok(());
         }
-        Err(VmmError::Network(format!(
+        Err(format!(
             "iptables -t {} {verb} {} {}: {}",
             rule.table,
             rule.chain,
             rule.spec.join(" "),
             String::from_utf8_lossy(&output.stderr).trim()
-        )))
+        ))
     }
 }
 
@@ -115,7 +122,7 @@ impl Default for IptablesLegacy {
 impl PacketFilter for IptablesLegacy {
     fn install_translation(&self, tap: &str, pool_ip: Ipv4Addr) -> Result<()> {
         for rule in translation_rules(tap, pool_ip) {
-            self.run(&rule, "-A", false)?;
+            self.run(&rule, "-A", false).map_err(VmmError::Network)?;
         }
         Ok(())
     }
@@ -123,8 +130,8 @@ impl PacketFilter for IptablesLegacy {
     fn remove_translation(&self, tap: &str, pool_ip: Ipv4Addr) -> Result<()> {
         let mut failures = Vec::new();
         for rule in translation_rules(tap, pool_ip) {
-            if let Err(error) = self.run(&rule, "-D", true) {
-                failures.push(error.to_string());
+            if let Err(failure) = self.run(&rule, "-D", true) {
+                failures.push(failure);
             }
         }
         if failures.is_empty() {

--- a/virt/arcbox-vm/src/network/packet_filter.rs
+++ b/virt/arcbox-vm/src/network/packet_filter.rs
@@ -1,0 +1,275 @@
+//! The packet-filter seam: how the identity-invariant translation is
+//! expressed in the host's netfilter framework.
+//!
+//! The *contract* is fixed by [`super::invariant`] and does not vary with
+//! the framework: for a sandbox behind `tap` whose external identity is
+//! `pool_ip`, with `mark = fwmark(pool_ip)`,
+//!
+//! 1. every packet entering from `tap` is marked `mark` (so post-routing
+//!    NAT, which cannot match the input interface, can pick the source
+//!    identity);
+//! 2. every packet whose *pre-NAT* destination is `pool_ip` is marked
+//!    `mark`, both forwarded (prerouting) and locally originated (output),
+//!    so the fwmark fib rule routes the rewritten destination out `tap`;
+//! 3. `pool_ip` is DNAT'd to [`GUEST_IP`] in prerouting and output;
+//! 4. traffic from `tap` to local services is SNAT'd to `pool_ip` in the
+//!    input hook, so DNS and relays keep seeing the pool identity;
+//! 5. forwarded traffic with source [`GUEST_IP`] *and* mark `mark` is SNAT'd
+//!    to `pool_ip` in postrouting — the source match keeps to-sandbox packets
+//!    (same mark, client source) out of the rewrite.
+//!
+//! How that is spelled is the environment's business. The System VM ships
+//! iptables-legacy and nothing else, so [`IptablesLegacy`] is the reference
+//! implementation. A stock distro is usually on the nft backend, and legacy
+//! and nft rulesets are mutually invisible — rules that exist but do not
+//! take effect — so a composer there supplies an nftables implementation
+//! rather than a path to a different `iptables` binary. Removal must
+//! tolerate absence: teardown runs for partially activated and crash-
+//! recovered TAPs alike.
+//!
+//! [`GUEST_IP`]: super::invariant::GUEST_IP
+
+use std::net::Ipv4Addr;
+use std::path::PathBuf;
+
+use super::invariant::{GUEST_IP, fwmark};
+use crate::error::{Result, VmmError};
+
+/// Installs and removes the per-TAP translation rules of one sandbox.
+///
+/// Methods are synchronous; the network manager calls them on the
+/// activation and teardown paths, which already run blocking netlink work.
+pub trait PacketFilter: Send + Sync {
+    /// Install the translation for `tap` ↔ `pool_ip`.
+    fn install_translation(&self, tap: &str, pool_ip: Ipv4Addr) -> Result<()>;
+
+    /// Remove the translation, tolerating rules that are already gone.
+    fn remove_translation(&self, tap: &str, pool_ip: Ipv4Addr) -> Result<()>;
+}
+
+/// [`PacketFilter`] over iptables-legacy — the System VM's userland.
+///
+/// Every rule carries the `arcbox-nat` comment for forensics
+/// (`iptables -S`); deletion goes by exact rule spec, not the comment.
+#[derive(Debug, Clone)]
+pub struct IptablesLegacy {
+    iptables: PathBuf,
+}
+
+impl IptablesLegacy {
+    /// Where the System VM's EROFS rootfs installs `iptables`.
+    pub const DEFAULT_PATH: &'static str = "/sbin/iptables";
+
+    /// Use the iptables binary at `iptables`.
+    pub fn new(iptables: impl Into<PathBuf>) -> Self {
+        Self {
+            iptables: iptables.into(),
+        }
+    }
+
+    /// Run one iptables verb on a rule. `tolerate_missing` treats exit
+    /// status 1 — iptables-legacy's "no matching rule" — as success so
+    /// teardown is idempotent; other failures (usage errors, the xtables
+    /// lock timing out) still propagate.
+    fn run(&self, rule: &XtRule, verb: &str, tolerate_missing: bool) -> Result<()> {
+        let output = std::process::Command::new(&self.iptables)
+            .args(["-w", "2", "-t", rule.table, verb, rule.chain])
+            .args(&rule.spec)
+            .output()
+            .map_err(|e| VmmError::Network(format!("run {}: {e}", self.iptables.display())))?;
+        if output.status.success() || (tolerate_missing && output.status.code() == Some(1)) {
+            return Ok(());
+        }
+        Err(VmmError::Network(format!(
+            "iptables -t {} {verb} {} {}: {}",
+            rule.table,
+            rule.chain,
+            rule.spec.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )))
+    }
+}
+
+impl Default for IptablesLegacy {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_PATH)
+    }
+}
+
+impl PacketFilter for IptablesLegacy {
+    fn install_translation(&self, tap: &str, pool_ip: Ipv4Addr) -> Result<()> {
+        for rule in translation_rules(tap, pool_ip) {
+            self.run(&rule, "-A", false)?;
+        }
+        Ok(())
+    }
+
+    fn remove_translation(&self, tap: &str, pool_ip: Ipv4Addr) -> Result<()> {
+        let mut failures = Vec::new();
+        for rule in translation_rules(tap, pool_ip) {
+            if let Err(error) = self.run(&rule, "-D", true) {
+                failures.push(error.to_string());
+            }
+        }
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(VmmError::Network(failures.join("; ")))
+        }
+    }
+}
+
+/// Comment tag on every translation rule, marking them as arcbox-owned for
+/// forensics (`iptables -S`). Deletion goes by exact rule spec, not the tag.
+const RULE_COMMENT: &str = "arcbox-nat";
+
+/// One iptables rule of the per-TAP translation set.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct XtRule {
+    pub table: &'static str,
+    pub chain: &'static str,
+    pub spec: Vec<String>,
+}
+
+/// The complete per-TAP translation rule set, in install order — the
+/// iptables rendering of the module-level contract.
+pub(crate) fn translation_rules(tap: &str, pool_ip: Ipv4Addr) -> Vec<XtRule> {
+    let mark = format!("{:#x}", fwmark(pool_ip));
+    let pool = format!("{pool_ip}/32");
+    let comment = |spec: &mut Vec<String>| {
+        spec.extend(["-m", "comment", "--comment", RULE_COMMENT].map(String::from));
+    };
+    let mut rules = Vec::new();
+    let mut rule = |table, chain, head: &[&str], tail: &[&str]| {
+        let mut spec: Vec<String> = head.iter().map(|s| (*s).to_owned()).collect();
+        comment(&mut spec);
+        spec.extend(tail.iter().map(|s| (*s).to_owned()));
+        rules.push(XtRule { table, chain, spec });
+    };
+
+    // 1. Mark sandbox-originated packets so POSTROUTING (which cannot match
+    //    the input interface) can select the right source identity.
+    rule(
+        "mangle",
+        "PREROUTING",
+        &["-i", tap],
+        &["-j", "MARK", "--set-mark", &mark],
+    );
+    // 2. Mark to-sandbox packets from their pre-NAT destination; the fwmark
+    //    fib rule then routes the DNAT'd destination out this TAP.
+    rule(
+        "mangle",
+        "PREROUTING",
+        &["-d", &pool],
+        &["-j", "MARK", "--set-mark", &mark],
+    );
+    rule(
+        "mangle",
+        "OUTPUT",
+        &["-d", &pool],
+        &["-j", "MARK", "--set-mark", &mark],
+    );
+    // 3. External identity → fixed guest identity, both directions.
+    let guest_ip = GUEST_IP.to_string();
+    rule(
+        "nat",
+        "PREROUTING",
+        &["-d", &pool],
+        &["-j", "DNAT", "--to-destination", &guest_ip],
+    );
+    rule(
+        "nat",
+        "OUTPUT",
+        &["-d", &pool],
+        &["-j", "DNAT", "--to-destination", &guest_ip],
+    );
+    // 4. Local services (DNS, relays) see the pool identity, and their
+    //    replies are addressed to it — which is what makes them routable
+    //    back out the right TAP (dst-based mark + fwmark table).
+    rule(
+        "nat",
+        "INPUT",
+        &["-i", tap],
+        &["-j", "SNAT", "--to-source", &pool_ip.to_string()],
+    );
+    // 5. Forwarded sandbox-originated traffic. The source match is the
+    //    definitive sandbox-origin signature at POSTROUTING (only pre-SNAT
+    //    sandbox packets carry the fixed guest source); the mark picks which
+    //    sandbox, keeping to-sandbox packets (marked with the same value but
+    //    carrying a client source) out of this rewrite.
+    rule(
+        "nat",
+        "POSTROUTING",
+        &[
+            "-s",
+            &format!("{GUEST_IP}/32"),
+            "-m",
+            "mark",
+            "--mark",
+            &mark,
+        ],
+        &["-j", "SNAT", "--to-source", &pool_ip.to_string()],
+    );
+    rules
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The rule specs are the NAT contract; pin them exactly so drift is loud.
+    #[test]
+    fn translation_rules_pin_the_nat_contract() {
+        let pool: Ipv4Addr = "172.20.0.2".parse().unwrap();
+        let rules = translation_rules("vmtap0-2", pool);
+        let rendered: Vec<String> = rules
+            .iter()
+            .map(|r| format!("-t {} {} {}", r.table, r.chain, r.spec.join(" ")))
+            .collect();
+        assert_eq!(
+            rendered,
+            [
+                "-t mangle PREROUTING -i vmtap0-2 -m comment --comment arcbox-nat -j MARK --set-mark 0xac140002",
+                "-t mangle PREROUTING -d 172.20.0.2/32 -m comment --comment arcbox-nat -j MARK --set-mark 0xac140002",
+                "-t mangle OUTPUT -d 172.20.0.2/32 -m comment --comment arcbox-nat -j MARK --set-mark 0xac140002",
+                "-t nat PREROUTING -d 172.20.0.2/32 -m comment --comment arcbox-nat -j DNAT --to-destination 169.254.100.2",
+                "-t nat OUTPUT -d 172.20.0.2/32 -m comment --comment arcbox-nat -j DNAT --to-destination 169.254.100.2",
+                "-t nat INPUT -i vmtap0-2 -m comment --comment arcbox-nat -j SNAT --to-source 172.20.0.2",
+                "-t nat POSTROUTING -s 169.254.100.2/32 -m mark --mark 0xac140002 -m comment --comment arcbox-nat -j SNAT --to-source 172.20.0.2",
+            ]
+        );
+    }
+
+    #[test]
+    fn snat_selection_never_rewrites_client_sources() {
+        // The POSTROUTING SNAT must be gated on the fixed guest source, not
+        // the mark alone: to-sandbox packets carry the same mark but a client
+        // source, and rewriting those would hide real client IPs from guests.
+        let rules = translation_rules("vmtap0-2", "172.20.0.2".parse().unwrap());
+        let postrouting = rules
+            .iter()
+            .find(|r| r.chain == "POSTROUTING")
+            .expect("POSTROUTING SNAT rule");
+        assert_eq!(postrouting.spec[0], "-s");
+        assert_eq!(postrouting.spec[1], format!("{GUEST_IP}/32"));
+    }
+
+    #[test]
+    fn iptables_legacy_defaults_to_the_system_vm_path() {
+        assert_eq!(
+            IptablesLegacy::default().iptables,
+            PathBuf::from(IptablesLegacy::DEFAULT_PATH)
+        );
+    }
+
+    #[test]
+    fn a_missing_binary_is_an_error_even_on_tolerant_removal() {
+        // Tolerance covers "no matching rule" (exit 1), never "could not run
+        // iptables at all": a wrong path must surface, not read as clean.
+        let filter = IptablesLegacy::new("/nonexistent/arcbox-iptables");
+        let err = filter
+            .remove_translation("vmtap0-2", "172.20.0.2".parse().unwrap())
+            .unwrap_err();
+        assert!(err.to_string().contains("run "), "{err}");
+    }
+}

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -112,6 +112,7 @@ impl SandboxManager {
             config.network.dns.clone(),
             Path::new(&config.firecracker.data_dir).join("sandbox-network-quarantine"),
             config.firecracker.sandbox_datapath,
+            environment.packet_filter,
         )?);
         let snapshots = Arc::new(SnapshotCatalog::new(&config.firecracker.data_dir));
         let templates = Arc::new(TemplateCatalog::new(&config.firecracker.data_dir));


### PR DESCRIPTION
CORE-127, seam 2 (packet filtering and NAT). **Stacked on #650** (needs `SandboxEnvironment`); merge #650 first, then retarget this to `master` — with branch auto-delete on, expect GitHub to close it when #650's branch goes; reopen + retarget is the recovery.

- `network/packet_filter.rs`: `PacketFilter { install_translation, remove_translation }` — the seam. The module doc states the contract (the five rule intents: mark-from-TAP, mark-by-pre-NAT-destination, DNAT pool→guest, SNAT tap→local input, SNAT guest-src+mark→pool) independent of any framework. `IptablesLegacy` is the reference implementation: today's exact `translation_rules`, the pinned-spec test, `-w 2`, tolerant `-D`, and the binary path as a field (`/sbin/iptables` default). A missing binary is an error even on tolerant removal (new test) — tolerance covers "no matching rule", never "could not run".
- `network/invariant.rs` keeps what does not vary with the framework: constants, `fwmark`, the sysctls, the fwmark fib rule, the per-sandbox table route, `tap_ifindex`; `install`/`remove` take `&dyn PacketFilter`.
- `NetworkManager` holds `Arc<dyn PacketFilter>` (`with_quarantine_dir` gains the argument; `new` uses the reference); `SandboxEnvironment.packet_filter` feeds it. The eBPF datapath is unchanged and still falls back to the filter.

Not moved: the guest agent's expose/port-forward mangle companions and `init.rs` FORWARD rules (`guest/arcbox-agent`) — that daemon composes the reference and is not the platform's; and `SandboxDatapath` stays a config enum (eBPF vs netfilter is a mechanism choice, not a userland fact).

Checked: clippy `-D warnings` on macOS (`--all-targets`) and on `aarch64-unknown-linux-musl` (CI shape), `cargo test -p arcbox-vm --lib` (179), `cargo check -p arcbox-agent --target aarch64-unknown-linux-musl --all-targets`. `test-vm-linux.yml` drives the iptables path on real KVM (`SandboxDatapath::Iptables` + the eBPF fallback).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox networking activation/teardown and NAT rule installation; wrong alternate PacketFilter implementations could break routing or isolation, but the reference path preserves existing iptables behavior.
> 
> **Overview**
> Introduces a **`PacketFilter`** seam so identity-invariant pool↔guest translation is expressed through pluggable netfilter rendering, not hard-coded iptables calls inside **`invariant`**.
> 
> **`network/packet_filter.rs`** defines the trait (`install_translation` / `remove_translation`) and documents the five rule intents (marks, DNAT, SNAT). **`IptablesLegacy`** is the reference implementation: the same seven **`translation_rules`** as before, append placement, tolerant **`remove`**, and configurable **`/sbin/iptables`** path. Contract-pinning tests move here; **`invariant`** keeps sysctls, fwmark fib rules, and per-sandbox table routes only.
> 
> **`NetworkManager`** stores **`Arc<dyn PacketFilter>`** and passes it into **`invariant::install`/`remove`** on the iptables datapath and eBPF fallback. **`SandboxEnvironment.packet_filter`** wires the default **`IptablesLegacy`** into **`SandboxManager`**. Guest agent comment in **`init.rs`** points at **`packet_filter::translation_rules`** instead of **`invariant`**.
> 
> Behavior on the System VM should match prior behavior; the change is mainly structure so hosts on nftables can supply a different **`PacketFilter`** without sharing rulesets with iptables-legacy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23d5e2601d38dc753afbde836b07d1e244c0ab4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->