### PR TITLE
feat(xtask): check-layers, a cargo-metadata gate for the layer rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-linux-engine-
 
+      # The layer rules this job exists to protect (engine/ and computer/
+      # are daemon-free and platform-neutral, common/ has no VM dependency,
+      # orchestrators depend on the port and never on an adapter) are
+      # checked mechanically from `cargo metadata` ahead of the build steps:
+      # a forbidden edge fails here with the rule's reason rather than as a
+      # Linux build break three crates away. The rules and the grandfathered
+      # edges live in xtask/src/commands/check_layers/rules.rs.
+      - name: Check layer rules
+        run: cargo run -p xtask -- check-layers
+
       - name: Check engine-layer crates on Linux
         run: cargo check --all-targets -p arcbox-atomic-file -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-snapshot -p arcbox-engine -p arcbox-computer
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,6 +1907,33 @@ name = "camino"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "cast"
@@ -8475,6 +8502,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "arcbox-constants",
+ "cargo_metadata",
  "clap",
  "dirs",
  "flate2",

--- a/common/AGENTS.md
+++ b/common/AGENTS.md
@@ -18,7 +18,10 @@ distribution".
   (`virt/arcbox-net/examples/tun_proxy.rs`, docs/surge-tun-proxy.md). Every
   change must serve **both**; adding a VM type here silently breaks the host
   harness. Most net-crate `lib.rs` headers restate this (arcbox-xnu-net's
-  does not) — keep them true.
+  does not) — keep them true. The dependency half is checked mechanically
+  by `cargo xtask check-layers` in CI (`linux-engine` job), for every
+  `common/` crate, net or not: no direct edge into `virt/`, `engine/`,
+  `computer/`, `app/` or `guest/`.
 
 ## arcbox-asset & distribution — invariants (net-purity rule does not apply)
 

--- a/computer/AGENTS.md
+++ b/computer/AGENTS.md
@@ -17,6 +17,10 @@ and its locked decisions live in the company repo:
   `Runtime` type anywhere here.
 - **Platform-neutral**: must compile and pass unit tests on Linux as well
   as macOS (the `linux-engine` CI job gates it).
+- **Mechanically checked**: `cargo xtask check-layers` (same CI job) fails
+  on a direct edge from `computer/` into `app/`, `arcbox-vmm`,
+  `arcbox-hypervisor`, a macOS-only crate or a VMM adapter — the rules
+  live in `xtask/src/commands/check_layers/rules.rs`.
 - Errors speak `arcbox_engine::EngineError`; predicates like
   `EngineError::Agent { code }` carry the agent's HTTP-style wire codes
   (404/412 obsolete-ticket, 423 paused, 503 retry) — those codes are

--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -16,6 +16,13 @@ The restructure plan and its locked decisions live in the company repo:
   the `virt/arcbox-hypervisor` trait layer.
 - **Platform-neutral**: every crate must compile and pass unit tests on
   Linux as well as macOS.
+- **Mechanically checked**: `cargo xtask check-layers` (CI `linux-engine`
+  job) fails on a direct edge from `engine/` into `app/`, a macOS-only
+  crate (the list above plus `arcbox-hv`), a VMM adapter, or `arcbox-vmm` /
+  `arcbox-hypervisor` — the last two are today's grandfathered edges
+  (`arcbox-engine -> arcbox-vmm` / `arcbox-hypervisor`, until
+  vm-stack-redesign R4); rules and exceptions live in
+  `xtask/src/commands/check_layers/rules.rs`.
 - **Own your errors**: each crate defines its own `thiserror` type built
   on `arcbox_error::CommonError`; `arcbox-core` converts via `From` (see
   `CoreError`'s `From<ImageError>`), so `is_not_found()`-style predicates

--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -13,7 +13,10 @@ The restructure plan and its locked decisions live in the company repo:
   socket paths, startup pipeline).
 - **No direct macOS-only dependency** (`arcbox-vz`, `arcbox-vmnet`,
   `arcbox-route`, `ifbridge`): platform backends are reached only through
-  the `virt/arcbox-hypervisor` trait layer.
+  the seam. Today that seam is `arcbox-vmm` + the `virt/arcbox-hypervisor`
+  trait layer, and both edges are grandfathered — the target is the
+  `virt/arcbox-vm-driver` port (vm-stack-redesign R4), after which
+  neither crate appears in an engine manifest.
 - **Platform-neutral**: every crate must compile and pass unit tests on
   Linux as well as macOS.
 - **Mechanically checked**: `cargo xtask check-layers` (CI `linux-engine`

--- a/xtask/AGENTS.md
+++ b/xtask/AGENTS.md
@@ -5,9 +5,10 @@ runners, samplers, asset staging, release tooling) belong here, not in
 ad-hoc shell scripts. Command shape lives in `src/main.rs`; design rules
 (when to use `xshell` vs `std::process::Command`, no script-wrapper
 facades) live in `README.md` — follow them, don't restate them. Commands
-today: `dev boot-assets`, `e2e`, `idle`, `macos dev`, `release
-{check-tool-updates,package-tarball}`. This file focuses on `e2e` and
-`idle`, the two the HV fix campaign leans on.
+today: `check-layers`, `dev boot-assets`, `e2e`, `idle`, `macos dev`,
+`release {check-tool-updates,package-tarball}`. This file focuses on
+`e2e` and `idle`, the two the HV fix campaign leans on, and on
+`check-layers`, the CI layer-rule gate.
 
 ## `xtask e2e` — the SKIP_BUILD / prebuild contract
 
