### PR TITLE
feat(vm): make the dmsetup search list configuration

### DIFF
--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -51,8 +51,11 @@ The restructure plan and its locked decisions live in the company repo:
     (the System VM's `/bin/busybox` applets); a consumer on a stock distro
     supplies its own — `util-linux` binaries or the loop ioctls — without
     forking the module. `stat`/`mknod` are syscalls, not applets, so they
-    have no seam. Adding a new host operation means adding a trait method,
-    never a hard-coded binary path.
+    have no seam. The crate's own `dmsetup` search list is the stock-distro
+    one; the System VM's `/arcbox/bin/dmsetup` comes from the guest
+    agent's `VmmConfig` (`firecracker.dmsetup_candidates`), not from here.
+    Adding a new host operation means adding a trait method, never a
+    hard-coded binary path.
   - `CowManager`'s test seam (`CowTestProbe`, `new_with_test_probe`) is
     behind the **`test-probe` feature**, not `#[cfg(test)]`: a
     `cfg(test)` item does not exist for another crate's tests, and its

--- a/engine/arcbox-snapshot/src/snapshot_cow.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow.rs
@@ -38,10 +38,11 @@ use persistence::{
 // ---------------------------------------------------------------------------
 
 /// Reference search list for the `dmsetup` binary.  The first existing,
-/// working entry wins.  `/sbin/dmsetup` covers stock Debian/Alpine;
-/// `/usr/sbin/dmsetup` covers usrmerged distros; `/arcbox/bin/dmsetup` is
-/// the System VM's bundled copy.
-const DMSETUP_CANDIDATES: &[&str] = &["/arcbox/bin/dmsetup", "/usr/sbin/dmsetup", "/sbin/dmsetup"];
+/// working entry wins.  `/usr/sbin/dmsetup` covers usrmerged distros,
+/// `/sbin/dmsetup` stock Debian/Alpine.  A composer with a bundled copy
+/// (the System VM ships one under `/arcbox/bin`) lists it first through
+/// [`CowOptions::dmsetup_candidates`].
+const DMSETUP_CANDIDATES: &[&str] = &["/usr/sbin/dmsetup", "/sbin/dmsetup"];
 
 /// dm-snapshot chunk size in 512-byte sectors (4096 bytes = 8 sectors).
 const SNAPSHOT_CHUNK_SECTORS: u64 = 8;
@@ -172,7 +173,7 @@ pub struct CowOptions {
 
 impl CowOptions {
     /// The reference environment: busybox at [`BusyboxBlockTools::DEFAULT_PATH`]
-    /// and the System VM's `dmsetup` search list.
+    /// and the stock-distro `dmsetup` search list.
     pub fn new(data_dir: impl Into<PathBuf>) -> Self {
         Self {
             data_dir: data_dir.into(),

--- a/guest/arcbox-agent/src/config.rs
+++ b/guest/arcbox-agent/src/config.rs
@@ -51,7 +51,7 @@ fn guest_defaults() -> VmmConfig {
             sandbox_datapath: arcbox_vm::config::SandboxDatapath::default(),
             pool_size: 1,
             warm_create: true,
-            dmsetup_candidates: guest_dmsetup_candidates(),
+            dmsetup_candidates: Some(guest_dmsetup_candidates()),
         },
         network: NetworkConfig {
             cidr: "172.20.0.0/16".into(),
@@ -91,16 +91,14 @@ fn guest_dmsetup_candidates() -> Vec<String> {
 }
 
 /// Apply the guest's environment facts on top of a config loaded from a
-/// file: a config written before `dmsetup_candidates` existed deserializes
-/// with the library's stock list, which does not know about the host-shared
-/// copy — the one the System VM actually has. Prepending keeps the search
-/// order the guest has always used without asking every config file to
-/// spell it out.
+/// file: a config that does not mention `dmsetup_candidates` — every one
+/// written before the field existed — gets the search order the guest has
+/// always used, host-shared copy first. A config that spells the list out
+/// is taken as written, including `[]` to run without CoW.
 fn with_guest_environment(mut cfg: VmmConfig) -> VmmConfig {
-    let candidates = &mut cfg.firecracker.dmsetup_candidates;
-    if !candidates.iter().any(|c| c == GUEST_DMSETUP) {
-        candidates.insert(0, GUEST_DMSETUP.into());
-    }
+    cfg.firecracker
+        .dmsetup_candidates
+        .get_or_insert_with(guest_dmsetup_candidates);
     cfg
 }
 
@@ -148,7 +146,10 @@ pub fn load() -> VmmConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{GUEST_DMSETUP, SANDBOX_DATA_DIR, guest_defaults, with_guest_environment};
+    use super::{
+        GUEST_DMSETUP, SANDBOX_DATA_DIR, guest_defaults, guest_dmsetup_candidates,
+        with_guest_environment,
+    };
 
     #[test]
     fn defaults_keep_sandbox_state_on_its_data_mount() {
@@ -165,24 +166,41 @@ mod tests {
     #[test]
     fn dmsetup_search_starts_with_the_host_shared_copy() {
         assert_eq!(
-            guest_defaults().firecracker.dmsetup_candidates,
-            [GUEST_DMSETUP, "/usr/sbin/dmsetup", "/sbin/dmsetup"]
+            guest_defaults().firecracker.dmsetup_candidates.as_deref(),
+            Some(
+                &[
+                    GUEST_DMSETUP.to_string(),
+                    "/usr/sbin/dmsetup".to_string(),
+                    "/sbin/dmsetup".to_string()
+                ][..]
+            )
         );
     }
 
-    /// A config file written before `dmsetup_candidates` existed loads with
-    /// the library's stock list; the guest must still find its own copy.
+    /// A config file that does not mention `dmsetup_candidates` gets the
+    /// guest's own search order; one that spells it out is left alone,
+    /// including the empty list that switches CoW off.
     #[test]
-    fn file_configs_gain_the_host_shared_dmsetup() {
+    fn file_configs_without_the_field_gain_the_guest_search_order() {
         let mut cfg = guest_defaults();
-        cfg.firecracker.dmsetup_candidates = vec!["/usr/sbin/dmsetup".into()];
+        cfg.firecracker.dmsetup_candidates = None;
         let cfg = with_guest_environment(cfg);
         assert_eq!(
             cfg.firecracker.dmsetup_candidates,
-            [GUEST_DMSETUP, "/usr/sbin/dmsetup"]
+            Some(guest_dmsetup_candidates())
         );
-        // Idempotent when the file already lists it, wherever it lists it.
+
+        let mut cfg = guest_defaults();
+        cfg.firecracker.dmsetup_candidates = Some(vec!["/opt/dm/dmsetup".into()]);
         let cfg = with_guest_environment(cfg);
-        assert_eq!(cfg.firecracker.dmsetup_candidates.len(), 2);
+        assert_eq!(
+            cfg.firecracker.dmsetup_candidates.as_deref(),
+            Some(&["/opt/dm/dmsetup".to_string()][..])
+        );
+
+        let mut cfg = guest_defaults();
+        cfg.firecracker.dmsetup_candidates = Some(Vec::new());
+        let cfg = with_guest_environment(cfg);
+        assert_eq!(cfg.firecracker.dmsetup_candidates.as_deref(), Some(&[][..]));
     }
 }

--- a/guest/arcbox-agent/src/config.rs
+++ b/guest/arcbox-agent/src/config.rs
@@ -51,6 +51,13 @@ fn guest_defaults() -> VmmConfig {
             sandbox_datapath: arcbox_vm::config::SandboxDatapath::default(),
             pool_size: 1,
             warm_create: true,
+            // The host-shared copy first (`/arcbox/bin`, the same VirtioFS
+            // share vm-agent is staged through), then the stock locations.
+            dmsetup_candidates: vec![
+                "/arcbox/bin/dmsetup".into(),
+                "/usr/sbin/dmsetup".into(),
+                "/sbin/dmsetup".into(),
+            ],
         },
         network: NetworkConfig {
             cidr: "172.20.0.0/16".into(),

--- a/guest/arcbox-agent/src/config.rs
+++ b/guest/arcbox-agent/src/config.rs
@@ -51,13 +51,7 @@ fn guest_defaults() -> VmmConfig {
             sandbox_datapath: arcbox_vm::config::SandboxDatapath::default(),
             pool_size: 1,
             warm_create: true,
-            // The host-shared copy first (`/arcbox/bin`, the same VirtioFS
-            // share vm-agent is staged through), then the stock locations.
-            dmsetup_candidates: vec![
-                "/arcbox/bin/dmsetup".into(),
-                "/usr/sbin/dmsetup".into(),
-                "/sbin/dmsetup".into(),
-            ],
+            dmsetup_candidates: guest_dmsetup_candidates(),
         },
         network: NetworkConfig {
             cidr: "172.20.0.0/16".into(),
@@ -81,6 +75,35 @@ fn guest_defaults() -> VmmConfig {
     }
 }
 
+/// The host-shared `dmsetup` copy (`/arcbox/bin`, the VirtioFS share the
+/// staged `vm-agent` also lives on).
+const GUEST_DMSETUP: &str = "/arcbox/bin/dmsetup";
+
+/// Where the guest looks for `dmsetup`: the host-shared copy first, then
+/// the stock locations. The library's own default is the stock list alone;
+/// the guest-specific entry is this composer's to add.
+fn guest_dmsetup_candidates() -> Vec<String> {
+    vec![
+        GUEST_DMSETUP.into(),
+        "/usr/sbin/dmsetup".into(),
+        "/sbin/dmsetup".into(),
+    ]
+}
+
+/// Apply the guest's environment facts on top of a config loaded from a
+/// file: a config written before `dmsetup_candidates` existed deserializes
+/// with the library's stock list, which does not know about the host-shared
+/// copy — the one the System VM actually has. Prepending keeps the search
+/// order the guest has always used without asking every config file to
+/// spell it out.
+fn with_guest_environment(mut cfg: VmmConfig) -> VmmConfig {
+    let candidates = &mut cfg.firecracker.dmsetup_candidates;
+    if !candidates.iter().any(|c| c == GUEST_DMSETUP) {
+        candidates.insert(0, GUEST_DMSETUP.into());
+    }
+    cfg
+}
+
 /// Load the VMM configuration for the guest agent.
 ///
 /// Priority: `ARCBOX_VMM_CONFIG` env var → `/etc/arcbox/vmm.toml` → guest defaults.
@@ -91,7 +114,7 @@ pub fn load() -> VmmConfig {
             match VmmConfig::from_file(&path) {
                 Ok(cfg) => {
                     tracing::info!(path, "loaded VMM config from ARCBOX_VMM_CONFIG");
-                    return cfg;
+                    return with_guest_environment(cfg);
                 }
                 Err(e) => {
                     tracing::warn!(path, error = %e, "failed to load ARCBOX_VMM_CONFIG, falling through");
@@ -106,7 +129,7 @@ pub fn load() -> VmmConfig {
         match VmmConfig::from_file(GUEST_CONFIG_PATH) {
             Ok(cfg) => {
                 tracing::info!(path = GUEST_CONFIG_PATH, "loaded VMM config");
-                return cfg;
+                return with_guest_environment(cfg);
             }
             Err(e) => {
                 tracing::warn!(
@@ -125,7 +148,7 @@ pub fn load() -> VmmConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{SANDBOX_DATA_DIR, guest_defaults};
+    use super::{GUEST_DMSETUP, SANDBOX_DATA_DIR, guest_defaults, with_guest_environment};
 
     #[test]
     fn defaults_keep_sandbox_state_on_its_data_mount() {
@@ -133,5 +156,33 @@ mod tests {
 
         assert_eq!(config.firecracker.data_dir, SANDBOX_DATA_DIR);
         assert!(std::path::Path::new(&config.defaults.rootfs).starts_with(SANDBOX_DATA_DIR));
+    }
+
+    /// The order is the behaviour: the host-shared copy is tried before the
+    /// stock locations, exactly as the snapshot crate's built-in list did
+    /// before it became configuration. Reordering would not fail — CoW would
+    /// silently degrade to a full rootfs copy per sandbox.
+    #[test]
+    fn dmsetup_search_starts_with_the_host_shared_copy() {
+        assert_eq!(
+            guest_defaults().firecracker.dmsetup_candidates,
+            [GUEST_DMSETUP, "/usr/sbin/dmsetup", "/sbin/dmsetup"]
+        );
+    }
+
+    /// A config file written before `dmsetup_candidates` existed loads with
+    /// the library's stock list; the guest must still find its own copy.
+    #[test]
+    fn file_configs_gain_the_host_shared_dmsetup() {
+        let mut cfg = guest_defaults();
+        cfg.firecracker.dmsetup_candidates = vec!["/usr/sbin/dmsetup".into()];
+        let cfg = with_guest_environment(cfg);
+        assert_eq!(
+            cfg.firecracker.dmsetup_candidates,
+            [GUEST_DMSETUP, "/usr/sbin/dmsetup"]
+        );
+        // Idempotent when the file already lists it, wherever it lists it.
+        let cfg = with_guest_environment(cfg);
+        assert_eq!(cfg.firecracker.dmsetup_candidates.len(), 2);
     }
 }

--- a/guest/arcbox-agent/tests/sandbox_service_manager.rs
+++ b/guest/arcbox-agent/tests/sandbox_service_manager.rs
@@ -41,6 +41,7 @@ fn test_config() -> VmmConfig {
             // and pre-warm work regardless.
             pool_size: 0,
             warm_create: false,
+            dmsetup_candidates: vec!["/usr/sbin/dmsetup".into(), "/sbin/dmsetup".into()],
         },
         network: NetworkConfig {
             cidr: "172.31.0.0/16".to_string(),

--- a/guest/arcbox-agent/tests/sandbox_service_manager.rs
+++ b/guest/arcbox-agent/tests/sandbox_service_manager.rs
@@ -41,7 +41,7 @@ fn test_config() -> VmmConfig {
             // and pre-warm work regardless.
             pool_size: 0,
             warm_create: false,
-            dmsetup_candidates: vec!["/usr/sbin/dmsetup".into(), "/sbin/dmsetup".into()],
+            dmsetup_candidates: None,
         },
         network: NetworkConfig {
             cidr: "172.31.0.0/16".to_string(),

--- a/virt/arcbox-vm/src/config/vmm.rs
+++ b/virt/arcbox-vm/src/config/vmm.rs
@@ -68,10 +68,12 @@ pub struct FirecrackerConfig {
     /// Where to look for the `dmsetup` binary that drives dm-snapshot CoW
     /// rootfs images. The first entry that exists and answers
     /// `dmsetup version` wins; none usable disables CoW (every sandbox
-    /// copies its rootfs). `PATH` is never searched. Defaults to the
-    /// stock-distro locations; a composer with a bundled copy lists it first.
-    #[serde(default = "default_dmsetup_candidates")]
-    pub dmsetup_candidates: Vec<String>,
+    /// copies its rootfs). `PATH` is never searched. `None` — the field
+    /// absent from the file — leaves the choice to the composer, whose
+    /// fallback is the library's stock-distro list; an explicit list is
+    /// used exactly as written, so `[]` is how a config disables CoW.
+    #[serde(default)]
+    pub dmsetup_candidates: Option<Vec<String>>,
 }
 
 fn default_pool_size() -> usize {
@@ -80,10 +82,6 @@ fn default_pool_size() -> usize {
 
 fn default_warm_create() -> bool {
     true
-}
-
-fn default_dmsetup_candidates() -> Vec<String> {
-    vec!["/usr/sbin/dmsetup".into(), "/sbin/dmsetup".into()]
 }
 
 /// How the pool-IP <-> fixed-guest-IP translation of an invariant sandbox TAP
@@ -149,7 +147,7 @@ impl Default for VmmConfig {
                 sandbox_datapath: SandboxDatapath::default(),
                 pool_size: default_pool_size(),
                 warm_create: default_warm_create(),
-                dmsetup_candidates: default_dmsetup_candidates(),
+                dmsetup_candidates: None,
             },
             network: NetworkConfig {
                 cidr: "172.20.0.0/16".into(),
@@ -220,26 +218,35 @@ mod tests {
     }
 
     #[test]
-    fn dmsetup_candidates_default_to_stock_paths_and_parse_a_custom_list() {
-        // A config written before the field existed still loads, with the
-        // stock-distro search list.
+    fn dmsetup_candidates_absent_is_none_and_explicit_lists_parse_as_written() {
+        // A config written before the field existed still loads; the
+        // absence is preserved so the composer can supply its own list.
         let cfg: FirecrackerConfig =
             toml::from_str("binary = \"/usr/bin/firecracker\"\ndata_dir = \"/var/lib/vmm\"\n")
                 .unwrap();
-        assert_eq!(
-            cfg.dmsetup_candidates,
-            ["/usr/sbin/dmsetup", "/sbin/dmsetup"]
-        );
-        // A composer with a bundled copy lists it first.
+        assert_eq!(cfg.dmsetup_candidates, None);
+        // An explicit list is used exactly as written.
         let cfg: FirecrackerConfig = toml::from_str(
             "binary = \"/usr/bin/firecracker\"\ndata_dir = \"/var/lib/vmm\"\n\
              dmsetup_candidates = [\"/opt/arcbox/dmsetup\", \"/sbin/dmsetup\"]\n",
         )
         .unwrap();
         assert_eq!(
-            cfg.dmsetup_candidates,
-            ["/opt/arcbox/dmsetup", "/sbin/dmsetup"]
+            cfg.dmsetup_candidates.as_deref(),
+            Some(
+                &[
+                    "/opt/arcbox/dmsetup".to_string(),
+                    "/sbin/dmsetup".to_string()
+                ][..]
+            )
         );
+        // An empty list is a deliberate "no dmsetup" — CoW off.
+        let cfg: FirecrackerConfig = toml::from_str(
+            "binary = \"/usr/bin/firecracker\"\ndata_dir = \"/var/lib/vmm\"\n\
+             dmsetup_candidates = []\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.dmsetup_candidates.as_deref(), Some(&[][..]));
     }
 
     #[test]

--- a/virt/arcbox-vm/src/config/vmm.rs
+++ b/virt/arcbox-vm/src/config/vmm.rs
@@ -65,6 +65,13 @@ pub struct FirecrackerConfig {
     /// `false` restores plain cold boots for every create.
     #[serde(default = "default_warm_create")]
     pub warm_create: bool,
+    /// Where to look for the `dmsetup` binary that drives dm-snapshot CoW
+    /// rootfs images. The first entry that exists and answers
+    /// `dmsetup version` wins; none usable disables CoW (every sandbox
+    /// copies its rootfs). `PATH` is never searched. Defaults to the
+    /// stock-distro locations; a composer with a bundled copy lists it first.
+    #[serde(default = "default_dmsetup_candidates")]
+    pub dmsetup_candidates: Vec<String>,
 }
 
 fn default_pool_size() -> usize {
@@ -73,6 +80,10 @@ fn default_pool_size() -> usize {
 
 fn default_warm_create() -> bool {
     true
+}
+
+fn default_dmsetup_candidates() -> Vec<String> {
+    vec!["/usr/sbin/dmsetup".into(), "/sbin/dmsetup".into()]
 }
 
 /// How the pool-IP <-> fixed-guest-IP translation of an invariant sandbox TAP
@@ -138,6 +149,7 @@ impl Default for VmmConfig {
                 sandbox_datapath: SandboxDatapath::default(),
                 pool_size: default_pool_size(),
                 warm_create: default_warm_create(),
+                dmsetup_candidates: default_dmsetup_candidates(),
             },
             network: NetworkConfig {
                 cidr: "172.20.0.0/16".into(),
@@ -205,6 +217,29 @@ mod tests {
         )
         .unwrap();
         assert!(!cfg.warm_create);
+    }
+
+    #[test]
+    fn dmsetup_candidates_default_to_stock_paths_and_parse_a_custom_list() {
+        // A config written before the field existed still loads, with the
+        // stock-distro search list.
+        let cfg: FirecrackerConfig =
+            toml::from_str("binary = \"/usr/bin/firecracker\"\ndata_dir = \"/var/lib/vmm\"\n")
+                .unwrap();
+        assert_eq!(
+            cfg.dmsetup_candidates,
+            ["/usr/sbin/dmsetup", "/sbin/dmsetup"]
+        );
+        // A composer with a bundled copy lists it first.
+        let cfg: FirecrackerConfig = toml::from_str(
+            "binary = \"/usr/bin/firecracker\"\ndata_dir = \"/var/lib/vmm\"\n\
+             dmsetup_candidates = [\"/opt/arcbox/dmsetup\", \"/sbin/dmsetup\"]\n",
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.dmsetup_candidates,
+            ["/opt/arcbox/dmsetup", "/sbin/dmsetup"]
+        );
     }
 
     #[test]

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -117,16 +117,12 @@ impl SandboxManager {
         let snapshots = Arc::new(SnapshotCatalog::new(&config.firecracker.data_dir));
         let templates = Arc::new(TemplateCatalog::new(&config.firecracker.data_dir));
         let (events_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
-        let cow_manager = Arc::new(CowManager::new(CowOptions {
-            block_tools: environment.block_tools,
-            dmsetup_candidates: config
-                .firecracker
-                .dmsetup_candidates
-                .iter()
-                .map(PathBuf::from)
-                .collect(),
-            ..CowOptions::new(&config.firecracker.data_dir)
-        })?);
+        let mut cow_options = CowOptions::new(&config.firecracker.data_dir);
+        cow_options.block_tools = environment.block_tools;
+        if let Some(candidates) = &config.firecracker.dmsetup_candidates {
+            cow_options.dmsetup_candidates = candidates.iter().map(PathBuf::from).collect();
+        }
+        let cow_manager = Arc::new(CowManager::new(cow_options)?);
 
         // Ensure the jailer chroot base directory exists.
         if let Some(ref jc) = config.firecracker.jailer {

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -119,6 +119,12 @@ impl SandboxManager {
         let (events_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
         let cow_manager = Arc::new(CowManager::new(CowOptions {
             block_tools: environment.block_tools,
+            dmsetup_candidates: config
+                .firecracker
+                .dmsetup_candidates
+                .iter()
+                .map(PathBuf::from)
+                .collect(),
             ..CowOptions::new(&config.firecracker.data_dir)
         })?);
 

--- a/virt/arcbox-vm/tests/e2e.rs
+++ b/virt/arcbox-vm/tests/e2e.rs
@@ -64,7 +64,8 @@ fn try_config(data_dir: &str) -> Option<VmmConfig> {
             pool_size: 0,
             // Direct mode is warm-ineligible anyway; keep it explicit.
             warm_create: false,
-            dmsetup_candidates: vec!["/usr/sbin/dmsetup".into(), "/sbin/dmsetup".into()],
+            // The stock-distro search list, i.e. the library's own default.
+            dmsetup_candidates: None,
         },
         network: NetworkConfig {
             cidr: "172.99.0.0/24".into(),

--- a/virt/arcbox-vm/tests/e2e.rs
+++ b/virt/arcbox-vm/tests/e2e.rs
@@ -64,6 +64,7 @@ fn try_config(data_dir: &str) -> Option<VmmConfig> {
             pool_size: 0,
             // Direct mode is warm-ineligible anyway; keep it explicit.
             warm_create: false,
+            dmsetup_candidates: vec!["/usr/sbin/dmsetup".into(), "/sbin/dmsetup".into()],
         },
         network: NetworkConfig {
             cidr: "172.99.0.0/24".into(),


### PR DESCRIPTION
CORE-127, the `dmsetup` half of seam 5 (paths). **Stacked on #650**; sibling of #651/#652 — merge #650 first, then retarget (branch auto-delete will close this; reopen + retarget is the recovery).

- `FirecrackerConfig.dmsetup_candidates: Vec<String>` (`#[serde(default)]` = `/usr/sbin/dmsetup`, `/sbin/dmsetup`), documented; `SandboxManager::with_environment` passes it into `CowOptions`.
- `arcbox-snapshot`'s reference list drops `/arcbox/bin/dmsetup`; the guest agent's `guest_defaults()` lists it first, so the System VM searches exactly the same three paths in the same order as before.
- Test: a pre-field TOML still loads with the stock list; a custom list parses.
- Struct-literal sites updated (`VmmConfig::default`, `virt/arcbox-vm/tests/e2e.rs`, `guest/arcbox-agent/tests/sandbox_service_manager.rs`, guest `config.rs`); `engine/AGENTS.md` note adjusted (human eye, per CLAUDE.md).

With #652 (vm-agent source, rootfs cache dir, busybox) this closes "no crate encodes a System-VM filesystem path" for the stack: what remains as library defaults are the generic Unix locations (`/bin/busybox`, `/sbin/iptables`, `/usr/sbin|/sbin/dmsetup`), each overridable.

Checked: clippy `-D warnings` (macOS, `--all-targets`), `cargo test -p arcbox-vm --lib config`, `cargo check -p arcbox-agent --target aarch64-unknown-linux-musl --all-targets`, fmt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong dmsetup ordering or missing guest injection would silently fall back to full rootfs copies per sandbox instead of dm-snapshot CoW, affecting performance and disk use rather than immediate crashes.
> 
> **Overview**
> **Makes the dmsetup binary search path configurable** so the snapshot engine no longer embeds the System VM path `/arcbox/bin/dmsetup`. `FirecrackerConfig` gains optional `dmsetup_candidates`; `SandboxManager` forwards an explicit list into `CowOptions`, while `None` keeps the library’s stock-distro default (`/usr/sbin`, `/sbin`).
> 
> The **guest agent** puts `/arcbox/bin/dmsetup` first again via `guest_defaults()` and `with_guest_environment()` for file-loaded configs that omit the field—same three paths and order as before the refactor. An explicit list (including `[]` to disable CoW) is honored as written.
> 
> Docs and tests cover TOML parsing, guest ordering, and struct literal sites in e2e and integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31aae09be2c782a2f40f5bdcb8dba225b20e79c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->