### PR TITLE
chore(assets): pin boot bundle 0.8.6 (patched containerd)

### DIFF
--- a/assets.lock
+++ b/assets.lock
@@ -16,9 +16,9 @@
 # and the [boot] bump.
 
 [boot]
-version = "0.8.5"
+version = "0.8.6"
 cdn = "https://boot.arcboxcdn.com"
-manifest_sha256 = "e47078a5e84a0dbd80fea92c3355329a62edf80ccfdd075d56dd4e6583a7e28f"
+manifest_sha256 = "326d7e100c885280570bdfa9edd08d852e99f9efd9a4149c1a5c46370003efa4"
 
 [[tools]]
 name = "docker"

--- a/docs/boot-assets.md
+++ b/docs/boot-assets.md
@@ -10,7 +10,8 @@ Each release contains per-architecture artifacts plus a unified multi-target man
 - `kernel` — pre-built Linux kernel (all drivers built-in, `CONFIG_MODULES=n`)
 - `rootfs.erofs` — minimal read-only EROFS rootfs (busybox + mkfs.btrfs + iptables-legacy + ebtables + ethtool + socat + CA certs)
 - `manifest.json` — manifest with SHA256 checksums and kernel cmdline (`schema_version` = major of `asset_version`)
-- Runtime binaries — dockerd, containerd, containerd-shim-runc-v2, runc, docker-init (from the Docker 29.7.2 static package, shipping containerd 2.3.3 and runc 1.4.3) plus k3s, firecracker/jailer, and the microVM vmlinux
+- Runtime binaries — dockerd, containerd-shim-runc-v2, runc, docker-init (from the Docker 29.7.2 static package, shipping runc 1.4.3) plus k3s, firecracker/jailer, and the microVM vmlinux
+- `containerd` — the one runtime binary **not** taken from Docker's package. boot-assets builds it from the same upstream tag Docker bundles (v2.3.3) plus [containerd#13805](https://github.com/containerd/containerd/pull/13805), which stops the overlay snapshotter appending `index=off` over a configured `index=on` — without it the `index=on,nfs_export=on` mount options the `~/ArcBox` live-container view needs are silently overridden and every overlay mount fails with `EINVAL`. It is versioned `29.7.2-arcbox.<patch>-<release>` and reports `v2.3.3-arcbox.<patch>-<release>` for itself, so a guest log names both the patch set and the build. It goes back to the stock package once the fix reaches a containerd release Docker ships
 
 No initramfs. The kernel boots directly into the EROFS rootfs (`root=/dev/vda ro rootfstype=erofs`).
 Agent and runtime binaries reach the guest through VirtioFS. Runtime binaries


### PR DESCRIPTION
Picks up arcboxlabs/boot-assets#52 → **v0.8.6**.

| | 0.8.5 | 0.8.6 |
|---|---|---|
| `containerd` | 29.7.2 (Docker's) | **29.7.2-arcbox.1-0.8.6** (built from v2.3.3 + containerd#13805) |
| `dockerd` / shim / `runc` / `docker-init` | 29.7.2 | 29.7.2 (unchanged) |
| kernel / rootfs / FEX / k3s | — | unchanged |

The guest containerd now carries [containerd#13805](https://github.com/containerd/containerd/pull/13805): the overlay snapshotter no longer appends `index=off` over a configured `index=on`. That is what ABX-424's live-container `~/ArcBox` view has been blocked on — `index=on,nfs_export=on` was silently overridden and every overlay mount failed `EINVAL`. The upstream backports (containerd#13878/13879/13880) are open and unreviewed and already missed v2.3.4, so no Docker release can carry the fix yet.

## Verified before pinning

- manifest `asset_version` = `0.8.6`, containerd entry = `29.7.2-arcbox.1-0.8.6`, dockerd still `29.7.2`
- both patched objects live on the CDN: `bin/containerd/29.7.2-arcbox.1-0.8.6/{arm64,x86_64}/containerd` answer 200, arm64 at 36,606,720 bytes — the exact size measured on the PR artifact
- `manifest_sha256` re-derived from the CDN-served bytes

## Blast radius

The patch only changes behaviour when an `index` option is configured. Nothing configures one today, so patched and stock behave identically here — both append `index=off`. This pin ships the *capability*; using it is ABX-424's next step.

Build fidelity, since it is no longer Docker's binary: same upstream tag (Docker ships vanilla containerd — the revision its 29.7.2 binary reports is exactly what `v2.3.3` dereferences to), same recipe (`make STATIC=1`), CGO enabled, Go pinned to 1.26.5, native per-arch runners. boot-assets checks the ref against the version embedded in Docker's own containerd before building, and refuses a dynamically-linked result.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces the guest containerd binary via the boot manifest; behavior is unchanged until overlay `index` options are used, but any containerd regression affects all VM container workloads.
> 
> **Overview**
> **Pins the guest boot bundle to v0.8.6** in `assets.lock` (version and `manifest_sha256`). Kernel, rootfs, dockerd, shim, runc, and docker-init stay on the same pins as 0.8.5; the manifest change is driven by a **custom guest `containerd`** (`29.7.2-arcbox.1-0.8.6`).
> 
> `docs/boot-assets.md` is updated to say runtime binaries from Docker’s 29.7.2 package no longer include stock `containerd`, and to document why boot-assets builds containerd from v2.3.3 plus [containerd#13805](https://github.com/containerd/containerd/pull/13805): without it, overlay mounts with `index=on,nfs_export=on` (needed for the `~/ArcBox` live-container view in ABX-424) are overridden with `index=off` and fail with `EINVAL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f5752ebe011525c647645707bf7ab663fd0a272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->