@@ -130,6 +131,39 @@ points above the hypervisor. Defaults: `--test boot_assets --backend vz
    (`ARCBOX_HV_E2E_VCPUS/MEMORY_MB/BALLOON/BOOT_ONLY=1`) one dimension
    at a time (this is how ABX-386's "vCPU count, threshold exactly 8" was
    localized). See `virt/AGENTS.md`.
+
+## `xtask check-layers` — the layer rules live in code
+
+`cargo xtask check-layers` reads `cargo metadata --no-deps`, builds the
+graph of **direct** edges between workspace members, and fails on any
+edge a layer rule forbids; CI runs it in the `linux-engine` job. The
+rules and the grandfathered edges are data in
+`src/commands/check_layers/rules.rs` (`RULES`, `EXCEPTIONS`); the
+evaluator (`evaluate.rs`) is a pure function over a small typed graph and
+is unit-tested on synthetic graphs, so a rule change comes with a test
+there, not with a manifest edit. `--verbose` prints every member edge and
+every grandfathered edge. Rules cover engine/computer (no `app/`, no
+macOS-only crate, no `arcbox-vmm` / `arcbox-hypervisor` / VMM adapter —
+engine's two edges are grandfathered until vm-stack-redesign R4), common
+(no virt/engine/computer/app/guest),
+`arcbox-vm-proto` and `arcbox-vm-driver` (leaf crates) and
+`arcbox-vm-agent` (no `arcbox-vm`/`arcbox-snapshot`/`tokio`/`aya`/`fc-sdk`).
+
+- **Adding a rule**: append a `Rule` whose `reason` names the document
+  that owns it (charter decision, design doc, AGENTS.md section) — the
+  reason is what a violation prints. A rule may name a crate that does not
+  exist yet (`arcbox-fc-driver`, `arcbox-vm-driver`); it is a no-op until
+  the crate lands. Every dependency kind counts (normal, dev, build), only
+  workspace members are walked, and an external crate is checked only
+  where a rule names it (`Forbidden::Crates`).
+- **Adding an exception**: append an `Exception` with the `reason` the
+  edge exists and the phase (`until`) that removes it. Exceptions are
+  checked before the rules, so they hold as rules tighten; an exception
+  whose edge no longer exists **fails the gate** — remove it with the
+  edge. Today's two: `arcbox-engine -> arcbox-vmm` and
+  `arcbox-engine -> arcbox-hypervisor`, until vm-stack-redesign R4.
+- **A new top-level directory** fails the gate until it is added to
+  `Layer` (`graph.rs`) — the rules must know every layer.
 
 ## `xtask idle`
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -12,6 +12,7 @@ description = "Cargo xtask build-automation tasks for the ArcBox workspace"
 [dependencies]
 anyhow.workspace = true
 arcbox-constants.workspace = true
+cargo_metadata = "0.23.1"
 clap = { workspace = true, features = ["derive", "env"] }
 dirs.workspace = true
 flate2 = "1.1.9"

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -24,6 +24,10 @@ devenv shell -- cargo xtask <command>
 
 ## Commands
 
+- `cargo xtask check-layers` — fail on any direct workspace dependency edge
+  that breaks a layer rule (rules and grandfathered edges live in
+  `src/commands/check_layers/rules.rs`); `--verbose` lists every edge. CI runs
+  it in the `linux-engine` job.
 - `cargo xtask dev boot-assets` — prepare `boot-assets/dev` from the user boot
   cache or a neighboring `arcbox-kernel` checkout.
 - `cargo xtask dev bpf` — rebuild the committed sandbox NAT BPF object and its
@@ -45,6 +49,12 @@ xtask/
     main.rs                  # CLI shape and dispatch only
     commands/
       mod.rs
+      check_layers.rs        # layer-rule gate over cargo metadata
+      check_layers/
+        evaluate.rs          # pure evaluator + synthetic-graph tests
+        graph.rs             # Layer / Member / Graph from cargo metadata
+        rule.rs              # Rule / Subject / Forbidden / Exception vocabulary
+        rules.rs             # the RULES and EXCEPTIONS tables
       dev.rs                 # development orchestration
       e2e.rs                 # e2e stress runner (prebuild + artifact archive)
       idle.rs                # idle CPU/RSS sampler

--- a/xtask/src/commands/check_layers.rs
+++ b/xtask/src/commands/check_layers.rs
@@ -2,21 +2,29 @@
 //!
 //! The layer rules — engine and computer are daemon-free, common has no VM
 //! dependency, orchestrators depend on the port and never on an adapter —
-//! live only in AGENTS.md prose today. `cargo xtask check-layers` reads
-//! `cargo metadata` and builds the graph of direct edges between workspace
-//! members ([`graph`]); the rules that are evaluated over it land next.
+//! used to live only in AGENTS.md prose. `cargo xtask check-layers` reads
+//! `cargo metadata`, builds the graph of direct edges between workspace
+//! members ([`graph`]), and fails on any edge the [`rules`] table forbids;
+//! CI runs it in the `linux-engine` job. The evaluator
+//! ([`evaluate::evaluate`]) is a pure function over that graph, so the rules
+//! are unit-tested on graphs written by hand rather than on whatever the tree
+//! happens to contain.
 //!
-//! Only direct edges, only workspace members: an external crate is a name
-//! the graph carries but never an edge of its own.
+//! Only direct edges, only workspace members: an external crate is checked
+//! only where a rule names it explicitly.
 
+pub mod evaluate;
 pub mod graph;
+pub mod rule;
+pub mod rules;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use cargo_metadata::MetadataCommand;
 use xtask_kit::repo;
 
 use crate::CheckLayersArgs;
-use graph::{Edge, Graph, Target};
+use evaluate::{Report, evaluate};
+use graph::Graph;
 
 pub fn run(args: CheckLayersArgs) -> Result<()> {
     let root = repo::root_from_xtask_manifest(env!("CARGO_MANIFEST_DIR"))?;
@@ -26,34 +34,50 @@ pub fn run(args: CheckLayersArgs) -> Result<()> {
         .exec()
         .context("reading the workspace with cargo metadata")?;
     let graph = Graph::try_from(&metadata)?;
-    let edges = member_edges(&graph);
-    if args.verbose {
-        for edge in &edges {
-            println!("edge: {edge}");
-        }
-    }
-    println!(
-        "layer graph: {} members, {} edges",
-        graph.members.len(),
-        edges.len()
-    );
-    Ok(())
+    let report = evaluate(&graph, rules::RULES, rules::EXCEPTIONS);
+    print_report(&graph, &report, args.verbose)
 }
 
-/// Every direct edge between two workspace members, in member order.
-fn member_edges(graph: &Graph) -> Vec<Edge> {
-    graph
-        .members
-        .iter()
-        .flat_map(|member| {
-            member
-                .deps
-                .iter()
-                .filter(|dep| matches!(graph.target(dep), Target::Member(_)))
-                .map(move |dep| Edge {
-                    from: member.name.clone(),
-                    to: dep.clone(),
-                })
-        })
-        .collect()
+/// Prints violations and stale exceptions to stderr, the edge walk (with
+/// `verbose`) and the summary to stdout, and fails when the gate is red.
+fn print_report(graph: &Graph, report: &Report, verbose: bool) -> Result<()> {
+    if verbose {
+        for edge in &report.edges {
+            println!("edge: {edge}");
+        }
+        for grandfathered in &report.grandfathered {
+            println!(
+                "allowed (grandfathered): {}: {} (until {})",
+                grandfathered.edge, grandfathered.exception.reason, grandfathered.exception.until
+            );
+        }
+    }
+    for violation in &report.violations {
+        eprintln!(
+            "layer rule violated: {}: {}",
+            violation.edge, violation.rule.reason
+        );
+    }
+    for exception in &report.stale_exceptions {
+        eprintln!(
+            "stale exception: {} -> {} is no longer an edge (was allowed until {}); \
+             remove it from the EXCEPTIONS table",
+            exception.from, exception.to, exception.until
+        );
+    }
+    let summary = format!(
+        "{} members, {} edges checked, {} grandfathered",
+        graph.members.len(),
+        report.edges.len(),
+        report.grandfathered.len()
+    );
+    if !report.is_clean() {
+        bail!(
+            "layer rules: {} violation(s), {} stale exception(s) ({summary})",
+            report.violations.len(),
+            report.stale_exceptions.len()
+        );
+    }
+    println!("layer rules: {summary}");
+    Ok(())
 }

--- a/xtask/src/commands/check_layers.rs
+++ b/xtask/src/commands/check_layers.rs
@@ -1,0 +1,59 @@
+//! Layer-rule gate over the workspace dependency graph.
+//!
+//! The layer rules — engine and computer are daemon-free, common has no VM
+//! dependency, orchestrators depend on the port and never on an adapter —
+//! live only in AGENTS.md prose today. `cargo xtask check-layers` reads
+//! `cargo metadata` and builds the graph of direct edges between workspace
+//! members ([`graph`]); the rules that are evaluated over it land next.
+//!
+//! Only direct edges, only workspace members: an external crate is a name
+//! the graph carries but never an edge of its own.
+
+pub mod graph;
+
+use anyhow::{Context, Result};
+use cargo_metadata::MetadataCommand;
+use xtask_kit::repo;
+
+use crate::CheckLayersArgs;
+use graph::{Edge, Graph, Target};
+
+pub fn run(args: CheckLayersArgs) -> Result<()> {
+    let root = repo::root_from_xtask_manifest(env!("CARGO_MANIFEST_DIR"))?;
+    let metadata = MetadataCommand::new()
+        .manifest_path(root.join("Cargo.toml"))
+        .no_deps()
+        .exec()
+        .context("reading the workspace with cargo metadata")?;
+    let graph = Graph::try_from(&metadata)?;
+    let edges = member_edges(&graph);
+    if args.verbose {
+        for edge in &edges {
+            println!("edge: {edge}");
+        }
+    }
+    println!(
+        "layer graph: {} members, {} edges",
+        graph.members.len(),
+        edges.len()
+    );
+    Ok(())
+}
+
+/// Every direct edge between two workspace members, in member order.
+fn member_edges(graph: &Graph) -> Vec<Edge> {
+    graph
+        .members
+        .iter()
+        .flat_map(|member| {
+            member
+                .deps
+                .iter()
+                .filter(|dep| matches!(graph.target(dep), Target::Member(_)))
+                .map(move |dep| Edge {
+                    from: member.name.clone(),
+                    to: dep.clone(),
+                })
+        })
+        .collect()
+}

--- a/xtask/src/commands/check_layers/evaluate.rs
+++ b/xtask/src/commands/check_layers/evaluate.rs
@@ -85,3 +85,162 @@ pub fn evaluate(graph: &Graph, rules: &[Rule], exceptions: &[Exception]) -> Repo
         .collect();
     report
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::check_layers::graph::{Layer, Member};
+    use crate::commands::check_layers::rule::{Forbidden, Subject};
+
+    fn member(name: &str, layer: Layer, deps: &[&str]) -> Member {
+        Member {
+            name: name.to_owned(),
+            layer,
+            deps: deps.iter().map(|dep| (*dep).to_owned()).collect(),
+        }
+    }
+
+    fn graph(members: Vec<Member>) -> Graph {
+        Graph { members }
+    }
+
+    fn edges(violations: &[Violation]) -> Vec<String> {
+        violations.iter().map(|v| v.edge.to_string()).collect()
+    }
+
+    const ENGINE_NO_APP: Rule = Rule {
+        subject: Subject::Layers(&[Layer::Engine, Layer::Computer]),
+        forbidden: Forbidden::Layers(&[Layer::App]),
+        reason: "engine is daemon-free",
+    };
+    const COMPUTER_NO_VMM: Rule = Rule {
+        subject: Subject::Layers(&[Layer::Computer]),
+        forbidden: Forbidden::Crates(&["arcbox-vmm"]),
+        reason: "computer reaches the platform through engine",
+    };
+    const PORT_IS_A_LEAF: Rule = Rule {
+        subject: Subject::Members(&["arcbox-vm-driver"]),
+        forbidden: Forbidden::AnyMember,
+        reason: "the port depends on nothing of ours",
+    };
+    const AGENT_STAYS_SMALL: Rule = Rule {
+        subject: Subject::Members(&["arcbox-vm-agent"]),
+        forbidden: Forbidden::Crates(&["tokio"]),
+        reason: "the in-sandbox binary stays small",
+    };
+
+    #[test]
+    fn layer_to_layer_rule_fires_on_the_forbidden_layer_only() {
+        let graph = graph(vec![
+            member(
+                "arcbox-engine",
+                Layer::Engine,
+                &["arcbox-core", "arcbox-image"],
+            ),
+            member("arcbox-image", Layer::Engine, &[]),
+            member("arcbox-core", Layer::App, &["arcbox-engine"]),
+        ]);
+        let report = evaluate(&graph, &[ENGINE_NO_APP], &[]);
+        assert_eq!(edges(&report.violations), ["arcbox-engine -> arcbox-core"]);
+        assert_eq!(report.violations[0].rule, ENGINE_NO_APP);
+        assert_eq!(report.edges.len(), 3);
+        assert!(!report.is_clean());
+    }
+
+    #[test]
+    fn layer_to_crate_rule_matches_the_named_member_from_the_named_layer_only() {
+        let graph = graph(vec![
+            member("arcbox-computer", Layer::Computer, &["arcbox-vmm"]),
+            member("arcbox-engine", Layer::Engine, &["arcbox-vmm"]),
+            member("arcbox-vmm", Layer::Virt, &[]),
+        ]);
+        let report = evaluate(&graph, &[COMPUTER_NO_VMM], &[]);
+        assert_eq!(edges(&report.violations), ["arcbox-computer -> arcbox-vmm"]);
+    }
+
+    #[test]
+    fn member_to_any_member_rule_lets_externals_through() {
+        let graph = graph(vec![
+            member("arcbox-vm-driver", Layer::Virt, &["arcbox-error", "serde"]),
+            member("arcbox-error", Layer::Common, &[]),
+        ]);
+        let report = evaluate(&graph, &[PORT_IS_A_LEAF], &[]);
+        assert_eq!(
+            edges(&report.violations),
+            ["arcbox-vm-driver -> arcbox-error"]
+        );
+    }
+
+    #[test]
+    fn crate_rule_matches_an_external_crate_by_name() {
+        let graph = graph(vec![
+            member("arcbox-vm-agent", Layer::Virt, &["libc", "tokio"]),
+            member("arcbox-vm", Layer::Virt, &["tokio"]),
+        ]);
+        let report = evaluate(&graph, &[AGENT_STAYS_SMALL], &[]);
+        assert_eq!(edges(&report.violations), ["arcbox-vm-agent -> tokio"]);
+        assert!(
+            report.edges.is_empty(),
+            "external edges are not member edges"
+        );
+    }
+
+    #[test]
+    fn a_rule_naming_an_absent_crate_is_a_no_op() {
+        let graph = graph(vec![
+            member("arcbox-engine", Layer::Engine, &["arcbox-image"]),
+            member("arcbox-image", Layer::Engine, &[]),
+        ]);
+        let rules = [
+            COMPUTER_NO_VMM,
+            PORT_IS_A_LEAF,
+            Rule {
+                subject: Subject::Layers(&[Layer::Engine]),
+                forbidden: Forbidden::Crates(&["arcbox-fc-driver"]),
+                reason: "not landed yet",
+            },
+        ];
+        let report = evaluate(&graph, &rules, &[]);
+        assert!(report.is_clean(), "{report:?}");
+        assert_eq!(report.edges.len(), 1);
+    }
+
+    #[test]
+    fn a_grandfathered_edge_is_reported_and_never_a_violation() {
+        let graph = graph(vec![
+            member("arcbox-engine", Layer::Engine, &["arcbox-core"]),
+            member("arcbox-core", Layer::App, &[]),
+        ]);
+        let exception = Exception {
+            from: "arcbox-engine",
+            to: "arcbox-core",
+            reason: "legacy",
+            until: "R4",
+        };
+        let report = evaluate(&graph, &[ENGINE_NO_APP], &[exception]);
+        assert!(report.is_clean(), "{report:?}");
+        assert_eq!(
+            report.grandfathered,
+            [Grandfathered {
+                edge: Edge {
+                    from: "arcbox-engine".to_owned(),
+                    to: "arcbox-core".to_owned(),
+                },
+                exception,
+            }]
+        );
+    }
+
+    #[test]
+    fn an_exception_matching_no_edge_is_stale() {
+        let graph = graph(vec![member("arcbox-engine", Layer::Engine, &[])]);
+        let exception = Exception {
+            from: "arcbox-engine",
+            to: "arcbox-vmm",
+            reason: "paid off",
+            until: "R4",
+        };
+        let report = evaluate(&graph, &[], &[exception]);
+        assert_eq!(report.stale_exceptions, [exception]);
+        assert!(!report.is_clean());
+    }
+}

--- a/xtask/src/commands/check_layers/evaluate.rs
+++ b/xtask/src/commands/check_layers/evaluate.rs
@@ -1,0 +1,87 @@
+//! The evaluator: a pure function from a graph and the rule tables to a
+//! [`Report`], so the rules are tested on graphs written by hand.
+
+use super::graph::{Edge, Graph, Target};
+use super::rule::{Exception, Rule};
+
+/// A direct edge that a rule forbids.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Violation {
+    /// The offending edge.
+    pub edge: Edge,
+    /// The rule it breaks.
+    pub rule: Rule,
+}
+
+/// A direct edge an exception allows for now.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Grandfathered {
+    /// The tolerated edge.
+    pub edge: Edge,
+    /// The exception that tolerates it.
+    pub exception: Exception,
+}
+
+/// Everything one evaluation found.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Report {
+    /// Every direct edge between two workspace members, in evaluation
+    /// order. Edges to external crates are matched against the rules that
+    /// name them but are not listed here.
+    pub edges: Vec<Edge>,
+    /// Edges an exception took out of rule evaluation.
+    pub grandfathered: Vec<Grandfathered>,
+    /// Edges the rules forbid, one entry per (edge, rule) pair.
+    pub violations: Vec<Violation>,
+    /// Exceptions that matched no edge: the debt they recorded is paid, so
+    /// they must be removed from the table.
+    pub stale_exceptions: Vec<Exception>,
+}
+
+impl Report {
+    /// Whether the gate passes: no violation and no stale exception.
+    pub fn is_clean(&self) -> bool {
+        self.violations.is_empty() && self.stale_exceptions.is_empty()
+    }
+}
+
+/// Evaluates every direct dependency of every member against `exceptions`
+/// first and `rules` second. Only direct edges are looked at, and an
+/// external crate matters only where a rule or exception names it.
+pub fn evaluate(graph: &Graph, rules: &[Rule], exceptions: &[Exception]) -> Report {
+    let mut report = Report::default();
+    let mut exception_used = vec![false; exceptions.len()];
+    for member in &graph.members {
+        for dep in &member.deps {
+            let target = graph.target(dep);
+            let edge = Edge {
+                from: member.name.clone(),
+                to: dep.clone(),
+            };
+            if matches!(target, Target::Member(_)) {
+                report.edges.push(edge.clone());
+            }
+            if let Some(index) = exceptions.iter().position(|e| e.covers(&edge)) {
+                exception_used[index] = true;
+                report.grandfathered.push(Grandfathered {
+                    edge,
+                    exception: exceptions[index],
+                });
+                continue;
+            }
+            for rule in rules.iter().filter(|rule| rule.forbids(member, target)) {
+                report.violations.push(Violation {
+                    edge: edge.clone(),
+                    rule: *rule,
+                });
+            }
+        }
+    }
+    report.stale_exceptions = exceptions
+        .iter()
+        .zip(exception_used)
+        .filter(|(_, used)| !used)
+        .map(|(exception, _)| *exception)
+        .collect();
+    report
+}

--- a/xtask/src/commands/check_layers/graph.rs
+++ b/xtask/src/commands/check_layers/graph.rs
@@ -117,6 +117,16 @@ pub enum Target<'a> {
     External(&'a str),
 }
 
+impl Target<'_> {
+    /// The package name.
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Member(member) => &member.name,
+            Self::External(name) => name,
+        }
+    }
+}
+
 /// The direct-dependency graph of the workspace members.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Graph {

--- a/xtask/src/commands/check_layers/graph.rs
+++ b/xtask/src/commands/check_layers/graph.rs
@@ -1,0 +1,230 @@
+//! The workspace dependency graph the layer rules are evaluated over.
+//!
+//! Built once from `cargo metadata` ([`Graph::try_from`]) and then read by
+//! the pure evaluator, so the evaluator can be tested on graphs written by
+//! hand.
+
+use std::fmt;
+
+use anyhow::{Context, Result, bail};
+use cargo_metadata::Metadata;
+use cargo_metadata::camino::Utf8Path;
+
+/// A layer is a top-level directory of the repository; a workspace member
+/// belongs to the layer its manifest lives under.
+///
+/// A member under a directory this enum does not name fails the gate: the
+/// layer rules must know every layer, so a new top-level directory is added
+/// here (and to the rules that concern it) before it can carry a crate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Layer {
+    Common,
+    Virt,
+    Rpc,
+    Runtime,
+    Engine,
+    Computer,
+    App,
+    Guest,
+    Sdk,
+    Fleet,
+    Tests,
+    Xtask,
+}
+
+impl Layer {
+    /// Every layer; keep in step with the variants above.
+    pub const ALL: [Self; 12] = [
+        Self::Common,
+        Self::Virt,
+        Self::Rpc,
+        Self::Runtime,
+        Self::Engine,
+        Self::Computer,
+        Self::App,
+        Self::Guest,
+        Self::Sdk,
+        Self::Fleet,
+        Self::Tests,
+        Self::Xtask,
+    ];
+
+    /// The repository directory holding this layer's crates.
+    pub const fn dir(self) -> &'static str {
+        match self {
+            Self::Common => "common",
+            Self::Virt => "virt",
+            Self::Rpc => "rpc",
+            Self::Runtime => "runtime",
+            Self::Engine => "engine",
+            Self::Computer => "computer",
+            Self::App => "app",
+            Self::Guest => "guest",
+            Self::Sdk => "sdk",
+            Self::Fleet => "fleet",
+            Self::Tests => "tests",
+            Self::Xtask => "xtask",
+        }
+    }
+
+    /// The layer whose directory is `dir`, if there is one.
+    pub fn from_dir(dir: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|layer| layer.dir() == dir)
+    }
+}
+
+impl fmt::Display for Layer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.dir())
+    }
+}
+
+/// A workspace member and its direct dependencies.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Member {
+    /// Package name.
+    pub name: String,
+    /// The layer the member's manifest lives under.
+    pub layer: Layer,
+    /// Package names of every direct dependency of every kind (normal, dev
+    /// and build), workspace members and external crates alike — sorted and
+    /// deduplicated. Renamed dependencies carry their real package name.
+    pub deps: Vec<String>,
+}
+
+/// A direct dependency edge between two crates, `from -> to`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Edge {
+    /// The dependent workspace member.
+    pub from: String,
+    /// The dependency's package name.
+    pub to: String,
+}
+
+impl fmt::Display for Edge {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} -> {}", self.from, self.to)
+    }
+}
+
+/// A dependency as the graph sees it: one of our workspace members, or an
+/// external crate the graph knows only by name.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Target<'a> {
+    /// A workspace member.
+    Member(&'a Member),
+    /// A crate outside the workspace.
+    External(&'a str),
+}
+
+/// The direct-dependency graph of the workspace members.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Graph {
+    /// Every workspace member, sorted by name.
+    pub members: Vec<Member>,
+}
+
+impl Graph {
+    /// Resolves a dependency name to a member of this graph, or to an
+    /// external crate when no member carries the name.
+    pub fn target<'a>(&'a self, name: &'a str) -> Target<'a> {
+        self.members
+            .iter()
+            .find(|member| member.name == name)
+            .map_or(Target::External(name), Target::Member)
+    }
+}
+
+impl TryFrom<&Metadata> for Graph {
+    type Error = anyhow::Error;
+
+    /// Builds the graph from `cargo metadata --no-deps` output: one member
+    /// per workspace package, placed in the layer of its manifest directory.
+    fn try_from(metadata: &Metadata) -> Result<Self> {
+        let mut members = Vec::new();
+        for package in &metadata.packages {
+            if !metadata.workspace_members.contains(&package.id) {
+                continue;
+            }
+            let layer = layer_of_manifest(&metadata.workspace_root, &package.manifest_path)
+                .with_context(|| format!("placing workspace member {} in a layer", package.name))?;
+            let mut deps: Vec<String> = package
+                .dependencies
+                .iter()
+                .map(|dependency| dependency.name.clone())
+                .collect();
+            deps.sort();
+            deps.dedup();
+            members.push(Member {
+                name: package.name.to_string(),
+                layer,
+                deps,
+            });
+        }
+        members.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(Self { members })
+    }
+}
+
+/// The layer of the member whose manifest is `manifest_path`: the first path
+/// component below the workspace root.
+fn layer_of_manifest(workspace_root: &Utf8Path, manifest_path: &Utf8Path) -> Result<Layer> {
+    let relative = manifest_path
+        .strip_prefix(workspace_root)
+        .with_context(|| {
+            format!("{manifest_path} lies outside the workspace root {workspace_root}")
+        })?;
+    let mut components = relative.components();
+    let (Some(dir), Some(_)) = (components.next(), components.next()) else {
+        bail!("{manifest_path} sits at the workspace root, under no layer directory");
+    };
+    Layer::from_dir(dir.as_str()).with_context(|| {
+        let known: Vec<&str> = Layer::ALL.iter().map(|layer| layer.dir()).collect();
+        format!(
+            "`{dir}` is not a layer directory (known: {}); add it to `Layer` in {}",
+            known.join(", "),
+            file!()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layer_is_the_first_directory_below_the_root() {
+        let root = Utf8Path::new("/ws");
+        assert_eq!(
+            layer_of_manifest(root, Utf8Path::new("/ws/engine/arcbox-engine/Cargo.toml")).unwrap(),
+            Layer::Engine
+        );
+        assert_eq!(
+            layer_of_manifest(root, Utf8Path::new("/ws/sdk/rust/Cargo.toml")).unwrap(),
+            Layer::Sdk
+        );
+        assert_eq!(
+            layer_of_manifest(root, Utf8Path::new("/ws/xtask/Cargo.toml")).unwrap(),
+            Layer::Xtask
+        );
+    }
+
+    #[test]
+    fn unknown_directory_names_itself_and_the_known_layers() {
+        let error = layer_of_manifest(
+            Utf8Path::new("/ws"),
+            Utf8Path::new("/ws/platform/node/Cargo.toml"),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("`platform`"), "{error}");
+        assert!(error.contains("common, virt"), "{error}");
+    }
+
+    #[test]
+    fn manifests_outside_or_at_the_root_have_no_layer() {
+        let root = Utf8Path::new("/ws");
+        assert!(layer_of_manifest(root, Utf8Path::new("/elsewhere/Cargo.toml")).is_err());
+        assert!(layer_of_manifest(root, Utf8Path::new("/ws/Cargo.toml")).is_err());
+    }
+}

--- a/xtask/src/commands/check_layers/rule.rs
+++ b/xtask/src/commands/check_layers/rule.rs
@@ -1,0 +1,97 @@
+//! The vocabulary the layer rules are written in.
+//!
+//! A [`Rule`] pairs a [`Subject`] (which members it constrains) with a
+//! [`Forbidden`] (what they must not depend on) and a reason naming the
+//! document that owns it. An [`Exception`] grandfathers one direct edge a
+//! rule would otherwise forbid, for a stated phase. The tables themselves
+//! live in [`super::rules`].
+
+use super::graph::{Edge, Layer, Member, Target};
+
+/// The dependent side of a rule: which workspace members it constrains.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Subject {
+    /// Every member whose manifest lives under one of these layers.
+    Layers(&'static [Layer]),
+    /// The named members. A name no member carries is a no-op, so a rule
+    /// may be written for a crate before it lands.
+    Members(&'static [&'static str]),
+}
+
+impl Subject {
+    /// Whether the rule constrains `member`.
+    pub fn covers(self, member: &Member) -> bool {
+        match self {
+            Self::Layers(layers) => layers.contains(&member.layer),
+            Self::Members(names) => names.contains(&member.name.as_str()),
+        }
+    }
+}
+
+/// The dependency side of a rule: what the subject must not depend on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Forbidden {
+    /// Any workspace member under one of these layers.
+    Layers(&'static [Layer]),
+    /// The named crates, matched literally by package name — workspace
+    /// members and external crates alike. This is the only way a rule
+    /// reaches an external crate; a name nothing depends on is a no-op.
+    Crates(&'static [&'static str]),
+    /// Every workspace member.
+    AnyMember,
+}
+
+impl Forbidden {
+    /// Whether depending on `target` is what the rule forbids.
+    pub fn matches(self, target: Target<'_>) -> bool {
+        match (self, target) {
+            (Self::Layers(layers), Target::Member(member)) => layers.contains(&member.layer),
+            (Self::Layers(_), Target::External(_)) => false,
+            (Self::Crates(names), target) => names.contains(&target.name()),
+            (Self::AnyMember, target) => matches!(target, Target::Member(_)),
+        }
+    }
+}
+
+/// One layer rule: no member in `subject` may have a direct dependency
+/// (of any kind) on anything `forbidden`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Rule {
+    /// Which members the rule constrains.
+    pub subject: Subject,
+    /// What they must not depend on.
+    pub forbidden: Forbidden,
+    /// Why — naming the charter decision, design doc or AGENTS.md section
+    /// that owns the rule. Printed with every violation.
+    pub reason: &'static str,
+}
+
+impl Rule {
+    /// Whether the direct edge `member -> target` violates this rule.
+    pub fn forbids(&self, member: &Member, target: Target<'_>) -> bool {
+        self.subject.covers(member) && self.forbidden.matches(target)
+    }
+}
+
+/// A grandfathered direct edge: allowed for now, never reported as a
+/// violation, and listed in verbose output. Every exception names the phase
+/// that removes it; an exception whose edge no longer exists fails the gate
+/// so the table cannot outlive the debt it records.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Exception {
+    /// The dependent workspace member.
+    pub from: &'static str,
+    /// The dependency's package name.
+    pub to: &'static str,
+    /// Why the edge exists today.
+    pub reason: &'static str,
+    /// The phase whose landing removes this exception.
+    pub until: &'static str,
+}
+
+impl Exception {
+    /// Whether this exception grandfathers `edge`.
+    pub fn covers(&self, edge: &Edge) -> bool {
+        edge.from == self.from && edge.to == self.to
+    }
+}

--- a/xtask/src/commands/check_layers/rules.rs
+++ b/xtask/src/commands/check_layers/rules.rs
@@ -1,0 +1,101 @@
+//! The layer rules and the grandfathered edges, as data.
+//!
+//! This table is the one place the layer rules are written down for the
+//! machine; the AGENTS.md files that state them in prose point here. To add a
+//! rule, append a [`Rule`] whose `reason` names the document that owns it —
+//! a rule may name a crate that does not exist yet, it is a no-op until the
+//! crate lands. To grandfather an edge, append an [`Exception`] with the
+//! reason the edge exists and the phase (`until`) that removes it; the gate
+//! fails once that edge is gone, so the exception leaves with it.
+
+use super::graph::Layer;
+use super::rule::{Exception, Forbidden, Rule, Subject};
+
+/// The daemon-free orchestration layers (architecture charter D1/D4).
+const ORCHESTRATION: &[Layer] = &[Layer::Engine, Layer::Computer];
+
+/// The layer rules, evaluated over every direct dependency edge.
+pub const RULES: &[Rule] = &[
+    Rule {
+        subject: Subject::Layers(ORCHESTRATION),
+        forbidden: Forbidden::Layers(&[Layer::App]),
+        reason: "charter D1/D4 — engine and computer are daemon-free and never reach app/",
+    },
+    Rule {
+        subject: Subject::Layers(ORCHESTRATION),
+        forbidden: Forbidden::Crates(&[
+            "arcbox-vz",
+            "arcbox-vmnet",
+            "arcbox-route",
+            "arcbox-hv",
+            "ifbridge",
+        ]),
+        reason: "charter D4 — macOS-only backends are reached only through the \
+                 platform seam, never directly",
+    },
+    Rule {
+        subject: Subject::Layers(&[Layer::Common]),
+        forbidden: Forbidden::Layers(&[
+            Layer::Virt,
+            Layer::Engine,
+            Layer::Computer,
+            Layer::App,
+            Layer::Guest,
+        ]),
+        reason: "common/AGENTS.md \"The one hard rule\" — no VM / VirtIO / device / \
+                 hypervisor dependency, so the host-only proxy harness stays buildable",
+    },
+    Rule {
+        subject: Subject::Members(&["arcbox-vm-proto"]),
+        forbidden: Forbidden::AnyMember,
+        reason: "CORE-127 — the guest/host sandbox wire is a leaf crate shared by \
+                 the in-sandbox binary and the host; it depends on nothing of ours",
+    },
+    Rule {
+        subject: Subject::Members(&["arcbox-vm-agent"]),
+        forbidden: Forbidden::Crates(&["arcbox-vm", "arcbox-snapshot", "tokio", "aya", "fc-sdk"]),
+        reason: "CORE-127 — the in-sandbox binary is a compiler-enforced crate boundary \
+                 and stays a small static musl binary",
+    },
+    Rule {
+        subject: Subject::Layers(ORCHESTRATION),
+        forbidden: Forbidden::Crates(&[
+            "arcbox-vmm",
+            "arcbox-hypervisor",
+            "arcbox-fc-driver",
+            "arcbox-vz-driver",
+            "arcbox-tap-net",
+            "arcbox-ch-driver",
+        ]),
+        reason: "vm-stack-redesign D-VM4 / charter D4 — orchestrators depend on the \
+                 port arcbox-vm-driver, never on a VMM adapter nor on arcbox-vmm / \
+                 arcbox-hypervisor directly (engine's two edges are grandfathered \
+                 until R4; computer/AGENTS.md \"Reaching the platform without a #[cfg]\")",
+    },
+    Rule {
+        subject: Subject::Members(&["arcbox-vm-driver"]),
+        forbidden: Forbidden::AnyMember,
+        reason: "vm-stack-redesign D-VM1 — the port sits below every adapter and \
+                 orchestrator; it depends on nothing of ours",
+    },
+];
+
+/// Direct edges the layer rules tolerate for now. An exception is checked
+/// before the rules, so it holds even as the rules tighten around it; the
+/// edge itself is the debt, and `until` names the phase that clears it.
+pub const EXCEPTIONS: &[Exception] = &[
+    Exception {
+        from: "arcbox-engine",
+        to: "arcbox-vmm",
+        reason: "engine drives the macOS backends through arcbox-vmm until the \
+                 arcbox-vm-driver port replaces that edge",
+        until: "vm-stack-redesign R4",
+    },
+    Exception {
+        from: "arcbox-engine",
+        to: "arcbox-hypervisor",
+        reason: "engine reaches the hypervisor seam directly until the \
+                 arcbox-vm-driver port replaces that edge",
+        until: "vm-stack-redesign R4",
+    },
+];

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod check_layers;
 pub mod dev;
 pub mod e2e;
 pub mod idle;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -14,6 +14,8 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// Fail on any workspace dependency edge that breaks a layer rule.
+    CheckLayers(CheckLayersArgs),
     /// Development-only repository orchestration.
     Dev(DevArgs),
     /// Repeated e2e test runs with artifact capture.
@@ -24,6 +26,13 @@ enum Command {
     Macos(MacosArgs),
     /// Release metadata and artifact generation.
     Release(ReleaseArgs),
+}
+
+#[derive(Args)]
+struct CheckLayersArgs {
+    /// Also list every member-to-member edge and every grandfathered edge.
+    #[arg(long)]
+    verbose: bool,
 }
 
 #[derive(Args)]
@@ -212,6 +221,7 @@ fn main() {
 
 fn run() -> Result<()> {
     match Cli::parse().command {
+        Command::CheckLayers(args) => commands::check_layers::run(args),
         Command::Dev(args) => commands::dev::run(args),
         Command::E2e(args) => commands::e2e::run(args),
         Command::Idle(args) => commands::idle::run(args),


### PR DESCRIPTION
## What

`cargo xtask check-layers` reads `cargo metadata --no-deps`, builds the graph of **direct** dependency edges between workspace members, and fails (one line per violation, exit 1) on any edge a layer rule forbids. Only direct edges, only workspace members; an external crate is checked only where a rule names it. A member's layer is the first directory of its manifest path (`common`, `virt`, `rpc`, `runtime`, `engine`, `computer`, `app`, `guest`, `sdk`, `fleet`, `tests`, `xtask`); a member under an unknown top-level directory fails the gate until `Layer` learns it.

The rules and exceptions are data (`xtask/src/commands/check_layers/rules.rs`); the evaluator is a pure function over a small typed graph and is unit-tested on synthetic graphs (one per rule shape, a grandfathered edge, a rule naming an absent crate, an external-name match, a stale exception).

## Rules

1. `engine/*`, `computer/*` → no `app/*` member (charter D1/D4 — daemon-free).
2. `engine/*`, `computer/*` → no `arcbox-vz`, `arcbox-vmnet`, `arcbox-route`, `arcbox-hv`, `ifbridge` (charter D4 — backends only through the platform seam).
3. `computer/*` → no `arcbox-vmm`, `arcbox-hypervisor` (charter D4 / computer/AGENTS.md — the platform is reached through `arcbox-engine`).
4. `common/*` → no `virt/*`, `engine/*`, `computer/*`, `app/*`, `guest/*` member (common/AGENTS.md "The one hard rule").
5. `arcbox-vm-proto` → no workspace member; `arcbox-vm-agent` → no `arcbox-vm`, `arcbox-snapshot`, `tokio`, `aya`, `fc-sdk` (CORE-127 — the in-sandbox binary is a compiler-enforced boundary and stays a small static musl binary).
6. `engine/*`, `computer/*` → no `arcbox-fc-driver`, `arcbox-vz-driver`, `arcbox-tap-net`, `arcbox-ch-driver` (vm-stack-redesign D-VM4 — orchestrators depend on the port, never on an adapter; a no-op until those crates land).
7. `arcbox-vm-driver` → no workspace member (D-VM1 — the port depends on nothing of ours; a no-op until it lands).

Every dependency kind counts (normal, dev, build).

## Grandfathered edges

- `arcbox-engine -> arcbox-vmm`
- `arcbox-engine -> arcbox-hypervisor`

Both allowed until vm-stack-redesign R4 replaces them with the `arcbox-vm-driver` port. Exceptions are checked before the rules, so they hold as the rules tighten; an exception whose edge no longer exists **fails the gate**, so the table cannot outlive the debt it records — R4 removes the edge and the exception together.

## Where it runs

`ci.yml`, `linux-engine` job, as the first step after the cargo cache restore and before the Linux check/test steps — a forbidden edge fails with the rule's reason rather than as a Linux build break three crates away.

## Adding a rule or an exception

Both are entries in `xtask/src/commands/check_layers/rules.rs`. A `Rule` pairs a `Subject` (layers or named members) with a `Forbidden` (layers, named crates — member or external — or any member) and a `reason` naming the owning document; a rule may name a crate that does not exist yet. An `Exception` names the edge, the reason it exists and the phase (`until`) that removes it. `xtask/AGENTS.md` has the section; `engine/`, `computer/`, `common/` AGENTS.md now say their layer rules are mechanically checked and point here.

## Validation

- `cargo fmt --all -- --check`, `cargo clippy -p xtask --all-targets -- -D warnings`, `cargo test -p xtask` (19 tests, 11 new) — clean.
- `cargo run -p xtask -- check-layers` on this tree: `layer rules: 62 members, 156 edges checked, 2 grandfathered`, exit 0.
- `--verbose` lists the 156 member edges and both grandfathered edges.
- Simulated a violation (temporary `arcbox-vz` + `arcbox-vmm` deps on `arcbox-computer`): two `layer rule violated:` lines with the rule reasons, `Error: layer rules: 2 violation(s), 0 stale exception(s) (…)`, exit 1; reverted.

Design: company repo `engineering/arcbox/architecture/vm-stack-redesign.md` (D-VM4) + charter D4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a CI gate and dev tooling only; no runtime or product code paths change. Risk is mainly that a misconfigured rule or stale exception could block merges until the table is updated.
> 
> **Overview**
> Adds **`cargo xtask check-layers`**, which builds a graph of **direct** workspace-member dependencies from `cargo metadata --no-deps` and fails when an edge violates the layer rules encoded in `xtask/src/commands/check_layers/rules.rs`. Violations print the rule’s **reason**; **grandfathered** edges (`arcbox-engine → arcbox-vmm` / `arcbox-hypervisor` until vm-stack R4) and **stale exceptions** (edge gone but exception still listed) also fail the gate.
> 
> The implementation is a small **pure evaluator** over typed `Layer` / `Rule` / `Exception` data, with **unit tests on synthetic graphs**; `xtask` gains **`cargo_metadata`** as a dependency.
> 
> **CI** runs the check first in the **`linux-engine`** job (after cache restore, before `cargo check`/`test`). **AGENTS.md** and **xtask** docs now state that engine/computer/common layer discipline is mechanically enforced and point at the rules table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ea6742292c796b94045a9012066210c2569aad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->