### PR TITLE
feat(vm-driver): add the VM port crate (R0 of the VM stack redesign)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,16 +188,16 @@ jobs:
             ${{ runner.os }}-cargo-linux-engine-
 
       - name: Check engine-layer crates on Linux
-        run: cargo check --all-targets -p arcbox-atomic-file -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-snapshot -p arcbox-engine -p arcbox-computer
+        run: cargo check --all-targets -p arcbox-atomic-file -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-vm-driver -p arcbox-snapshot -p arcbox-engine -p arcbox-computer
 
       # `--no-fail-fast` so one red run reports every broken crate rather
       # than stopping at the first, which otherwise hides later failures
       # behind a fix-and-rerun loop.
       - name: Test engine-layer crates on Linux
-        run: cargo test --no-fail-fast -p arcbox-atomic-file -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-snapshot -p arcbox-engine -p arcbox-computer
+        run: cargo test --no-fail-fast -p arcbox-atomic-file -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-vm-driver -p arcbox-snapshot -p arcbox-engine -p arcbox-computer
 
       - name: Check engine-layer crates on aarch64-unknown-linux-musl
-        run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-atomic-file -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-snapshot
+        run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-atomic-file -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-vm-driver -p arcbox-snapshot
 
   # Pure proto-contract analysis — no Rust toolchain, no build. Runs in
   # parallel with `ci` on a cheap Linux runner. The desktop and agent

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,6 +1222,7 @@ dependencies = [
  "async-trait",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcbox-vm-driver"
+version = "0.7.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "arcbox-vm-proto"
 version = "0.7.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,9 +1219,11 @@ dependencies = [
 name = "arcbox-vm-driver"
 version = "0.7.0"
 dependencies = [
+ "async-trait",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,6 +1219,7 @@ dependencies = [
 name = "arcbox-vm-driver"
 version = "0.7.0"
 dependencies = [
+ "arcbox-vm-driver",
  "async-trait",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "virt/arcbox-virtio-balloon",
     "virt/arcbox-vm",
     "virt/arcbox-vm-proto",
+    "virt/arcbox-vm-driver",
     "virt/arcbox-vm-agent",
     "virt/arcbox-fs",
     "virt/arcbox-net",
@@ -269,6 +270,7 @@ arcbox-virtio-vsock = { version = "0.7.0", path = "virt/arcbox-virtio-vsock" } #
 arcbox-virtio-balloon = { version = "0.7.0", path = "virt/arcbox-virtio-balloon" } # x-release-please-version
 arcbox-vm = { version = "0.7.0", path = "virt/arcbox-vm" } # x-release-please-version
 arcbox-vm-proto = { version = "0.7.0", path = "virt/arcbox-vm-proto" } # x-release-please-version
+arcbox-vm-driver = { version = "0.7.0", path = "virt/arcbox-vm-driver" } # x-release-please-version
 arcbox-fs = { version = "0.7.0", path = "virt/arcbox-fs" } # x-release-please-version
 arcbox-net = { version = "0.7.0", path = "virt/arcbox-net" } # x-release-please-version
 arcbox-vmnet = { version = "0.7.0", path = "virt/arcbox-vmnet" } # x-release-please-version

--- a/virt/arcbox-vm-driver/Cargo.toml
+++ b/virt/arcbox-vm-driver/Cargo.toml
@@ -8,11 +8,11 @@ repository.workspace = true
 description       = "The VM driver port: the vocabulary of a VM on this host — spec, driver/handle traits, capabilities, guest-network port — that VMM adapters implement and orchestrators consume."
 
 [dependencies]
+async-trait.workspace = true
 serde.workspace = true
-thiserror.workspace = true
-
-[dev-dependencies]
 serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
 
 [lints]
 workspace = true

--- a/virt/arcbox-vm-driver/Cargo.toml
+++ b/virt/arcbox-vm-driver/Cargo.toml
@@ -20,5 +20,15 @@ tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio.workspace = true
 
+# The crate's own tests always exercise the testkit (the fake passes the
+# contract): a path-only self dev-dependency turns the feature on for test
+# builds and is stripped at publish time.
+[dev-dependencies]
+arcbox-vm-driver = { path = ".", features = ["testkit"] }
+
+[[test]]
+name = "fake_contract"
+required-features = ["testkit"]
+
 [lints]
 workspace = true

--- a/virt/arcbox-vm-driver/Cargo.toml
+++ b/virt/arcbox-vm-driver/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name              = "arcbox-vm-driver"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description       = "The VM driver port: the vocabulary of a VM on this host — spec, driver/handle traits, capabilities, guest-network port — that VMM adapters implement and orchestrators consume."
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/virt/arcbox-vm-driver/Cargo.toml
+++ b/virt/arcbox-vm-driver/Cargo.toml
@@ -10,12 +10,13 @@ description       = "The VM driver port: the vocabulary of a VM on this host —
 [features]
 # Fakes and the contract test-kit: `FakeDriver`, `FakeNetwork`,
 # `driver_contract!`. Off by default so production builds carry none of it.
-testkit = []
+testkit = ["dep:tempfile"]
 
 [dependencies]
 async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio.workspace = true
 

--- a/virt/arcbox-vm-driver/Cargo.toml
+++ b/virt/arcbox-vm-driver/Cargo.toml
@@ -7,6 +7,11 @@ license.workspace = true
 repository.workspace = true
 description       = "The VM driver port: the vocabulary of a VM on this host — spec, driver/handle traits, capabilities, guest-network port — that VMM adapters implement and orchestrators consume."
 
+[features]
+# Fakes and the contract test-kit: `FakeDriver`, `FakeNetwork`,
+# `driver_contract!`. Off by default so production builds carry none of it.
+testkit = []
+
 [dependencies]
 async-trait.workspace = true
 serde.workspace = true

--- a/virt/arcbox-vm-driver/README.md
+++ b/virt/arcbox-vm-driver/README.md
@@ -34,6 +34,7 @@ that the flags and the accessors agree.
 | `VsockListen` | `handle.vsock_listener()` | accept guest-initiated vsock connections |
 | `Checkpoint` | `handle.checkpoint()` | capture to disk; `Resume` or `HoldQuiesced` afterwards |
 | `Adopt` / `Detach` | `driver.adopt()` / `handle.detach()` | VMs that outlive the process (external VMMs) |
+| `Prepare` | `driver.prepare()` | spawn the VMM ahead of a boot: pid journaled and READY listener bound before the guest starts; `boot` is exactly prepare-then-boot |
 | `Balloon` | `handle.balloon()` | set/read the memory balloon |
 | `Console` | `handle.console()` | read guest console output |
 | `DebugSnapshot` | `handle.debug()` | driver-specific JSON for post-mortems |

--- a/virt/arcbox-vm-driver/README.md
+++ b/virt/arcbox-vm-driver/README.md
@@ -1,0 +1,78 @@
+# arcbox-vm-driver
+
+The VM driver port: the vocabulary of "a VM on this host" — the
+serializable `VmSpec`, the `VmDriver`/`VmHandle` traits, the capability
+traits, and the `GuestNetwork` port — that VMM adapters (Firecracker,
+Virtualization.framework, the in-process HV engine, Cloud Hypervisor)
+implement and orchestrators consume. No `arcbox-*` dependency: it sits
+below every adapter, and only a composition root names both sides.
+
+## The mandatory surface
+
+`VmDriver` boots a `VmSpec` into a `Box<dyn VmHandle>` (or restores one
+from a `CheckpointImage`). A handle's mandatory verbs are:
+
+| Verb | What it is |
+|------|------------|
+| `id()` / `record()` | identify — the `VmRecord` is durable and stable for the handle's life |
+| `state()` / `events()` | observe — `Running` / `Quiesced` / `Exited(status)`; `Exited` is broadcast once; neither blocks |
+| `shutdown(mode)` | stop — `Kill` always succeeds; `Graceful { timeout }` asks the guest and kills at the deadline |
+
+Dropping a handle kills the VM unless a `Detach` released it.
+
+## Capabilities
+
+Everything else is optional and reached through an `Option<&dyn Cap>`
+accessor; `None` means "this driver cannot" or "this VM was not built with
+the device", never an error at call time. `DriverCapabilities` says which
+accessors a driver's handles can return `Some` for, and the contract checks
+that the flags and the accessors agree.
+
+| Capability | Accessor | Does |
+|------------|----------|------|
+| `Vsock` | `handle.vsock()` | dial a guest vsock port → `VsockConn { fd, mode }` |
+| `VsockListen` | `handle.vsock_listener()` | accept guest-initiated vsock connections |
+| `Checkpoint` | `handle.checkpoint()` | capture to disk; `Resume` or `HoldQuiesced` afterwards |
+| `Adopt` / `Detach` | `driver.adopt()` / `handle.detach()` | VMs that outlive the process (external VMMs) |
+| `Balloon` | `handle.balloon()` | set/read the memory balloon |
+| `Console` | `handle.console()` | read guest console output |
+| `DebugSnapshot` | `handle.debug()` | driver-specific JSON for post-mortems |
+
+`net::GuestNetwork` is the second port: reserve a lease, activate it into
+a `NicSpec`, quarantine/release, and the `NetworkReconcile` cleanup-token
+protocol.
+
+## Usage
+
+```rust
+let driver: Arc<dyn VmDriver> = root.pick_driver();          // composition root
+let vm = driver.boot(spec, &runtime_dir).await?;              // Box<dyn VmHandle>
+let mut events = vm.events();
+if let Some(vsock) = vm.vsock() {
+    let conn = vsock.dial(AGENT_PORT).await?;                 // conn.mode picks the transport
+}
+if let Some(cp) = vm.checkpoint() {
+    let image = cp.checkpoint(&dir, CheckpointOptions::default()).await?;
+}
+vm.shutdown(ShutdownMode::Graceful { timeout: Duration::from_secs(5) }).await?;
+```
+
+## Running the contract against an adapter
+
+Enable the `testkit` feature in the adapter's dev-dependencies, implement
+`ContractHarness` (driver, a spec asking for every device the driver
+claims, fresh runtime dirs, the agent port to dial, and how to wait for
+guest readiness), and instantiate the macro in a test target:
+
+```rust
+use arcbox_vm_driver::driver_contract;
+driver_contract!(fc, FcHarness::new());   // → mod fc { #[tokio::test] async fn ... }
+```
+
+`FakeHarness` is the reference implementation, and `tests/fake_contract.rs`
+runs the same checks against `FakeDriver`, both fully claimed and with no
+capabilities claimed. `FakeDriver` and `FakeNetwork` are what runtime unit
+tests build their real actors and state machines on — no hypervisor needed.
+
+Design: company repo `engineering/arcbox/architecture/vm-stack-redesign.md`
+(D-VM1, D-VM7, D-VM9).

--- a/virt/arcbox-vm-driver/src/capability.rs
+++ b/virt/arcbox-vm-driver/src/capability.rs
@@ -1,0 +1,186 @@
+//! What a handle *may* be able to do, one small trait per capability.
+//!
+//! A handle exposes each of these through an `Option<&dyn Cap>` accessor
+//! (`VmHandle::vsock`, `VmHandle::checkpoint`, ...). `None` is the answer for
+//! "this driver cannot" *and* for "this VM was not built with the device";
+//! a method on one of these traits never returns an "unsupported" error as
+//! its normal answer. [`crate::DriverCapabilities`] says which accessors a
+//! driver's handles can ever return `Some` for.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::driver::{VmHandle, VmRecord, VsockConn};
+use crate::error::Result;
+
+/// Dial a vsock port inside the guest.
+#[async_trait]
+pub trait Vsock: Send + Sync {
+    /// Connects to `port` in the guest and returns the stream.
+    ///
+    /// Fails with [`crate::Error::WrongState`] when the VM is not running.
+    async fn dial(&self, port: u32) -> Result<VsockConn>;
+}
+
+/// Accept vsock connections the guest initiates (the READY dial-out).
+#[async_trait]
+pub trait VsockListen: Send + Sync {
+    /// Starts listening on host-side `port`; the guest connects to it.
+    async fn listen(&self, port: u32) -> Result<Box<dyn VsockListener>>;
+}
+
+/// A bound vsock listener; one guest connection per `accept`.
+#[async_trait]
+pub trait VsockListener: Send {
+    /// Waits for the next guest connection.
+    ///
+    /// Fails once the VM has exited — nothing more can arrive.
+    async fn accept(&mut self) -> Result<VsockConn>;
+}
+
+/// Capture the VM's state to disk.
+///
+/// Quiescing is this capability's own business: the driver freezes the guest
+/// for the capture and, per [`CheckpointOptions::after`], either resumes it
+/// or leaves it [`crate::VmState::Quiesced`]. There is no pause verb on the
+/// handle.
+#[async_trait]
+pub trait Checkpoint: Send + Sync {
+    /// Writes a checkpoint of the VM into `dst` (created if missing).
+    async fn checkpoint(&self, dst: &Path, opts: CheckpointOptions) -> Result<CheckpointImage>;
+}
+
+/// How to take a checkpoint.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CheckpointOptions {
+    /// What the guest does once the capture is on disk.
+    pub after: AfterCheckpoint,
+    /// Full image or incremental.
+    pub kind: CheckpointKind,
+}
+
+/// What the guest does once a checkpoint is captured.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AfterCheckpoint {
+    /// Keep running.
+    #[default]
+    Resume,
+    /// Stay frozen; the handle reports [`crate::VmState::Quiesced`] until it
+    /// is shut down. This is how an orchestrator implements "pause": hold,
+    /// then `shutdown(Kill)`; "resume" is a restore.
+    HoldQuiesced,
+}
+
+/// Full or incremental capture.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckpointKind {
+    /// Everything: memory and device state.
+    #[default]
+    Full,
+    /// Only pages dirtied since the previous checkpoint (needs
+    /// [`crate::VmSpec::dirty_tracking`] and a driver whose
+    /// [`crate::DriverCapabilities::diff_checkpoint`] is set).
+    Diff,
+}
+
+/// A checkpoint on disk: where it is and who can read it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckpointImage {
+    /// The directory holding the image files.
+    pub dir: PathBuf,
+    /// The on-disk format, named by the driver that wrote it.
+    pub format: CheckpointFormat,
+    /// Full or incremental.
+    pub kind: CheckpointKind,
+}
+
+/// A checkpoint's on-disk format, e.g. `firecracker/v1`.
+///
+/// A driver refuses to restore a format it did not write
+/// ([`crate::Error::ForeignCheckpoint`]); the name is how it tells.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CheckpointFormat(String);
+
+impl CheckpointFormat {
+    /// Names a format.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    /// The format name.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for CheckpointFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for CheckpointFormat {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Find a VM that outlived the process which booted it.
+///
+/// Present on external-process VMMs only: an in-process VM dies with its
+/// process, so "adopt" has no meaning there and the accessor is `None`.
+#[async_trait]
+pub trait Adopt: Send + Sync {
+    /// Rebuilds a handle for the VM `record` names.
+    ///
+    /// `Ok(None)` means nothing survived — a stale record, a dead pid — which
+    /// is an outcome, not an absence of the capability.
+    async fn adopt(&self, record: &VmRecord) -> Result<Option<Box<dyn VmHandle>>>;
+}
+
+/// Give up ownership of a running VM without stopping it.
+///
+/// After `detach`, dropping the handle no longer kills the VM; the returned
+/// record is what [`Adopt::adopt`] takes to pick it up again. Present iff
+/// the driver has [`Adopt`].
+#[async_trait]
+pub trait Detach: Send + Sync {
+    /// Releases the VM from this handle and returns its durable record.
+    async fn detach(&self) -> Result<VmRecord>;
+}
+
+/// The guest memory balloon.
+#[async_trait]
+pub trait Balloon: Send + Sync {
+    /// Asks the guest to give back memory until it holds `bytes`.
+    async fn set_target(&self, bytes: u64) -> Result<()>;
+    /// What the balloon was told and what it reports.
+    async fn stats(&self) -> Result<BalloonStats>;
+}
+
+/// The balloon's target and, when the guest reports it, its actual size.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BalloonStats {
+    /// The most recent target, in bytes.
+    pub target_bytes: u64,
+    /// The size the guest reports, in bytes, when it does.
+    pub current_bytes: Option<u64>,
+}
+
+/// The guest console's output.
+#[async_trait]
+pub trait Console: Send + Sync {
+    /// Takes up to `max_bytes` of console output not yet read.
+    async fn read_output(&self, max_bytes: usize) -> Result<Vec<u8>>;
+}
+
+/// A point-in-time view of the VM's internals for diagnostics.
+pub trait DebugSnapshot: Send + Sync {
+    /// The driver's own JSON — queues, counters, whatever helps a post-mortem.
+    fn snapshot(&self) -> serde_json::Value;
+}

--- a/virt/arcbox-vm-driver/src/capability.rs
+++ b/virt/arcbox-vm-driver/src/capability.rs
@@ -13,16 +13,85 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use crate::driver::{VmHandle, VmRecord, VsockConn};
+use crate::driver::{ExitStatus, RestoreSpec, VmHandle, VmRecord, VsockConn};
 use crate::error::Result;
+use crate::spec::{IsolationSpec, VmId, VmSpec};
 
 /// Dial a vsock port inside the guest.
 #[async_trait]
 pub trait Vsock: Send + Sync {
     /// Connects to `port` in the guest and returns the stream.
     ///
-    /// Fails with [`crate::Error::WrongState`] when the VM is not running.
+    /// Fails with [`crate::Error::WrongState`] when the VM is not running,
+    /// and with [`crate::Error::Io`] of kind
+    /// [`ConnectionRefused`](std::io::ErrorKind::ConnectionRefused) when
+    /// the guest has no listener on `port` yet — the one outcome a caller
+    /// retries on; every other error is final.
     async fn dial(&self, port: u32) -> Result<VsockConn>;
+}
+
+/// Spawn the VMM before there is a guest to boot.
+///
+/// External-process VMMs pay for the process spawn, the jailer setup, and
+/// the API socket up front. A warm pool prepares its slots long before a
+/// boot is asked for, journals the pid before any guest runs, and binds the
+/// READY vsock listener while nothing can race it. The split is invisible
+/// to a plain boot: `VmDriver::boot(spec, dir)` MUST behave exactly like
+/// `prepare(&spec.id, &spec.isolation, dir)` followed by
+/// [`PreparedVm::boot`] with `spec`, and `restore` likewise — the contract
+/// asserts it. Present iff [`crate::DriverCapabilities::prepare`].
+#[async_trait]
+pub trait Prepare: Send + Sync {
+    /// Spawns the VMM process for `id` under `isolation`, with
+    /// `runtime_dir` as its private scratch space, without booting a guest.
+    async fn prepare(
+        &self,
+        id: &VmId,
+        isolation: &IsolationSpec,
+        runtime_dir: &Path,
+    ) -> Result<Box<dyn PreparedVm>>;
+}
+
+/// A spawned VMM waiting for a spec.
+///
+/// Dropping it kills the process unless a `boot` or `restore` succeeded,
+/// after which the returned handle owns it.
+#[async_trait]
+pub trait PreparedVm: Send + Sync {
+    /// The VM's identity.
+    fn id(&self) -> &VmId;
+
+    /// The durable record — pid and API socket are already known, and the
+    /// handle that `boot`/`restore` returns reports this same record.
+    fn record(&self) -> VmRecord;
+
+    /// `true` while the VMM process is up. Never signals a reaped pid: once
+    /// this answers `false` it stays `false`.
+    fn alive(&self) -> bool;
+
+    /// Bind a vsock listener now; it is live before the guest starts, so a
+    /// dial-out the guest makes at boot cannot be missed. `Some` iff
+    /// [`crate::DriverCapabilities::vsock_listen`].
+    fn vsock_listener(&self) -> Option<&dyn VsockListen> {
+        None
+    }
+
+    /// Boots `spec` on this process. `spec.id` and `spec.isolation` must
+    /// equal what `prepare` was given ([`crate::Error::InvalidSpec`]
+    /// otherwise); the handle shares this process. At most one `boot` or
+    /// `restore` succeeds per prepared VM.
+    async fn boot(&self, spec: VmSpec) -> Result<Box<dyn VmHandle>>;
+
+    /// Boots a checkpoint on this process; the same rules as [`boot`](Self::boot).
+    async fn restore(
+        &self,
+        image: &CheckpointImage,
+        spec: RestoreSpec,
+    ) -> Result<Box<dyn VmHandle>>;
+
+    /// Kills and reaps the process now. Idempotent, and valid after a boot
+    /// too (it kills that VM); the status is how the process ended.
+    async fn discard(&self) -> Result<ExitStatus>;
 }
 
 /// Accept vsock connections the guest initiates (the READY dial-out).

--- a/virt/arcbox-vm-driver/src/driver.rs
+++ b/virt/arcbox-vm-driver/src/driver.rs
@@ -4,17 +4,135 @@
 //! nothing a single VMM happens to offer: identify a VM, observe it, stop
 //! it. Everything else — vsock, checkpoints, adopt/detach, balloon, console,
 //! debug — is a capability reached through an `Option<&dyn Cap>` accessor
-//! (`capability` module), present only when both the driver can do it and
+//! ([`crate::capability`]), present only when both the driver can do it and
 //! the spec asked for the device.
 
 use std::fmt;
 use std::os::fd::OwnedFd;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
 
-use crate::spec::{IsolationSpec, NicSpec, VmId};
+use crate::capability::{
+    Adopt, Balloon, Checkpoint, CheckpointImage, Console, DebugSnapshot, Detach, Vsock, VsockListen,
+};
+use crate::error::Result;
+use crate::spec::{IsolationSpec, NicSpec, VmId, VmSpec};
+
+/// A VMM adapter: boots specs into handles.
+///
+/// Object-safe on purpose — roots keep an `Arc<dyn VmDriver>` and never name
+/// the adapter again.
+#[async_trait]
+pub trait VmDriver: Send + Sync {
+    /// A short stable name (`"fc"`, `"vz"`, `"hv"`), recorded in
+    /// [`VmRecord::driver`] and [`crate::Error::Driver`].
+    fn name(&self) -> &'static str;
+
+    /// What this driver can do, independent of any one VM.
+    fn capabilities(&self) -> DriverCapabilities;
+
+    /// Boots `spec` with `runtime_dir` as the VM's private scratch space
+    /// (sockets, logs, staged files) and returns a handle to the running VM.
+    ///
+    /// The driver validates the spec ([`VmSpec::validate`]) and fails with
+    /// [`crate::Error::InvalidSpec`] before touching the host. A returned
+    /// handle owns the VM: dropping it kills the VM unless a
+    /// [`Detach`] released it first.
+    async fn boot(&self, spec: VmSpec, runtime_dir: &Path) -> Result<Box<dyn VmHandle>>;
+
+    /// Boots a new VM from a checkpoint this driver wrote.
+    ///
+    /// Fails with [`crate::Error::ForeignCheckpoint`] for a
+    /// [`CheckpointImage::format`] the driver does not recognise as its own.
+    async fn restore(
+        &self,
+        image: &CheckpointImage,
+        spec: RestoreSpec,
+        runtime_dir: &Path,
+    ) -> Result<Box<dyn VmHandle>>;
+
+    /// The adopt capability, for VMs that outlive the process which booted
+    /// them (external-process VMMs). `Some` iff
+    /// [`DriverCapabilities::adopt`].
+    fn adopt(&self) -> Option<&dyn Adopt>;
+}
+
+/// A running (or just-exited) VM.
+///
+/// The mandatory surface is identify ([`id`](Self::id) /
+/// [`record`](Self::record)), observe ([`state`](Self::state) /
+/// [`events`](Self::events)), and stop ([`shutdown`](Self::shutdown)).
+/// Every other verb is a capability accessor that returns `Some` only when
+/// the driver can and the spec asked. Dropping the handle kills the VM
+/// unless [`Detach`] released it.
+#[async_trait]
+pub trait VmHandle: Send + Sync {
+    /// The VM's identity.
+    fn id(&self) -> &VmId;
+
+    /// The durable record; identical for the handle's whole life.
+    fn record(&self) -> VmRecord;
+
+    /// Where the VM is right now. Observational: never blocks.
+    fn state(&self) -> VmState;
+
+    /// Subscribes to what the VM does on its own. Observational: never
+    /// blocks. [`VmEvent::Exited`] is delivered exactly once; a subscriber
+    /// that arrives after the exit reads it from [`state`](Self::state).
+    fn events(&self) -> broadcast::Receiver<VmEvent>;
+
+    /// Stops the VM.
+    ///
+    /// [`ShutdownMode::Kill`] always succeeds for a live VM.
+    /// [`ShutdownMode::Graceful`] asks the guest and kills it at the
+    /// deadline; the returned [`ExitStatus`] says which happened. Calling
+    /// it on an exited VM returns the recorded status.
+    async fn shutdown(&self, mode: ShutdownMode) -> Result<ExitStatus>;
+
+    /// Dial guest vsock ports. `Some` iff the driver has vsock and the spec
+    /// had a [`crate::VsockSpec`].
+    fn vsock(&self) -> Option<&dyn Vsock> {
+        None
+    }
+
+    /// Checkpoint the VM. `Some` iff [`DriverCapabilities::checkpoint`].
+    fn checkpoint(&self) -> Option<&dyn Checkpoint> {
+        None
+    }
+
+    /// Accept guest-initiated vsock connections. `Some` iff the driver can
+    /// listen and the spec had a [`crate::VsockSpec`].
+    fn vsock_listener(&self) -> Option<&dyn VsockListen> {
+        None
+    }
+
+    /// Give the VM up without stopping it. `Some` iff
+    /// [`DriverCapabilities::adopt`].
+    fn detach(&self) -> Option<&dyn Detach> {
+        None
+    }
+
+    /// The memory balloon. `Some` iff the driver has one and the spec set
+    /// [`VmSpec::balloon`].
+    fn balloon(&self) -> Option<&dyn Balloon> {
+        None
+    }
+
+    /// The guest console output. `Some` iff the driver exposes it and the
+    /// spec's [`VmSpec::console`] is not `Off`.
+    fn console(&self) -> Option<&dyn Console> {
+        None
+    }
+
+    /// A diagnostic snapshot. `Some` iff [`DriverCapabilities::debug`].
+    fn debug(&self) -> Option<&dyn DebugSnapshot> {
+        None
+    }
+}
 
 /// What a driver can do, independent of any one VM.
 ///
@@ -25,15 +143,19 @@ use crate::spec::{IsolationSpec, NicSpec, VmId};
 /// flag here agrees with the matching handle accessor.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DriverCapabilities {
-    /// Handles can dial guest vsock ports (`Vsock`).
+    /// Handles can dial guest vsock ports ([`Vsock`]).
     pub vsock: bool,
-    /// Handles can listen for guest-initiated vsock connections (`VsockListen`).
+    /// Handles can listen for guest-initiated vsock connections
+    /// ([`VsockListen`]).
     pub vsock_listen: bool,
-    /// Handles can be checkpointed and the driver can restore the result.
+    /// Handles can be checkpointed ([`Checkpoint`]) and the driver can
+    /// restore the result.
     pub checkpoint: bool,
-    /// Checkpoints can be incremental (`CheckpointKind::Diff`).
+    /// Checkpoints can be incremental
+    /// ([`CheckpointKind::Diff`](crate::CheckpointKind::Diff)).
     pub diff_checkpoint: bool,
-    /// VMs outlive this process and can be adopted back (`Adopt` / `Detach`).
+    /// VMs outlive this process and can be adopted back ([`Adopt`] /
+    /// [`Detach`]).
     pub adopt: bool,
     /// Handles expose a memory balloon.
     pub balloon: bool,
@@ -75,8 +197,9 @@ impl NestedVirt {
 
 /// Where a VM is in its life.
 ///
-/// `Quiesced` is reached only through the `Checkpoint` capability's
-/// `HoldQuiesced` option; there is no pause verb on the handle.
+/// `Quiesced` is reached only through the [`Checkpoint`] capability's
+/// [`HoldQuiesced`](crate::AfterCheckpoint::HoldQuiesced) option; there is
+/// no pause verb on the handle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum VmState {
@@ -98,7 +221,7 @@ impl fmt::Display for VmState {
     }
 }
 
-/// Something the VM did on its own, delivered through `VmHandle::events`.
+/// Something the VM did on its own, delivered through [`VmHandle::events`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum VmEvent {
@@ -182,7 +305,7 @@ pub enum ShutdownMode {
 }
 
 /// The durable identity of a VM: what survives this process and what
-/// `Adopt` consumes to find the VM again.
+/// [`Adopt`] consumes to find the VM again.
 ///
 /// Stable for a handle's whole life — the same value before, during, and
 /// after the VM runs.
@@ -190,7 +313,7 @@ pub enum ShutdownMode {
 pub struct VmRecord {
     /// The VM's identity.
     pub id: VmId,
-    /// The driver that booted it (`VmDriver::name`).
+    /// The driver that booted it ([`VmDriver::name`]).
     pub driver: String,
     /// The per-VM directory the driver was given at boot.
     pub runtime_dir: PathBuf,

--- a/virt/arcbox-vm-driver/src/driver.rs
+++ b/virt/arcbox-vm-driver/src/driver.rs
@@ -17,10 +17,11 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
 use crate::capability::{
-    Adopt, Balloon, Checkpoint, CheckpointImage, Console, DebugSnapshot, Detach, Vsock, VsockListen,
+    Adopt, Balloon, Checkpoint, CheckpointImage, Console, DebugSnapshot, Detach, Prepare, Vsock,
+    VsockListen,
 };
 use crate::error::Result;
-use crate::spec::{IsolationSpec, NicSpec, VmId, VmSpec};
+use crate::spec::{DiskSpec, IsolationSpec, NicSpec, VmId, VmSpec};
 
 /// A VMM adapter: boots specs into handles.
 ///
@@ -59,6 +60,13 @@ pub trait VmDriver: Send + Sync {
     /// them (external-process VMMs). `Some` iff
     /// [`DriverCapabilities::adopt`].
     fn adopt(&self) -> Option<&dyn Adopt>;
+
+    /// The prepare capability: spawn the VMM ahead of a boot. `Some` iff
+    /// [`DriverCapabilities::prepare`]; [`boot`](Self::boot) and
+    /// [`restore`](Self::restore) behave exactly like prepare-then-boot.
+    fn prepare(&self) -> Option<&dyn Prepare> {
+        None
+    }
 }
 
 /// A running (or just-exited) VM.
@@ -157,6 +165,8 @@ pub struct DriverCapabilities {
     /// VMs outlive this process and can be adopted back ([`Adopt`] /
     /// [`Detach`]).
     pub adopt: bool,
+    /// The VMM can be spawned ahead of a boot ([`Prepare`]).
+    pub prepare: bool,
     /// Handles expose a memory balloon.
     pub balloon: bool,
     /// Handles expose the guest console output.
@@ -343,6 +353,11 @@ pub struct RestoreSpec {
     /// lands on fresh host attachments).
     #[serde(default)]
     pub nics: Vec<NicSpec>,
+    /// The disks the image references — the same ids — at their host paths
+    /// for *this* restore: a restored VM's rootfs is a fresh copy-on-write
+    /// device, never the path recorded at checkpoint time.
+    #[serde(default)]
+    pub disks: Vec<DiskSpec>,
     /// How the restored VMM process is confined.
     #[serde(default)]
     pub isolation: IsolationSpec,

--- a/virt/arcbox-vm-driver/src/driver.rs
+++ b/virt/arcbox-vm-driver/src/driver.rs
@@ -1,0 +1,330 @@
+//! The port itself: what a driver does, what a handle to a running VM is.
+//!
+//! The vocabulary here is what every orchestrator needs from every VMM and
+//! nothing a single VMM happens to offer: identify a VM, observe it, stop
+//! it. Everything else — vsock, checkpoints, adopt/detach, balloon, console,
+//! debug — is a capability reached through an `Option<&dyn Cap>` accessor
+//! (`capability` module), present only when both the driver can do it and
+//! the spec asked for the device.
+
+use std::fmt;
+use std::os::fd::OwnedFd;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::spec::{IsolationSpec, NicSpec, VmId};
+
+/// What a driver can do, independent of any one VM.
+///
+/// `capabilities()` describes the driver; a handle exposes a capability only
+/// when the spec also asked for the device (a VM booted without
+/// [`crate::VsockSpec`] has nothing to dial). The contract test-kit boots a
+/// spec that asks for everything the driver claims and checks that each
+/// flag here agrees with the matching handle accessor.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DriverCapabilities {
+    /// Handles can dial guest vsock ports (`Vsock`).
+    pub vsock: bool,
+    /// Handles can listen for guest-initiated vsock connections (`VsockListen`).
+    pub vsock_listen: bool,
+    /// Handles can be checkpointed and the driver can restore the result.
+    pub checkpoint: bool,
+    /// Checkpoints can be incremental (`CheckpointKind::Diff`).
+    pub diff_checkpoint: bool,
+    /// VMs outlive this process and can be adopted back (`Adopt` / `Detach`).
+    pub adopt: bool,
+    /// Handles expose a memory balloon.
+    pub balloon: bool,
+    /// Handles expose the guest console output.
+    pub console: bool,
+    /// Handles expose a debug snapshot.
+    pub debug: bool,
+    /// Whether guests may run their own hypervisor.
+    pub nested_virt: NestedVirt,
+}
+
+/// Whether guests under this driver may run their own hypervisor, and if
+/// not, why — in the platform's own words.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NestedVirt {
+    /// Nested virtualization is available to guests.
+    pub supported: bool,
+    /// Why not, when `supported` is false; empty otherwise.
+    pub reason: String,
+}
+
+impl NestedVirt {
+    /// Nested virtualization is available.
+    pub fn supported() -> Self {
+        Self {
+            supported: true,
+            reason: String::new(),
+        }
+    }
+
+    /// Nested virtualization is unavailable for `reason`.
+    pub fn unsupported(reason: impl Into<String>) -> Self {
+        Self {
+            supported: false,
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Where a VM is in its life.
+///
+/// `Quiesced` is reached only through the `Checkpoint` capability's
+/// `HoldQuiesced` option; there is no pause verb on the handle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VmState {
+    /// The guest is executing.
+    Running,
+    /// The guest is frozen after a checkpoint that asked to hold it.
+    Quiesced,
+    /// The VM is gone; the status says how.
+    Exited(ExitStatus),
+}
+
+impl fmt::Display for VmState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Running => f.write_str("running"),
+            Self::Quiesced => f.write_str("quiesced"),
+            Self::Exited(status) => write!(f, "exited ({status})"),
+        }
+    }
+}
+
+/// Something the VM did on its own, delivered through `VmHandle::events`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum VmEvent {
+    /// The VM stopped, whether asked to or not. Delivered exactly once.
+    Exited(ExitStatus),
+    /// The guest asked for a reset (a reboot); the orchestrator decides
+    /// whether to honor it with a stop-and-boot.
+    ResetRequested,
+}
+
+/// How a VM ended.
+///
+/// External-process VMMs report the process's wait status; in-process VMMs
+/// synthesize one (a stop on request is a clean exit, a forced kill is
+/// `signal: Some(SIGKILL)`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExitStatus {
+    /// The exit code, when the VM exited normally.
+    pub code: Option<i32>,
+    /// The signal that killed the VM, when it did not.
+    pub signal: Option<i32>,
+}
+
+impl ExitStatus {
+    /// A normal exit with `code`.
+    pub const fn exited(code: i32) -> Self {
+        Self {
+            code: Some(code),
+            signal: None,
+        }
+    }
+
+    /// A death by `signal`.
+    pub const fn signaled(signal: i32) -> Self {
+        Self {
+            code: None,
+            signal: Some(signal),
+        }
+    }
+
+    /// `true` for a normal exit with code 0 and no signal.
+    pub const fn is_clean(&self) -> bool {
+        matches!(self.code, Some(0)) && self.signal.is_none()
+    }
+}
+
+impl fmt::Display for ExitStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self.code, self.signal) {
+            (Some(code), None) => write!(f, "exit code {code}"),
+            (None, Some(signal)) => write!(f, "signal {signal}"),
+            (Some(code), Some(signal)) => write!(f, "exit code {code}, signal {signal}"),
+            (None, None) => f.write_str("unknown status"),
+        }
+    }
+}
+
+impl From<std::process::ExitStatus> for ExitStatus {
+    /// The wait status of an external VMM process, as the port sees it.
+    fn from(status: std::process::ExitStatus) -> Self {
+        use std::os::unix::process::ExitStatusExt as _;
+        Self {
+            code: status.code(),
+            signal: status.signal(),
+        }
+    }
+}
+
+/// How to stop a VM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShutdownMode {
+    /// Ask the guest to power off and wait up to `timeout`; a guest still
+    /// alive at the deadline is killed, and the returned status says which
+    /// happened.
+    Graceful {
+        /// How long the guest gets before it is killed.
+        timeout: Duration,
+    },
+    /// Stop the VM without asking the guest.
+    Kill,
+}
+
+/// The durable identity of a VM: what survives this process and what
+/// `Adopt` consumes to find the VM again.
+///
+/// Stable for a handle's whole life — the same value before, during, and
+/// after the VM runs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VmRecord {
+    /// The VM's identity.
+    pub id: VmId,
+    /// The driver that booted it (`VmDriver::name`).
+    pub driver: String,
+    /// The per-VM directory the driver was given at boot.
+    pub runtime_dir: PathBuf,
+    /// The VMM process, for external-process VMMs; `None` in-process.
+    #[serde(default)]
+    pub process: Option<ProcessRecord>,
+}
+
+/// An external VMM process.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProcessRecord {
+    /// The VMM's pid.
+    pub pid: u32,
+    /// The VMM's control socket, when it has one.
+    #[serde(default)]
+    pub api_socket: Option<PathBuf>,
+}
+
+/// What may change when a checkpoint is restored into a new VM.
+///
+/// Everything else — CPUs, memory, disks, devices — is fixed by the image.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RestoreSpec {
+    /// The restored VM's identity.
+    pub id: VmId,
+    /// The NICs to attach, in the image's bus order (a restored VM usually
+    /// lands on fresh host attachments).
+    #[serde(default)]
+    pub nics: Vec<NicSpec>,
+    /// How the restored VMM process is confined.
+    #[serde(default)]
+    pub isolation: IsolationSpec,
+}
+
+/// A connected vsock stream to the guest.
+///
+/// The consumer builds its transport from `fd` — the port hands over a raw
+/// stream socket, not an I/O object — and picks the transport style from
+/// `mode`. The descriptor's blocking flag is unspecified; the consumer sets
+/// what its reactor needs.
+#[derive(Debug)]
+pub struct VsockConn {
+    /// The connected stream socket, owned by the consumer from here on.
+    pub fd: OwnedFd,
+    /// Which transport style the driver requires on this socket.
+    pub mode: IoMode,
+}
+
+/// The one transport fact a driver has to tell its consumer.
+///
+/// The Hypervisor.framework socketpair stalls the kqueue reactor under rapid
+/// connect/teardown, so its driver hands back `Blocking`; every other
+/// adapter hands back `Async`. This is where the old backend match on the
+/// transport side stops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IoMode {
+    /// Register the socket with an async reactor.
+    Async,
+    /// Drive the socket with blocking I/O on a dedicated thread.
+    Blocking,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exit_status_is_clean_only_for_code_zero_without_signal() {
+        assert!(ExitStatus::exited(0).is_clean());
+        assert!(!ExitStatus::exited(1).is_clean());
+        assert!(!ExitStatus::signaled(9).is_clean());
+        assert!(
+            !ExitStatus {
+                code: Some(0),
+                signal: Some(15)
+            }
+            .is_clean()
+        );
+        assert!(
+            !ExitStatus {
+                code: None,
+                signal: None
+            }
+            .is_clean()
+        );
+    }
+
+    #[test]
+    fn exit_status_display_names_what_ended_the_vm() {
+        assert_eq!(ExitStatus::exited(3).to_string(), "exit code 3");
+        assert_eq!(ExitStatus::signaled(9).to_string(), "signal 9");
+        assert_eq!(
+            ExitStatus {
+                code: None,
+                signal: None
+            }
+            .to_string(),
+            "unknown status"
+        );
+        assert_eq!(
+            VmState::Exited(ExitStatus::exited(0)).to_string(),
+            "exited (exit code 0)"
+        );
+    }
+
+    #[test]
+    fn process_exit_status_maps_code_and_signal() {
+        use std::os::unix::process::ExitStatusExt as _;
+        let exited = std::process::ExitStatus::from_raw(3 << 8);
+        assert_eq!(ExitStatus::from(exited), ExitStatus::exited(3));
+        let killed = std::process::ExitStatus::from_raw(9);
+        assert_eq!(ExitStatus::from(killed), ExitStatus::signaled(9));
+    }
+
+    #[test]
+    fn vm_record_round_trips_and_defaults_the_process() {
+        let record = VmRecord {
+            id: VmId::new("vm-1").unwrap(),
+            driver: "fc".into(),
+            runtime_dir: "/run/arcbox/vm-1".into(),
+            process: Some(ProcessRecord {
+                pid: 4242,
+                api_socket: Some("/run/arcbox/vm-1/api.sock".into()),
+            }),
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        assert_eq!(serde_json::from_str::<VmRecord>(&json).unwrap(), record);
+
+        let in_process: VmRecord = serde_json::from_value(serde_json::json!({
+            "id": "vm-2",
+            "driver": "hv",
+            "runtime_dir": "/run/arcbox/vm-2",
+        }))
+        .unwrap();
+        assert_eq!(in_process.process, None);
+    }
+}

--- a/virt/arcbox-vm-driver/src/error.rs
+++ b/virt/arcbox-vm-driver/src/error.rs
@@ -4,6 +4,7 @@
 //! something says so through a capability accessor returning `None`, never
 //! through an error at call time.
 
+use crate::capability::CheckpointFormat;
 use crate::driver::VmState;
 use crate::spec::VmId;
 
@@ -30,9 +31,14 @@ pub enum Error {
         expected: &'static str,
     },
 
+    /// A restore was asked of a checkpoint another driver (or another
+    /// version of this one) wrote.
+    #[error("checkpoint format {0} is not one this driver wrote")]
+    ForeignCheckpoint(CheckpointFormat),
+
     /// The adapter itself failed: process spawn, API call, file staging.
     ///
-    /// `driver` is the adapter's `VmDriver::name`; `source` carries
+    /// `driver` is the adapter's [`crate::VmDriver::name`]; `source` carries
     /// the underlying error when there is one worth chaining.
     #[error("driver `{driver}`: {message}")]
     Driver {

--- a/virt/arcbox-vm-driver/src/error.rs
+++ b/virt/arcbox-vm-driver/src/error.rs
@@ -4,6 +4,7 @@
 //! something says so through a capability accessor returning `None`, never
 //! through an error at call time.
 
+use crate::driver::VmState;
 use crate::spec::VmId;
 
 /// Errors raised by drivers, handles, and the guest-network port.
@@ -16,6 +17,18 @@ pub enum Error {
     /// No VM with this id is known to the driver or network.
     #[error("vm {0} not found")]
     NotFound(VmId),
+
+    /// The VM is in a state the operation cannot act on (dialing an exited
+    /// VM, checkpointing one that already exited).
+    #[error("vm {id} is {state}; expected {expected}")]
+    WrongState {
+        /// The VM.
+        id: VmId,
+        /// Where it actually is.
+        state: VmState,
+        /// What the operation needed, e.g. `"running"`.
+        expected: &'static str,
+    },
 
     /// The adapter itself failed: process spawn, API call, file staging.
     ///

--- a/virt/arcbox-vm-driver/src/error.rs
+++ b/virt/arcbox-vm-driver/src/error.rs
@@ -9,7 +9,7 @@ use crate::spec::VmId;
 /// Errors raised by drivers, handles, and the guest-network port.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// A `VmSpec` (or a piece of it) failed validation.
+    /// A [`crate::VmSpec`] (or a piece of it) failed validation.
     #[error("invalid spec: {0}")]
     InvalidSpec(String),
 

--- a/virt/arcbox-vm-driver/src/error.rs
+++ b/virt/arcbox-vm-driver/src/error.rs
@@ -1,0 +1,45 @@
+//! The one error type every port method speaks.
+//!
+//! There is deliberately no `Unsupported` variant: a driver that cannot do
+//! something says so through a capability accessor returning `None`, never
+//! through an error at call time.
+
+use crate::spec::VmId;
+
+/// Errors raised by drivers, handles, and the guest-network port.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A `VmSpec` (or a piece of it) failed validation.
+    #[error("invalid spec: {0}")]
+    InvalidSpec(String),
+
+    /// No VM with this id is known to the driver or network.
+    #[error("vm {0} not found")]
+    NotFound(VmId),
+
+    /// The adapter itself failed: process spawn, API call, file staging.
+    ///
+    /// `driver` is the adapter's `VmDriver::name`; `source` carries
+    /// the underlying error when there is one worth chaining.
+    #[error("driver `{driver}`: {message}")]
+    Driver {
+        /// The adapter that raised the error.
+        driver: &'static str,
+        /// What failed, in the adapter's words.
+        message: String,
+        /// The underlying error, if any.
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
+
+    /// A host I/O failure surfaced unchanged.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// The guest-network port refused or failed an operation.
+    #[error("network: {0}")]
+    Network(String),
+}
+
+/// `Result` specialised to this crate's [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;

--- a/virt/arcbox-vm-driver/src/lib.rs
+++ b/virt/arcbox-vm-driver/src/lib.rs
@@ -11,6 +11,9 @@
 //! # What is here
 //!
 //! - [`spec`] — the serializable per-VM shape: [`VmSpec`] and its parts.
+//! - [`driver`] — the handle vocabulary: [`VmState`], [`VmEvent`],
+//!   [`ExitStatus`], [`ShutdownMode`], the durable [`VmRecord`], and
+//!   [`DriverCapabilities`], what a driver claims it can do.
 //! - [`error`] — the one [`Error`] every port method speaks. There is no
 //!   `Unsupported` variant: what a driver cannot do is a capability
 //!   accessor returning `None`, never an error at call time.
@@ -32,9 +35,14 @@
 
 #![warn(missing_docs)]
 
+pub mod driver;
 pub mod error;
 pub mod spec;
 
+pub use driver::{
+    DriverCapabilities, ExitStatus, IoMode, NestedVirt, ProcessRecord, RestoreSpec, ShutdownMode,
+    VmEvent, VmRecord, VmState, VsockConn,
+};
 pub use error::{Error, Result};
 pub use spec::{
     BootSpec, CacheMode, CgroupSpec, ConsoleSpec, DiskSpec, IsolationSpec, MacAddr, NicAttachment,

--- a/virt/arcbox-vm-driver/src/lib.rs
+++ b/virt/arcbox-vm-driver/src/lib.rs
@@ -10,20 +10,19 @@
 //!
 //! # What is here
 //!
-//! - [`spec`] — the serializable per-VM shape, starting with the identity
-//!   vocabulary: [`VmId`] and [`MacAddr`].
+//! - [`spec`] — the serializable per-VM shape: [`VmSpec`] and its parts.
 //! - [`error`] — the one [`Error`] every port method speaks. There is no
 //!   `Unsupported` variant: what a driver cannot do is a capability
 //!   accessor returning `None`, never an error at call time.
 //!
-//! The full `VmSpec`, the driver and handle traits, the capability traits,
-//! the guest-network port, and the `testkit` feature (fake driver, fake
-//! network, contract test-kit) land in the sibling modules.
+//! The driver and handle traits, the capability traits, the guest-network
+//! port, and the `testkit` feature (fake driver, fake network, contract
+//! test-kit) land in the sibling modules.
 //!
 //! # Rules the crate is held to
 //!
 //! - No `arcbox-*` dependency, ever: the port sits below every adapter.
-//! - Data is `serde`; behavior is a trait object. A VM spec can be
+//! - Data is `serde`; behavior is a trait object. A [`VmSpec`] can be
 //!   written in a TOML file; a driver cannot.
 //! - Node-wide knobs (binary paths, seccomp, jailer defaults) are the
 //!   adapter's own config, not part of the spec.
@@ -37,4 +36,7 @@ pub mod error;
 pub mod spec;
 
 pub use error::{Error, Result};
-pub use spec::{MacAddr, VmId};
+pub use spec::{
+    BootSpec, CacheMode, CgroupSpec, ConsoleSpec, DiskSpec, IsolationSpec, MacAddr, NicAttachment,
+    NicSpec, ShareSpec, VmId, VmSpec, VsockSpec,
+};

--- a/virt/arcbox-vm-driver/src/lib.rs
+++ b/virt/arcbox-vm-driver/src/lib.rs
@@ -21,12 +21,15 @@
 //!   [`Console`], [`DebugSnapshot`]. A handle exposes each through an
 //!   `Option<&dyn Cap>` accessor, `Some` only when the driver can and the
 //!   spec asked; `capabilities()` must agree with the accessors.
+//! - [`net`] — the second port: [`net::GuestNetwork`] plans and builds
+//!   what a NIC is attached to and hands the driver a [`NicSpec`];
+//!   [`net::NetworkReconcile`] is its token-guarded cleanup protocol.
 //! - [`error`] — the one [`Error`] every port method speaks. There is no
 //!   `Unsupported` variant: what a driver cannot do is a capability
 //!   accessor returning `None`, never an error at call time.
 //!
-//! The guest-network port and the `testkit` feature (fake driver, fake
-//! network, contract test-kit) land in the sibling modules.
+//! The `testkit` feature (fake driver, fake network, contract test-kit)
+//! lands in the sibling module.
 //!
 //! # Rules the crate is held to
 //!
@@ -44,6 +47,7 @@
 pub mod capability;
 pub mod driver;
 pub mod error;
+pub mod net;
 pub mod spec;
 
 pub use capability::{

--- a/virt/arcbox-vm-driver/src/lib.rs
+++ b/virt/arcbox-vm-driver/src/lib.rs
@@ -17,10 +17,11 @@
 //!   ([`VmState`], [`VmEvent`], [`ExitStatus`], [`ShutdownMode`],
 //!   [`VmRecord`]) and [`DriverCapabilities`], what a driver claims.
 //! - [`capability`] — everything optional, one trait each: [`Vsock`],
-//!   [`VsockListen`], [`Checkpoint`], [`Adopt`]/[`Detach`], [`Balloon`],
-//!   [`Console`], [`DebugSnapshot`]. A handle exposes each through an
-//!   `Option<&dyn Cap>` accessor, `Some` only when the driver can and the
-//!   spec asked; `capabilities()` must agree with the accessors.
+//!   [`VsockListen`], [`Checkpoint`], [`Adopt`]/[`Detach`], [`Prepare`],
+//!   [`Balloon`], [`Console`], [`DebugSnapshot`]. A handle (or the driver,
+//!   for `Adopt` and `Prepare`) exposes each through an `Option<&dyn Cap>`
+//!   accessor, `Some` only when the driver can and the spec asked;
+//!   `capabilities()` must agree with the accessors.
 //! - [`net`] — the second port: [`net::GuestNetwork`] plans and builds
 //!   what a NIC is attached to and hands the driver a [`NicSpec`];
 //!   [`net::NetworkReconcile`] is its token-guarded cleanup protocol.
@@ -55,8 +56,8 @@ pub mod testkit;
 
 pub use capability::{
     Adopt, AfterCheckpoint, Balloon, BalloonStats, Checkpoint, CheckpointFormat, CheckpointImage,
-    CheckpointKind, CheckpointOptions, Console, DebugSnapshot, Detach, Vsock, VsockListen,
-    VsockListener,
+    CheckpointKind, CheckpointOptions, Console, DebugSnapshot, Detach, Prepare, PreparedVm, Vsock,
+    VsockListen, VsockListener,
 };
 pub use driver::{
     DriverCapabilities, ExitStatus, IoMode, NestedVirt, ProcessRecord, RestoreSpec, ShutdownMode,

--- a/virt/arcbox-vm-driver/src/lib.rs
+++ b/virt/arcbox-vm-driver/src/lib.rs
@@ -1,0 +1,40 @@
+//! `arcbox-vm-driver` — the VM driver port: the vocabulary of "a VM on this
+//! host", and nothing else.
+//!
+//! ArcBox runs VMs under several VMMs — Firecracker and Cloud Hypervisor as
+//! external processes, Virtualization.framework as a managed VMM, its own
+//! Hypervisor.framework engine in-process. Orchestrators (the computer
+//! runtime, the engine's machine registry) must not know which. This crate
+//! is the seam between them: adapters implement it, orchestrators consume
+//! it, and only a composition root names both.
+//!
+//! # What is here
+//!
+//! - [`spec`] — the serializable per-VM shape, starting with the identity
+//!   vocabulary: [`VmId`] and [`MacAddr`].
+//! - [`error`] — the one [`Error`] every port method speaks. There is no
+//!   `Unsupported` variant: what a driver cannot do is a capability
+//!   accessor returning `None`, never an error at call time.
+//!
+//! The full `VmSpec`, the driver and handle traits, the capability traits,
+//! the guest-network port, and the `testkit` feature (fake driver, fake
+//! network, contract test-kit) land in the sibling modules.
+//!
+//! # Rules the crate is held to
+//!
+//! - No `arcbox-*` dependency, ever: the port sits below every adapter.
+//! - Data is `serde`; behavior is a trait object. A VM spec can be
+//!   written in a TOML file; a driver cannot.
+//! - Node-wide knobs (binary paths, seccomp, jailer defaults) are the
+//!   adapter's own config, not part of the spec.
+//!
+//! Design: company repo `engineering/arcbox/architecture/vm-stack-redesign.md`
+//! (D-VM1, D-VM7, D-VM9).
+
+#![warn(missing_docs)]
+
+pub mod error;
+pub mod spec;
+
+pub use error::{Error, Result};
+pub use spec::{MacAddr, VmId};

--- a/virt/arcbox-vm-driver/src/lib.rs
+++ b/virt/arcbox-vm-driver/src/lib.rs
@@ -28,7 +28,6 @@
 //! - [`error`] — the one [`Error`] every port method speaks. There is no
 //!   `Unsupported` variant: what a driver cannot do is a capability
 //!   accessor returning `None`, never an error at call time.
-//!
 //! - `testkit` (feature) — the fakes and the contract test-kit: a
 //!   `FakeDriver` and `FakeNetwork` for runtime unit tests on any host, and
 //!   `driver_contract!`, the checks every adapter must pass.

--- a/virt/arcbox-vm-driver/src/lib.rs
+++ b/virt/arcbox-vm-driver/src/lib.rs
@@ -29,8 +29,8 @@
 //!   accessor returning `None`, never an error at call time.
 //!
 //! - `testkit` (feature) — the fakes and the contract test-kit: a
-//!   `FakeDriver` for runtime unit tests on any host, and the checks every
-//!   adapter must pass.
+//!   `FakeDriver` and `FakeNetwork` for runtime unit tests on any host, and
+//!   `driver_contract!`, the checks every adapter must pass.
 //!
 //! # Rules the crate is held to
 //!

--- a/virt/arcbox-vm-driver/src/lib.rs
+++ b/virt/arcbox-vm-driver/src/lib.rs
@@ -11,16 +11,22 @@
 //! # What is here
 //!
 //! - [`spec`] — the serializable per-VM shape: [`VmSpec`] and its parts.
-//! - [`driver`] — the handle vocabulary: [`VmState`], [`VmEvent`],
-//!   [`ExitStatus`], [`ShutdownMode`], the durable [`VmRecord`], and
-//!   [`DriverCapabilities`], what a driver claims it can do.
+//! - [`driver`] — the port: [`VmDriver`] boots a spec into a [`VmHandle`],
+//!   whose mandatory surface is identify (`id`/`record`), observe
+//!   (`state`/`events`), and stop (`shutdown`); plus the handle vocabulary
+//!   ([`VmState`], [`VmEvent`], [`ExitStatus`], [`ShutdownMode`],
+//!   [`VmRecord`]) and [`DriverCapabilities`], what a driver claims.
+//! - [`capability`] — everything optional, one trait each: [`Vsock`],
+//!   [`VsockListen`], [`Checkpoint`], [`Adopt`]/[`Detach`], [`Balloon`],
+//!   [`Console`], [`DebugSnapshot`]. A handle exposes each through an
+//!   `Option<&dyn Cap>` accessor, `Some` only when the driver can and the
+//!   spec asked; `capabilities()` must agree with the accessors.
 //! - [`error`] — the one [`Error`] every port method speaks. There is no
 //!   `Unsupported` variant: what a driver cannot do is a capability
 //!   accessor returning `None`, never an error at call time.
 //!
-//! The driver and handle traits, the capability traits, the guest-network
-//! port, and the `testkit` feature (fake driver, fake network, contract
-//! test-kit) land in the sibling modules.
+//! The guest-network port and the `testkit` feature (fake driver, fake
+//! network, contract test-kit) land in the sibling modules.
 //!
 //! # Rules the crate is held to
 //!
@@ -35,13 +41,19 @@
 
 #![warn(missing_docs)]
 
+pub mod capability;
 pub mod driver;
 pub mod error;
 pub mod spec;
 
+pub use capability::{
+    Adopt, AfterCheckpoint, Balloon, BalloonStats, Checkpoint, CheckpointFormat, CheckpointImage,
+    CheckpointKind, CheckpointOptions, Console, DebugSnapshot, Detach, Vsock, VsockListen,
+    VsockListener,
+};
 pub use driver::{
     DriverCapabilities, ExitStatus, IoMode, NestedVirt, ProcessRecord, RestoreSpec, ShutdownMode,
-    VmEvent, VmRecord, VmState, VsockConn,
+    VmDriver, VmEvent, VmHandle, VmRecord, VmState, VsockConn,
 };
 pub use error::{Error, Result};
 pub use spec::{

--- a/virt/arcbox-vm-driver/src/lib.rs
+++ b/virt/arcbox-vm-driver/src/lib.rs
@@ -28,8 +28,9 @@
 //!   `Unsupported` variant: what a driver cannot do is a capability
 //!   accessor returning `None`, never an error at call time.
 //!
-//! The `testkit` feature (fake driver, fake network, contract test-kit)
-//! lands in the sibling module.
+//! - `testkit` (feature) — the fakes and the contract test-kit: a
+//!   `FakeDriver` for runtime unit tests on any host, and the checks every
+//!   adapter must pass.
 //!
 //! # Rules the crate is held to
 //!
@@ -49,6 +50,8 @@ pub mod driver;
 pub mod error;
 pub mod net;
 pub mod spec;
+#[cfg(feature = "testkit")]
+pub mod testkit;
 
 pub use capability::{
     Adopt, AfterCheckpoint, Balloon, BalloonStats, Checkpoint, CheckpointFormat, CheckpointImage,

--- a/virt/arcbox-vm-driver/src/net.rs
+++ b/virt/arcbox-vm-driver/src/net.rs
@@ -1,0 +1,169 @@
+//! The second port in this crate: what a VM's NIC is attached to.
+//!
+//! [`GuestNetwork`] plans and builds the host side of a guest interface —
+//! an address, a TAP or equivalent, filters — and hands the driver a
+//! [`NicSpec`] to boot with. The Linux TAP adapter, the platform's IPv6
+//! dataplane, and the trivial MAC-minting networks behind the VZ/HV drivers
+//! all sit behind it. Cleanup after a VM is a two-step, token-guarded
+//! protocol ([`NetworkReconcile`]) because host forwarding state outlives
+//! the VM and must be confirmed gone before an address is reused.
+
+use std::net::IpAddr;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+use crate::spec::{MacAddr, NicSpec, VmId};
+
+/// Plans, builds, and tears down the host side of guest NICs.
+#[async_trait]
+pub trait GuestNetwork: Send + Sync {
+    /// Reserves an address and plans host resources for `vm`; nothing is
+    /// created on the host yet.
+    async fn reserve(&self, vm: &VmId, policy: NetworkPolicy) -> Result<NetworkLease>;
+
+    /// Creates the host side (TAP, filters) for `lease` and returns the NIC
+    /// the driver boots with.
+    async fn activate(&self, lease: &NetworkLease, mode: AttachMode) -> Result<NicSpec>;
+
+    /// Tears the host side down but keeps the address reserved until the
+    /// cleanup protocol confirms host forwarding state is gone. Idempotent.
+    async fn quarantine(&self, lease: NetworkLease) -> Result<()>;
+
+    /// Returns the address to the pool outright, skipping quarantine.
+    async fn release(&self, lease: NetworkLease) -> Result<()>;
+
+    /// The network as the guest sees it: what goes on the kernel command
+    /// line or into a net-reconfigure command.
+    fn identity(&self, lease: &NetworkLease) -> NetworkIdentity;
+
+    /// The cleanup-token protocol and startup sweep, when the network keeps
+    /// a quarantine ledger.
+    fn reconcile(&self) -> Option<&dyn NetworkReconcile> {
+        None
+    }
+}
+
+/// What kind of connectivity a VM gets.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkPolicy {
+    /// The connectivity mode.
+    pub mode: NetworkMode,
+}
+
+/// Connectivity modes a network may offer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum NetworkMode {
+    /// Host and guest can talk; nothing beyond the host.
+    Isolated,
+    /// Egress through the host's address.
+    Nat,
+    /// The guest appears on the host's link.
+    Bridged,
+}
+
+/// How the host side is attached, for networks that keep the legacy shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachMode {
+    /// Fixed guest identity with per-interface translation host-side: every
+    /// fresh boot and every invariant-snapshot restore.
+    Invariant,
+    /// The interface carries the pool address itself: restores of
+    /// checkpoints taken before the invariant identity existed.
+    LegacySnapshot,
+}
+
+/// A reserved address and the host resources planned for one VM.
+///
+/// Serialized into the VM's durable record so cleanup can be replayed after
+/// a crash; `cleanup_token` is what the two-step cleanup protocol checks.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkLease {
+    /// The VM this lease belongs to.
+    pub vm: VmId,
+    /// The guest's address.
+    pub ip: IpAddr,
+    /// The subnet prefix length.
+    pub prefix_len: u8,
+    /// The gateway the guest routes through.
+    pub gateway: IpAddr,
+    /// The guest's MAC address.
+    pub mac: MacAddr,
+    /// Opaque; presented to [`NetworkReconcile::finalize_cleanup`] to prove
+    /// the caller is finishing *this* generation of the VM's cleanup.
+    pub cleanup_token: String,
+}
+
+/// The network as the guest sees it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkIdentity {
+    /// The guest's address.
+    pub ip: IpAddr,
+    /// The subnet prefix length.
+    pub prefix_len: u8,
+    /// The gateway the guest routes through.
+    pub gateway: IpAddr,
+    /// Resolvers the guest should use.
+    pub dns: Vec<IpAddr>,
+    /// The guest's MAC address.
+    pub mac: MacAddr,
+}
+
+/// The quarantine ledger's cleanup protocol.
+///
+/// Two flows share the token discipline. Per VM: after `quarantine`, the
+/// host side (forwarding rules, listeners) is cleaned by someone else, who
+/// then `validate`s and `finalize`s with the lease's token; only then does
+/// the address return to the pool. At startup: the network sweeps what a
+/// previous process left behind and, when there is anything, mints a
+/// startup token that gates the same validate/finalize pair before the
+/// network declares itself settled.
+#[async_trait]
+pub trait NetworkReconcile: Send + Sync {
+    /// VMs whose leases are quarantined, with the token each finalization
+    /// must present.
+    async fn pending_cleanups(&self) -> Vec<(VmId, String)>;
+
+    /// Checks that `token` names `vm`'s pending cleanup generation.
+    async fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<()>;
+
+    /// Ends `vm`'s quarantine and returns its address to the pool.
+    async fn finalize_cleanup(&self, vm: &VmId, token: &str) -> Result<()>;
+
+    /// The token for the startup sweep's host-side cleanup, while one is
+    /// pending.
+    async fn startup_cleanup_token(&self) -> Option<String>;
+
+    /// Checks that `token` names the pending startup cleanup.
+    async fn validate_startup_cleanup(&self, token: &str) -> Result<()>;
+
+    /// Marks the startup sweep's host-side cleanup done.
+    async fn finalize_startup_cleanup(&self, token: &str) -> Result<()>;
+
+    /// Waits until no startup cleanup is pending.
+    async fn wait_startup_cleanup_complete(&self);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lease_round_trips_through_json() {
+        let lease = NetworkLease {
+            vm: VmId::new("vm-1").unwrap(),
+            ip: "10.200.0.2".parse().unwrap(),
+            prefix_len: 16,
+            gateway: "10.200.0.1".parse().unwrap(),
+            mac: "02:fa:ce:00:00:02".parse().unwrap(),
+            cleanup_token: "gen-1".into(),
+        };
+        let json = serde_json::to_string(&lease).unwrap();
+        assert_eq!(serde_json::from_str::<NetworkLease>(&json).unwrap(), lease);
+        assert!(json.contains("\"02:fa:ce:00:00:02\""));
+        assert!(json.contains("\"10.200.0.2\""));
+    }
+}

--- a/virt/arcbox-vm-driver/src/spec.rs
+++ b/virt/arcbox-vm-driver/src/spec.rs
@@ -209,9 +209,10 @@ pub struct VmSpec {
 impl VmSpec {
     /// Checks the invariants no driver can repair.
     ///
-    /// CPU and memory are at least 1; disk ids and NIC ids are non-empty
-    /// and unique; at most one disk is the root; every MAC is a non-nil
-    /// unicast address; every boot path is non-empty.
+    /// CPU and memory are at least 1; disk ids, NIC ids and share tags are
+    /// non-empty and unique; at most one disk is the root; every MAC is a
+    /// non-nil unicast address; every boot, disk and share path is
+    /// non-empty; the vsock guest CID is 3 or above.
     pub fn validate(&self) -> Result<()> {
         if self.cpus == 0 {
             return Err(Error::InvalidSpec("cpus must be at least 1".into()));
@@ -252,6 +253,28 @@ impl VmSpec {
                     nic.id, nic.mac
                 )));
             }
+        }
+        if let Some(vsock) = &self.vsock
+            && vsock.guest_cid < VsockSpec::FIRST_GUEST_CID
+        {
+            return Err(Error::InvalidSpec(format!(
+                "vsock guest_cid {} is reserved; use {} or above",
+                vsock.guest_cid,
+                VsockSpec::FIRST_GUEST_CID
+            )));
+        }
+        let mut share_tags = HashSet::new();
+        for share in &self.shares {
+            if share.tag.is_empty() {
+                return Err(Error::InvalidSpec("share tag must not be empty".into()));
+            }
+            if !share_tags.insert(share.tag.as_str()) {
+                return Err(Error::InvalidSpec(format!(
+                    "duplicate share tag `{}`",
+                    share.tag
+                )));
+            }
+            require_path("share host path", &share.host_path)?;
         }
         Ok(())
     }
@@ -381,8 +404,14 @@ pub enum NicAttachment {
 /// The vsock device.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VsockSpec {
-    /// The guest's context id (3 or above; 2 is the host).
+    /// The guest's context id: [`Self::FIRST_GUEST_CID`] or above (0 and 1
+    /// are reserved, 2 is the host).
     pub guest_cid: u32,
+}
+
+impl VsockSpec {
+    /// The lowest context id a guest may take.
+    pub const FIRST_GUEST_CID: u32 = 3;
 }
 
 /// One shared host directory (virtiofs).
@@ -592,6 +621,47 @@ mod tests {
         let mut s = spec();
         s.nics[0].id.clear();
         assert!(invalid(&s).contains("nic id"));
+    }
+
+    #[test]
+    fn vsock_guest_cid_must_not_be_reserved() {
+        for cid in 0..VsockSpec::FIRST_GUEST_CID {
+            let mut s = spec();
+            s.vsock = Some(VsockSpec { guest_cid: cid });
+            assert!(invalid(&s).contains("guest_cid"), "cid {cid} accepted");
+        }
+        let mut s = spec();
+        s.vsock = Some(VsockSpec {
+            guest_cid: VsockSpec::FIRST_GUEST_CID,
+        });
+        s.validate().unwrap();
+    }
+
+    #[test]
+    fn share_tags_must_be_unique_and_paths_non_empty() {
+        let share = ShareSpec {
+            tag: "data".into(),
+            host_path: "/srv/data".into(),
+            read_only: false,
+        };
+        let mut s = spec();
+        s.shares = vec![share.clone(), share.clone()];
+        assert!(invalid(&s).contains("duplicate share tag"));
+        let mut s = spec();
+        s.shares = vec![ShareSpec {
+            tag: String::new(),
+            ..share.clone()
+        }];
+        assert!(invalid(&s).contains("share tag"));
+        let mut s = spec();
+        s.shares = vec![ShareSpec {
+            host_path: PathBuf::new(),
+            ..share.clone()
+        }];
+        assert!(invalid(&s).contains("share host path"));
+        let mut s = spec();
+        s.shares = vec![share];
+        s.validate().unwrap();
     }
 
     #[test]

--- a/virt/arcbox-vm-driver/src/spec.rs
+++ b/virt/arcbox-vm-driver/src/spec.rs
@@ -2,11 +2,13 @@
 //!
 //! Everything here is data. Node-wide knobs — VMM binary paths, seccomp,
 //! jailer defaults, MTU — are the adapter's own `DriverConfig`; a
-//! `VmSpec` says only what *this* VM is made of, so the same spec renders
+//! [`VmSpec`] says only what *this* VM is made of, so the same spec renders
 //! into a Firecracker API payload, a Virtualization.framework configuration,
 //! or an in-process VMM's config without the orchestrator knowing which.
 
 use std::fmt;
+use std::os::fd::RawFd;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
@@ -159,12 +161,251 @@ impl<'de> Deserialize<'de> for MacAddr {
     }
 }
 
+/// Everything a driver needs to boot one VM.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VmSpec {
+    /// The VM's identity.
+    pub id: VmId,
+    /// Virtual CPU count, at least 1.
+    pub cpus: u32,
+    /// Guest memory in MiB, at least 1.
+    pub memory_mib: u32,
+    /// How the guest starts.
+    pub boot: BootSpec,
+    /// Block devices, in bus order.
+    #[serde(default)]
+    pub disks: Vec<DiskSpec>,
+    /// Network interfaces, in bus order.
+    #[serde(default)]
+    pub nics: Vec<NicSpec>,
+    /// The vsock device, when the guest should have one.
+    #[serde(default)]
+    pub vsock: Option<VsockSpec>,
+    /// Shared host directories (virtiofs).
+    #[serde(default)]
+    pub shares: Vec<ShareSpec>,
+    /// Where the guest console goes.
+    #[serde(default)]
+    pub console: ConsoleSpec,
+    /// Attach a memory balloon.
+    #[serde(default)]
+    pub balloon: bool,
+    /// Attach an entropy (virtio-rng) device.
+    #[serde(default)]
+    pub entropy: bool,
+    /// Track dirty pages so a checkpoint can be incremental.
+    #[serde(default)]
+    pub dirty_tracking: bool,
+    /// How the VMM process is confined.
+    #[serde(default)]
+    pub isolation: IsolationSpec,
+}
+
+/// How the guest starts.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum BootSpec {
+    /// Direct kernel boot.
+    Kernel {
+        /// The kernel image (vmlinux / Image).
+        image: PathBuf,
+        /// The kernel command line, verbatim.
+        cmdline: String,
+        /// An optional initial ramdisk.
+        initrd: Option<PathBuf>,
+    },
+    /// Firmware (UEFI) boot; the firmware finds the OS on the disks.
+    Firmware {
+        /// The firmware image.
+        image: PathBuf,
+    },
+    /// A macOS guest under Virtualization.framework.
+    MacOs {
+        /// The auxiliary storage (NVRAM) file.
+        aux_storage: PathBuf,
+        /// The opaque hardware-model blob the guest was installed for.
+        hardware_model: Vec<u8>,
+        /// The opaque machine-identifier blob.
+        machine_id: Vec<u8>,
+    },
+}
+
+/// One block device.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiskSpec {
+    /// Unique within the spec; drivers use it as the device's name.
+    pub id: String,
+    /// The backing file on the host.
+    pub path: PathBuf,
+    /// Expose the disk read-only.
+    #[serde(default)]
+    pub read_only: bool,
+    /// This disk holds the root filesystem (at most one per spec).
+    #[serde(default)]
+    pub root: bool,
+    /// Host-side write caching.
+    #[serde(default)]
+    pub cache: CacheMode,
+}
+
+/// Host-side write caching for a disk (Firecracker's `DriveCacheType`).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheMode {
+    /// Writes complete when the host has them in memory (today's value).
+    #[default]
+    Unsafe,
+    /// Writes complete when the host has flushed them.
+    Writeback,
+}
+
+/// One network interface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NicSpec {
+    /// Unique within the spec; drivers use it as the device's name.
+    pub id: String,
+    /// The guest-visible MAC address.
+    pub mac: MacAddr,
+    /// What the host side of the interface is plugged into.
+    pub attachment: NicAttachment,
+}
+
+/// The host side of a NIC.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum NicAttachment {
+    /// A Linux TAP device the guest network created.
+    Tap {
+        /// The interface name (`tap12`).
+        name: String,
+    },
+    /// The VMM's own NAT (Virtualization.framework's `NAT` attachment).
+    HostNat,
+    /// A host socket the VMM reads and writes Ethernet frames on.
+    ///
+    /// The number is a *borrowed* descriptor: the caller keeps it open for the
+    /// duration of `VmDriver::boot`, and the driver duplicates it if
+    /// the VMM needs it beyond that call.
+    FileHandle {
+        /// The raw descriptor number, valid in the calling process.
+        fd: RawFd,
+    },
+    /// A host bridge interface (vmnet bridged mode, a Linux bridge).
+    Bridge {
+        /// The host interface to bridge onto.
+        interface: String,
+    },
+}
+
+/// The vsock device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VsockSpec {
+    /// The guest's context id (3 or above; 2 is the host).
+    pub guest_cid: u32,
+}
+
+/// One shared host directory (virtiofs).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ShareSpec {
+    /// The mount tag the guest sees.
+    pub tag: String,
+    /// The host directory.
+    pub host_path: PathBuf,
+    /// Export read-only.
+    #[serde(default)]
+    pub read_only: bool,
+}
+
+/// Where the guest console goes.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ConsoleSpec {
+    /// No console device.
+    #[default]
+    Off,
+    /// Append console output to a file.
+    File(PathBuf),
+    /// Serve the console on a Unix socket.
+    Socket(PathBuf),
+}
+
+/// How the VMM process is confined.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum IsolationSpec {
+    /// Run the VMM as the caller, unconfined.
+    #[default]
+    None,
+    /// Run under a jailer (Firecracker's `jailer`, or an equivalent).
+    Jailer {
+        /// The uid the VMM drops to.
+        uid: u32,
+        /// The gid the VMM drops to.
+        gid: u32,
+        /// The directory the per-VM chroot is created under.
+        chroot_base: PathBuf,
+        /// A network namespace to enter (`/var/run/netns/<name>`).
+        netns: Option<PathBuf>,
+        /// Start the VMM in a fresh PID namespace.
+        new_pid_ns: bool,
+        /// Cgroup placement.
+        cgroup: Option<CgroupSpec>,
+    },
+}
+
+/// Cgroup placement for a jailed VMM.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CgroupSpec {
+    /// The cgroup hierarchy version (1 or 2).
+    pub version: u8,
+    /// The parent cgroup, relative to the hierarchy root.
+    pub parent: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn mac(n: u8) -> MacAddr {
         MacAddr::new([0x02, 0, 0, 0, 0, n])
+    }
+
+    fn spec() -> VmSpec {
+        VmSpec {
+            id: VmId::new("vm-1").unwrap(),
+            cpus: 2,
+            memory_mib: 512,
+            boot: BootSpec::Kernel {
+                image: "/boot/vmlinux".into(),
+                cmdline: "console=ttyS0".into(),
+                initrd: None,
+            },
+            disks: vec![DiskSpec {
+                id: "rootfs".into(),
+                path: "/img/rootfs.ext4".into(),
+                read_only: false,
+                root: true,
+                cache: CacheMode::default(),
+            }],
+            nics: vec![NicSpec {
+                id: "eth0".into(),
+                mac: mac(1),
+                attachment: NicAttachment::Tap {
+                    name: "tap0".into(),
+                },
+            }],
+            vsock: Some(VsockSpec { guest_cid: 3 }),
+            shares: vec![],
+            console: ConsoleSpec::Off,
+            balloon: false,
+            entropy: true,
+            dirty_tracking: false,
+            isolation: IsolationSpec::None,
+        }
     }
 
     #[test]
@@ -214,5 +455,44 @@ mod tests {
         assert!(!MacAddr::new([0x01, 0, 0x5e, 0, 0, 1]).is_unicast());
         assert!(MacAddr::new([0; 6]).is_nil());
         assert!(!mac(1).is_nil());
+    }
+
+    #[test]
+    fn spec_round_trips_through_json_with_defaults_filled() {
+        let mut s = spec();
+        s.isolation = IsolationSpec::Jailer {
+            uid: 1000,
+            gid: 1000,
+            chroot_base: "/srv/jailer".into(),
+            netns: None,
+            new_pid_ns: true,
+            cgroup: Some(CgroupSpec {
+                version: 2,
+                parent: Some("arcbox".into()),
+            }),
+        };
+        s.console = ConsoleSpec::File("/tmp/console.log".into());
+        s.nics.push(NicSpec {
+            id: "eth1".into(),
+            mac: mac(3),
+            attachment: NicAttachment::FileHandle { fd: 7 },
+        });
+        let json = serde_json::to_string(&s).unwrap();
+        let back: VmSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, s);
+
+        // A minimal document — only the required fields — decodes with the
+        // documented defaults, which is what a hand-written TOML relies on.
+        let minimal = serde_json::json!({
+            "id": "vm-2",
+            "cpus": 1,
+            "memory_mib": 128,
+            "boot": { "firmware": { "image": "/fw/OVMF.fd" } },
+        });
+        let s: VmSpec = serde_json::from_value(minimal).unwrap();
+        assert_eq!(s.console, ConsoleSpec::Off);
+        assert_eq!(s.isolation, IsolationSpec::None);
+        assert!(s.disks.is_empty() && s.nics.is_empty() && s.vsock.is_none());
+        assert!(!s.balloon && !s.entropy && !s.dirty_tracking);
     }
 }

--- a/virt/arcbox-vm-driver/src/spec.rs
+++ b/virt/arcbox-vm-driver/src/spec.rs
@@ -390,6 +390,13 @@ pub enum NicAttachment {
     /// The number is a *borrowed* descriptor: the caller keeps it open for the
     /// duration of `VmDriver::boot`, and the driver duplicates it if
     /// the VMM needs it beyond that call.
+    ///
+    /// It is meaningful only in the process that opened it, so a spec
+    /// carrying this variant is process-local: it serializes (the number is
+    /// just data), but it is not what goes into a durable record or a TOML
+    /// file — an orchestrator persists the VM's identity as
+    /// [`VmRecord`](crate::driver::VmRecord) and re-derives the attachment
+    /// when it builds the next spec.
     FileHandle {
         /// The raw descriptor number, valid in the calling process.
         fd: RawFd,

--- a/virt/arcbox-vm-driver/src/spec.rs
+++ b/virt/arcbox-vm-driver/src/spec.rs
@@ -6,9 +6,10 @@
 //! into a Firecracker API payload, a Virtualization.framework configuration,
 //! or an in-process VMM's config without the orchestrator knowing which.
 
+use std::collections::HashSet;
 use std::fmt;
 use std::os::fd::RawFd;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
@@ -162,6 +163,10 @@ impl<'de> Deserialize<'de> for MacAddr {
 }
 
 /// Everything a driver needs to boot one VM.
+///
+/// Validate with [`VmSpec::validate`] before handing it to a driver; drivers
+/// validate again at `VmDriver::boot`, so an orchestrator that
+/// forgets still gets [`Error::InvalidSpec`] rather than a half-built VM.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VmSpec {
     /// The VM's identity.
@@ -201,6 +206,64 @@ pub struct VmSpec {
     pub isolation: IsolationSpec,
 }
 
+impl VmSpec {
+    /// Checks the invariants no driver can repair.
+    ///
+    /// CPU and memory are at least 1; disk ids and NIC ids are non-empty
+    /// and unique; at most one disk is the root; every MAC is a non-nil
+    /// unicast address; every boot path is non-empty.
+    pub fn validate(&self) -> Result<()> {
+        if self.cpus == 0 {
+            return Err(Error::InvalidSpec("cpus must be at least 1".into()));
+        }
+        if self.memory_mib == 0 {
+            return Err(Error::InvalidSpec("memory_mib must be at least 1".into()));
+        }
+        self.boot.validate()?;
+        let mut disk_ids = HashSet::new();
+        for disk in &self.disks {
+            if disk.id.is_empty() {
+                return Err(Error::InvalidSpec("disk id must not be empty".into()));
+            }
+            if !disk_ids.insert(disk.id.as_str()) {
+                return Err(Error::InvalidSpec(format!(
+                    "duplicate disk id `{}`",
+                    disk.id
+                )));
+            }
+            require_path("disk path", &disk.path)?;
+        }
+        if self.disks.iter().filter(|d| d.root).count() > 1 {
+            return Err(Error::InvalidSpec(
+                "more than one disk is marked root".into(),
+            ));
+        }
+        let mut nic_ids = HashSet::new();
+        for nic in &self.nics {
+            if nic.id.is_empty() {
+                return Err(Error::InvalidSpec("nic id must not be empty".into()));
+            }
+            if !nic_ids.insert(nic.id.as_str()) {
+                return Err(Error::InvalidSpec(format!("duplicate nic id `{}`", nic.id)));
+            }
+            if nic.mac.is_nil() || !nic.mac.is_unicast() {
+                return Err(Error::InvalidSpec(format!(
+                    "nic `{}` mac {} is not a unicast address",
+                    nic.id, nic.mac
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn require_path(what: &str, path: &Path) -> Result<()> {
+    if path.as_os_str().is_empty() {
+        return Err(Error::InvalidSpec(format!("{what} must not be empty")));
+    }
+    Ok(())
+}
+
 /// How the guest starts.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -229,6 +292,22 @@ pub enum BootSpec {
         /// The opaque machine-identifier blob.
         machine_id: Vec<u8>,
     },
+}
+
+impl BootSpec {
+    fn validate(&self) -> Result<()> {
+        match self {
+            Self::Kernel { image, initrd, .. } => {
+                require_path("kernel image", image)?;
+                if let Some(initrd) = initrd {
+                    require_path("initrd", initrd)?;
+                }
+                Ok(())
+            }
+            Self::Firmware { image } => require_path("firmware image", image),
+            Self::MacOs { aux_storage, .. } => require_path("aux storage", aux_storage),
+        }
+    }
 }
 
 /// One block device.
@@ -408,6 +487,13 @@ mod tests {
         }
     }
 
+    fn invalid(spec: &VmSpec) -> String {
+        match spec.validate() {
+            Err(Error::InvalidSpec(msg)) => msg,
+            other => panic!("expected InvalidSpec, got {other:?}"),
+        }
+    }
+
     #[test]
     fn vm_id_accepts_the_documented_alphabet_and_nothing_else() {
         assert!(VmId::new("a.b_c-D9").is_ok());
@@ -455,6 +541,87 @@ mod tests {
         assert!(!MacAddr::new([0x01, 0, 0x5e, 0, 0, 1]).is_unicast());
         assert!(MacAddr::new([0; 6]).is_nil());
         assert!(!mac(1).is_nil());
+    }
+
+    #[test]
+    fn a_well_formed_spec_validates() {
+        spec().validate().unwrap();
+    }
+
+    #[test]
+    fn zero_cpus_or_memory_are_rejected() {
+        let mut s = spec();
+        s.cpus = 0;
+        assert!(invalid(&s).contains("cpus"));
+        let mut s = spec();
+        s.memory_mib = 0;
+        assert!(invalid(&s).contains("memory_mib"));
+    }
+
+    #[test]
+    fn disk_ids_must_be_unique_and_root_is_singular() {
+        let mut s = spec();
+        s.disks.push(s.disks[0].clone());
+        assert!(invalid(&s).contains("duplicate disk id"));
+        let mut s = spec();
+        let mut second = s.disks[0].clone();
+        second.id = "data".into();
+        s.disks.push(second);
+        assert!(invalid(&s).contains("root"));
+        let mut s = spec();
+        s.disks[0].id.clear();
+        assert!(invalid(&s).contains("disk id"));
+        let mut s = spec();
+        s.disks[0].path = PathBuf::new();
+        assert!(invalid(&s).contains("disk path"));
+    }
+
+    #[test]
+    fn nic_ids_must_be_unique_and_macs_unicast() {
+        let mut s = spec();
+        let mut second = s.nics[0].clone();
+        second.mac = mac(2);
+        s.nics.push(second);
+        assert!(invalid(&s).contains("duplicate nic id"));
+        let mut s = spec();
+        s.nics[0].mac = MacAddr::new([0x01, 0, 0, 0, 0, 1]);
+        assert!(invalid(&s).contains("unicast"));
+        let mut s = spec();
+        s.nics[0].mac = MacAddr::new([0; 6]);
+        assert!(invalid(&s).contains("unicast"));
+        let mut s = spec();
+        s.nics[0].id.clear();
+        assert!(invalid(&s).contains("nic id"));
+    }
+
+    #[test]
+    fn boot_paths_must_be_non_empty() {
+        let mut s = spec();
+        s.boot = BootSpec::Kernel {
+            image: PathBuf::new(),
+            cmdline: String::new(),
+            initrd: None,
+        };
+        assert!(invalid(&s).contains("kernel image"));
+        let mut s = spec();
+        s.boot = BootSpec::Kernel {
+            image: "/boot/vmlinux".into(),
+            cmdline: String::new(),
+            initrd: Some(PathBuf::new()),
+        };
+        assert!(invalid(&s).contains("initrd"));
+        let mut s = spec();
+        s.boot = BootSpec::Firmware {
+            image: PathBuf::new(),
+        };
+        assert!(invalid(&s).contains("firmware image"));
+        let mut s = spec();
+        s.boot = BootSpec::MacOs {
+            aux_storage: PathBuf::new(),
+            hardware_model: vec![],
+            machine_id: vec![],
+        };
+        assert!(invalid(&s).contains("aux storage"));
     }
 
     #[test]

--- a/virt/arcbox-vm-driver/src/spec.rs
+++ b/virt/arcbox-vm-driver/src/spec.rs
@@ -1,0 +1,218 @@
+//! What a VM looks like before it runs: the serializable per-VM shape.
+//!
+//! Everything here is data. Node-wide knobs — VMM binary paths, seccomp,
+//! jailer defaults, MTU — are the adapter's own `DriverConfig`; a
+//! `VmSpec` says only what *this* VM is made of, so the same spec renders
+//! into a Firecracker API payload, a Virtualization.framework configuration,
+//! or an in-process VMM's config without the orchestrator knowing which.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+/// The identity of a VM: non-empty, at most 64 characters, `[A-Za-z0-9._-]`.
+///
+/// Drivers use it as a runtime-directory and socket-name component, which is
+/// what the character set protects.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct VmId(String);
+
+impl VmId {
+    /// The longest id a driver has to fit into a path or socket name.
+    pub const MAX_LEN: usize = 64;
+
+    /// Validates `id` and wraps it.
+    pub fn new(id: impl Into<String>) -> Result<Self> {
+        let id = id.into();
+        if id.is_empty() {
+            return Err(Error::InvalidSpec("vm id must not be empty".into()));
+        }
+        if id.len() > Self::MAX_LEN {
+            return Err(Error::InvalidSpec(format!(
+                "vm id `{id}` exceeds {} characters",
+                Self::MAX_LEN
+            )));
+        }
+        if let Some(bad) = id
+            .chars()
+            .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')))
+        {
+            return Err(Error::InvalidSpec(format!(
+                "vm id `{id}` contains `{bad}`; allowed: A-Z a-z 0-9 . _ -"
+            )));
+        }
+        Ok(Self(id))
+    }
+
+    /// The id as text.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for VmId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for VmId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for VmId {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self> {
+        Self::new(value)
+    }
+}
+
+impl From<VmId> for String {
+    fn from(id: VmId) -> Self {
+        id.0
+    }
+}
+
+/// A 48-bit Ethernet address, written `aa:bb:cc:dd:ee:ff`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MacAddr([u8; 6]);
+
+impl MacAddr {
+    /// Wraps six octets, most significant first.
+    pub const fn new(octets: [u8; 6]) -> Self {
+        Self(octets)
+    }
+
+    /// The six octets, most significant first.
+    pub const fn octets(&self) -> [u8; 6] {
+        self.0
+    }
+
+    /// `true` unless the group (multicast) bit is set.
+    pub const fn is_unicast(&self) -> bool {
+        self.0[0] & 0x01 == 0
+    }
+
+    /// `true` when every octet is zero — no NIC may carry this address.
+    pub const fn is_nil(&self) -> bool {
+        matches!(self.0, [0, 0, 0, 0, 0, 0])
+    }
+}
+
+impl fmt::Display for MacAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, octet) in self.0.iter().enumerate() {
+            if i > 0 {
+                f.write_str(":")?;
+            }
+            write!(f, "{octet:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for MacAddr {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let invalid =
+            || Error::InvalidSpec(format!("`{s}` is not a MAC address (aa:bb:cc:dd:ee:ff)"));
+        let mut octets = [0u8; 6];
+        let mut parts = s.split(':');
+        for octet in &mut octets {
+            let part = parts.next().ok_or_else(invalid)?;
+            if part.len() != 2 {
+                return Err(invalid());
+            }
+            *octet = u8::from_str_radix(part, 16).map_err(|_| invalid())?;
+        }
+        if parts.next().is_some() {
+            return Err(invalid());
+        }
+        Ok(Self(octets))
+    }
+}
+
+impl Serialize for MacAddr {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for MacAddr {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mac(n: u8) -> MacAddr {
+        MacAddr::new([0x02, 0, 0, 0, 0, n])
+    }
+
+    #[test]
+    fn vm_id_accepts_the_documented_alphabet_and_nothing_else() {
+        assert!(VmId::new("a.b_c-D9").is_ok());
+        assert!(VmId::new("x".repeat(VmId::MAX_LEN)).is_ok());
+        assert!(VmId::new("").is_err());
+        assert!(VmId::new("x".repeat(VmId::MAX_LEN + 1)).is_err());
+        assert!(VmId::new("has space").is_err());
+        assert!(VmId::new("slash/y").is_err());
+        assert!(VmId::new("ünïcode").is_err());
+    }
+
+    #[test]
+    fn vm_id_deserialization_validates() {
+        let ok: VmId = serde_json::from_str("\"vm-1\"").unwrap();
+        assert_eq!(ok.as_str(), "vm-1");
+        assert!(serde_json::from_str::<VmId>("\"bad id\"").is_err());
+        assert_eq!(serde_json::to_string(&ok).unwrap(), "\"vm-1\"");
+    }
+
+    #[test]
+    fn mac_parses_and_prints_canonical_form() {
+        let m: MacAddr = "AA:bb:0C:dd:ee:0f".parse().unwrap();
+        assert_eq!(m.octets(), [0xaa, 0xbb, 0x0c, 0xdd, 0xee, 0x0f]);
+        assert_eq!(m.to_string(), "aa:bb:0c:dd:ee:0f");
+        for bad in [
+            "aa:bb:cc:dd:ee",
+            "aa:bb:cc:dd:ee:ff:00",
+            "aa:bb:cc:dd:ee:g0",
+            "aabbccddeeff",
+            "a:b:c:d:e:f",
+        ] {
+            assert!(bad.parse::<MacAddr>().is_err(), "{bad} parsed");
+        }
+        assert_eq!(serde_json::to_string(&m).unwrap(), "\"aa:bb:0c:dd:ee:0f\"");
+        assert_eq!(
+            serde_json::from_str::<MacAddr>("\"aa:bb:0c:dd:ee:0f\"").unwrap(),
+            m
+        );
+        assert!(serde_json::from_str::<MacAddr>("\"nope\"").is_err());
+    }
+
+    #[test]
+    fn mac_classifies_unicast_and_nil() {
+        assert!(MacAddr::new([0x02, 1, 2, 3, 4, 5]).is_unicast());
+        assert!(!MacAddr::new([0x01, 0, 0x5e, 0, 0, 1]).is_unicast());
+        assert!(MacAddr::new([0; 6]).is_nil());
+        assert!(!mac(1).is_nil());
+    }
+}

--- a/virt/arcbox-vm-driver/src/testkit/contract.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract.rs
@@ -13,23 +13,19 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Duration;
 
 use async_trait::async_trait;
 
 use super::FakeDriver;
-use crate::capability::{
-    AfterCheckpoint, CheckpointFormat, CheckpointImage, CheckpointKind, CheckpointOptions,
-};
-use crate::driver::{RestoreSpec, ShutdownMode, VmDriver, VmEvent, VmHandle, VmState};
-use crate::error::Error;
+use crate::driver::{VmDriver, VmHandle};
 use crate::spec::{
     BootSpec, CacheMode, ConsoleSpec, DiskSpec, MacAddr, NicAttachment, NicSpec, VmId, VmSpec,
     VsockSpec,
 };
 
-/// How long a check waits for something the guest or VMM must do.
-const DEADLINE: Duration = Duration::from_secs(60);
+mod checks;
+
+pub use checks::*;
 
 /// What the contract needs from an adapter's test setup.
 #[async_trait]
@@ -49,7 +45,14 @@ pub trait ContractHarness: Send + Sync {
     /// the guest has one (an agent port). `None` skips the dial check.
     fn dial_port(&self) -> Option<u32>;
 
-    /// Waits until the guest behind `handle` is usable. A no-op for the fake.
+    /// The host-side vsock port a booted guest dials out to as soon as it is
+    /// up (its READY announce), if it does that; [`ready`](Self::ready) must
+    /// not return before that dial-out was made. `None` skips the
+    /// prepared-listener check.
+    fn guest_dial_out_port(&self) -> Option<u32>;
+
+    /// Waits until the guest behind `handle` is usable. For the fake this
+    /// is where the "guest" makes its dial-out.
     async fn ready(&self, handle: &dyn VmHandle);
 }
 
@@ -80,6 +83,9 @@ impl FakeHarness {
     pub fn fake(&self) -> &FakeDriver {
         &self.driver
     }
+
+    /// The port the fake "guest" dials out to from [`ContractHarness::ready`].
+    pub const READY_PORT: u32 = 1025;
 }
 
 impl Default for FakeHarness {
@@ -106,7 +112,7 @@ impl ContractHarness for FakeHarness {
             },
             disks: vec![DiskSpec {
                 id: "rootfs".into(),
-                path: "/fake/rootfs.ext4".into(),
+                path: self.disk_file("rootfs.ext4"),
                 read_only: false,
                 root: true,
                 cache: CacheMode::Unsafe,
@@ -139,248 +145,28 @@ impl ContractHarness for FakeHarness {
         Some(1024)
     }
 
-    async fn ready(&self, _handle: &dyn VmHandle) {}
-}
+    fn guest_dial_out_port(&self) -> Option<u32> {
+        Some(Self::READY_PORT)
+    }
 
-fn id(name: &str) -> VmId {
-    VmId::new(format!("contract-{name}")).expect("contract vm id")
-}
-
-async fn boot(h: &dyn ContractHarness, name: &str) -> Box<dyn VmHandle> {
-    let spec = h.spec(&id(name));
-    let handle = h.driver().boot(spec, &h.runtime_dir()).await.expect("boot");
-    h.ready(&*handle).await;
-    handle
-}
-
-/// A booted VM reports `Running`, `shutdown(Kill)` succeeds with a status
-/// that is not clean, and the handle then reports `Exited` with it.
-pub async fn boot_reports_running_then_exits_on_kill(h: &dyn ContractHarness) {
-    let vm = boot(h, "boot").await;
-    assert_eq!(*vm.id(), id("boot"));
-    assert_eq!(vm.state(), VmState::Running);
-    let status = vm.shutdown(ShutdownMode::Kill).await.expect("kill");
-    assert!(!status.is_clean(), "a kill reported a clean exit: {status}");
-    assert_eq!(vm.state(), VmState::Exited(status));
-}
-
-/// `events()` delivers `Exited` once, with the shutdown's status, and
-/// nothing after it.
-pub async fn events_deliver_exit_exactly_once(h: &dyn ContractHarness) {
-    let vm = boot(h, "events").await;
-    let mut events = vm.events();
-    let status = vm.shutdown(ShutdownMode::Kill).await.expect("kill");
-    let event = tokio::time::timeout(DEADLINE, events.recv())
-        .await
-        .expect("an exit event before the deadline")
-        .expect("the events channel is open");
-    assert_eq!(event, VmEvent::Exited(status));
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    match events.try_recv() {
-        Ok(VmEvent::Exited(again)) => panic!("Exited delivered twice: {again}"),
-        Ok(other) => panic!("unexpected event after exit: {other:?}"),
-        Err(_) => {}
+    async fn ready(&self, handle: &dyn VmHandle) {
+        // The fake guest announces itself the moment it is "up".
+        self.driver
+            .guest_dial(handle.id(), Self::READY_PORT)
+            .expect("the fake guest dials out on boot");
     }
 }
 
-/// Every flag in `capabilities()` agrees with the matching accessor on a
-/// handle booted from a spec that asks for everything the driver claims.
-pub async fn capabilities_agree_with_accessors(h: &dyn ContractHarness) {
-    let driver = h.driver();
-    let caps = driver.capabilities();
-    let vm = boot(h, "caps").await;
-    assert_eq!(caps.vsock, vm.vsock().is_some(), "vsock");
-    assert_eq!(
-        caps.vsock_listen,
-        vm.vsock_listener().is_some(),
-        "vsock_listen"
-    );
-    assert_eq!(caps.checkpoint, vm.checkpoint().is_some(), "checkpoint");
-    assert!(
-        caps.checkpoint || !caps.diff_checkpoint,
-        "diff without checkpoint"
-    );
-    assert_eq!(caps.adopt, vm.detach().is_some(), "detach");
-    assert_eq!(caps.adopt, driver.adopt().is_some(), "adopt");
-    assert_eq!(caps.balloon, vm.balloon().is_some(), "balloon");
-    assert_eq!(caps.console, vm.console().is_some(), "console");
-    assert_eq!(caps.debug, vm.debug().is_some(), "debug");
-    assert_eq!(caps.prepare, driver.prepare().is_some(), "prepare");
-    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
-}
-
-/// A checkpoint with `Resume` leaves the VM running and yields an image
-/// in `dst` in the driver's own format.
-pub async fn checkpoint_resume_keeps_running(h: &dyn ContractHarness) {
-    let vm = boot(h, "ckpt-resume").await;
-    let Some(cp) = vm.checkpoint() else {
-        assert!(!h.driver().capabilities().checkpoint);
-        return;
-    };
-    let dst = h.runtime_dir().join("checkpoint");
-    let image = cp
-        .checkpoint(&dst, CheckpointOptions::default())
-        .await
-        .expect("checkpoint");
-    assert_eq!(image.dir, dst);
-    assert_eq!(image.kind, CheckpointKind::Full);
-    assert!(image.dir.is_dir(), "image dir exists");
-    assert_eq!(vm.state(), VmState::Running);
-    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
-}
-
-/// A checkpoint with `HoldQuiesced` leaves the VM `Quiesced` until it is
-/// shut down.
-pub async fn checkpoint_hold_quiesces(h: &dyn ContractHarness) {
-    let vm = boot(h, "ckpt-hold").await;
-    let Some(cp) = vm.checkpoint() else {
-        assert!(!h.driver().capabilities().checkpoint);
-        return;
-    };
-    let opts = CheckpointOptions {
-        after: AfterCheckpoint::HoldQuiesced,
-        kind: CheckpointKind::Full,
-    };
-    cp.checkpoint(&h.runtime_dir().join("checkpoint"), opts)
-        .await
-        .expect("checkpoint");
-    assert_eq!(vm.state(), VmState::Quiesced);
-    let status = vm.shutdown(ShutdownMode::Kill).await.expect("kill");
-    assert_eq!(vm.state(), VmState::Exited(status));
-}
-
-/// A checkpoint restores into a new, running VM under a new id.
-pub async fn restore_yields_a_live_vm(h: &dyn ContractHarness) {
-    let source = boot(h, "restore-src").await;
-    let Some(cp) = source.checkpoint() else {
-        assert!(!h.driver().capabilities().checkpoint);
-        return;
-    };
-    let opts = CheckpointOptions {
-        after: AfterCheckpoint::HoldQuiesced,
-        kind: CheckpointKind::Full,
-    };
-    let image = cp
-        .checkpoint(&h.runtime_dir().join("checkpoint"), opts)
-        .await
-        .expect("checkpoint");
-    source
-        .shutdown(ShutdownMode::Kill)
-        .await
-        .expect("kill source");
-
-    let template = h.spec(&id("restore-dst"));
-    let restore = RestoreSpec {
-        id: id("restore-dst"),
-        nics: template.nics,
-        disks: template.disks,
-        isolation: template.isolation,
-    };
-    let restored = h
-        .driver()
-        .restore(&image, restore, &h.runtime_dir())
-        .await
-        .expect("restore");
-    assert_eq!(*restored.id(), id("restore-dst"));
-    assert_eq!(restored.state(), VmState::Running);
-    h.ready(&*restored).await;
-    restored.shutdown(ShutdownMode::Kill).await.expect("kill");
-}
-
-/// `detach` leaves the VM running for `adopt` to pick up; after that VM
-/// is gone, `adopt` reports `None`.
-pub async fn detach_then_adopt_round_trip(h: &dyn ContractHarness) {
-    let driver = h.driver();
-    let vm = boot(h, "adopt").await;
-    let Some(adopt) = driver.adopt() else {
-        assert!(!driver.capabilities().adopt);
-        assert!(vm.detach().is_none(), "detach without adopt");
-        return;
-    };
-    let record = vm
-        .detach()
-        .expect("detach accessor")
-        .detach()
-        .await
-        .expect("detach");
-    assert_eq!(record, vm.record());
-    drop(vm);
-
-    let adopted = adopt
-        .adopt(&record)
-        .await
-        .expect("adopt")
-        .expect("the detached vm survived");
-    assert_eq!(*adopted.id(), record.id);
-    assert_eq!(adopted.state(), VmState::Running);
-    adopted.shutdown(ShutdownMode::Kill).await.expect("kill");
-    assert!(
-        adopt
-            .adopt(&record)
-            .await
-            .expect("adopt after exit")
-            .is_none(),
-        "adopt found a vm that was killed"
-    );
-}
-
-/// `Vsock::dial` to the harness's agent port succeeds on a ready guest.
-pub async fn vsock_dial_reaches_the_guest(h: &dyn ContractHarness) {
-    let Some(port) = h.dial_port() else {
-        return;
-    };
-    let vm = boot(h, "dial").await;
-    let Some(vsock) = vm.vsock() else {
-        assert!(!h.driver().capabilities().vsock);
-        return;
-    };
-    let conn = tokio::time::timeout(DEADLINE, vsock.dial(port))
-        .await
-        .expect("dial before the deadline")
-        .expect("dial");
-    assert!(std::os::fd::AsRawFd::as_raw_fd(&conn.fd) >= 0);
-    drop(conn);
-    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
-}
-
-/// `restore` refuses an image in a format the driver did not write.
-pub async fn foreign_checkpoint_is_refused(h: &dyn ContractHarness) {
-    let format = CheckpointFormat::new("contract/never-written");
-    let image = CheckpointImage {
-        dir: h.runtime_dir(),
-        format: format.clone(),
-        kind: CheckpointKind::Full,
-    };
-    let restore = RestoreSpec {
-        id: id("foreign"),
-        nics: vec![],
-        disks: vec![],
-        isolation: Default::default(),
-    };
-    match h.driver().restore(&image, restore, &h.runtime_dir()).await {
-        Err(Error::ForeignCheckpoint(refused)) => assert_eq!(refused, format),
-        Err(other) => panic!("expected ForeignCheckpoint, got {other}"),
-        Ok(_) => panic!("a foreign checkpoint was restored"),
+impl FakeHarness {
+    /// A real (empty) file under the harness root, so a contract check that
+    /// copies a disk for a restore has something to copy.
+    fn disk_file(&self, name: &str) -> PathBuf {
+        let path = self.root.path().join(name);
+        if !path.exists() {
+            std::fs::write(&path, b"").expect("disk file under the harness root");
+        }
+        path
     }
-}
-
-/// `record()` is the same value before, during, and after the VM runs,
-/// and names the driver and runtime dir it was booted with.
-pub async fn record_is_stable(h: &dyn ContractHarness) {
-    let driver = h.driver();
-    let dir = h.runtime_dir();
-    let vm = driver
-        .boot(h.spec(&id("record")), &dir)
-        .await
-        .expect("boot");
-    let first = vm.record();
-    assert_eq!(first.id, id("record"));
-    assert_eq!(first.driver, driver.name());
-    assert_eq!(first.runtime_dir, dir);
-    h.ready(&*vm).await;
-    assert_eq!(vm.record(), first);
-    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
-    assert_eq!(vm.record(), first);
 }
 
 /// Instantiates the driver contract as a test module.
@@ -411,6 +197,10 @@ macro_rules! driver_contract {
                 vsock_dial_reaches_the_guest,
                 foreign_checkpoint_is_refused,
                 record_is_stable,
+                prepare_then_boot_matches_boot,
+                prepared_listener_is_live_before_boot,
+                discard_kills_a_prepared_vm,
+                restore_reattaches_disks,
             }
         }
     };

--- a/virt/arcbox-vm-driver/src/testkit/contract.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract.rs
@@ -1,0 +1,332 @@
+//! The driver contract: what every adapter must do the same way.
+//!
+//! An adapter instantiates [`driver_contract!`](crate::driver_contract) in
+//! its own (usually `#[ignore]`d, hardware-backed) test crate with a
+//! [`ContractHarness`] that knows how to build a spec for that VMM and how
+//! to tell when its guest is usable; the macro expands to one `#[tokio::test]`
+//! per check below.
+//!
+//! Each check is also a plain `pub async fn` here, so an adapter can run one
+//! of them by hand under a custom setup.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::capability::{
+    AfterCheckpoint, CheckpointFormat, CheckpointImage, CheckpointKind, CheckpointOptions,
+};
+use crate::driver::{RestoreSpec, ShutdownMode, VmDriver, VmEvent, VmHandle, VmState};
+use crate::error::Error;
+use crate::spec::{VmId, VmSpec};
+
+/// How long a check waits for something the guest or VMM must do.
+const DEADLINE: Duration = Duration::from_secs(60);
+
+/// What the contract needs from an adapter's test setup.
+#[async_trait]
+pub trait ContractHarness: Send + Sync {
+    /// The driver under test.
+    fn driver(&self) -> Arc<dyn VmDriver>;
+
+    /// A bootable spec for `id` that asks for every device the driver
+    /// claims a capability for (vsock, balloon, console, ...), so the
+    /// capability agreement check sees each accessor at its `Some`.
+    fn spec(&self, id: &VmId) -> VmSpec;
+
+    /// A fresh, empty per-VM runtime directory; a new one on every call.
+    fn runtime_dir(&self) -> PathBuf;
+
+    /// A guest vsock port that answers a dial once the guest is ready, if
+    /// the guest has one (an agent port). `None` skips the dial check.
+    fn dial_port(&self) -> Option<u32>;
+
+    /// Waits until the guest behind `handle` is usable. A no-op for the fake.
+    async fn ready(&self, handle: &dyn VmHandle);
+}
+
+fn id(name: &str) -> VmId {
+    VmId::new(format!("contract-{name}")).expect("contract vm id")
+}
+
+async fn boot(h: &dyn ContractHarness, name: &str) -> Box<dyn VmHandle> {
+    let spec = h.spec(&id(name));
+    let handle = h.driver().boot(spec, &h.runtime_dir()).await.expect("boot");
+    h.ready(&*handle).await;
+    handle
+}
+
+/// A booted VM reports `Running`, `shutdown(Kill)` succeeds with a status
+/// that is not clean, and the handle then reports `Exited` with it.
+pub async fn boot_reports_running_then_exits_on_kill(h: &dyn ContractHarness) {
+    let vm = boot(h, "boot").await;
+    assert_eq!(*vm.id(), id("boot"));
+    assert_eq!(vm.state(), VmState::Running);
+    let status = vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+    assert!(!status.is_clean(), "a kill reported a clean exit: {status}");
+    assert_eq!(vm.state(), VmState::Exited(status));
+}
+
+/// `events()` delivers `Exited` once, with the shutdown's status, and
+/// nothing after it.
+pub async fn events_deliver_exit_exactly_once(h: &dyn ContractHarness) {
+    let vm = boot(h, "events").await;
+    let mut events = vm.events();
+    let status = vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+    let event = tokio::time::timeout(DEADLINE, events.recv())
+        .await
+        .expect("an exit event before the deadline")
+        .expect("the events channel is open");
+    assert_eq!(event, VmEvent::Exited(status));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    match events.try_recv() {
+        Ok(VmEvent::Exited(again)) => panic!("Exited delivered twice: {again}"),
+        Ok(other) => panic!("unexpected event after exit: {other:?}"),
+        Err(_) => {}
+    }
+}
+
+/// Every flag in `capabilities()` agrees with the matching accessor on a
+/// handle booted from a spec that asks for everything the driver claims.
+pub async fn capabilities_agree_with_accessors(h: &dyn ContractHarness) {
+    let driver = h.driver();
+    let caps = driver.capabilities();
+    let vm = boot(h, "caps").await;
+    assert_eq!(caps.vsock, vm.vsock().is_some(), "vsock");
+    assert_eq!(
+        caps.vsock_listen,
+        vm.vsock_listener().is_some(),
+        "vsock_listen"
+    );
+    assert_eq!(caps.checkpoint, vm.checkpoint().is_some(), "checkpoint");
+    assert!(
+        caps.checkpoint || !caps.diff_checkpoint,
+        "diff without checkpoint"
+    );
+    assert_eq!(caps.adopt, vm.detach().is_some(), "detach");
+    assert_eq!(caps.adopt, driver.adopt().is_some(), "adopt");
+    assert_eq!(caps.balloon, vm.balloon().is_some(), "balloon");
+    assert_eq!(caps.console, vm.console().is_some(), "console");
+    assert_eq!(caps.debug, vm.debug().is_some(), "debug");
+    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+}
+
+/// A checkpoint with `Resume` leaves the VM running and yields an image
+/// in `dst` in the driver's own format.
+pub async fn checkpoint_resume_keeps_running(h: &dyn ContractHarness) {
+    let vm = boot(h, "ckpt-resume").await;
+    let Some(cp) = vm.checkpoint() else {
+        assert!(!h.driver().capabilities().checkpoint);
+        return;
+    };
+    let dst = h.runtime_dir().join("checkpoint");
+    let image = cp
+        .checkpoint(&dst, CheckpointOptions::default())
+        .await
+        .expect("checkpoint");
+    assert_eq!(image.dir, dst);
+    assert_eq!(image.kind, CheckpointKind::Full);
+    assert!(image.dir.is_dir(), "image dir exists");
+    assert_eq!(vm.state(), VmState::Running);
+    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+}
+
+/// A checkpoint with `HoldQuiesced` leaves the VM `Quiesced` until it is
+/// shut down.
+pub async fn checkpoint_hold_quiesces(h: &dyn ContractHarness) {
+    let vm = boot(h, "ckpt-hold").await;
+    let Some(cp) = vm.checkpoint() else {
+        assert!(!h.driver().capabilities().checkpoint);
+        return;
+    };
+    let opts = CheckpointOptions {
+        after: AfterCheckpoint::HoldQuiesced,
+        kind: CheckpointKind::Full,
+    };
+    cp.checkpoint(&h.runtime_dir().join("checkpoint"), opts)
+        .await
+        .expect("checkpoint");
+    assert_eq!(vm.state(), VmState::Quiesced);
+    let status = vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+    assert_eq!(vm.state(), VmState::Exited(status));
+}
+
+/// A checkpoint restores into a new, running VM under a new id.
+pub async fn restore_yields_a_live_vm(h: &dyn ContractHarness) {
+    let source = boot(h, "restore-src").await;
+    let Some(cp) = source.checkpoint() else {
+        assert!(!h.driver().capabilities().checkpoint);
+        return;
+    };
+    let opts = CheckpointOptions {
+        after: AfterCheckpoint::HoldQuiesced,
+        kind: CheckpointKind::Full,
+    };
+    let image = cp
+        .checkpoint(&h.runtime_dir().join("checkpoint"), opts)
+        .await
+        .expect("checkpoint");
+    source
+        .shutdown(ShutdownMode::Kill)
+        .await
+        .expect("kill source");
+
+    let restore = RestoreSpec {
+        id: id("restore-dst"),
+        nics: h.spec(&id("restore-dst")).nics,
+        isolation: h.spec(&id("restore-dst")).isolation,
+    };
+    let restored = h
+        .driver()
+        .restore(&image, restore, &h.runtime_dir())
+        .await
+        .expect("restore");
+    assert_eq!(*restored.id(), id("restore-dst"));
+    assert_eq!(restored.state(), VmState::Running);
+    h.ready(&*restored).await;
+    restored.shutdown(ShutdownMode::Kill).await.expect("kill");
+}
+
+/// `detach` leaves the VM running for `adopt` to pick up; after that VM
+/// is gone, `adopt` reports `None`.
+pub async fn detach_then_adopt_round_trip(h: &dyn ContractHarness) {
+    let driver = h.driver();
+    let vm = boot(h, "adopt").await;
+    let Some(adopt) = driver.adopt() else {
+        assert!(!driver.capabilities().adopt);
+        assert!(vm.detach().is_none(), "detach without adopt");
+        return;
+    };
+    let record = vm
+        .detach()
+        .expect("detach accessor")
+        .detach()
+        .await
+        .expect("detach");
+    assert_eq!(record, vm.record());
+    drop(vm);
+
+    let adopted = adopt
+        .adopt(&record)
+        .await
+        .expect("adopt")
+        .expect("the detached vm survived");
+    assert_eq!(*adopted.id(), record.id);
+    assert_eq!(adopted.state(), VmState::Running);
+    adopted.shutdown(ShutdownMode::Kill).await.expect("kill");
+    assert!(
+        adopt
+            .adopt(&record)
+            .await
+            .expect("adopt after exit")
+            .is_none(),
+        "adopt found a vm that was killed"
+    );
+}
+
+/// `Vsock::dial` to the harness's agent port succeeds on a ready guest.
+pub async fn vsock_dial_reaches_the_guest(h: &dyn ContractHarness) {
+    let Some(port) = h.dial_port() else {
+        return;
+    };
+    let vm = boot(h, "dial").await;
+    let Some(vsock) = vm.vsock() else {
+        assert!(!h.driver().capabilities().vsock);
+        return;
+    };
+    let conn = tokio::time::timeout(DEADLINE, vsock.dial(port))
+        .await
+        .expect("dial before the deadline")
+        .expect("dial");
+    assert!(std::os::fd::AsRawFd::as_raw_fd(&conn.fd) >= 0);
+    drop(conn);
+    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+}
+
+/// `restore` refuses an image in a format the driver did not write.
+pub async fn foreign_checkpoint_is_refused(h: &dyn ContractHarness) {
+    let format = CheckpointFormat::new("contract/never-written");
+    let image = CheckpointImage {
+        dir: h.runtime_dir(),
+        format: format.clone(),
+        kind: CheckpointKind::Full,
+    };
+    let restore = RestoreSpec {
+        id: id("foreign"),
+        nics: vec![],
+        isolation: Default::default(),
+    };
+    match h.driver().restore(&image, restore, &h.runtime_dir()).await {
+        Err(Error::ForeignCheckpoint(refused)) => assert_eq!(refused, format),
+        Err(other) => panic!("expected ForeignCheckpoint, got {other}"),
+        Ok(_) => panic!("a foreign checkpoint was restored"),
+    }
+}
+
+/// `record()` is the same value before, during, and after the VM runs,
+/// and names the driver and runtime dir it was booted with.
+pub async fn record_is_stable(h: &dyn ContractHarness) {
+    let driver = h.driver();
+    let dir = h.runtime_dir();
+    let vm = driver
+        .boot(h.spec(&id("record")), &dir)
+        .await
+        .expect("boot");
+    let first = vm.record();
+    assert_eq!(first.id, id("record"));
+    assert_eq!(first.driver, driver.name());
+    assert_eq!(first.runtime_dir, dir);
+    h.ready(&*vm).await;
+    assert_eq!(vm.record(), first);
+    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+    assert_eq!(vm.record(), first);
+}
+
+/// Instantiates the driver contract as a test module.
+///
+/// `driver_contract!(fc, FcHarness::new())` expands to `mod fc` holding one
+/// `#[tokio::test]` per contract check; each test evaluates the harness
+/// expression afresh and runs the check against it. The invoking crate
+/// needs `tokio` (with `macros` and `rt`) as a dev-dependency.
+#[macro_export]
+macro_rules! driver_contract {
+    ($mod:ident, $harness:expr) => {
+        mod $mod {
+            #[allow(
+                unused_imports,
+                reason = "the harness expression may or may not name items of the enclosing module"
+            )]
+            use super::*;
+
+            $crate::__driver_contract_checks! {
+                $harness;
+                boot_reports_running_then_exits_on_kill,
+                events_deliver_exit_exactly_once,
+                capabilities_agree_with_accessors,
+                checkpoint_resume_keeps_running,
+                checkpoint_hold_quiesces,
+                restore_yields_a_live_vm,
+                detach_then_adopt_round_trip,
+                vsock_dial_reaches_the_guest,
+                foreign_checkpoint_is_refused,
+                record_is_stable,
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __driver_contract_checks {
+    ($harness:expr; $($check:ident),* $(,)?) => {
+        $(
+            #[tokio::test]
+            async fn $check() {
+                let harness = $harness;
+                $crate::testkit::contract::$check(&harness).await;
+            }
+        )*
+    };
+}

--- a/virt/arcbox-vm-driver/src/testkit/contract.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract.rs
@@ -205,6 +205,7 @@ pub async fn capabilities_agree_with_accessors(h: &dyn ContractHarness) {
     assert_eq!(caps.balloon, vm.balloon().is_some(), "balloon");
     assert_eq!(caps.console, vm.console().is_some(), "console");
     assert_eq!(caps.debug, vm.debug().is_some(), "debug");
+    assert_eq!(caps.prepare, driver.prepare().is_some(), "prepare");
     vm.shutdown(ShutdownMode::Kill).await.expect("kill");
 }
 
@@ -268,10 +269,12 @@ pub async fn restore_yields_a_live_vm(h: &dyn ContractHarness) {
         .await
         .expect("kill source");
 
+    let template = h.spec(&id("restore-dst"));
     let restore = RestoreSpec {
         id: id("restore-dst"),
-        nics: h.spec(&id("restore-dst")).nics,
-        isolation: h.spec(&id("restore-dst")).isolation,
+        nics: template.nics,
+        disks: template.disks,
+        isolation: template.isolation,
     };
     let restored = h
         .driver()
@@ -351,6 +354,7 @@ pub async fn foreign_checkpoint_is_refused(h: &dyn ContractHarness) {
     let restore = RestoreSpec {
         id: id("foreign"),
         nics: vec![],
+        disks: vec![],
         isolation: Default::default(),
     };
     match h.driver().restore(&image, restore, &h.runtime_dir()).await {

--- a/virt/arcbox-vm-driver/src/testkit/contract.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract.rs
@@ -4,23 +4,29 @@
 //! its own (usually `#[ignore]`d, hardware-backed) test crate with a
 //! [`ContractHarness`] that knows how to build a spec for that VMM and how
 //! to tell when its guest is usable; the macro expands to one `#[tokio::test]`
-//! per check below.
+//! per check below. [`FakeHarness`] is the reference harness, and the fake
+//! passes the same checks (`tests/fake_contract.rs`).
 //!
 //! Each check is also a plain `pub async fn` here, so an adapter can run one
 //! of them by hand under a custom setup.
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
 
+use super::FakeDriver;
 use crate::capability::{
     AfterCheckpoint, CheckpointFormat, CheckpointImage, CheckpointKind, CheckpointOptions,
 };
 use crate::driver::{RestoreSpec, ShutdownMode, VmDriver, VmEvent, VmHandle, VmState};
 use crate::error::Error;
-use crate::spec::{VmId, VmSpec};
+use crate::spec::{
+    BootSpec, CacheMode, ConsoleSpec, DiskSpec, MacAddr, NicAttachment, NicSpec, VmId, VmSpec,
+    VsockSpec,
+};
 
 /// How long a check waits for something the guest or VMM must do.
 const DEADLINE: Duration = Duration::from_secs(60);
@@ -45,6 +51,95 @@ pub trait ContractHarness: Send + Sync {
 
     /// Waits until the guest behind `handle` is usable. A no-op for the fake.
     async fn ready(&self, handle: &dyn VmHandle);
+}
+
+/// The reference harness: [`FakeDriver`] over temporary directories.
+pub struct FakeHarness {
+    driver: Arc<FakeDriver>,
+    root: tempfile::TempDir,
+    dirs: AtomicUsize,
+}
+
+impl FakeHarness {
+    /// A harness over `FakeDriver::new()`.
+    pub fn new() -> Self {
+        Self::with_driver(FakeDriver::new())
+    }
+
+    /// A harness over a configured fake — a reduced capability set, say.
+    pub fn with_driver(driver: FakeDriver) -> Self {
+        Self {
+            driver: Arc::new(driver),
+            root: tempfile::tempdir().expect("temporary directory for the fake harness"),
+            dirs: AtomicUsize::new(0),
+        }
+    }
+
+    /// The fake behind the harness, for pushing console bytes or guest
+    /// connections.
+    pub fn fake(&self) -> &FakeDriver {
+        &self.driver
+    }
+}
+
+impl Default for FakeHarness {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ContractHarness for FakeHarness {
+    fn driver(&self) -> Arc<dyn VmDriver> {
+        self.driver.clone()
+    }
+
+    fn spec(&self, id: &VmId) -> VmSpec {
+        VmSpec {
+            id: id.clone(),
+            cpus: 1,
+            memory_mib: 128,
+            boot: BootSpec::Kernel {
+                image: "/fake/vmlinux".into(),
+                cmdline: "console=hvc0".into(),
+                initrd: None,
+            },
+            disks: vec![DiskSpec {
+                id: "rootfs".into(),
+                path: "/fake/rootfs.ext4".into(),
+                read_only: false,
+                root: true,
+                cache: CacheMode::Unsafe,
+            }],
+            nics: vec![NicSpec {
+                id: "eth0".into(),
+                mac: MacAddr::new([0x02, 0xfa, 0xce, 0, 0, 1]),
+                attachment: NicAttachment::Tap {
+                    name: "tap0".into(),
+                },
+            }],
+            vsock: Some(VsockSpec { guest_cid: 3 }),
+            shares: vec![],
+            console: ConsoleSpec::File(self.root.path().join(format!("{id}.console"))),
+            balloon: true,
+            entropy: true,
+            dirty_tracking: true,
+            isolation: Default::default(),
+        }
+    }
+
+    fn runtime_dir(&self) -> PathBuf {
+        let n = self.dirs.fetch_add(1, Ordering::Relaxed);
+        let dir = self.root.path().join(format!("vm{n}"));
+        std::fs::create_dir_all(&dir).expect("runtime dir under the harness root");
+        dir
+    }
+
+    fn dial_port(&self) -> Option<u32> {
+        Some(1024)
+    }
+
+    async fn ready(&self, _handle: &dyn VmHandle) {}
 }
 
 fn id(name: &str) -> VmId {

--- a/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
@@ -212,7 +212,6 @@ pub async fn vsock_dial_reaches_the_guest(h: &dyn ContractHarness) {
         .await
         .expect("dial before the deadline")
         .expect("dial");
-    assert!(std::os::fd::AsRawFd::as_raw_fd(&conn.fd) >= 0);
     drop(conn);
     vm.shutdown(ShutdownMode::Kill).await.expect("kill");
 }
@@ -315,7 +314,13 @@ fn assert_same_capabilities(a: &dyn VmHandle, b: &dyn VmHandle) {
 /// the guest's boot-time dial-out is accepted, never missed.
 pub async fn prepared_listener_is_live_before_boot(h: &dyn ContractHarness) {
     let driver = h.driver();
-    let (Some(prepare), Some(port)) = (driver.prepare(), h.guest_dial_out_port()) else {
+    let Some(prepare) = driver.prepare() else {
+        assert!(!driver.capabilities().prepare);
+        return;
+    };
+    // A guest that makes no dial-out at boot has nothing for this check to
+    // catch; the harness says so by naming no port.
+    let Some(port) = h.guest_dial_out_port() else {
         return;
     };
     let spec = h.spec(&id("prep-listen"));
@@ -342,6 +347,7 @@ pub async fn prepared_listener_is_live_before_boot(h: &dyn ContractHarness) {
 pub async fn discard_kills_a_prepared_vm(h: &dyn ContractHarness) {
     let driver = h.driver();
     let Some(prepare) = driver.prepare() else {
+        assert!(!driver.capabilities().prepare);
         return;
     };
     let spec = h.spec(&id("prep-discard"));

--- a/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
@@ -1,0 +1,421 @@
+//! The contract checks, one `pub async fn` each; [`driver_contract!`]
+//! wraps every one of them in a `#[tokio::test]`.
+//!
+//! [`driver_contract!`]: crate::driver_contract
+
+use std::time::Duration;
+
+use super::ContractHarness;
+use crate::capability::{
+    AfterCheckpoint, CheckpointFormat, CheckpointImage, CheckpointKind, CheckpointOptions,
+};
+use crate::driver::{RestoreSpec, ShutdownMode, VmEvent, VmHandle, VmRecord, VmState};
+use crate::error::Error;
+use crate::spec::VmId;
+
+/// How long a check waits for something the guest or VMM must do.
+const DEADLINE: Duration = Duration::from_secs(60);
+
+fn id(name: &str) -> VmId {
+    VmId::new(format!("contract-{name}")).expect("contract vm id")
+}
+
+async fn boot(h: &dyn ContractHarness, name: &str) -> Box<dyn VmHandle> {
+    let spec = h.spec(&id(name));
+    let handle = h.driver().boot(spec, &h.runtime_dir()).await.expect("boot");
+    h.ready(&*handle).await;
+    handle
+}
+
+/// A booted VM reports `Running`, `shutdown(Kill)` succeeds with a status
+/// that is not clean, and the handle then reports `Exited` with it.
+pub async fn boot_reports_running_then_exits_on_kill(h: &dyn ContractHarness) {
+    let vm = boot(h, "boot").await;
+    assert_eq!(*vm.id(), id("boot"));
+    assert_eq!(vm.state(), VmState::Running);
+    let status = vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+    assert!(!status.is_clean(), "a kill reported a clean exit: {status}");
+    assert_eq!(vm.state(), VmState::Exited(status));
+}
+
+/// `events()` delivers `Exited` once, with the shutdown's status, and
+/// nothing after it.
+pub async fn events_deliver_exit_exactly_once(h: &dyn ContractHarness) {
+    let vm = boot(h, "events").await;
+    let mut events = vm.events();
+    let status = vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+    let event = tokio::time::timeout(DEADLINE, events.recv())
+        .await
+        .expect("an exit event before the deadline")
+        .expect("the events channel is open");
+    assert_eq!(event, VmEvent::Exited(status));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    match events.try_recv() {
+        Ok(VmEvent::Exited(again)) => panic!("Exited delivered twice: {again}"),
+        Ok(other) => panic!("unexpected event after exit: {other:?}"),
+        Err(_) => {}
+    }
+}
+
+/// Every flag in `capabilities()` agrees with the matching accessor on a
+/// handle booted from a spec that asks for everything the driver claims.
+pub async fn capabilities_agree_with_accessors(h: &dyn ContractHarness) {
+    let driver = h.driver();
+    let caps = driver.capabilities();
+    let vm = boot(h, "caps").await;
+    assert_eq!(caps.vsock, vm.vsock().is_some(), "vsock");
+    assert_eq!(
+        caps.vsock_listen,
+        vm.vsock_listener().is_some(),
+        "vsock_listen"
+    );
+    assert_eq!(caps.checkpoint, vm.checkpoint().is_some(), "checkpoint");
+    assert!(
+        caps.checkpoint || !caps.diff_checkpoint,
+        "diff without checkpoint"
+    );
+    assert_eq!(caps.adopt, vm.detach().is_some(), "detach");
+    assert_eq!(caps.adopt, driver.adopt().is_some(), "adopt");
+    assert_eq!(caps.balloon, vm.balloon().is_some(), "balloon");
+    assert_eq!(caps.console, vm.console().is_some(), "console");
+    assert_eq!(caps.debug, vm.debug().is_some(), "debug");
+    assert_eq!(caps.prepare, driver.prepare().is_some(), "prepare");
+    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+}
+
+/// A checkpoint with `Resume` leaves the VM running and yields an image
+/// in `dst` in the driver's own format.
+pub async fn checkpoint_resume_keeps_running(h: &dyn ContractHarness) {
+    let vm = boot(h, "ckpt-resume").await;
+    let Some(cp) = vm.checkpoint() else {
+        assert!(!h.driver().capabilities().checkpoint);
+        return;
+    };
+    let dst = h.runtime_dir().join("checkpoint");
+    let image = cp
+        .checkpoint(&dst, CheckpointOptions::default())
+        .await
+        .expect("checkpoint");
+    assert_eq!(image.dir, dst);
+    assert_eq!(image.kind, CheckpointKind::Full);
+    assert!(image.dir.is_dir(), "image dir exists");
+    assert_eq!(vm.state(), VmState::Running);
+    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+}
+
+/// A checkpoint with `HoldQuiesced` leaves the VM `Quiesced` until it is
+/// shut down.
+pub async fn checkpoint_hold_quiesces(h: &dyn ContractHarness) {
+    let vm = boot(h, "ckpt-hold").await;
+    let Some(cp) = vm.checkpoint() else {
+        assert!(!h.driver().capabilities().checkpoint);
+        return;
+    };
+    let opts = CheckpointOptions {
+        after: AfterCheckpoint::HoldQuiesced,
+        kind: CheckpointKind::Full,
+    };
+    cp.checkpoint(&h.runtime_dir().join("checkpoint"), opts)
+        .await
+        .expect("checkpoint");
+    assert_eq!(vm.state(), VmState::Quiesced);
+    let status = vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+    assert_eq!(vm.state(), VmState::Exited(status));
+}
+
+/// A checkpoint restores into a new, running VM under a new id.
+pub async fn restore_yields_a_live_vm(h: &dyn ContractHarness) {
+    let source = boot(h, "restore-src").await;
+    let Some(cp) = source.checkpoint() else {
+        assert!(!h.driver().capabilities().checkpoint);
+        return;
+    };
+    let opts = CheckpointOptions {
+        after: AfterCheckpoint::HoldQuiesced,
+        kind: CheckpointKind::Full,
+    };
+    let image = cp
+        .checkpoint(&h.runtime_dir().join("checkpoint"), opts)
+        .await
+        .expect("checkpoint");
+    source
+        .shutdown(ShutdownMode::Kill)
+        .await
+        .expect("kill source");
+
+    let template = h.spec(&id("restore-dst"));
+    let restore = RestoreSpec {
+        id: id("restore-dst"),
+        nics: template.nics,
+        disks: template.disks,
+        isolation: template.isolation,
+    };
+    let restored = h
+        .driver()
+        .restore(&image, restore, &h.runtime_dir())
+        .await
+        .expect("restore");
+    assert_eq!(*restored.id(), id("restore-dst"));
+    assert_eq!(restored.state(), VmState::Running);
+    h.ready(&*restored).await;
+    restored.shutdown(ShutdownMode::Kill).await.expect("kill");
+}
+
+/// `detach` leaves the VM running for `adopt` to pick up; after that VM
+/// is gone, `adopt` reports `None`.
+pub async fn detach_then_adopt_round_trip(h: &dyn ContractHarness) {
+    let driver = h.driver();
+    let vm = boot(h, "adopt").await;
+    let Some(adopt) = driver.adopt() else {
+        assert!(!driver.capabilities().adopt);
+        assert!(vm.detach().is_none(), "detach without adopt");
+        return;
+    };
+    let record = vm
+        .detach()
+        .expect("detach accessor")
+        .detach()
+        .await
+        .expect("detach");
+    assert_eq!(record, vm.record());
+    drop(vm);
+
+    let adopted = adopt
+        .adopt(&record)
+        .await
+        .expect("adopt")
+        .expect("the detached vm survived");
+    assert_eq!(*adopted.id(), record.id);
+    assert_eq!(adopted.state(), VmState::Running);
+    adopted.shutdown(ShutdownMode::Kill).await.expect("kill");
+    assert!(
+        adopt
+            .adopt(&record)
+            .await
+            .expect("adopt after exit")
+            .is_none(),
+        "adopt found a vm that was killed"
+    );
+}
+
+/// `Vsock::dial` to the harness's agent port succeeds on a ready guest.
+pub async fn vsock_dial_reaches_the_guest(h: &dyn ContractHarness) {
+    let Some(port) = h.dial_port() else {
+        return;
+    };
+    let vm = boot(h, "dial").await;
+    let Some(vsock) = vm.vsock() else {
+        assert!(!h.driver().capabilities().vsock);
+        return;
+    };
+    let conn = tokio::time::timeout(DEADLINE, vsock.dial(port))
+        .await
+        .expect("dial before the deadline")
+        .expect("dial");
+    assert!(std::os::fd::AsRawFd::as_raw_fd(&conn.fd) >= 0);
+    drop(conn);
+    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+}
+
+/// `restore` refuses an image in a format the driver did not write.
+pub async fn foreign_checkpoint_is_refused(h: &dyn ContractHarness) {
+    let format = CheckpointFormat::new("contract/never-written");
+    let image = CheckpointImage {
+        dir: h.runtime_dir(),
+        format: format.clone(),
+        kind: CheckpointKind::Full,
+    };
+    let restore = RestoreSpec {
+        id: id("foreign"),
+        nics: vec![],
+        disks: vec![],
+        isolation: Default::default(),
+    };
+    match h.driver().restore(&image, restore, &h.runtime_dir()).await {
+        Err(Error::ForeignCheckpoint(refused)) => assert_eq!(refused, format),
+        Err(other) => panic!("expected ForeignCheckpoint, got {other}"),
+        Ok(_) => panic!("a foreign checkpoint was restored"),
+    }
+}
+
+/// `record()` is the same value before, during, and after the VM runs,
+/// and names the driver and runtime dir it was booted with.
+pub async fn record_is_stable(h: &dyn ContractHarness) {
+    let driver = h.driver();
+    let dir = h.runtime_dir();
+    let vm = driver
+        .boot(h.spec(&id("record")), &dir)
+        .await
+        .expect("boot");
+    let first = vm.record();
+    assert_eq!(first.id, id("record"));
+    assert_eq!(first.driver, driver.name());
+    assert_eq!(first.runtime_dir, dir);
+    h.ready(&*vm).await;
+    assert_eq!(vm.record(), first);
+    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+    assert_eq!(vm.record(), first);
+}
+
+/// `prepare` then `PreparedVm::boot` yields the same kind of handle as a
+/// plain `boot`: same state, same record shape, same capabilities.
+pub async fn prepare_then_boot_matches_boot(h: &dyn ContractHarness) {
+    let driver = h.driver();
+    let plain = boot(h, "prep-plain").await;
+    let Some(prepare) = driver.prepare() else {
+        assert!(!driver.capabilities().prepare);
+        plain.shutdown(ShutdownMode::Kill).await.expect("kill");
+        return;
+    };
+    let spec = h.spec(&id("prep-two-phase"));
+    let prepared = prepare
+        .prepare(&spec.id, &spec.isolation, &h.runtime_dir())
+        .await
+        .expect("prepare");
+    assert!(prepared.alive());
+    assert_eq!(*prepared.id(), spec.id);
+    let record = prepared.record();
+    assert_eq!(record.id, spec.id);
+    let two_phase = prepared.boot(spec).await.expect("boot on the prepared vm");
+    h.ready(&*two_phase).await;
+    assert_eq!(two_phase.record(), record, "the handle shares the process");
+    assert!(prepared.alive());
+    assert_eq!(two_phase.state(), plain.state());
+    assert_same_shape(&plain.record(), &two_phase.record());
+    assert_same_capabilities(&*plain, &*two_phase);
+    two_phase.shutdown(ShutdownMode::Kill).await.expect("kill");
+    assert!(!prepared.alive(), "alive after the vm exited");
+    plain.shutdown(ShutdownMode::Kill).await.expect("kill");
+}
+
+fn assert_same_shape(a: &VmRecord, b: &VmRecord) {
+    assert_eq!(a.driver, b.driver);
+    assert_eq!(a.process.is_some(), b.process.is_some(), "process record");
+}
+
+fn assert_same_capabilities(a: &dyn VmHandle, b: &dyn VmHandle) {
+    assert_eq!(a.vsock().is_some(), b.vsock().is_some(), "vsock");
+    assert_eq!(
+        a.vsock_listener().is_some(),
+        b.vsock_listener().is_some(),
+        "vsock_listen"
+    );
+    assert_eq!(
+        a.checkpoint().is_some(),
+        b.checkpoint().is_some(),
+        "checkpoint"
+    );
+    assert_eq!(a.detach().is_some(), b.detach().is_some(), "detach");
+    assert_eq!(a.balloon().is_some(), b.balloon().is_some(), "balloon");
+    assert_eq!(a.console().is_some(), b.console().is_some(), "console");
+    assert_eq!(a.debug().is_some(), b.debug().is_some(), "debug");
+}
+
+/// A listener bound on a prepared VM is live before the guest starts:
+/// the guest's boot-time dial-out is accepted, never missed.
+pub async fn prepared_listener_is_live_before_boot(h: &dyn ContractHarness) {
+    let driver = h.driver();
+    let (Some(prepare), Some(port)) = (driver.prepare(), h.guest_dial_out_port()) else {
+        return;
+    };
+    let spec = h.spec(&id("prep-listen"));
+    let prepared = prepare
+        .prepare(&spec.id, &spec.isolation, &h.runtime_dir())
+        .await
+        .expect("prepare");
+    let Some(listen) = prepared.vsock_listener() else {
+        assert!(!driver.capabilities().vsock_listen);
+        return;
+    };
+    let mut listener = listen.listen(port).await.expect("listen before boot");
+    let vm = prepared.boot(spec).await.expect("boot");
+    h.ready(&*vm).await;
+    tokio::time::timeout(DEADLINE, listener.accept())
+        .await
+        .expect("the guest's dial-out before the deadline")
+        .expect("accept");
+    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+}
+
+/// `discard` kills a prepared VM before or after its boot; a second call
+/// is fine.
+pub async fn discard_kills_a_prepared_vm(h: &dyn ContractHarness) {
+    let driver = h.driver();
+    let Some(prepare) = driver.prepare() else {
+        return;
+    };
+    let spec = h.spec(&id("prep-discard"));
+    let prepared = prepare
+        .prepare(&spec.id, &spec.isolation, &h.runtime_dir())
+        .await
+        .expect("prepare");
+    assert!(prepared.alive());
+    let status = prepared.discard().await.expect("discard");
+    assert!(!prepared.alive());
+    assert_eq!(prepared.discard().await.expect("second discard"), status);
+    assert!(
+        prepared.boot(spec.clone()).await.is_err(),
+        "boot after discard"
+    );
+
+    let spec = h.spec(&id("prep-discard-booted"));
+    let prepared = prepare
+        .prepare(&spec.id, &spec.isolation, &h.runtime_dir())
+        .await
+        .expect("prepare");
+    let vm = prepared.boot(spec).await.expect("boot");
+    prepared.discard().await.expect("discard after boot");
+    assert!(!prepared.alive());
+    assert!(matches!(vm.state(), VmState::Exited(_)), "{}", vm.state());
+}
+
+/// A restore names the image's disks at new host paths (a copy here, a
+/// fresh CoW device in production) and comes up under the new id.
+pub async fn restore_reattaches_disks(h: &dyn ContractHarness) {
+    let source = boot(h, "reattach-src").await;
+    let Some(cp) = source.checkpoint() else {
+        assert!(!h.driver().capabilities().checkpoint);
+        return;
+    };
+    let opts = CheckpointOptions {
+        after: AfterCheckpoint::HoldQuiesced,
+        kind: CheckpointKind::Full,
+    };
+    let image = cp
+        .checkpoint(&h.runtime_dir().join("checkpoint"), opts)
+        .await
+        .expect("checkpoint");
+    source
+        .shutdown(ShutdownMode::Kill)
+        .await
+        .expect("kill source");
+
+    let template = h.spec(&id("reattach-dst"));
+    let copies = h.runtime_dir();
+    let disks = template
+        .disks
+        .into_iter()
+        .map(|mut disk| {
+            let copy = copies.join(format!("{}.restored", disk.id));
+            std::fs::copy(&disk.path, &copy).expect("copy the disk for the restore");
+            disk.path = copy;
+            disk
+        })
+        .collect();
+    let restore = RestoreSpec {
+        id: id("reattach-dst"),
+        nics: template.nics,
+        disks,
+        isolation: template.isolation,
+    };
+    let restored = h
+        .driver()
+        .restore(&image, restore, &h.runtime_dir())
+        .await
+        .expect("restore onto the copied disks");
+    assert_eq!(*restored.id(), id("reattach-dst"));
+    assert_eq!(restored.record().id, id("reattach-dst"));
+    assert_eq!(restored.state(), VmState::Running);
+    h.ready(&*restored).await;
+    restored.shutdown(ShutdownMode::Kill).await.expect("kill");
+}

--- a/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
@@ -1,6 +1,7 @@
 //! An in-memory [`VmDriver`] for tests that need a VM without a hypervisor.
 
 use std::collections::HashMap;
+use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -18,7 +19,13 @@ use crate::spec::{VmId, VmSpec};
 /// An in-memory VM driver.
 ///
 /// VMs are a real state machine (`Running` → `Exited` on shutdown, kill, or
-/// drop) with an events broadcast; the capabilities land alongside.
+/// drop) with an events broadcast. `Vsock::dial` returns one end of a
+/// socketpair whose other end echoes; `VsockListen` accepts what
+/// [`FakeDriver::guest_dial`] pushes; `Console` returns what
+/// [`FakeDriver::push_console`] pushed; `Balloon` and `DebugSnapshot` report
+/// the VM's own state. [`FakeDriver::builder`] narrows the claimed
+/// capabilities — the accessors follow the claims, so the contract can be
+/// run against a reduced set.
 ///
 /// The driver's name is `"fake"`.
 #[derive(Clone)]
@@ -27,18 +34,73 @@ pub struct FakeDriver {
 }
 
 struct DriverInner {
+    caps: DriverCapabilities,
     /// Every VM booted and not yet seen exited.
     vms: Mutex<HashMap<VmId, Arc<VmInner>>>,
 }
 
-impl FakeDriver {
-    /// A driver with no scripted failures.
-    pub fn new() -> Self {
-        Self {
+/// Configures a [`FakeDriver`].
+#[derive(Debug)]
+pub struct FakeDriverBuilder {
+    caps: DriverCapabilities,
+}
+
+impl FakeDriverBuilder {
+    /// Claims exactly `caps`; the handles' accessors follow the claims.
+    pub fn capabilities(mut self, caps: DriverCapabilities) -> Self {
+        self.caps = caps;
+        self
+    }
+
+    /// Builds the driver.
+    pub fn build(self) -> FakeDriver {
+        FakeDriver {
             inner: Arc::new(DriverInner {
+                caps: self.caps,
                 vms: Mutex::new(HashMap::new()),
             }),
         }
+    }
+}
+
+impl FakeDriver {
+    /// A driver claiming every capability it implements.
+    pub fn new() -> Self {
+        Self::builder().build()
+    }
+
+    /// A driver to configure; starts from every implemented capability
+    /// claimed.
+    pub fn builder() -> FakeDriverBuilder {
+        FakeDriverBuilder {
+            caps: DriverCapabilities {
+                vsock: true,
+                vsock_listen: true,
+                balloon: true,
+                console: true,
+                debug: true,
+                nested_virt: NestedVirt::unsupported("the fake driver runs no hypervisor"),
+                ..DriverCapabilities::default()
+            },
+        }
+    }
+
+    /// The guest side of a vsock connection to host-side `port` on `vm`.
+    ///
+    /// The returned stream is what the "guest" writes; the host end is
+    /// queued for the VM's `VsockListener::accept` on that port (before or
+    /// after `listen` — the queue is per port, not per listener).
+    pub fn guest_dial(&self, vm: &VmId, port: u32) -> Result<UnixStream> {
+        let vm = self.inner.live(vm)?;
+        let (host, guest) = UnixStream::pair()?;
+        vm.push_inbound(port, host);
+        Ok(guest)
+    }
+
+    /// Appends `bytes` to what `Console::read_output` returns for `vm`.
+    pub fn push_console(&self, vm: &VmId, bytes: &[u8]) -> Result<()> {
+        self.inner.live(vm)?.push_console(bytes);
+        Ok(())
     }
 
     fn register(&self, spec: VmSpec, runtime_dir: &Path) -> Result<Box<dyn VmHandle>> {
@@ -61,7 +123,8 @@ impl FakeDriver {
             runtime_dir: runtime_dir.to_path_buf(),
             process: None,
         };
-        let vm = VmInner::new(spec, record);
+        let balloon_target_bytes = u64::from(spec.memory_mib) << 20;
+        let vm = VmInner::new(spec, record, self.inner.caps.clone(), balloon_target_bytes);
         vms.insert(vm.id().clone(), Arc::clone(&vm));
         Ok(Box::new(FakeVm::new(vm)))
     }
@@ -73,6 +136,21 @@ impl Default for FakeDriver {
     }
 }
 
+impl DriverInner {
+    /// The VM if it has not exited; an exited entry is forgotten here.
+    fn live(&self, id: &VmId) -> Result<Arc<VmInner>> {
+        let mut vms = lock(&self.vms);
+        match vms.get(id) {
+            Some(vm) if !matches!(vm.state(), VmState::Exited(_)) => Ok(Arc::clone(vm)),
+            Some(_) => {
+                vms.remove(id);
+                Err(Error::NotFound(id.clone()))
+            }
+            None => Err(Error::NotFound(id.clone())),
+        }
+    }
+}
+
 #[async_trait]
 impl VmDriver for FakeDriver {
     fn name(&self) -> &'static str {
@@ -80,10 +158,7 @@ impl VmDriver for FakeDriver {
     }
 
     fn capabilities(&self) -> DriverCapabilities {
-        DriverCapabilities {
-            nested_virt: NestedVirt::unsupported("the fake driver runs no hypervisor"),
-            ..DriverCapabilities::default()
-        }
+        self.inner.caps.clone()
     }
 
     async fn boot(&self, spec: VmSpec, runtime_dir: &Path) -> Result<Box<dyn VmHandle>> {
@@ -109,9 +184,11 @@ impl VmDriver for FakeDriver {
 mod tests {
     use std::time::Duration;
 
+    use std::io::{Read as _, Write as _};
+
     use super::*;
-    use crate::driver::{ExitStatus, ShutdownMode, VmEvent};
-    use crate::spec::BootSpec;
+    use crate::driver::{ExitStatus, IoMode, ShutdownMode, VmEvent};
+    use crate::spec::{BootSpec, ConsoleSpec, VsockSpec};
 
     fn spec(id: &str) -> VmSpec {
         VmSpec {
@@ -132,6 +209,16 @@ mod tests {
             entropy: false,
             dirty_tracking: false,
             isolation: Default::default(),
+        }
+    }
+
+    /// A spec asking for every device the fake implements.
+    fn full_spec(id: &str) -> VmSpec {
+        VmSpec {
+            vsock: Some(VsockSpec { guest_cid: 3 }),
+            console: ConsoleSpec::File("/fake/console.log".into()),
+            balloon: true,
+            ..spec(id)
         }
     }
 
@@ -193,5 +280,97 @@ mod tests {
             ),
             "{err}"
         );
+    }
+
+    #[tokio::test]
+    async fn accessors_follow_the_spec_and_the_claims() {
+        let driver = FakeDriver::new();
+        let bare = driver
+            .boot(spec("bare"), Path::new("/run/bare"))
+            .await
+            .unwrap();
+        assert!(bare.vsock().is_none() && bare.vsock_listener().is_none());
+        assert!(bare.balloon().is_none() && bare.console().is_none());
+        assert!(bare.debug().is_some());
+
+        let full = driver
+            .boot(full_spec("full"), Path::new("/run/full"))
+            .await
+            .unwrap();
+        assert!(full.vsock().is_some() && full.vsock_listener().is_some());
+        assert!(full.balloon().is_some() && full.console().is_some());
+
+        let narrow = FakeDriver::builder()
+            .capabilities(DriverCapabilities::default())
+            .build();
+        let vm = narrow
+            .boot(full_spec("narrow"), Path::new("/run/narrow"))
+            .await
+            .unwrap();
+        assert!(vm.vsock().is_none() && vm.debug().is_none() && vm.balloon().is_none());
+    }
+
+    #[tokio::test]
+    async fn dial_reaches_an_echoing_guest() {
+        let driver = FakeDriver::new();
+        let vm = driver
+            .boot(full_spec("vm-1"), Path::new("/run/vm-1"))
+            .await
+            .unwrap();
+        let conn = vm.vsock().unwrap().dial(1024).await.unwrap();
+        assert_eq!(conn.mode, IoMode::Async);
+        let mut stream = UnixStream::from(conn.fd);
+        stream.write_all(b"ping").unwrap();
+        let mut buf = [0u8; 4];
+        stream.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"ping");
+
+        vm.shutdown(ShutdownMode::Kill).await.unwrap();
+        assert!(matches!(
+            vm.vsock().unwrap().dial(1024).await,
+            Err(Error::WrongState { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn guest_dial_is_accepted_by_the_listener_in_order() {
+        let driver = FakeDriver::new();
+        let vm = driver
+            .boot(full_spec("vm-1"), Path::new("/run/vm-1"))
+            .await
+            .unwrap();
+        // Pushed before `listen`: the queue is per port, not per listener.
+        let mut early = driver.guest_dial(vm.id(), 7).unwrap();
+        early.write_all(b"early").unwrap();
+        let mut listener = vm.vsock_listener().unwrap().listen(7).await.unwrap();
+        let mut first = UnixStream::from(listener.accept().await.unwrap().fd);
+        let mut buf = [0u8; 5];
+        first.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"early");
+
+        let accept = tokio::spawn(async move { listener.accept().await.map(|c| c.mode) });
+        tokio::task::yield_now().await;
+        let _late = driver.guest_dial(vm.id(), 7).unwrap();
+        assert_eq!(accept.await.unwrap().unwrap(), IoMode::Async);
+
+        vm.shutdown(ShutdownMode::Kill).await.unwrap();
+        assert!(matches!(
+            driver.guest_dial(vm.id(), 7),
+            Err(Error::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn console_hands_out_pushed_bytes_once() {
+        let driver = FakeDriver::new();
+        let vm = driver
+            .boot(full_spec("vm-1"), Path::new("/run/vm-1"))
+            .await
+            .unwrap();
+        driver.push_console(vm.id(), b"hello world").unwrap();
+        let console = vm.console().unwrap();
+        assert_eq!(console.read_output(5).await.unwrap(), b"hello");
+        assert_eq!(console.read_output(64).await.unwrap(), b" world");
+        assert!(console.read_output(64).await.unwrap().is_empty());
     }
 }

--- a/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
@@ -1,6 +1,6 @@
 //! An in-memory [`VmDriver`] for tests that need a VM without a hypervisor.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -112,6 +112,7 @@ impl FakeDriver {
                 checkpoint: true,
                 diff_checkpoint: true,
                 adopt: true,
+                prepare: false,
                 balloon: true,
                 console: true,
                 debug: true,
@@ -239,9 +240,17 @@ impl VmDriver for FakeDriver {
         if file.format.as_str() != CHECKPOINT_FORMAT {
             return Err(Error::ForeignCheckpoint(file.format));
         }
+        let image_disks: BTreeSet<&str> = file.spec.disks.iter().map(|d| d.id.as_str()).collect();
+        let given_disks: BTreeSet<&str> = spec.disks.iter().map(|d| d.id.as_str()).collect();
+        if image_disks != given_disks {
+            return Err(Error::InvalidSpec(format!(
+                "restore disks {given_disks:?} must name exactly the image's disks {image_disks:?}"
+            )));
+        }
         let mut vm_spec = file.spec;
         vm_spec.id = spec.id;
         vm_spec.nics = spec.nics;
+        vm_spec.disks = spec.disks;
         vm_spec.isolation = spec.isolation;
         vm_spec.validate()?;
         self.register(vm_spec, runtime_dir, file.balloon_target_bytes)

--- a/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
@@ -1,17 +1,18 @@
 //! An in-memory [`VmDriver`] for tests that need a VM without a hypervisor.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 use std::os::unix::net::UnixStream;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
-use super::fake_vm::{CHECKPOINT_FORMAT, CheckpointFile, FakeVm, VmInner};
+use super::fake_prepared::Preparer;
+use super::fake_vm::{FakeVm, VmInner};
 use super::fake_vsock::Inbound;
 use super::lock;
-use crate::capability::{Adopt, CheckpointImage};
+use crate::capability::{Adopt, CheckpointImage, Prepare, PreparedVm as _};
 use crate::driver::{
     DriverCapabilities, NestedVirt, RestoreSpec, VmDriver, VmHandle, VmRecord, VmState,
 };
@@ -33,24 +34,31 @@ pub(super) struct Knobs {
 /// one end of a socketpair whose other end echoes; `VsockListen` accepts
 /// what [`FakeDriver::guest_dial`] pushes; `Checkpoint` writes a
 /// `checkpoint.json` that `restore` reads back; `Adopt`/`Detach` go through
-/// the driver's registry; `Console` returns what
-/// [`FakeDriver::push_console`] pushed. [`FakeDriver::builder`] scripts
-/// failures and narrows the claimed capabilities — the accessors follow
-/// the claims, so the contract can be run against a reduced set.
+/// the driver's registry; `Prepare` hands out a process with a synthetic
+/// pid that `boot`/`restore` then run on — the driver's own `boot` is
+/// exactly that pair; `Console` returns what [`FakeDriver::push_console`]
+/// pushed. [`FakeDriver::builder`] scripts failures and narrows the claimed
+/// capabilities — the accessors follow the claims, so the contract can be
+/// run against a reduced set.
 ///
 /// The driver's name is `"fake"`; its checkpoint format is `"fake/v1"`.
 #[derive(Clone)]
 pub struct FakeDriver {
     inner: Arc<DriverInner>,
     adopter: Adopter,
+    preparer: Preparer,
 }
 
 /// The driver's name, as `VmDriver::name` reports it.
-const NAME: &str = "fake";
+pub(super) const NAME: &str = "fake";
 
-struct DriverInner {
-    caps: DriverCapabilities,
-    knobs: Arc<Knobs>,
+/// The first synthetic pid a prepared fake process gets.
+const FIRST_PID: u32 = 100_000;
+
+pub(super) struct DriverInner {
+    pub(super) caps: DriverCapabilities,
+    pub(super) knobs: Arc<Knobs>,
+    next_pid: AtomicU32,
     /// Every VM booted or restored and not yet seen exited.
     vms: Mutex<HashMap<VmId, Arc<VmInner>>>,
 }
@@ -89,10 +97,12 @@ impl FakeDriverBuilder {
         let inner = Arc::new(DriverInner {
             caps: self.caps,
             knobs: Arc::new(self.knobs),
+            next_pid: AtomicU32::new(FIRST_PID),
             vms: Mutex::new(HashMap::new()),
         });
         FakeDriver {
             adopter: Adopter(Arc::clone(&inner)),
+            preparer: Preparer(Arc::clone(&inner)),
             inner,
         }
     }
@@ -113,7 +123,7 @@ impl FakeDriver {
                 checkpoint: true,
                 diff_checkpoint: true,
                 adopt: true,
-                prepare: false,
+                prepare: true,
                 balloon: true,
                 console: true,
                 debug: true,
@@ -140,14 +150,28 @@ impl FakeDriver {
         self.inner.live(vm)?.push_console(bytes);
         Ok(())
     }
+}
 
-    fn register(
+impl Default for FakeDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DriverInner {
+    pub(super) fn next_pid(&self) -> u32 {
+        self.next_pid.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Enters a running VM into the registry; the id must not be live.
+    pub(super) fn register(
         &self,
         spec: VmSpec,
-        runtime_dir: &Path,
+        record: VmRecord,
         balloon_target_bytes: u64,
-    ) -> Result<Box<dyn VmHandle>> {
-        let mut vms = lock(&self.inner.vms);
+        inbound: Arc<Inbound>,
+    ) -> Result<Arc<VmInner>> {
+        let mut vms = lock(&self.vms);
         if let Some(existing) = vms.get(&spec.id) {
             match existing.state() {
                 VmState::Exited(_) => {}
@@ -160,33 +184,18 @@ impl FakeDriver {
                 }
             }
         }
-        let record = VmRecord {
-            id: spec.id.clone(),
-            driver: NAME.to_owned(),
-            runtime_dir: runtime_dir.to_path_buf(),
-            process: None,
-        };
-        let inbound = Inbound::new(spec.id.clone());
         let vm = VmInner::new(
             spec,
             record,
-            self.inner.caps.clone(),
-            Arc::clone(&self.inner.knobs),
+            self.caps.clone(),
+            Arc::clone(&self.knobs),
             balloon_target_bytes,
             inbound,
         );
         vms.insert(vm.id().clone(), Arc::clone(&vm));
-        Ok(Box::new(FakeVm::new(vm)))
+        Ok(vm)
     }
-}
 
-impl Default for FakeDriver {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DriverInner {
     /// The VM if it has not exited; an exited entry is forgotten here.
     fn live(&self, id: &VmId) -> Result<Arc<VmInner>> {
         let mut vms = lock(&self.vms);
@@ -212,21 +221,10 @@ impl VmDriver for FakeDriver {
     }
 
     async fn boot(&self, spec: VmSpec, runtime_dir: &Path) -> Result<Box<dyn VmHandle>> {
-        spec.validate()?;
-        if self
-            .inner
-            .knobs
-            .fail_boot_once
-            .swap(false, Ordering::AcqRel)
-        {
-            return Err(Error::Driver {
-                driver: NAME,
-                message: "scripted boot failure".into(),
-                source: None,
-            });
-        }
-        let balloon_target_bytes = u64::from(spec.memory_mib) << 20;
-        self.register(spec, runtime_dir, balloon_target_bytes)
+        self.preparer
+            .prepare_sync(&spec.id, &spec.isolation, runtime_dir)
+            .boot(spec)
+            .await
     }
 
     async fn restore(
@@ -235,32 +233,18 @@ impl VmDriver for FakeDriver {
         spec: RestoreSpec,
         runtime_dir: &Path,
     ) -> Result<Box<dyn VmHandle>> {
-        if !self.inner.caps.checkpoint || image.format.as_str() != CHECKPOINT_FORMAT {
-            return Err(Error::ForeignCheckpoint(image.format.clone()));
-        }
-        let bytes = tokio::fs::read(image.dir.join("checkpoint.json")).await?;
-        let file: CheckpointFile = serde_json::from_slice(&bytes).map_err(std::io::Error::from)?;
-        if file.format.as_str() != CHECKPOINT_FORMAT {
-            return Err(Error::ForeignCheckpoint(file.format));
-        }
-        let image_disks: BTreeSet<&str> = file.spec.disks.iter().map(|d| d.id.as_str()).collect();
-        let given_disks: BTreeSet<&str> = spec.disks.iter().map(|d| d.id.as_str()).collect();
-        if image_disks != given_disks {
-            return Err(Error::InvalidSpec(format!(
-                "restore disks {given_disks:?} must name exactly the image's disks {image_disks:?}"
-            )));
-        }
-        let mut vm_spec = file.spec;
-        vm_spec.id = spec.id;
-        vm_spec.nics = spec.nics;
-        vm_spec.disks = spec.disks;
-        vm_spec.isolation = spec.isolation;
-        vm_spec.validate()?;
-        self.register(vm_spec, runtime_dir, file.balloon_target_bytes)
+        self.preparer
+            .prepare_sync(&spec.id, &spec.isolation, runtime_dir)
+            .restore(image, spec)
+            .await
     }
 
     fn adopt(&self) -> Option<&dyn Adopt> {
         self.inner.caps.adopt.then_some(&self.adopter)
+    }
+
+    fn prepare(&self) -> Option<&dyn Prepare> {
+        self.inner.caps.prepare.then_some(&self.preparer)
     }
 }
 

--- a/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
@@ -3,11 +3,12 @@
 use std::collections::HashMap;
 use std::os::unix::net::UnixStream;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
-use super::fake_vm::{FakeVm, VmInner};
+use super::fake_vm::{CHECKPOINT_FORMAT, CheckpointFile, FakeVm, VmInner};
 use super::lock;
 use crate::capability::{Adopt, CheckpointImage};
 use crate::driver::{
@@ -16,26 +17,40 @@ use crate::driver::{
 use crate::error::{Error, Result};
 use crate::spec::{VmId, VmSpec};
 
+/// Scripted failures, armed once and consumed by the next matching call.
+#[derive(Debug, Default)]
+pub(super) struct Knobs {
+    pub(super) fail_boot_once: AtomicBool,
+    pub(super) fail_checkpoint_once: AtomicBool,
+}
+
 /// An in-memory VM driver.
 ///
-/// VMs are a real state machine (`Running` → `Exited` on shutdown, kill, or
-/// drop) with an events broadcast. `Vsock::dial` returns one end of a
-/// socketpair whose other end echoes; `VsockListen` accepts what
-/// [`FakeDriver::guest_dial`] pushes; `Console` returns what
-/// [`FakeDriver::push_console`] pushed; `Balloon` and `DebugSnapshot` report
-/// the VM's own state. [`FakeDriver::builder`] narrows the claimed
-/// capabilities — the accessors follow the claims, so the contract can be
-/// run against a reduced set.
+/// VMs are a real state machine (`Running` → `Quiesced` under
+/// `HoldQuiesced` → `Exited` on shutdown, kill, or drop) with an events
+/// broadcast, and every capability is implemented: `Vsock::dial` returns
+/// one end of a socketpair whose other end echoes; `VsockListen` accepts
+/// what [`FakeDriver::guest_dial`] pushes; `Checkpoint` writes a
+/// `checkpoint.json` that `restore` reads back; `Adopt`/`Detach` go through
+/// the driver's registry; `Console` returns what
+/// [`FakeDriver::push_console`] pushed. [`FakeDriver::builder`] scripts
+/// failures and narrows the claimed capabilities — the accessors follow
+/// the claims, so the contract can be run against a reduced set.
 ///
-/// The driver's name is `"fake"`.
+/// The driver's name is `"fake"`; its checkpoint format is `"fake/v1"`.
 #[derive(Clone)]
 pub struct FakeDriver {
     inner: Arc<DriverInner>,
+    adopter: Adopter,
 }
+
+/// The driver's name, as `VmDriver::name` reports it.
+const NAME: &str = "fake";
 
 struct DriverInner {
     caps: DriverCapabilities,
-    /// Every VM booted and not yet seen exited.
+    knobs: Arc<Knobs>,
+    /// Every VM booted or restored and not yet seen exited.
     vms: Mutex<HashMap<VmId, Arc<VmInner>>>,
 }
 
@@ -43,6 +58,7 @@ struct DriverInner {
 #[derive(Debug)]
 pub struct FakeDriverBuilder {
     caps: DriverCapabilities,
+    knobs: Knobs,
 }
 
 impl FakeDriverBuilder {
@@ -52,36 +68,56 @@ impl FakeDriverBuilder {
         self
     }
 
+    /// The next `boot` fails with [`Error::Driver`].
+    pub fn fail_boot_once(self) -> Self {
+        self.knobs.fail_boot_once.store(true, Ordering::Release);
+        self
+    }
+
+    /// The next `Checkpoint::checkpoint` on any VM fails with
+    /// [`Error::Driver`].
+    pub fn fail_checkpoint_once(self) -> Self {
+        self.knobs
+            .fail_checkpoint_once
+            .store(true, Ordering::Release);
+        self
+    }
+
     /// Builds the driver.
     pub fn build(self) -> FakeDriver {
+        let inner = Arc::new(DriverInner {
+            caps: self.caps,
+            knobs: Arc::new(self.knobs),
+            vms: Mutex::new(HashMap::new()),
+        });
         FakeDriver {
-            inner: Arc::new(DriverInner {
-                caps: self.caps,
-                vms: Mutex::new(HashMap::new()),
-            }),
+            adopter: Adopter(Arc::clone(&inner)),
+            inner,
         }
     }
 }
 
 impl FakeDriver {
-    /// A driver claiming every capability it implements.
+    /// A driver claiming every capability, with no scripted failures.
     pub fn new() -> Self {
         Self::builder().build()
     }
 
-    /// A driver to configure; starts from every implemented capability
-    /// claimed.
+    /// A driver to configure; starts from every capability claimed.
     pub fn builder() -> FakeDriverBuilder {
         FakeDriverBuilder {
             caps: DriverCapabilities {
                 vsock: true,
                 vsock_listen: true,
+                checkpoint: true,
+                diff_checkpoint: true,
+                adopt: true,
                 balloon: true,
                 console: true,
                 debug: true,
                 nested_virt: NestedVirt::unsupported("the fake driver runs no hypervisor"),
-                ..DriverCapabilities::default()
             },
+            knobs: Knobs::default(),
         }
     }
 
@@ -103,7 +139,12 @@ impl FakeDriver {
         Ok(())
     }
 
-    fn register(&self, spec: VmSpec, runtime_dir: &Path) -> Result<Box<dyn VmHandle>> {
+    fn register(
+        &self,
+        spec: VmSpec,
+        runtime_dir: &Path,
+        balloon_target_bytes: u64,
+    ) -> Result<Box<dyn VmHandle>> {
         let mut vms = lock(&self.inner.vms);
         if let Some(existing) = vms.get(&spec.id) {
             match existing.state() {
@@ -119,12 +160,17 @@ impl FakeDriver {
         }
         let record = VmRecord {
             id: spec.id.clone(),
-            driver: self.name().to_owned(),
+            driver: NAME.to_owned(),
             runtime_dir: runtime_dir.to_path_buf(),
             process: None,
         };
-        let balloon_target_bytes = u64::from(spec.memory_mib) << 20;
-        let vm = VmInner::new(spec, record, self.inner.caps.clone(), balloon_target_bytes);
+        let vm = VmInner::new(
+            spec,
+            record,
+            self.inner.caps.clone(),
+            Arc::clone(&self.inner.knobs),
+            balloon_target_bytes,
+        );
         vms.insert(vm.id().clone(), Arc::clone(&vm));
         Ok(Box::new(FakeVm::new(vm)))
     }
@@ -154,7 +200,7 @@ impl DriverInner {
 #[async_trait]
 impl VmDriver for FakeDriver {
     fn name(&self) -> &'static str {
-        "fake"
+        NAME
     }
 
     fn capabilities(&self) -> DriverCapabilities {
@@ -163,214 +209,72 @@ impl VmDriver for FakeDriver {
 
     async fn boot(&self, spec: VmSpec, runtime_dir: &Path) -> Result<Box<dyn VmHandle>> {
         spec.validate()?;
-        self.register(spec, runtime_dir)
+        if self
+            .inner
+            .knobs
+            .fail_boot_once
+            .swap(false, Ordering::AcqRel)
+        {
+            return Err(Error::Driver {
+                driver: NAME,
+                message: "scripted boot failure".into(),
+                source: None,
+            });
+        }
+        let balloon_target_bytes = u64::from(spec.memory_mib) << 20;
+        self.register(spec, runtime_dir, balloon_target_bytes)
     }
 
     async fn restore(
         &self,
         image: &CheckpointImage,
-        _spec: RestoreSpec,
-        _runtime_dir: &Path,
+        spec: RestoreSpec,
+        runtime_dir: &Path,
     ) -> Result<Box<dyn VmHandle>> {
-        Err(Error::ForeignCheckpoint(image.format.clone()))
+        if !self.inner.caps.checkpoint || image.format.as_str() != CHECKPOINT_FORMAT {
+            return Err(Error::ForeignCheckpoint(image.format.clone()));
+        }
+        let bytes = tokio::fs::read(image.dir.join("checkpoint.json")).await?;
+        let file: CheckpointFile = serde_json::from_slice(&bytes).map_err(std::io::Error::from)?;
+        if file.format.as_str() != CHECKPOINT_FORMAT {
+            return Err(Error::ForeignCheckpoint(file.format));
+        }
+        let mut vm_spec = file.spec;
+        vm_spec.id = spec.id;
+        vm_spec.nics = spec.nics;
+        vm_spec.isolation = spec.isolation;
+        vm_spec.validate()?;
+        self.register(vm_spec, runtime_dir, file.balloon_target_bytes)
     }
 
     fn adopt(&self) -> Option<&dyn Adopt> {
-        None
+        self.inner.caps.adopt.then_some(&self.adopter)
+    }
+}
+
+/// The `Adopt` capability, on its own type so its `adopt` method does not
+/// shadow the driver's accessor of the same name.
+#[derive(Clone)]
+struct Adopter(Arc<DriverInner>);
+
+#[async_trait]
+impl Adopt for Adopter {
+    async fn adopt(&self, record: &VmRecord) -> Result<Option<Box<dyn VmHandle>>> {
+        let vm = match self.0.live(&record.id) {
+            Ok(vm) => vm,
+            Err(Error::NotFound(_)) => return Ok(None),
+            Err(other) => return Err(other),
+        };
+        if vm.is_owned() {
+            return Err(Error::Driver {
+                driver: NAME,
+                message: format!("vm {} is still owned by a live handle", record.id),
+                source: None,
+            });
+        }
+        Ok(Some(Box::new(FakeVm::new(vm))))
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use std::io::{Read as _, Write as _};
-
-    use super::*;
-    use crate::driver::{ExitStatus, IoMode, ShutdownMode, VmEvent};
-    use crate::spec::{BootSpec, ConsoleSpec, VsockSpec};
-
-    fn spec(id: &str) -> VmSpec {
-        VmSpec {
-            id: VmId::new(id).unwrap(),
-            cpus: 1,
-            memory_mib: 64,
-            boot: BootSpec::Kernel {
-                image: "/fake/vmlinux".into(),
-                cmdline: String::new(),
-                initrd: None,
-            },
-            disks: vec![],
-            nics: vec![],
-            vsock: None,
-            shares: vec![],
-            console: Default::default(),
-            balloon: false,
-            entropy: false,
-            dirty_tracking: false,
-            isolation: Default::default(),
-        }
-    }
-
-    /// A spec asking for every device the fake implements.
-    fn full_spec(id: &str) -> VmSpec {
-        VmSpec {
-            vsock: Some(VsockSpec { guest_cid: 3 }),
-            console: ConsoleSpec::File("/fake/console.log".into()),
-            balloon: true,
-            ..spec(id)
-        }
-    }
-
-    #[tokio::test]
-    async fn shutdown_is_idempotent_and_reports_the_first_status() {
-        let driver = FakeDriver::new();
-        let vm = driver
-            .boot(spec("vm-1"), Path::new("/run/vm-1"))
-            .await
-            .unwrap();
-        let graceful = ShutdownMode::Graceful {
-            timeout: Duration::from_secs(1),
-        };
-        assert_eq!(vm.shutdown(graceful).await.unwrap(), ExitStatus::exited(0));
-        assert_eq!(
-            vm.shutdown(ShutdownMode::Kill).await.unwrap(),
-            ExitStatus::exited(0)
-        );
-        assert_eq!(vm.state(), VmState::Exited(ExitStatus::exited(0)));
-    }
-
-    #[tokio::test]
-    async fn dropping_the_handle_kills_the_vm_and_frees_the_id() {
-        let driver = FakeDriver::new();
-        let vm = driver
-            .boot(spec("vm-1"), Path::new("/run/vm-1"))
-            .await
-            .unwrap();
-        let mut events = vm.events();
-        drop(vm);
-        assert_eq!(
-            events.try_recv().unwrap(),
-            VmEvent::Exited(ExitStatus::signaled(9))
-        );
-        // The id is free again: the exited entry is pruned on the way in.
-        driver
-            .boot(spec("vm-1"), Path::new("/run/vm-1"))
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn a_live_id_cannot_be_booted_twice() {
-        let driver = FakeDriver::new();
-        let _vm = driver
-            .boot(spec("vm-1"), Path::new("/run/vm-1"))
-            .await
-            .unwrap();
-        let Err(err) = driver.boot(spec("vm-1"), Path::new("/run/vm-1")).await else {
-            panic!("second boot of a live id succeeded");
-        };
-        assert!(
-            matches!(
-                err,
-                Error::WrongState {
-                    state: VmState::Running,
-                    ..
-                }
-            ),
-            "{err}"
-        );
-    }
-
-    #[tokio::test]
-    async fn accessors_follow_the_spec_and_the_claims() {
-        let driver = FakeDriver::new();
-        let bare = driver
-            .boot(spec("bare"), Path::new("/run/bare"))
-            .await
-            .unwrap();
-        assert!(bare.vsock().is_none() && bare.vsock_listener().is_none());
-        assert!(bare.balloon().is_none() && bare.console().is_none());
-        assert!(bare.debug().is_some());
-
-        let full = driver
-            .boot(full_spec("full"), Path::new("/run/full"))
-            .await
-            .unwrap();
-        assert!(full.vsock().is_some() && full.vsock_listener().is_some());
-        assert!(full.balloon().is_some() && full.console().is_some());
-
-        let narrow = FakeDriver::builder()
-            .capabilities(DriverCapabilities::default())
-            .build();
-        let vm = narrow
-            .boot(full_spec("narrow"), Path::new("/run/narrow"))
-            .await
-            .unwrap();
-        assert!(vm.vsock().is_none() && vm.debug().is_none() && vm.balloon().is_none());
-    }
-
-    #[tokio::test]
-    async fn dial_reaches_an_echoing_guest() {
-        let driver = FakeDriver::new();
-        let vm = driver
-            .boot(full_spec("vm-1"), Path::new("/run/vm-1"))
-            .await
-            .unwrap();
-        let conn = vm.vsock().unwrap().dial(1024).await.unwrap();
-        assert_eq!(conn.mode, IoMode::Async);
-        let mut stream = UnixStream::from(conn.fd);
-        stream.write_all(b"ping").unwrap();
-        let mut buf = [0u8; 4];
-        stream.read_exact(&mut buf).unwrap();
-        assert_eq!(&buf, b"ping");
-
-        vm.shutdown(ShutdownMode::Kill).await.unwrap();
-        assert!(matches!(
-            vm.vsock().unwrap().dial(1024).await,
-            Err(Error::WrongState { .. })
-        ));
-    }
-
-    #[tokio::test]
-    async fn guest_dial_is_accepted_by_the_listener_in_order() {
-        let driver = FakeDriver::new();
-        let vm = driver
-            .boot(full_spec("vm-1"), Path::new("/run/vm-1"))
-            .await
-            .unwrap();
-        // Pushed before `listen`: the queue is per port, not per listener.
-        let mut early = driver.guest_dial(vm.id(), 7).unwrap();
-        early.write_all(b"early").unwrap();
-        let mut listener = vm.vsock_listener().unwrap().listen(7).await.unwrap();
-        let mut first = UnixStream::from(listener.accept().await.unwrap().fd);
-        let mut buf = [0u8; 5];
-        first.read_exact(&mut buf).unwrap();
-        assert_eq!(&buf, b"early");
-
-        let accept = tokio::spawn(async move { listener.accept().await.map(|c| c.mode) });
-        tokio::task::yield_now().await;
-        let _late = driver.guest_dial(vm.id(), 7).unwrap();
-        assert_eq!(accept.await.unwrap().unwrap(), IoMode::Async);
-
-        vm.shutdown(ShutdownMode::Kill).await.unwrap();
-        assert!(matches!(
-            driver.guest_dial(vm.id(), 7),
-            Err(Error::NotFound(_))
-        ));
-    }
-
-    #[tokio::test]
-    async fn console_hands_out_pushed_bytes_once() {
-        let driver = FakeDriver::new();
-        let vm = driver
-            .boot(full_spec("vm-1"), Path::new("/run/vm-1"))
-            .await
-            .unwrap();
-        driver.push_console(vm.id(), b"hello world").unwrap();
-        let console = vm.console().unwrap();
-        assert_eq!(console.read_output(5).await.unwrap(), b"hello");
-        assert_eq!(console.read_output(64).await.unwrap(), b" world");
-        assert!(console.read_output(64).await.unwrap().is_empty());
-    }
-}
+mod tests;

--- a/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 
 use super::fake_vm::{CHECKPOINT_FORMAT, CheckpointFile, FakeVm, VmInner};
+use super::fake_vsock::Inbound;
 use super::lock;
 use crate::capability::{Adopt, CheckpointImage};
 use crate::driver::{
@@ -165,12 +166,14 @@ impl FakeDriver {
             runtime_dir: runtime_dir.to_path_buf(),
             process: None,
         };
+        let inbound = Inbound::new(spec.id.clone());
         let vm = VmInner::new(
             spec,
             record,
             self.inner.caps.clone(),
             Arc::clone(&self.inner.knobs),
             balloon_target_bytes,
+            inbound,
         );
         vms.insert(vm.id().clone(), Arc::clone(&vm));
         Ok(Box::new(FakeVm::new(vm)))

--- a/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
@@ -1,0 +1,197 @@
+//! An in-memory [`VmDriver`] for tests that need a VM without a hypervisor.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+
+use super::fake_vm::{FakeVm, VmInner};
+use super::lock;
+use crate::capability::{Adopt, CheckpointImage};
+use crate::driver::{
+    DriverCapabilities, NestedVirt, RestoreSpec, VmDriver, VmHandle, VmRecord, VmState,
+};
+use crate::error::{Error, Result};
+use crate::spec::{VmId, VmSpec};
+
+/// An in-memory VM driver.
+///
+/// VMs are a real state machine (`Running` → `Exited` on shutdown, kill, or
+/// drop) with an events broadcast; the capabilities land alongside.
+///
+/// The driver's name is `"fake"`.
+#[derive(Clone)]
+pub struct FakeDriver {
+    inner: Arc<DriverInner>,
+}
+
+struct DriverInner {
+    /// Every VM booted and not yet seen exited.
+    vms: Mutex<HashMap<VmId, Arc<VmInner>>>,
+}
+
+impl FakeDriver {
+    /// A driver with no scripted failures.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(DriverInner {
+                vms: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    fn register(&self, spec: VmSpec, runtime_dir: &Path) -> Result<Box<dyn VmHandle>> {
+        let mut vms = lock(&self.inner.vms);
+        if let Some(existing) = vms.get(&spec.id) {
+            match existing.state() {
+                VmState::Exited(_) => {}
+                state => {
+                    return Err(Error::WrongState {
+                        id: spec.id.clone(),
+                        state,
+                        expected: "no vm with this id",
+                    });
+                }
+            }
+        }
+        let record = VmRecord {
+            id: spec.id.clone(),
+            driver: self.name().to_owned(),
+            runtime_dir: runtime_dir.to_path_buf(),
+            process: None,
+        };
+        let vm = VmInner::new(spec, record);
+        vms.insert(vm.id().clone(), Arc::clone(&vm));
+        Ok(Box::new(FakeVm::new(vm)))
+    }
+}
+
+impl Default for FakeDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl VmDriver for FakeDriver {
+    fn name(&self) -> &'static str {
+        "fake"
+    }
+
+    fn capabilities(&self) -> DriverCapabilities {
+        DriverCapabilities {
+            nested_virt: NestedVirt::unsupported("the fake driver runs no hypervisor"),
+            ..DriverCapabilities::default()
+        }
+    }
+
+    async fn boot(&self, spec: VmSpec, runtime_dir: &Path) -> Result<Box<dyn VmHandle>> {
+        spec.validate()?;
+        self.register(spec, runtime_dir)
+    }
+
+    async fn restore(
+        &self,
+        image: &CheckpointImage,
+        _spec: RestoreSpec,
+        _runtime_dir: &Path,
+    ) -> Result<Box<dyn VmHandle>> {
+        Err(Error::ForeignCheckpoint(image.format.clone()))
+    }
+
+    fn adopt(&self) -> Option<&dyn Adopt> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::driver::{ExitStatus, ShutdownMode, VmEvent};
+    use crate::spec::BootSpec;
+
+    fn spec(id: &str) -> VmSpec {
+        VmSpec {
+            id: VmId::new(id).unwrap(),
+            cpus: 1,
+            memory_mib: 64,
+            boot: BootSpec::Kernel {
+                image: "/fake/vmlinux".into(),
+                cmdline: String::new(),
+                initrd: None,
+            },
+            disks: vec![],
+            nics: vec![],
+            vsock: None,
+            shares: vec![],
+            console: Default::default(),
+            balloon: false,
+            entropy: false,
+            dirty_tracking: false,
+            isolation: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn shutdown_is_idempotent_and_reports_the_first_status() {
+        let driver = FakeDriver::new();
+        let vm = driver
+            .boot(spec("vm-1"), Path::new("/run/vm-1"))
+            .await
+            .unwrap();
+        let graceful = ShutdownMode::Graceful {
+            timeout: Duration::from_secs(1),
+        };
+        assert_eq!(vm.shutdown(graceful).await.unwrap(), ExitStatus::exited(0));
+        assert_eq!(
+            vm.shutdown(ShutdownMode::Kill).await.unwrap(),
+            ExitStatus::exited(0)
+        );
+        assert_eq!(vm.state(), VmState::Exited(ExitStatus::exited(0)));
+    }
+
+    #[tokio::test]
+    async fn dropping_the_handle_kills_the_vm_and_frees_the_id() {
+        let driver = FakeDriver::new();
+        let vm = driver
+            .boot(spec("vm-1"), Path::new("/run/vm-1"))
+            .await
+            .unwrap();
+        let mut events = vm.events();
+        drop(vm);
+        assert_eq!(
+            events.try_recv().unwrap(),
+            VmEvent::Exited(ExitStatus::signaled(9))
+        );
+        // The id is free again: the exited entry is pruned on the way in.
+        driver
+            .boot(spec("vm-1"), Path::new("/run/vm-1"))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_live_id_cannot_be_booted_twice() {
+        let driver = FakeDriver::new();
+        let _vm = driver
+            .boot(spec("vm-1"), Path::new("/run/vm-1"))
+            .await
+            .unwrap();
+        let Err(err) = driver.boot(spec("vm-1"), Path::new("/run/vm-1")).await else {
+            panic!("second boot of a live id succeeded");
+        };
+        assert!(
+            matches!(
+                err,
+                Error::WrongState {
+                    state: VmState::Running,
+                    ..
+                }
+            ),
+            "{err}"
+        );
+    }
+}

--- a/virt/arcbox-vm-driver/src/testkit/fake_driver/tests.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_driver/tests.rs
@@ -1,0 +1,330 @@
+//! Unit tests for the fake driver: what the contract does not cover.
+
+use std::io::{Read as _, Write as _};
+use std::time::Duration;
+
+use super::*;
+use crate::capability::{AfterCheckpoint, CheckpointFormat, CheckpointKind, CheckpointOptions};
+use crate::driver::{ExitStatus, IoMode, ShutdownMode, VmEvent};
+use crate::spec::{BootSpec, ConsoleSpec, IsolationSpec, VsockSpec};
+
+fn spec(id: &str) -> VmSpec {
+    VmSpec {
+        id: VmId::new(id).unwrap(),
+        cpus: 1,
+        memory_mib: 64,
+        boot: BootSpec::Kernel {
+            image: "/fake/vmlinux".into(),
+            cmdline: String::new(),
+            initrd: None,
+        },
+        disks: vec![],
+        nics: vec![],
+        vsock: None,
+        shares: vec![],
+        console: Default::default(),
+        balloon: false,
+        entropy: false,
+        dirty_tracking: false,
+        isolation: Default::default(),
+    }
+}
+
+/// A spec asking for every device the fake implements.
+fn full_spec(id: &str) -> VmSpec {
+    VmSpec {
+        vsock: Some(VsockSpec { guest_cid: 3 }),
+        console: ConsoleSpec::File("/fake/console.log".into()),
+        balloon: true,
+        ..spec(id)
+    }
+}
+
+#[tokio::test]
+async fn shutdown_is_idempotent_and_reports_the_first_status() {
+    let driver = FakeDriver::new();
+    let vm = driver
+        .boot(spec("vm-1"), Path::new("/run/vm-1"))
+        .await
+        .unwrap();
+    let graceful = ShutdownMode::Graceful {
+        timeout: Duration::from_secs(1),
+    };
+    assert_eq!(vm.shutdown(graceful).await.unwrap(), ExitStatus::exited(0));
+    assert_eq!(
+        vm.shutdown(ShutdownMode::Kill).await.unwrap(),
+        ExitStatus::exited(0)
+    );
+    assert_eq!(vm.state(), VmState::Exited(ExitStatus::exited(0)));
+}
+
+#[tokio::test]
+async fn dropping_the_handle_kills_the_vm_and_frees_the_id() {
+    let driver = FakeDriver::new();
+    let vm = driver
+        .boot(spec("vm-1"), Path::new("/run/vm-1"))
+        .await
+        .unwrap();
+    let mut events = vm.events();
+    drop(vm);
+    assert_eq!(
+        events.try_recv().unwrap(),
+        VmEvent::Exited(ExitStatus::signaled(9))
+    );
+    // The id is free again: the exited entry is pruned on the way in.
+    driver
+        .boot(spec("vm-1"), Path::new("/run/vm-1"))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn a_live_id_cannot_be_booted_twice() {
+    let driver = FakeDriver::new();
+    let _vm = driver
+        .boot(spec("vm-1"), Path::new("/run/vm-1"))
+        .await
+        .unwrap();
+    let Err(err) = driver.boot(spec("vm-1"), Path::new("/run/vm-1")).await else {
+        panic!("second boot of a live id succeeded");
+    };
+    assert!(
+        matches!(
+            err,
+            Error::WrongState {
+                state: VmState::Running,
+                ..
+            }
+        ),
+        "{err}"
+    );
+}
+
+#[tokio::test]
+async fn accessors_follow_the_spec_and_the_claims() {
+    let driver = FakeDriver::new();
+    let bare = driver
+        .boot(spec("bare"), Path::new("/run/bare"))
+        .await
+        .unwrap();
+    assert!(bare.vsock().is_none() && bare.vsock_listener().is_none());
+    assert!(bare.balloon().is_none() && bare.console().is_none());
+    assert!(bare.debug().is_some());
+
+    let full = driver
+        .boot(full_spec("full"), Path::new("/run/full"))
+        .await
+        .unwrap();
+    assert!(full.vsock().is_some() && full.vsock_listener().is_some());
+    assert!(full.balloon().is_some() && full.console().is_some());
+
+    let narrow = FakeDriver::builder()
+        .capabilities(DriverCapabilities::default())
+        .build();
+    let vm = narrow
+        .boot(full_spec("narrow"), Path::new("/run/narrow"))
+        .await
+        .unwrap();
+    assert!(vm.vsock().is_none() && vm.debug().is_none() && vm.balloon().is_none());
+}
+
+#[tokio::test]
+async fn dial_reaches_an_echoing_guest() {
+    let driver = FakeDriver::new();
+    let vm = driver
+        .boot(full_spec("vm-1"), Path::new("/run/vm-1"))
+        .await
+        .unwrap();
+    let conn = vm.vsock().unwrap().dial(1024).await.unwrap();
+    assert_eq!(conn.mode, IoMode::Async);
+    let mut stream = UnixStream::from(conn.fd);
+    stream.write_all(b"ping").unwrap();
+    let mut buf = [0u8; 4];
+    stream.read_exact(&mut buf).unwrap();
+    assert_eq!(&buf, b"ping");
+
+    vm.shutdown(ShutdownMode::Kill).await.unwrap();
+    assert!(matches!(
+        vm.vsock().unwrap().dial(1024).await,
+        Err(Error::WrongState { .. })
+    ));
+}
+
+#[tokio::test]
+async fn guest_dial_is_accepted_by_the_listener_in_order() {
+    let driver = FakeDriver::new();
+    let vm = driver
+        .boot(full_spec("vm-1"), Path::new("/run/vm-1"))
+        .await
+        .unwrap();
+    // Pushed before `listen`: the queue is per port, not per listener.
+    let mut early = driver.guest_dial(vm.id(), 7).unwrap();
+    early.write_all(b"early").unwrap();
+    let mut listener = vm.vsock_listener().unwrap().listen(7).await.unwrap();
+    let mut first = UnixStream::from(listener.accept().await.unwrap().fd);
+    let mut buf = [0u8; 5];
+    first.read_exact(&mut buf).unwrap();
+    assert_eq!(&buf, b"early");
+
+    let accept = tokio::spawn(async move { listener.accept().await.map(|c| c.mode) });
+    tokio::task::yield_now().await;
+    let _late = driver.guest_dial(vm.id(), 7).unwrap();
+    assert_eq!(accept.await.unwrap().unwrap(), IoMode::Async);
+
+    vm.shutdown(ShutdownMode::Kill).await.unwrap();
+    assert!(matches!(
+        driver.guest_dial(vm.id(), 7),
+        Err(Error::NotFound(_))
+    ));
+}
+
+#[tokio::test]
+async fn console_hands_out_pushed_bytes_once() {
+    let driver = FakeDriver::new();
+    let vm = driver
+        .boot(full_spec("vm-1"), Path::new("/run/vm-1"))
+        .await
+        .unwrap();
+    driver.push_console(vm.id(), b"hello world").unwrap();
+    let console = vm.console().unwrap();
+    assert_eq!(console.read_output(5).await.unwrap(), b"hello");
+    assert_eq!(console.read_output(64).await.unwrap(), b" world");
+    assert!(console.read_output(64).await.unwrap().is_empty());
+}
+
+fn restore_spec(id: &str) -> RestoreSpec {
+    RestoreSpec {
+        id: VmId::new(id).unwrap(),
+        nics: vec![],
+        isolation: IsolationSpec::None,
+    }
+}
+
+#[tokio::test]
+async fn checkpoint_writes_an_image_restore_reads_back_with_overrides() {
+    let dir = tempfile::tempdir().unwrap();
+    let driver = FakeDriver::new();
+    let vm = driver.boot(full_spec("vm-1"), dir.path()).await.unwrap();
+    vm.balloon().unwrap().set_target(8 << 20).await.unwrap();
+
+    let hold = CheckpointOptions {
+        after: AfterCheckpoint::HoldQuiesced,
+        kind: CheckpointKind::Full,
+    };
+    let image = vm
+        .checkpoint()
+        .unwrap()
+        .checkpoint(&dir.path().join("ckpt"), hold)
+        .await
+        .unwrap();
+    assert_eq!(vm.state(), VmState::Quiesced);
+    assert_eq!(image.format, CheckpointFormat::new("fake/v1"));
+    assert!(image.dir.join("checkpoint.json").is_file());
+    // A quiesced VM can be checkpointed again and resumed.
+    let resume = CheckpointOptions::default();
+    vm.checkpoint()
+        .unwrap()
+        .checkpoint(&dir.path().join("ckpt2"), resume)
+        .await
+        .unwrap();
+    assert_eq!(vm.state(), VmState::Running);
+    vm.shutdown(ShutdownMode::Kill).await.unwrap();
+
+    let restored = driver
+        .restore(&image, restore_spec("vm-2"), dir.path())
+        .await
+        .unwrap();
+    assert_eq!(restored.id().as_str(), "vm-2");
+    assert_eq!(restored.state(), VmState::Running);
+    assert_eq!(restored.record().driver, "fake");
+    // Everything the restore spec does not override comes from the image.
+    assert!(restored.vsock().is_some() && restored.console().is_some());
+    assert_eq!(
+        restored
+            .balloon()
+            .unwrap()
+            .stats()
+            .await
+            .unwrap()
+            .target_bytes,
+        8 << 20
+    );
+}
+
+#[tokio::test]
+async fn restore_refuses_foreign_and_unclaimed_checkpoints() {
+    let dir = tempfile::tempdir().unwrap();
+    let foreign = CheckpointImage {
+        dir: dir.path().to_path_buf(),
+        format: CheckpointFormat::new("firecracker/v1"),
+        kind: CheckpointKind::Full,
+    };
+    let err = FakeDriver::new()
+        .restore(&foreign, restore_spec("vm-2"), dir.path())
+        .await
+        .err()
+        .unwrap();
+    assert!(matches!(err, Error::ForeignCheckpoint(f) if f.as_str() == "firecracker/v1"));
+
+    let unclaimed = FakeDriver::builder()
+        .capabilities(DriverCapabilities::default())
+        .build();
+    let own = CheckpointImage {
+        format: CheckpointFormat::new("fake/v1"),
+        ..foreign
+    };
+    let err = unclaimed
+        .restore(&own, restore_spec("vm-2"), dir.path())
+        .await
+        .err()
+        .unwrap();
+    assert!(matches!(err, Error::ForeignCheckpoint(_)));
+}
+
+#[tokio::test]
+async fn detach_keeps_the_vm_alive_for_adopt_and_only_once() {
+    let driver = FakeDriver::new();
+    let vm = driver
+        .boot(spec("vm-1"), Path::new("/run/vm-1"))
+        .await
+        .unwrap();
+    let record = vm.detach().unwrap().detach().await.unwrap();
+    assert_eq!(record, vm.record());
+    drop(vm);
+
+    let adopt = driver.adopt().unwrap();
+    let again = adopt.adopt(&record).await.unwrap().unwrap();
+    assert_eq!(again.state(), VmState::Running);
+    // Two owners is a caller bug, not a second handle.
+    assert!(matches!(
+        adopt.adopt(&record).await,
+        Err(Error::Driver { .. })
+    ));
+
+    drop(again);
+    assert!(adopt.adopt(&record).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn scripted_failures_fire_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let driver = FakeDriver::builder()
+        .fail_boot_once()
+        .fail_checkpoint_once()
+        .build();
+    assert!(matches!(
+        driver.boot(spec("vm-1"), dir.path()).await.err(),
+        Some(Error::Driver { .. })
+    ));
+    let vm = driver.boot(spec("vm-1"), dir.path()).await.unwrap();
+    let cp = vm.checkpoint().unwrap();
+    assert!(matches!(
+        cp.checkpoint(&dir.path().join("a"), CheckpointOptions::default())
+            .await
+            .err(),
+        Some(Error::Driver { .. })
+    ));
+    cp.checkpoint(&dir.path().join("b"), CheckpointOptions::default())
+        .await
+        .unwrap();
+}

--- a/virt/arcbox-vm-driver/src/testkit/fake_driver/tests.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_driver/tests.rs
@@ -374,3 +374,49 @@ async fn scripted_failures_fire_once() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn a_discarded_prepared_vm_refuses_listeners_before_and_after_its_boot() {
+    let driver = FakeDriver::new();
+    let prepare = driver.prepare().unwrap();
+
+    // Discarded before any boot: listen, boot and alive all say so.
+    let spec = full_spec("vm-1");
+    let prepared = prepare
+        .prepare(&spec.id, &spec.isolation, Path::new("/run/vm-1"))
+        .await
+        .unwrap();
+    prepared.discard().await.unwrap();
+    assert!(!prepared.alive());
+    assert!(matches!(
+        prepared.vsock_listener().unwrap().listen(7).await.err(),
+        Some(Error::WrongState { .. })
+    ));
+    assert!(matches!(
+        prepared.boot(spec).await.err(),
+        Some(Error::WrongState { .. })
+    ));
+
+    // Discarded after a boot: the same answers, and the handle agrees.
+    let spec = full_spec("vm-2");
+    let prepared = prepare
+        .prepare(&spec.id, &spec.isolation, Path::new("/run/vm-2"))
+        .await
+        .unwrap();
+    let vm = prepared.boot(spec.clone()).await.unwrap();
+    let status = prepared.discard().await.unwrap();
+    assert_eq!(vm.state(), VmState::Exited(status));
+    assert!(!prepared.alive());
+    assert!(matches!(
+        prepared.vsock_listener().unwrap().listen(7).await.err(),
+        Some(Error::WrongState { .. })
+    ));
+    assert!(matches!(
+        vm.vsock_listener().unwrap().listen(7).await.err(),
+        Some(Error::WrongState { .. })
+    ));
+    assert!(matches!(
+        prepared.boot(spec).await.err(),
+        Some(Error::WrongState { .. })
+    ));
+}

--- a/virt/arcbox-vm-driver/src/testkit/fake_driver/tests.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_driver/tests.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use super::*;
 use crate::capability::{AfterCheckpoint, CheckpointFormat, CheckpointKind, CheckpointOptions};
 use crate::driver::{ExitStatus, IoMode, ShutdownMode, VmEvent};
-use crate::spec::{BootSpec, ConsoleSpec, IsolationSpec, VsockSpec};
+use crate::spec::{BootSpec, ConsoleSpec, DiskSpec, IsolationSpec, VsockSpec};
 
 fn spec(id: &str) -> VmSpec {
     VmSpec {
@@ -196,6 +196,7 @@ fn restore_spec(id: &str) -> RestoreSpec {
     RestoreSpec {
         id: VmId::new(id).unwrap(),
         nics: vec![],
+        disks: vec![],
         isolation: IsolationSpec::None,
     }
 }
@@ -249,6 +250,51 @@ async fn checkpoint_writes_an_image_restore_reads_back_with_overrides() {
             .target_bytes,
         8 << 20
     );
+}
+
+#[tokio::test]
+async fn restore_must_name_exactly_the_images_disks() {
+    let dir = tempfile::tempdir().unwrap();
+    let driver = FakeDriver::new();
+    let mut with_disk = full_spec("vm-1");
+    with_disk.disks.push(DiskSpec {
+        id: "rootfs".into(),
+        path: dir.path().join("rootfs.ext4"),
+        read_only: false,
+        root: true,
+        cache: Default::default(),
+    });
+    let vm = driver.boot(with_disk, dir.path()).await.unwrap();
+    let hold = CheckpointOptions {
+        after: AfterCheckpoint::HoldQuiesced,
+        kind: CheckpointKind::Full,
+    };
+    let image = vm
+        .checkpoint()
+        .unwrap()
+        .checkpoint(&dir.path().join("ckpt"), hold)
+        .await
+        .unwrap();
+    vm.shutdown(ShutdownMode::Kill).await.unwrap();
+
+    // No disks named: refused; the image has one.
+    let Err(err) = driver
+        .restore(&image, restore_spec("vm-2"), dir.path())
+        .await
+    else {
+        panic!("restore without the image's disks succeeded");
+    };
+    assert!(matches!(err, Error::InvalidSpec(_)), "{err}");
+
+    let mut renamed = restore_spec("vm-2");
+    renamed.disks.push(DiskSpec {
+        id: "rootfs".into(),
+        path: dir.path().join("rootfs.restored"),
+        read_only: false,
+        root: true,
+        cache: Default::default(),
+    });
+    driver.restore(&image, renamed, dir.path()).await.unwrap();
 }
 
 #[tokio::test]

--- a/virt/arcbox-vm-driver/src/testkit/fake_network.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_network.rs
@@ -91,6 +91,27 @@ impl Ledger {
     fn lowest_free_host(&self) -> Option<u16> {
         (FIRST_HOST..u16::MAX).find(|n| !self.used.contains(n))
     }
+
+    /// The error for a lease that is not the VM's current one — an older
+    /// generation, or one whose address has since been handed to another VM.
+    fn stale(&self, lease: &NetworkLease) -> Error {
+        let other_holder = self
+            .active
+            .iter()
+            .chain(self.quarantined.iter())
+            .find(|(vm, held)| **vm != lease.vm && held.ip == lease.ip)
+            .map(|(vm, _)| vm);
+        match other_holder {
+            Some(vm) => Error::Network(format!(
+                "vm {} lease {} is stale: {} is now held by vm {vm}",
+                lease.vm, lease.cleanup_token, lease.ip
+            )),
+            None => Error::Network(format!(
+                "vm {} lease {} is not its current lease",
+                lease.vm, lease.cleanup_token
+            )),
+        }
+    }
 }
 
 fn host_number(ip: IpAddr) -> Result<u16> {
@@ -160,6 +181,7 @@ impl GuestNetwork for FakeNetwork {
 
     async fn quarantine(&self, lease: NetworkLease) -> Result<()> {
         let mut ledger = lock(&self.ledger);
+        let host = host_number(lease.ip)?;
         if let Some(existing) = ledger.quarantined.get(&lease.vm) {
             if existing.cleanup_token == lease.cleanup_token {
                 return Ok(());
@@ -169,20 +191,46 @@ impl GuestNetwork for FakeNetwork {
                 lease.vm
             )));
         }
-        // A lease replayed from a durable record after a crash is quarantined
-        // even if this process never handed it out.
-        ledger.used.insert(host_number(lease.ip)?);
-        ledger.active.remove(&lease.vm);
+        match ledger.active.get(&lease.vm) {
+            Some(current) if *current == lease => {
+                ledger.active.remove(&lease.vm);
+            }
+            Some(_) => return Err(ledger.stale(&lease)),
+            // A lease replayed from a durable record after a crash is
+            // quarantined even if this process never handed it out — unless
+            // its address has since gone to another VM, which makes the
+            // record stale rather than orphaned.
+            None => {
+                if ledger.used.contains(&host) {
+                    return Err(ledger.stale(&lease));
+                }
+                ledger.used.insert(host);
+            }
+        }
         ledger.quarantined.insert(lease.vm.clone(), lease);
         Ok(())
     }
 
     async fn release(&self, lease: NetworkLease) -> Result<()> {
         let mut ledger = lock(&self.ledger);
-        ledger.active.remove(&lease.vm);
-        ledger.quarantined.remove(&lease.vm);
-        ledger.used.remove(&host_number(lease.ip)?);
-        Ok(())
+        let host = host_number(lease.ip)?;
+        let current = ledger
+            .active
+            .get(&lease.vm)
+            .or_else(|| ledger.quarantined.get(&lease.vm));
+        match current {
+            Some(current) if *current == lease => {
+                ledger.active.remove(&lease.vm);
+                ledger.quarantined.remove(&lease.vm);
+                ledger.used.remove(&host);
+                Ok(())
+            }
+            Some(_) => Err(ledger.stale(&lease)),
+            // Nothing held for this VM: releasing again is a no-op, unless
+            // the address now belongs to someone else.
+            None if ledger.used.contains(&host) => Err(ledger.stale(&lease)),
+            None => Ok(()),
+        }
     }
 
     fn identity(&self, lease: &NetworkLease) -> NetworkIdentity {
@@ -349,6 +397,56 @@ mod tests {
         assert!(reconcile.pending_cleanups().await.is_empty());
         let c = net.reserve(&id("c"), policy()).await.unwrap();
         assert_eq!(c.ip, a.ip);
+    }
+
+    #[tokio::test]
+    async fn stale_leases_neither_free_nor_quarantine_a_reassigned_address() {
+        let net = FakeNetwork::new();
+        let a1 = net.reserve(&id("a"), policy()).await.unwrap();
+        net.release(a1.clone()).await.unwrap();
+        // Releasing what is already released is a no-op...
+        net.release(a1.clone()).await.unwrap();
+        // ...until the address belongs to someone else.
+        let second = net.reserve(&id("b"), policy()).await.unwrap();
+        assert_eq!(second.ip, a1.ip);
+        assert!(net.release(a1.clone()).await.is_err());
+        assert!(net.quarantine(a1.clone()).await.is_err());
+        // The new holder keeps it: nobody else gets that address.
+        let third = net.reserve(&id("c"), policy()).await.unwrap();
+        assert_ne!(third.ip, second.ip);
+
+        // A VM's older generation cannot touch its current lease either.
+        let a2 = net.reserve(&id("a"), policy()).await.unwrap();
+        assert!(net.release(a1.clone()).await.is_err());
+        assert!(net.quarantine(a1).await.is_err());
+        assert!(net.activate(&a2, AttachMode::Invariant).await.is_ok());
+
+        // A quarantined lease is released only by itself.
+        net.quarantine(a2.clone()).await.unwrap();
+        let mut forged = a2.clone();
+        forged.cleanup_token = "forged".into();
+        assert!(net.release(forged).await.is_err());
+        net.release(a2.clone()).await.unwrap();
+        assert!(net.reconcile().unwrap().pending_cleanups().await.is_empty());
+        let reused = net.reserve(&id("d"), policy()).await.unwrap();
+        assert_eq!(reused.ip, a2.ip);
+
+        // A durable-record replay of an address nobody holds still lands in
+        // quarantine and pins the address until its token finalizes it.
+        let mut replayed = reused.clone();
+        replayed.vm = id("ghost");
+        replayed.ip = "10.200.0.5".parse().unwrap(); // the lowest free host
+        replayed.cleanup_token = "ghost-1".into();
+        net.quarantine(replayed.clone()).await.unwrap();
+        let next = net.reserve(&id("e"), policy()).await.unwrap();
+        assert_eq!(next.ip, "10.200.0.6".parse::<IpAddr>().unwrap());
+        let reconcile = net.reconcile().unwrap();
+        reconcile
+            .finalize_cleanup(&id("ghost"), "ghost-1")
+            .await
+            .unwrap();
+        let unpinned = net.reserve(&id("f"), policy()).await.unwrap();
+        assert_eq!(unpinned.ip, replayed.ip);
     }
 
     #[tokio::test]

--- a/virt/arcbox-vm-driver/src/testkit/fake_network.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_network.rs
@@ -1,0 +1,390 @@
+//! An in-memory [`GuestNetwork`] with a quarantine ledger.
+
+use std::collections::{BTreeSet, HashMap};
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use tokio::sync::watch;
+
+use super::lock;
+use crate::error::{Error, Result};
+use crate::net::{
+    AttachMode, GuestNetwork, NetworkIdentity, NetworkLease, NetworkPolicy, NetworkReconcile,
+};
+use crate::spec::{MacAddr, NicAttachment, NicSpec, VmId};
+
+/// An in-memory guest network.
+///
+/// Leases come from `10.200.0.0/16` (gateway `10.200.0.1`, lowest free host
+/// number first, so a released address is reused); `activate` returns a
+/// `NicSpec` on `tapN`; `quarantine` moves a lease into a ledger that
+/// [`NetworkReconcile`] drains through the token protocol.
+/// [`FakeNetwork::with_startup_cleanup`] starts with a pending startup
+/// cleanup so that half of the protocol can be exercised too.
+pub struct FakeNetwork {
+    ledger: Mutex<Ledger>,
+    /// `true` while a startup cleanup is pending.
+    startup_pending: watch::Sender<bool>,
+}
+
+#[derive(Default)]
+struct Ledger {
+    /// Host numbers in use, active or quarantined.
+    used: BTreeSet<u16>,
+    active: HashMap<VmId, NetworkLease>,
+    quarantined: HashMap<VmId, NetworkLease>,
+    startup: Option<StartupCleanup>,
+    minted: u64,
+}
+
+struct StartupCleanup {
+    token: String,
+    host_cleaned: bool,
+}
+
+const PREFIX_LEN: u8 = 16;
+const GATEWAY: Ipv4Addr = Ipv4Addr::new(10, 200, 0, 1);
+/// Host numbers below this are the network and gateway addresses.
+const FIRST_HOST: u16 = 2;
+
+impl FakeNetwork {
+    /// A network with nothing pending.
+    pub fn new() -> Self {
+        Self::build(None)
+    }
+
+    /// A network whose startup sweep found leftovers: `token` gates the
+    /// startup cleanup and `wait_startup_cleanup_complete` blocks until it
+    /// is finalized.
+    pub fn with_startup_cleanup(token: impl Into<String>) -> Self {
+        Self::build(Some(StartupCleanup {
+            token: token.into(),
+            host_cleaned: false,
+        }))
+    }
+
+    fn build(startup: Option<StartupCleanup>) -> Self {
+        let pending = startup.is_some();
+        Self {
+            ledger: Mutex::new(Ledger {
+                startup,
+                ..Ledger::default()
+            }),
+            startup_pending: watch::Sender::new(pending),
+        }
+    }
+
+    fn set_startup_pending(&self, ledger: &Ledger) {
+        let pending = ledger.startup.as_ref().is_some_and(|s| !s.host_cleaned);
+        self.startup_pending.send_replace(pending);
+    }
+}
+
+impl Default for FakeNetwork {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Ledger {
+    fn lowest_free_host(&self) -> Option<u16> {
+        (FIRST_HOST..u16::MAX).find(|n| !self.used.contains(n))
+    }
+}
+
+fn host_number(ip: IpAddr) -> Result<u16> {
+    match ip {
+        IpAddr::V4(v4) if v4.octets()[..2] == [10, 200] => {
+            let [_, _, hi, lo] = v4.octets();
+            Ok(u16::from_be_bytes([hi, lo]))
+        }
+        other => Err(Error::Network(format!(
+            "{other} is not a fake-network address (10.200.0.0/16)"
+        ))),
+    }
+}
+
+#[async_trait]
+impl GuestNetwork for FakeNetwork {
+    async fn reserve(&self, vm: &VmId, _policy: NetworkPolicy) -> Result<NetworkLease> {
+        let mut ledger = lock(&self.ledger);
+        if ledger.active.contains_key(vm) || ledger.quarantined.contains_key(vm) {
+            return Err(Error::Network(format!("vm {vm} already holds a lease")));
+        }
+        let host = ledger
+            .lowest_free_host()
+            .ok_or_else(|| Error::Network("fake network address pool exhausted".into()))?;
+        ledger.used.insert(host);
+        ledger.minted += 1;
+        let [hi, lo] = host.to_be_bytes();
+        let lease = NetworkLease {
+            vm: vm.clone(),
+            ip: IpAddr::V4(Ipv4Addr::new(10, 200, hi, lo)),
+            prefix_len: PREFIX_LEN,
+            gateway: IpAddr::V4(GATEWAY),
+            mac: MacAddr::new([0x02, 0xfa, 0xce, 0x00, hi, lo]),
+            cleanup_token: format!("fake-cleanup-{}", ledger.minted),
+        };
+        ledger.active.insert(vm.clone(), lease.clone());
+        Ok(lease)
+    }
+
+    async fn activate(&self, lease: &NetworkLease, _mode: AttachMode) -> Result<NicSpec> {
+        let ledger = lock(&self.ledger);
+        if ledger.quarantined.contains_key(&lease.vm) {
+            return Err(Error::Network(format!(
+                "vm {} lease is quarantined; reserve a new one",
+                lease.vm
+            )));
+        }
+        let reserved = ledger
+            .active
+            .get(&lease.vm)
+            .ok_or_else(|| Error::NotFound(lease.vm.clone()))?;
+        if reserved != lease {
+            return Err(Error::Network(format!(
+                "vm {} lease does not match the one reserved",
+                lease.vm
+            )));
+        }
+        let host = host_number(lease.ip)?;
+        Ok(NicSpec {
+            id: "eth0".into(),
+            mac: lease.mac,
+            attachment: NicAttachment::Tap {
+                name: format!("tap{host}"),
+            },
+        })
+    }
+
+    async fn quarantine(&self, lease: NetworkLease) -> Result<()> {
+        let mut ledger = lock(&self.ledger);
+        if let Some(existing) = ledger.quarantined.get(&lease.vm) {
+            if existing.cleanup_token == lease.cleanup_token {
+                return Ok(());
+            }
+            return Err(Error::Network(format!(
+                "vm {} already has a different quarantined lease",
+                lease.vm
+            )));
+        }
+        // A lease replayed from a durable record after a crash is quarantined
+        // even if this process never handed it out.
+        ledger.used.insert(host_number(lease.ip)?);
+        ledger.active.remove(&lease.vm);
+        ledger.quarantined.insert(lease.vm.clone(), lease);
+        Ok(())
+    }
+
+    async fn release(&self, lease: NetworkLease) -> Result<()> {
+        let mut ledger = lock(&self.ledger);
+        ledger.active.remove(&lease.vm);
+        ledger.quarantined.remove(&lease.vm);
+        ledger.used.remove(&host_number(lease.ip)?);
+        Ok(())
+    }
+
+    fn identity(&self, lease: &NetworkLease) -> NetworkIdentity {
+        NetworkIdentity {
+            ip: lease.ip,
+            prefix_len: lease.prefix_len,
+            gateway: lease.gateway,
+            dns: vec![lease.gateway],
+            mac: lease.mac,
+        }
+    }
+
+    fn reconcile(&self) -> Option<&dyn NetworkReconcile> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl NetworkReconcile for FakeNetwork {
+    async fn pending_cleanups(&self) -> Vec<(VmId, String)> {
+        lock(&self.ledger)
+            .quarantined
+            .iter()
+            .map(|(vm, lease)| (vm.clone(), lease.cleanup_token.clone()))
+            .collect()
+    }
+
+    async fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<()> {
+        lock(&self.ledger).validate_cleanup(vm, token)
+    }
+
+    async fn finalize_cleanup(&self, vm: &VmId, token: &str) -> Result<()> {
+        let mut ledger = lock(&self.ledger);
+        ledger.validate_cleanup(vm, token)?;
+        if let Some(lease) = ledger.quarantined.remove(vm) {
+            ledger.used.remove(&host_number(lease.ip)?);
+        }
+        Ok(())
+    }
+
+    async fn startup_cleanup_token(&self) -> Option<String> {
+        lock(&self.ledger)
+            .startup
+            .as_ref()
+            .filter(|s| !s.host_cleaned)
+            .map(|s| s.token.clone())
+    }
+
+    async fn validate_startup_cleanup(&self, token: &str) -> Result<()> {
+        lock(&self.ledger).validate_startup_cleanup(token)
+    }
+
+    async fn finalize_startup_cleanup(&self, token: &str) -> Result<()> {
+        let mut ledger = lock(&self.ledger);
+        ledger.validate_startup_cleanup(token)?;
+        if !ledger.quarantined.is_empty() {
+            return Err(Error::Network(
+                "cleanup generations remain pending; finalize them first".into(),
+            ));
+        }
+        if let Some(startup) = ledger.startup.as_mut() {
+            startup.host_cleaned = true;
+        }
+        self.set_startup_pending(&ledger);
+        Ok(())
+    }
+
+    async fn wait_startup_cleanup_complete(&self) {
+        let mut pending = self.startup_pending.subscribe();
+        // A closed channel cannot happen: the sender lives in `self`.
+        let _ = pending.wait_for(|pending| !pending).await;
+    }
+}
+
+impl Ledger {
+    fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<()> {
+        let lease = self
+            .quarantined
+            .get(vm)
+            .ok_or_else(|| Error::Network(format!("vm {vm} has no pending cleanup")))?;
+        if lease.cleanup_token != token {
+            return Err(Error::Network(format!(
+                "vm {vm} cleanup token does not name the pending generation"
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_startup_cleanup(&self, token: &str) -> Result<()> {
+        match &self.startup {
+            Some(startup) if !startup.host_cleaned && startup.token == token => Ok(()),
+            Some(startup) if !startup.host_cleaned => {
+                Err(Error::Network("startup cleanup token mismatch".into()))
+            }
+            _ => Err(Error::Network("no startup cleanup is pending".into())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::net::NetworkMode;
+
+    fn id(s: &str) -> VmId {
+        VmId::new(s).unwrap()
+    }
+
+    fn policy() -> NetworkPolicy {
+        NetworkPolicy {
+            mode: NetworkMode::Nat,
+        }
+    }
+
+    #[tokio::test]
+    async fn leases_take_the_lowest_free_host_and_release_reuses_it() {
+        let net = FakeNetwork::new();
+        let a = net.reserve(&id("a"), policy()).await.unwrap();
+        let b = net.reserve(&id("b"), policy()).await.unwrap();
+        assert_eq!(a.ip, "10.200.0.2".parse::<IpAddr>().unwrap());
+        assert_eq!(b.ip, "10.200.0.3".parse::<IpAddr>().unwrap());
+        assert!(a.mac.is_unicast() && a.mac != b.mac);
+        assert!(net.reserve(&id("a"), policy()).await.is_err());
+
+        let nic = net.activate(&a, AttachMode::Invariant).await.unwrap();
+        assert_eq!(
+            nic.attachment,
+            NicAttachment::Tap {
+                name: "tap2".into()
+            }
+        );
+        assert_eq!(nic.mac, a.mac);
+
+        net.release(a.clone()).await.unwrap();
+        let c = net.reserve(&id("c"), policy()).await.unwrap();
+        assert_eq!(c.ip, a.ip);
+    }
+
+    #[tokio::test]
+    async fn quarantine_holds_the_address_until_the_token_finalizes_it() {
+        let net = FakeNetwork::new();
+        let a = net.reserve(&id("a"), policy()).await.unwrap();
+        net.quarantine(a.clone()).await.unwrap();
+        net.quarantine(a.clone()).await.unwrap(); // idempotent
+        let mut other = a.clone();
+        other.cleanup_token = "other".into();
+        assert!(net.quarantine(other).await.is_err());
+        assert!(net.activate(&a, AttachMode::Invariant).await.is_err());
+
+        let reconcile = net.reconcile().unwrap();
+        assert_eq!(
+            reconcile.pending_cleanups().await,
+            vec![(id("a"), a.cleanup_token.clone())]
+        );
+        assert!(reconcile.validate_cleanup(&id("a"), "wrong").await.is_err());
+        // Still held: the next lease does not get a's address.
+        let b = net.reserve(&id("b"), policy()).await.unwrap();
+        assert_ne!(b.ip, a.ip);
+
+        reconcile
+            .finalize_cleanup(&id("a"), &a.cleanup_token)
+            .await
+            .unwrap();
+        assert!(reconcile.pending_cleanups().await.is_empty());
+        let c = net.reserve(&id("c"), policy()).await.unwrap();
+        assert_eq!(c.ip, a.ip);
+    }
+
+    #[tokio::test]
+    async fn startup_cleanup_gates_on_its_token_and_on_drained_quarantines() {
+        let net = std::sync::Arc::new(FakeNetwork::with_startup_cleanup("boot-1"));
+        let reconcile = net.reconcile().unwrap();
+        assert_eq!(
+            reconcile.startup_cleanup_token().await.as_deref(),
+            Some("boot-1")
+        );
+        assert!(reconcile.validate_startup_cleanup("boot-2").await.is_err());
+
+        let a = net.reserve(&id("a"), policy()).await.unwrap();
+        net.quarantine(a.clone()).await.unwrap();
+        // A quarantined lease keeps the startup cleanup from finalizing.
+        assert!(reconcile.finalize_startup_cleanup("boot-1").await.is_err());
+
+        let waiter = tokio::spawn({
+            let net = std::sync::Arc::clone(&net);
+            async move { net.wait_startup_cleanup_complete().await }
+        });
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        reconcile
+            .finalize_cleanup(&id("a"), &a.cleanup_token)
+            .await
+            .unwrap();
+        reconcile.finalize_startup_cleanup("boot-1").await.unwrap();
+        assert_eq!(reconcile.startup_cleanup_token().await, None);
+        tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
+            .await
+            .expect("waiter released")
+            .unwrap();
+
+        // Nothing pending: returns at once.
+        FakeNetwork::new().wait_startup_cleanup_complete().await;
+    }
+}

--- a/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeSet;
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -47,9 +47,7 @@ impl Preparer {
             isolation: isolation.clone(),
             inbound: Inbound::new(id.clone()),
             record,
-            booted: Mutex::new(None),
-            ended: Mutex::new(None),
-            consumed: AtomicBool::new(false),
+            phase: Mutex::new(Phase::Prepared),
         }
     }
 }
@@ -73,35 +71,36 @@ pub(super) struct PreparedFake {
     isolation: IsolationSpec,
     inbound: Arc<Inbound>,
     record: VmRecord,
-    /// The VM booted on this process, once there is one.
-    booted: Mutex<Option<Arc<VmInner>>>,
-    /// Set by `discard` (or a killing `Drop`) before any boot.
-    ended: Mutex<Option<ExitStatus>>,
-    /// A boot or restore succeeded; the handle owns the process now.
-    consumed: AtomicBool,
+    /// One lock for the whole life of the process, so a `boot` racing a
+    /// `discard` cannot both pass: whichever takes the lock first decides.
+    phase: Mutex<Phase>,
+}
+
+/// Where a prepared process is in its life.
+enum Phase {
+    /// Spawned, no guest yet; `Drop` kills it.
+    Prepared,
+    /// A boot or restore succeeded; the VM's handle owns the process now.
+    Booted(Arc<VmInner>),
+    /// Killed before any boot.
+    Discarded(ExitStatus),
 }
 
 impl PreparedFake {
-    fn ended(&self) -> Option<ExitStatus> {
-        *lock(&self.ended)
-    }
-
-    fn require_unused(&self) -> Result<()> {
-        if let Some(status) = self.ended() {
-            return Err(Error::WrongState {
-                id: self.record.id.clone(),
-                state: VmState::Exited(status),
-                expected: "a prepared vm that was not discarded",
-            });
-        }
-        if let Some(vm) = lock(&self.booted).as_ref() {
-            return Err(Error::WrongState {
+    fn require_unused(&self, phase: &Phase) -> Result<()> {
+        match phase {
+            Phase::Prepared => Ok(()),
+            Phase::Booted(vm) => Err(Error::WrongState {
                 id: self.record.id.clone(),
                 state: vm.state(),
                 expected: "a prepared vm that was not booted yet",
-            });
+            }),
+            Phase::Discarded(status) => Err(Error::WrongState {
+                id: self.record.id.clone(),
+                state: VmState::Exited(*status),
+                expected: "a prepared vm that was not discarded",
+            }),
         }
-        Ok(())
     }
 
     fn require_same_identity(&self, id: &VmId, isolation: &IsolationSpec) -> Result<()> {
@@ -123,7 +122,8 @@ impl PreparedFake {
     fn launch(&self, spec: VmSpec, balloon_target_bytes: u64) -> Result<Box<dyn VmHandle>> {
         self.require_same_identity(&spec.id, &spec.isolation)?;
         spec.validate()?;
-        self.require_unused()?;
+        let mut phase = lock(&self.phase);
+        self.require_unused(&phase)?;
         if self
             .driver
             .knobs
@@ -142,16 +142,21 @@ impl PreparedFake {
             balloon_target_bytes,
             Arc::clone(&self.inbound),
         )?;
-        *lock(&self.booted) = Some(Arc::clone(&vm));
-        self.consumed.store(true, Ordering::Release);
+        *phase = Phase::Booted(Arc::clone(&vm));
         Ok(Box::new(FakeVm::new(vm)))
     }
 
-    fn kill(&self) -> ExitStatus {
-        let booted = lock(&self.booted).clone();
-        let status = match booted {
-            Some(vm) => vm.exit(ExitStatus::signaled(SIGKILL)),
-            None => *lock(&self.ended).get_or_insert(ExitStatus::signaled(SIGKILL)),
+    /// Kills whatever `phase` says is running: the booted VM, or the bare
+    /// process itself.
+    fn kill(&self, phase: &mut Phase) -> ExitStatus {
+        let status = match phase {
+            Phase::Booted(vm) => vm.exit(ExitStatus::signaled(SIGKILL)),
+            Phase::Discarded(status) => *status,
+            Phase::Prepared => {
+                let status = ExitStatus::signaled(SIGKILL);
+                *phase = Phase::Discarded(status);
+                status
+            }
         };
         self.inbound.close(status);
         status
@@ -160,8 +165,9 @@ impl PreparedFake {
 
 impl Drop for PreparedFake {
     fn drop(&mut self) {
-        if !self.consumed.load(Ordering::Acquire) {
-            self.kill();
+        let mut phase = lock(&self.phase);
+        if matches!(*phase, Phase::Prepared) {
+            self.kill(&mut phase);
         }
     }
 }
@@ -177,9 +183,10 @@ impl PreparedVm for PreparedFake {
     }
 
     fn alive(&self) -> bool {
-        match lock(&self.booted).as_ref() {
-            Some(vm) => !matches!(vm.state(), VmState::Exited(_)),
-            None => self.ended().is_none(),
+        match &*lock(&self.phase) {
+            Phase::Prepared => true,
+            Phase::Booted(vm) => !matches!(vm.state(), VmState::Exited(_)),
+            Phase::Discarded(_) => false,
         }
     }
 
@@ -221,14 +228,22 @@ impl PreparedVm for PreparedFake {
     }
 
     async fn discard(&self) -> Result<ExitStatus> {
-        Ok(self.kill())
+        Ok(self.kill(&mut lock(&self.phase)))
     }
 }
 
 #[async_trait]
 impl VsockListen for PreparedFake {
     async fn listen(&self, port: u32) -> Result<Box<dyn VsockListener>> {
-        if let Some(status) = self.ended() {
+        let exited = match &*lock(&self.phase) {
+            Phase::Prepared => None,
+            Phase::Booted(vm) => match vm.state() {
+                VmState::Exited(status) => Some(status),
+                VmState::Running | VmState::Quiesced => None,
+            },
+            Phase::Discarded(status) => Some(*status),
+        };
+        if let Some(status) = exited {
             return Err(Error::WrongState {
                 id: self.record.id.clone(),
                 state: VmState::Exited(status),

--- a/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
@@ -1,0 +1,243 @@
+//! The fake's `Prepare` capability: a "spawned" VMM waiting for a spec.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+
+use super::fake_driver::{DriverInner, NAME};
+use super::fake_vm::{CHECKPOINT_FORMAT, CheckpointFile, FakeVm, VmInner};
+use super::fake_vsock::{FakeListener, Inbound};
+use super::lock;
+use crate::capability::{CheckpointImage, Prepare, PreparedVm, VsockListen, VsockListener};
+use crate::driver::{ExitStatus, ProcessRecord, RestoreSpec, VmHandle, VmRecord, VmState};
+use crate::error::{Error, Result};
+use crate::spec::{IsolationSpec, VmId, VmSpec};
+
+/// What `discard` reports for a process killed before or after its boot.
+const SIGKILL: i32 = 9;
+
+/// The `Prepare` capability, on its own type so its `prepare` method does
+/// not shadow the driver's accessor of the same name.
+#[derive(Clone)]
+pub(super) struct Preparer(pub(super) Arc<DriverInner>);
+
+impl Preparer {
+    /// The synchronous heart of `prepare`, shared with the driver's plain
+    /// `boot`/`restore` so those are exactly prepare-then-boot.
+    pub(super) fn prepare_sync(
+        &self,
+        id: &VmId,
+        isolation: &IsolationSpec,
+        runtime_dir: &Path,
+    ) -> PreparedFake {
+        let record = VmRecord {
+            id: id.clone(),
+            driver: NAME.to_owned(),
+            runtime_dir: runtime_dir.to_path_buf(),
+            process: Some(ProcessRecord {
+                pid: self.0.next_pid(),
+                api_socket: Some(runtime_dir.join("api.sock")),
+            }),
+        };
+        PreparedFake {
+            driver: Arc::clone(&self.0),
+            isolation: isolation.clone(),
+            inbound: Inbound::new(id.clone()),
+            record,
+            booted: Mutex::new(None),
+            ended: Mutex::new(None),
+            consumed: AtomicBool::new(false),
+        }
+    }
+}
+
+#[async_trait]
+impl Prepare for Preparer {
+    async fn prepare(
+        &self,
+        id: &VmId,
+        isolation: &IsolationSpec,
+        runtime_dir: &Path,
+    ) -> Result<Box<dyn PreparedVm>> {
+        Ok(Box::new(self.prepare_sync(id, isolation, runtime_dir)))
+    }
+}
+
+/// A prepared fake process: a record with a synthetic pid, listeners that
+/// outlive the boot, and at most one VM booted on it.
+pub(super) struct PreparedFake {
+    driver: Arc<DriverInner>,
+    isolation: IsolationSpec,
+    inbound: Arc<Inbound>,
+    record: VmRecord,
+    /// The VM booted on this process, once there is one.
+    booted: Mutex<Option<Arc<VmInner>>>,
+    /// Set by `discard` (or a killing `Drop`) before any boot.
+    ended: Mutex<Option<ExitStatus>>,
+    /// A boot or restore succeeded; the handle owns the process now.
+    consumed: AtomicBool,
+}
+
+impl PreparedFake {
+    fn ended(&self) -> Option<ExitStatus> {
+        *lock(&self.ended)
+    }
+
+    fn require_unused(&self) -> Result<()> {
+        if let Some(status) = self.ended() {
+            return Err(Error::WrongState {
+                id: self.record.id.clone(),
+                state: VmState::Exited(status),
+                expected: "a prepared vm that was not discarded",
+            });
+        }
+        if let Some(vm) = lock(&self.booted).as_ref() {
+            return Err(Error::WrongState {
+                id: self.record.id.clone(),
+                state: vm.state(),
+                expected: "a prepared vm that was not booted yet",
+            });
+        }
+        Ok(())
+    }
+
+    fn require_same_identity(&self, id: &VmId, isolation: &IsolationSpec) -> Result<()> {
+        if *id != self.record.id {
+            return Err(Error::InvalidSpec(format!(
+                "spec id {id} does not match the prepared vm {}",
+                self.record.id
+            )));
+        }
+        if *isolation != self.isolation {
+            return Err(Error::InvalidSpec(format!(
+                "spec isolation does not match what vm {} was prepared with",
+                self.record.id
+            )));
+        }
+        Ok(())
+    }
+
+    fn launch(&self, spec: VmSpec, balloon_target_bytes: u64) -> Result<Box<dyn VmHandle>> {
+        self.require_same_identity(&spec.id, &spec.isolation)?;
+        spec.validate()?;
+        self.require_unused()?;
+        if self
+            .driver
+            .knobs
+            .fail_boot_once
+            .swap(false, Ordering::AcqRel)
+        {
+            return Err(Error::Driver {
+                driver: NAME,
+                message: "scripted boot failure".into(),
+                source: None,
+            });
+        }
+        let vm = self.driver.register(
+            spec,
+            self.record.clone(),
+            balloon_target_bytes,
+            Arc::clone(&self.inbound),
+        )?;
+        *lock(&self.booted) = Some(Arc::clone(&vm));
+        self.consumed.store(true, Ordering::Release);
+        Ok(Box::new(FakeVm::new(vm)))
+    }
+
+    fn kill(&self) -> ExitStatus {
+        let booted = lock(&self.booted).clone();
+        let status = match booted {
+            Some(vm) => vm.exit(ExitStatus::signaled(SIGKILL)),
+            None => *lock(&self.ended).get_or_insert(ExitStatus::signaled(SIGKILL)),
+        };
+        self.inbound.close(status);
+        status
+    }
+}
+
+impl Drop for PreparedFake {
+    fn drop(&mut self) {
+        if !self.consumed.load(Ordering::Acquire) {
+            self.kill();
+        }
+    }
+}
+
+#[async_trait]
+impl PreparedVm for PreparedFake {
+    fn id(&self) -> &VmId {
+        &self.record.id
+    }
+
+    fn record(&self) -> VmRecord {
+        self.record.clone()
+    }
+
+    fn alive(&self) -> bool {
+        match lock(&self.booted).as_ref() {
+            Some(vm) => !matches!(vm.state(), VmState::Exited(_)),
+            None => self.ended().is_none(),
+        }
+    }
+
+    fn vsock_listener(&self) -> Option<&dyn VsockListen> {
+        self.driver.caps.vsock_listen.then_some(self)
+    }
+
+    async fn boot(&self, spec: VmSpec) -> Result<Box<dyn VmHandle>> {
+        let balloon_target_bytes = u64::from(spec.memory_mib) << 20;
+        self.launch(spec, balloon_target_bytes)
+    }
+
+    async fn restore(
+        &self,
+        image: &CheckpointImage,
+        spec: RestoreSpec,
+    ) -> Result<Box<dyn VmHandle>> {
+        if !self.driver.caps.checkpoint || image.format.as_str() != CHECKPOINT_FORMAT {
+            return Err(Error::ForeignCheckpoint(image.format.clone()));
+        }
+        let bytes = tokio::fs::read(image.dir.join("checkpoint.json")).await?;
+        let file: CheckpointFile = serde_json::from_slice(&bytes).map_err(std::io::Error::from)?;
+        if file.format.as_str() != CHECKPOINT_FORMAT {
+            return Err(Error::ForeignCheckpoint(file.format));
+        }
+        let image_disks: BTreeSet<&str> = file.spec.disks.iter().map(|d| d.id.as_str()).collect();
+        let given_disks: BTreeSet<&str> = spec.disks.iter().map(|d| d.id.as_str()).collect();
+        if image_disks != given_disks {
+            return Err(Error::InvalidSpec(format!(
+                "restore disks {given_disks:?} must name exactly the image's disks {image_disks:?}"
+            )));
+        }
+        let mut vm_spec = file.spec;
+        vm_spec.id = spec.id;
+        vm_spec.nics = spec.nics;
+        vm_spec.disks = spec.disks;
+        vm_spec.isolation = spec.isolation;
+        self.launch(vm_spec, file.balloon_target_bytes)
+    }
+
+    async fn discard(&self) -> Result<ExitStatus> {
+        Ok(self.kill())
+    }
+}
+
+#[async_trait]
+impl VsockListen for PreparedFake {
+    async fn listen(&self, port: u32) -> Result<Box<dyn VsockListener>> {
+        if let Some(status) = self.ended() {
+            return Err(Error::WrongState {
+                id: self.record.id.clone(),
+                state: VmState::Exited(status),
+                expected: "a live prepared vm",
+            });
+        }
+        Ok(Box::new(FakeListener {
+            inbound: Arc::clone(&self.inbound),
+            port,
+        }))
+    }
+}

--- a/virt/arcbox-vm-driver/src/testkit/fake_vm.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_vm.rs
@@ -4,15 +4,20 @@
 use std::collections::{HashMap, VecDeque};
 use std::io::{Read as _, Write as _};
 use std::os::unix::net::UnixStream;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use tokio::sync::{Notify, broadcast};
 
+use super::fake_driver::Knobs;
 use super::lock;
 use crate::capability::{
-    Balloon, BalloonStats, Console, DebugSnapshot, Vsock, VsockListen, VsockListener,
+    AfterCheckpoint, Balloon, BalloonStats, Checkpoint, CheckpointFormat, CheckpointImage,
+    CheckpointKind, CheckpointOptions, Console, DebugSnapshot, Detach, Vsock, VsockListen,
+    VsockListener,
 };
 use crate::driver::{
     DriverCapabilities, ExitStatus, IoMode, ShutdownMode, VmEvent, VmHandle, VmRecord, VmState,
@@ -24,13 +29,28 @@ use crate::spec::{ConsoleSpec, VmId, VmSpec};
 /// What `shutdown(Kill)` and a killing `Drop` report.
 const SIGKILL: i32 = 9;
 
+/// The on-disk format the fake writes and the only one it restores.
+pub(super) const CHECKPOINT_FORMAT: &str = "fake/v1";
+
+/// The contents of a fake checkpoint's `checkpoint.json`.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct CheckpointFile {
+    pub(super) format: CheckpointFormat,
+    pub(super) kind: CheckpointKind,
+    pub(super) spec: VmSpec,
+    pub(super) balloon_target_bytes: u64,
+}
+
 /// The VM's shared state; the driver's registry and every handle to the VM
 /// hold an `Arc` of it.
 pub(super) struct VmInner {
     spec: VmSpec,
     record: VmRecord,
     caps: DriverCapabilities,
+    knobs: Arc<Knobs>,
     state: Mutex<VmState>,
+    /// A live, non-detached handle exists.
+    owned: AtomicBool,
     events: broadcast::Sender<VmEvent>,
     /// Guest-initiated connections waiting for a host `accept`, per port.
     inbound: Mutex<HashMap<u32, VecDeque<UnixStream>>>,
@@ -45,6 +65,7 @@ impl VmInner {
         spec: VmSpec,
         record: VmRecord,
         caps: DriverCapabilities,
+        knobs: Arc<Knobs>,
         balloon_target_bytes: u64,
     ) -> Arc<Self> {
         let (events, _) = broadcast::channel(16);
@@ -52,7 +73,9 @@ impl VmInner {
             spec,
             record,
             caps,
+            knobs,
             state: Mutex::new(VmState::Running),
+            owned: AtomicBool::new(false),
             events,
             inbound: Mutex::new(HashMap::new()),
             wake: Notify::new(),
@@ -67,6 +90,10 @@ impl VmInner {
 
     pub(super) fn state(&self) -> VmState {
         *lock(&self.state)
+    }
+
+    pub(super) fn is_owned(&self) -> bool {
+        self.owned.load(Ordering::Acquire)
     }
 
     /// Moves to `Exited(status)` and returns the status the VM ended with:
@@ -123,15 +150,25 @@ impl VmInner {
 
 /// A [`VmHandle`] onto a fake VM.
 ///
-/// Dropping it kills the VM; the driver's registry forgets exited VMs on
-/// its next lookup.
+/// Dropping it kills the VM unless it was detached; the driver's registry
+/// forgets exited VMs on its next lookup.
 pub struct FakeVm {
     vm: Arc<VmInner>,
+    checkpointer: Checkpointer,
+    ownership: Ownership,
 }
 
 impl FakeVm {
     pub(super) fn new(vm: Arc<VmInner>) -> Self {
-        Self { vm }
+        vm.owned.store(true, Ordering::Release);
+        Self {
+            checkpointer: Checkpointer(Arc::clone(&vm)),
+            ownership: Ownership {
+                vm: Arc::clone(&vm),
+                detached: AtomicBool::new(false),
+            },
+            vm,
+        }
     }
 
     fn has_vsock(&self) -> bool {
@@ -141,7 +178,9 @@ impl FakeVm {
 
 impl Drop for FakeVm {
     fn drop(&mut self) {
-        self.vm.exit(ExitStatus::signaled(SIGKILL));
+        if !self.ownership.detached.load(Ordering::Acquire) {
+            self.vm.exit(ExitStatus::signaled(SIGKILL));
+        }
     }
 }
 
@@ -175,8 +214,16 @@ impl VmHandle for FakeVm {
         (self.vm.caps.vsock && self.has_vsock()).then_some(self)
     }
 
+    fn checkpoint(&self) -> Option<&dyn Checkpoint> {
+        self.vm.caps.checkpoint.then_some(&self.checkpointer)
+    }
+
     fn vsock_listener(&self) -> Option<&dyn VsockListen> {
         (self.vm.caps.vsock_listen && self.has_vsock()).then_some(self)
+    }
+
+    fn detach(&self) -> Option<&dyn Detach> {
+        self.vm.caps.adopt.then_some(&self.ownership)
     }
 
     fn balloon(&self) -> Option<&dyn Balloon> {
@@ -260,6 +307,72 @@ impl VsockListener for FakeListener {
     }
 }
 
+/// The `Checkpoint` capability, on its own type so its `checkpoint` method
+/// does not shadow the handle's accessor of the same name.
+struct Checkpointer(Arc<VmInner>);
+
+#[async_trait]
+impl Checkpoint for Checkpointer {
+    async fn checkpoint(&self, dst: &Path, opts: CheckpointOptions) -> Result<CheckpointImage> {
+        let vm = &self.0;
+        vm.require_alive()?;
+        if opts.kind == CheckpointKind::Diff && !vm.caps.diff_checkpoint {
+            return Err(Error::Driver {
+                driver: "fake",
+                message: "diff checkpoints are not enabled on this fake".into(),
+                source: None,
+            });
+        }
+        if vm.knobs.fail_checkpoint_once.swap(false, Ordering::AcqRel) {
+            return Err(Error::Driver {
+                driver: "fake",
+                message: "scripted checkpoint failure".into(),
+                source: None,
+            });
+        }
+        let file = CheckpointFile {
+            format: CheckpointFormat::new(CHECKPOINT_FORMAT),
+            kind: opts.kind,
+            spec: vm.spec.clone(),
+            balloon_target_bytes: vm.balloon_target_bytes.load(Ordering::Acquire),
+        };
+        let json = serde_json::to_vec_pretty(&file).map_err(std::io::Error::from)?;
+        tokio::fs::create_dir_all(dst).await?;
+        tokio::fs::write(dst.join("checkpoint.json"), json).await?;
+        {
+            let mut state = lock(&vm.state);
+            if !matches!(*state, VmState::Exited(_)) {
+                *state = match opts.after {
+                    AfterCheckpoint::Resume => VmState::Running,
+                    AfterCheckpoint::HoldQuiesced => VmState::Quiesced,
+                };
+            }
+        }
+        Ok(CheckpointImage {
+            dir: dst.to_path_buf(),
+            format: file.format,
+            kind: opts.kind,
+        })
+    }
+}
+
+/// The `Detach` capability, on its own type so its `detach` method does not
+/// shadow the handle's accessor of the same name.
+struct Ownership {
+    vm: Arc<VmInner>,
+    detached: AtomicBool,
+}
+
+#[async_trait]
+impl Detach for Ownership {
+    async fn detach(&self) -> Result<VmRecord> {
+        self.vm.require_alive()?;
+        self.detached.store(true, Ordering::Release);
+        self.vm.owned.store(false, Ordering::Release);
+        Ok(self.vm.record.clone())
+    }
+}
+
 #[async_trait]
 impl Balloon for FakeVm {
     async fn set_target(&self, bytes: u64) -> Result<()> {
@@ -288,14 +401,14 @@ impl Console for FakeVm {
 
 impl DebugSnapshot for FakeVm {
     fn snapshot(&self) -> serde_json::Value {
-        let inbound_ports: Vec<u32> = lock(&self.vm.inbound).keys().copied().collect();
+        let listeners: Vec<u32> = lock(&self.vm.inbound).keys().copied().collect();
         serde_json::json!({
             "driver": "fake",
             "id": self.vm.id().as_str(),
             "state": self.vm.state().to_string(),
             "balloon_target_bytes": self.vm.balloon_target_bytes.load(Ordering::Acquire),
             "console_pending_bytes": lock(&self.vm.console).len(),
-            "inbound_ports": inbound_ports,
+            "inbound_ports": listeners,
         })
     }
 }

--- a/virt/arcbox-vm-driver/src/testkit/fake_vm.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_vm.rs
@@ -1,0 +1,106 @@
+//! The fake driver's VM: an in-memory state machine behind a real
+//! [`VmHandle`].
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use tokio::sync::broadcast;
+
+use super::lock;
+use crate::driver::{ExitStatus, ShutdownMode, VmEvent, VmHandle, VmRecord, VmState};
+use crate::error::Result;
+use crate::spec::{VmId, VmSpec};
+
+/// What `shutdown(Kill)` and a killing `Drop` report.
+const SIGKILL: i32 = 9;
+
+/// The VM's shared state; the driver's registry and every handle to the VM
+/// hold an `Arc` of it.
+pub(super) struct VmInner {
+    spec: VmSpec,
+    record: VmRecord,
+    state: Mutex<VmState>,
+    events: broadcast::Sender<VmEvent>,
+}
+
+impl VmInner {
+    pub(super) fn new(spec: VmSpec, record: VmRecord) -> Arc<Self> {
+        let (events, _) = broadcast::channel(16);
+        Arc::new(Self {
+            spec,
+            record,
+            state: Mutex::new(VmState::Running),
+            events,
+        })
+    }
+
+    pub(super) fn id(&self) -> &VmId {
+        &self.spec.id
+    }
+
+    pub(super) fn state(&self) -> VmState {
+        *lock(&self.state)
+    }
+
+    /// Moves to `Exited(status)` and returns the status the VM ended with:
+    /// `status`, or the earlier one if it had already exited.
+    fn exit(&self, status: ExitStatus) -> ExitStatus {
+        {
+            let mut state = lock(&self.state);
+            if let VmState::Exited(earlier) = *state {
+                return earlier;
+            }
+            *state = VmState::Exited(status);
+        }
+        // A send error only means nobody is subscribed.
+        let _ = self.events.send(VmEvent::Exited(status));
+        status
+    }
+}
+
+/// A [`VmHandle`] onto a fake VM.
+///
+/// Dropping it kills the VM; the driver's registry forgets exited VMs on
+/// its next lookup.
+pub struct FakeVm {
+    vm: Arc<VmInner>,
+}
+
+impl FakeVm {
+    pub(super) fn new(vm: Arc<VmInner>) -> Self {
+        Self { vm }
+    }
+}
+
+impl Drop for FakeVm {
+    fn drop(&mut self) {
+        self.vm.exit(ExitStatus::signaled(SIGKILL));
+    }
+}
+
+#[async_trait]
+impl VmHandle for FakeVm {
+    fn id(&self) -> &VmId {
+        self.vm.id()
+    }
+
+    fn record(&self) -> VmRecord {
+        self.vm.record.clone()
+    }
+
+    fn state(&self) -> VmState {
+        self.vm.state()
+    }
+
+    fn events(&self) -> broadcast::Receiver<VmEvent> {
+        self.vm.events.subscribe()
+    }
+
+    async fn shutdown(&self, mode: ShutdownMode) -> Result<ExitStatus> {
+        let status = match mode {
+            ShutdownMode::Graceful { .. } => ExitStatus::exited(0),
+            ShutdownMode::Kill => ExitStatus::signaled(SIGKILL),
+        };
+        Ok(self.vm.exit(status))
+    }
+}

--- a/virt/arcbox-vm-driver/src/testkit/fake_vm.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_vm.rs
@@ -1,8 +1,6 @@
 //! The fake driver's VM: an in-memory state machine behind a real
 //! [`VmHandle`].
 
-use std::collections::{HashMap, VecDeque};
-use std::io::{Read as _, Write as _};
 use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -10,9 +8,10 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Notify, broadcast};
+use tokio::sync::broadcast;
 
 use super::fake_driver::Knobs;
+use super::fake_vsock::{FakeListener, Inbound, echo_peer};
 use super::lock;
 use crate::capability::{
     AfterCheckpoint, Balloon, BalloonStats, Checkpoint, CheckpointFormat, CheckpointImage,
@@ -52,10 +51,9 @@ pub(super) struct VmInner {
     /// A live, non-detached handle exists.
     owned: AtomicBool,
     events: broadcast::Sender<VmEvent>,
-    /// Guest-initiated connections waiting for a host `accept`, per port.
-    inbound: Mutex<HashMap<u32, VecDeque<UnixStream>>>,
-    /// Woken on every `inbound` push and on exit.
-    wake: Notify,
+    /// Guest-initiated connections; shared with the prepared process the VM
+    /// was booted on, so listeners bound before boot keep working.
+    inbound: Arc<Inbound>,
     console: Mutex<Vec<u8>>,
     balloon_target_bytes: AtomicU64,
 }
@@ -67,6 +65,7 @@ impl VmInner {
         caps: DriverCapabilities,
         knobs: Arc<Knobs>,
         balloon_target_bytes: u64,
+        inbound: Arc<Inbound>,
     ) -> Arc<Self> {
         let (events, _) = broadcast::channel(16);
         Arc::new(Self {
@@ -77,8 +76,7 @@ impl VmInner {
             state: Mutex::new(VmState::Running),
             owned: AtomicBool::new(false),
             events,
-            inbound: Mutex::new(HashMap::new()),
-            wake: Notify::new(),
+            inbound,
             console: Mutex::new(Vec::new()),
             balloon_target_bytes: AtomicU64::new(balloon_target_bytes),
         })
@@ -98,7 +96,7 @@ impl VmInner {
 
     /// Moves to `Exited(status)` and returns the status the VM ended with:
     /// `status`, or the earlier one if it had already exited.
-    fn exit(&self, status: ExitStatus) -> ExitStatus {
+    pub(super) fn exit(&self, status: ExitStatus) -> ExitStatus {
         {
             let mut state = lock(&self.state);
             if let VmState::Exited(earlier) = *state {
@@ -108,7 +106,7 @@ impl VmInner {
         }
         // A send error only means nobody is subscribed.
         let _ = self.events.send(VmEvent::Exited(status));
-        self.wake.notify_waiters();
+        self.inbound.close(status);
         status
     }
 
@@ -136,11 +134,7 @@ impl VmInner {
 
     /// A guest-side connection to host `port`; the host `accept`s it.
     pub(super) fn push_inbound(&self, port: u32, stream: UnixStream) {
-        lock(&self.inbound)
-            .entry(port)
-            .or_default()
-            .push_back(stream);
-        self.wake.notify_waiters();
+        self.inbound.push(port, stream);
     }
 
     pub(super) fn push_console(&self, bytes: &[u8]) {
@@ -244,28 +238,10 @@ impl Vsock for FakeVm {
     /// Any port answers: the guest side echoes every byte back.
     async fn dial(&self, _port: u32) -> Result<VsockConn> {
         self.vm.require_running()?;
-        let (host, guest) = UnixStream::pair()?;
-        std::thread::Builder::new()
-            .name("fake-vsock-echo".into())
-            .spawn(move || echo(guest))?;
         Ok(VsockConn {
-            fd: host.into(),
+            fd: echo_peer()?.into(),
             mode: IoMode::Async,
         })
-    }
-}
-
-fn echo(mut stream: UnixStream) {
-    let mut buf = [0u8; 4096];
-    loop {
-        match stream.read(&mut buf) {
-            Ok(0) | Err(_) => return,
-            Ok(n) => {
-                if stream.write_all(&buf[..n]).is_err() {
-                    return;
-                }
-            }
-        }
     }
 }
 
@@ -274,36 +250,9 @@ impl VsockListen for FakeVm {
     async fn listen(&self, port: u32) -> Result<Box<dyn VsockListener>> {
         self.vm.require_alive()?;
         Ok(Box::new(FakeListener {
-            vm: Arc::clone(&self.vm),
+            inbound: Arc::clone(&self.vm.inbound),
             port,
         }))
-    }
-}
-
-struct FakeListener {
-    vm: Arc<VmInner>,
-    port: u32,
-}
-
-#[async_trait]
-impl VsockListener for FakeListener {
-    async fn accept(&mut self) -> Result<VsockConn> {
-        loop {
-            // Register for the wake-up before checking, so a push between the
-            // check and the await is not lost.
-            let woken = self.vm.wake.notified();
-            let next = lock(&self.vm.inbound)
-                .get_mut(&self.port)
-                .and_then(VecDeque::pop_front);
-            if let Some(stream) = next {
-                return Ok(VsockConn {
-                    fd: stream.into(),
-                    mode: IoMode::Async,
-                });
-            }
-            self.vm.require_alive()?;
-            woken.await;
-        }
     }
 }
 
@@ -401,14 +350,13 @@ impl Console for FakeVm {
 
 impl DebugSnapshot for FakeVm {
     fn snapshot(&self) -> serde_json::Value {
-        let listeners: Vec<u32> = lock(&self.vm.inbound).keys().copied().collect();
         serde_json::json!({
             "driver": "fake",
             "id": self.vm.id().as_str(),
             "state": self.vm.state().to_string(),
             "balloon_target_bytes": self.vm.balloon_target_bytes.load(Ordering::Acquire),
             "console_pending_bytes": lock(&self.vm.console).len(),
-            "inbound_ports": listeners,
+            "inbound_ports": self.vm.inbound.pending_ports(),
         })
     }
 }

--- a/virt/arcbox-vm-driver/src/testkit/fake_vm.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_vm.rs
@@ -1,15 +1,25 @@
 //! The fake driver's VM: an in-memory state machine behind a real
 //! [`VmHandle`].
 
+use std::collections::{HashMap, VecDeque};
+use std::io::{Read as _, Write as _};
+use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use tokio::sync::broadcast;
+use tokio::sync::{Notify, broadcast};
 
 use super::lock;
-use crate::driver::{ExitStatus, ShutdownMode, VmEvent, VmHandle, VmRecord, VmState};
-use crate::error::Result;
-use crate::spec::{VmId, VmSpec};
+use crate::capability::{
+    Balloon, BalloonStats, Console, DebugSnapshot, Vsock, VsockListen, VsockListener,
+};
+use crate::driver::{
+    DriverCapabilities, ExitStatus, IoMode, ShutdownMode, VmEvent, VmHandle, VmRecord, VmState,
+    VsockConn,
+};
+use crate::error::{Error, Result};
+use crate::spec::{ConsoleSpec, VmId, VmSpec};
 
 /// What `shutdown(Kill)` and a killing `Drop` report.
 const SIGKILL: i32 = 9;
@@ -19,18 +29,35 @@ const SIGKILL: i32 = 9;
 pub(super) struct VmInner {
     spec: VmSpec,
     record: VmRecord,
+    caps: DriverCapabilities,
     state: Mutex<VmState>,
     events: broadcast::Sender<VmEvent>,
+    /// Guest-initiated connections waiting for a host `accept`, per port.
+    inbound: Mutex<HashMap<u32, VecDeque<UnixStream>>>,
+    /// Woken on every `inbound` push and on exit.
+    wake: Notify,
+    console: Mutex<Vec<u8>>,
+    balloon_target_bytes: AtomicU64,
 }
 
 impl VmInner {
-    pub(super) fn new(spec: VmSpec, record: VmRecord) -> Arc<Self> {
+    pub(super) fn new(
+        spec: VmSpec,
+        record: VmRecord,
+        caps: DriverCapabilities,
+        balloon_target_bytes: u64,
+    ) -> Arc<Self> {
         let (events, _) = broadcast::channel(16);
         Arc::new(Self {
             spec,
             record,
+            caps,
             state: Mutex::new(VmState::Running),
             events,
+            inbound: Mutex::new(HashMap::new()),
+            wake: Notify::new(),
+            console: Mutex::new(Vec::new()),
+            balloon_target_bytes: AtomicU64::new(balloon_target_bytes),
         })
     }
 
@@ -54,7 +81,43 @@ impl VmInner {
         }
         // A send error only means nobody is subscribed.
         let _ = self.events.send(VmEvent::Exited(status));
+        self.wake.notify_waiters();
         status
+    }
+
+    fn require_running(&self) -> Result<()> {
+        match self.state() {
+            VmState::Running => Ok(()),
+            state => Err(Error::WrongState {
+                id: self.spec.id.clone(),
+                state,
+                expected: "running",
+            }),
+        }
+    }
+
+    fn require_alive(&self) -> Result<()> {
+        match self.state() {
+            state @ VmState::Exited(_) => Err(Error::WrongState {
+                id: self.spec.id.clone(),
+                state,
+                expected: "running or quiesced",
+            }),
+            VmState::Running | VmState::Quiesced => Ok(()),
+        }
+    }
+
+    /// A guest-side connection to host `port`; the host `accept`s it.
+    pub(super) fn push_inbound(&self, port: u32, stream: UnixStream) {
+        lock(&self.inbound)
+            .entry(port)
+            .or_default()
+            .push_back(stream);
+        self.wake.notify_waiters();
+    }
+
+    pub(super) fn push_console(&self, bytes: &[u8]) {
+        lock(&self.console).extend_from_slice(bytes);
     }
 }
 
@@ -69,6 +132,10 @@ pub struct FakeVm {
 impl FakeVm {
     pub(super) fn new(vm: Arc<VmInner>) -> Self {
         Self { vm }
+    }
+
+    fn has_vsock(&self) -> bool {
+        self.vm.spec.vsock.is_some()
     }
 }
 
@@ -102,5 +169,133 @@ impl VmHandle for FakeVm {
             ShutdownMode::Kill => ExitStatus::signaled(SIGKILL),
         };
         Ok(self.vm.exit(status))
+    }
+
+    fn vsock(&self) -> Option<&dyn Vsock> {
+        (self.vm.caps.vsock && self.has_vsock()).then_some(self)
+    }
+
+    fn vsock_listener(&self) -> Option<&dyn VsockListen> {
+        (self.vm.caps.vsock_listen && self.has_vsock()).then_some(self)
+    }
+
+    fn balloon(&self) -> Option<&dyn Balloon> {
+        (self.vm.caps.balloon && self.vm.spec.balloon).then_some(self)
+    }
+
+    fn console(&self) -> Option<&dyn Console> {
+        (self.vm.caps.console && self.vm.spec.console != ConsoleSpec::Off).then_some(self)
+    }
+
+    fn debug(&self) -> Option<&dyn DebugSnapshot> {
+        self.vm.caps.debug.then_some(self)
+    }
+}
+
+#[async_trait]
+impl Vsock for FakeVm {
+    /// Any port answers: the guest side echoes every byte back.
+    async fn dial(&self, _port: u32) -> Result<VsockConn> {
+        self.vm.require_running()?;
+        let (host, guest) = UnixStream::pair()?;
+        std::thread::Builder::new()
+            .name("fake-vsock-echo".into())
+            .spawn(move || echo(guest))?;
+        Ok(VsockConn {
+            fd: host.into(),
+            mode: IoMode::Async,
+        })
+    }
+}
+
+fn echo(mut stream: UnixStream) {
+    let mut buf = [0u8; 4096];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) | Err(_) => return,
+            Ok(n) => {
+                if stream.write_all(&buf[..n]).is_err() {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl VsockListen for FakeVm {
+    async fn listen(&self, port: u32) -> Result<Box<dyn VsockListener>> {
+        self.vm.require_alive()?;
+        Ok(Box::new(FakeListener {
+            vm: Arc::clone(&self.vm),
+            port,
+        }))
+    }
+}
+
+struct FakeListener {
+    vm: Arc<VmInner>,
+    port: u32,
+}
+
+#[async_trait]
+impl VsockListener for FakeListener {
+    async fn accept(&mut self) -> Result<VsockConn> {
+        loop {
+            // Register for the wake-up before checking, so a push between the
+            // check and the await is not lost.
+            let woken = self.vm.wake.notified();
+            let next = lock(&self.vm.inbound)
+                .get_mut(&self.port)
+                .and_then(VecDeque::pop_front);
+            if let Some(stream) = next {
+                return Ok(VsockConn {
+                    fd: stream.into(),
+                    mode: IoMode::Async,
+                });
+            }
+            self.vm.require_alive()?;
+            woken.await;
+        }
+    }
+}
+
+#[async_trait]
+impl Balloon for FakeVm {
+    async fn set_target(&self, bytes: u64) -> Result<()> {
+        self.vm.require_alive()?;
+        self.vm.balloon_target_bytes.store(bytes, Ordering::Release);
+        Ok(())
+    }
+
+    async fn stats(&self) -> Result<BalloonStats> {
+        let target_bytes = self.vm.balloon_target_bytes.load(Ordering::Acquire);
+        Ok(BalloonStats {
+            target_bytes,
+            current_bytes: Some(target_bytes),
+        })
+    }
+}
+
+#[async_trait]
+impl Console for FakeVm {
+    async fn read_output(&self, max_bytes: usize) -> Result<Vec<u8>> {
+        let mut console = lock(&self.vm.console);
+        let n = max_bytes.min(console.len());
+        Ok(console.drain(..n).collect())
+    }
+}
+
+impl DebugSnapshot for FakeVm {
+    fn snapshot(&self) -> serde_json::Value {
+        let inbound_ports: Vec<u32> = lock(&self.vm.inbound).keys().copied().collect();
+        serde_json::json!({
+            "driver": "fake",
+            "id": self.vm.id().as_str(),
+            "state": self.vm.state().to_string(),
+            "balloon_target_bytes": self.vm.balloon_target_bytes.load(Ordering::Acquire),
+            "console_pending_bytes": lock(&self.vm.console).len(),
+            "inbound_ports": inbound_ports,
+        })
     }
 }

--- a/virt/arcbox-vm-driver/src/testkit/fake_vm.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_vm.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
-use super::fake_driver::Knobs;
+use super::fake_driver::{Knobs, NAME};
 use super::fake_vsock::{FakeListener, Inbound, echo_peer};
 use super::lock;
 use crate::capability::{
@@ -267,14 +267,14 @@ impl Checkpoint for Checkpointer {
         vm.require_alive()?;
         if opts.kind == CheckpointKind::Diff && !vm.caps.diff_checkpoint {
             return Err(Error::Driver {
-                driver: "fake",
+                driver: NAME,
                 message: "diff checkpoints are not enabled on this fake".into(),
                 source: None,
             });
         }
         if vm.knobs.fail_checkpoint_once.swap(false, Ordering::AcqRel) {
             return Err(Error::Driver {
-                driver: "fake",
+                driver: NAME,
                 message: "scripted checkpoint failure".into(),
                 source: None,
             });
@@ -351,7 +351,7 @@ impl Console for FakeVm {
 impl DebugSnapshot for FakeVm {
     fn snapshot(&self) -> serde_json::Value {
         serde_json::json!({
-            "driver": "fake",
+            "driver": NAME,
             "id": self.vm.id().as_str(),
             "state": self.vm.state().to_string(),
             "balloon_target_bytes": self.vm.balloon_target_bytes.load(Ordering::Acquire),

--- a/virt/arcbox-vm-driver/src/testkit/fake_vsock.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_vsock.rs
@@ -1,0 +1,124 @@
+//! The fake's vsock plumbing: guest-initiated connections queued per port,
+//! and the echoing peer a `dial` gets.
+
+use std::collections::{HashMap, VecDeque};
+use std::io::{Read as _, Write as _};
+use std::os::unix::net::UnixStream;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use tokio::sync::Notify;
+
+use super::lock;
+use crate::capability::VsockListener;
+use crate::driver::{ExitStatus, IoMode, VmState, VsockConn};
+use crate::error::{Error, Result};
+use crate::spec::VmId;
+
+/// Guest-initiated connections waiting for a host `accept`, per port.
+///
+/// Created when a VM is prepared, so a listener bound before the guest
+/// starts and the VM booted afterwards share the same queues.
+pub(super) struct Inbound {
+    id: VmId,
+    queues: Mutex<HashMap<u32, VecDeque<UnixStream>>>,
+    /// Woken on every push and on close.
+    wake: Notify,
+    /// Set when the VM (or the prepared process) is gone; `accept` fails
+    /// with it once the queues are drained.
+    closed: Mutex<Option<ExitStatus>>,
+}
+
+impl Inbound {
+    pub(super) fn new(id: VmId) -> Arc<Self> {
+        Arc::new(Self {
+            id,
+            queues: Mutex::new(HashMap::new()),
+            wake: Notify::new(),
+            closed: Mutex::new(None),
+        })
+    }
+
+    /// Queues a guest-side connection to host `port`.
+    pub(super) fn push(&self, port: u32, stream: UnixStream) {
+        lock(&self.queues)
+            .entry(port)
+            .or_default()
+            .push_back(stream);
+        self.wake.notify_waiters();
+    }
+
+    /// No more connections can arrive: the VM ended with `status`.
+    pub(super) fn close(&self, status: ExitStatus) {
+        lock(&self.closed).get_or_insert(status);
+        self.wake.notify_waiters();
+    }
+
+    /// Ports with connections still queued.
+    pub(super) fn pending_ports(&self) -> Vec<u32> {
+        lock(&self.queues)
+            .iter()
+            .filter(|(_, q)| !q.is_empty())
+            .map(|(port, _)| *port)
+            .collect()
+    }
+}
+
+/// A bound fake listener: pops the port's queue, waits otherwise.
+pub(super) struct FakeListener {
+    pub(super) inbound: Arc<Inbound>,
+    pub(super) port: u32,
+}
+
+#[async_trait]
+impl VsockListener for FakeListener {
+    async fn accept(&mut self) -> Result<VsockConn> {
+        loop {
+            // Register for the wake-up before checking, so a push between the
+            // check and the await is not lost.
+            let woken = self.inbound.wake.notified();
+            let next = lock(&self.inbound.queues)
+                .get_mut(&self.port)
+                .and_then(VecDeque::pop_front);
+            if let Some(stream) = next {
+                return Ok(VsockConn {
+                    fd: stream.into(),
+                    mode: IoMode::Async,
+                });
+            }
+            let closed = *lock(&self.inbound.closed);
+            if let Some(status) = closed {
+                return Err(Error::WrongState {
+                    id: self.inbound.id.clone(),
+                    state: VmState::Exited(status),
+                    expected: "running or quiesced",
+                });
+            }
+            woken.await;
+        }
+    }
+}
+
+/// One end of a socketpair whose other end echoes every byte back until
+/// this end closes.
+pub(super) fn echo_peer() -> std::io::Result<UnixStream> {
+    let (host, guest) = UnixStream::pair()?;
+    std::thread::Builder::new()
+        .name("fake-vsock-echo".into())
+        .spawn(move || echo(guest))?;
+    Ok(host)
+}
+
+fn echo(mut stream: UnixStream) {
+    let mut buf = [0u8; 4096];
+    loop {
+        match stream.read(&mut buf) {
+            Ok(0) | Err(_) => return,
+            Ok(n) => {
+                if stream.write_all(&buf[..n]).is_err() {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/virt/arcbox-vm-driver/src/testkit/mod.rs
+++ b/virt/arcbox-vm-driver/src/testkit/mod.rs
@@ -1,18 +1,19 @@
 //! Fakes and the contract test-kit (feature `testkit`).
 //!
 //! - [`FakeDriver`] — an in-memory [`VmDriver`](crate::VmDriver) with a
-//!   real state machine and events. Runtime unit tests drive their real
+//!   real state machine, events, and the live capabilities (vsock both
+//!   ways, balloon, console, debug). Runtime unit tests drive their real
 //!   actors and state machines against it on any host, no KVM required.
 //!
-//! The capabilities, the fake network, and the contract test-kit land in
-//! the sibling modules.
+//! Checkpoint/restore and adopt/detach, the fake network, and the contract
+//! test-kit land in the sibling modules.
 
 use std::sync::{Mutex, MutexGuard, PoisonError};
 
 pub mod fake_driver;
 mod fake_vm;
 
-pub use fake_driver::FakeDriver;
+pub use fake_driver::{FakeDriver, FakeDriverBuilder};
 pub use fake_vm::FakeVm;
 
 /// Locks `mutex`, tolerating poison: a fake that panicked while holding a

--- a/virt/arcbox-vm-driver/src/testkit/mod.rs
+++ b/virt/arcbox-vm-driver/src/testkit/mod.rs
@@ -19,6 +19,7 @@ pub mod contract;
 pub mod fake_driver;
 pub mod fake_network;
 mod fake_vm;
+mod fake_vsock;
 
 pub use contract::{ContractHarness, FakeHarness};
 pub use fake_driver::{FakeDriver, FakeDriverBuilder};

--- a/virt/arcbox-vm-driver/src/testkit/mod.rs
+++ b/virt/arcbox-vm-driver/src/testkit/mod.rs
@@ -1,0 +1,23 @@
+//! Fakes and the contract test-kit (feature `testkit`).
+//!
+//! - [`FakeDriver`] — an in-memory [`VmDriver`](crate::VmDriver) with a
+//!   real state machine and events. Runtime unit tests drive their real
+//!   actors and state machines against it on any host, no KVM required.
+//!
+//! The capabilities, the fake network, and the contract test-kit land in
+//! the sibling modules.
+
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+pub mod fake_driver;
+mod fake_vm;
+
+pub use fake_driver::FakeDriver;
+pub use fake_vm::FakeVm;
+
+/// Locks `mutex`, tolerating poison: a fake that panicked while holding a
+/// lock has already failed the test, and the state behind it is still the
+/// most useful thing to show.
+pub(crate) fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}

--- a/virt/arcbox-vm-driver/src/testkit/mod.rs
+++ b/virt/arcbox-vm-driver/src/testkit/mod.rs
@@ -1,12 +1,11 @@
 //! Fakes and the contract test-kit (feature `testkit`).
 //!
 //! - [`FakeDriver`] — an in-memory [`VmDriver`](crate::VmDriver) with a
-//!   real state machine, events, and the live capabilities (vsock both
-//!   ways, balloon, console, debug). Runtime unit tests drive their real
-//!   actors and state machines against it on any host, no KVM required.
+//!   real state machine, events, every capability, and scripted failures.
+//!   Runtime unit tests drive their real actors and state machines against
+//!   it on any host, no KVM required.
 //!
-//! Checkpoint/restore and adopt/detach, the fake network, and the contract
-//! test-kit land in the sibling modules.
+//! The fake network and the contract test-kit land in the sibling modules.
 
 use std::sync::{Mutex, MutexGuard, PoisonError};
 

--- a/virt/arcbox-vm-driver/src/testkit/mod.rs
+++ b/virt/arcbox-vm-driver/src/testkit/mod.rs
@@ -9,14 +9,18 @@
 //!   handing out `10.200.0.0/16` leases with a quarantine ledger and the
 //!   [`NetworkReconcile`](crate::net::NetworkReconcile) token protocol.
 //!
-//! The contract test-kit lands in the sibling module.
+//! - [`contract`] — the checks every adapter must pass, packaged as the
+//!   [`driver_contract!`](crate::driver_contract) macro over a
+//!   [`ContractHarness`].
 
 use std::sync::{Mutex, MutexGuard, PoisonError};
 
+pub mod contract;
 pub mod fake_driver;
 pub mod fake_network;
 mod fake_vm;
 
+pub use contract::ContractHarness;
 pub use fake_driver::{FakeDriver, FakeDriverBuilder};
 pub use fake_network::FakeNetwork;
 pub use fake_vm::FakeVm;

--- a/virt/arcbox-vm-driver/src/testkit/mod.rs
+++ b/virt/arcbox-vm-driver/src/testkit/mod.rs
@@ -5,14 +5,20 @@
 //!   Runtime unit tests drive their real actors and state machines against
 //!   it on any host, no KVM required.
 //!
-//! The fake network and the contract test-kit land in the sibling modules.
+//! - [`FakeNetwork`] — an in-memory [`GuestNetwork`](crate::net::GuestNetwork)
+//!   handing out `10.200.0.0/16` leases with a quarantine ledger and the
+//!   [`NetworkReconcile`](crate::net::NetworkReconcile) token protocol.
+//!
+//! The contract test-kit lands in the sibling module.
 
 use std::sync::{Mutex, MutexGuard, PoisonError};
 
 pub mod fake_driver;
+pub mod fake_network;
 mod fake_vm;
 
 pub use fake_driver::{FakeDriver, FakeDriverBuilder};
+pub use fake_network::FakeNetwork;
 pub use fake_vm::FakeVm;
 
 /// Locks `mutex`, tolerating poison: a fake that panicked while holding a

--- a/virt/arcbox-vm-driver/src/testkit/mod.rs
+++ b/virt/arcbox-vm-driver/src/testkit/mod.rs
@@ -11,7 +11,7 @@
 //!
 //! - [`contract`] — the checks every adapter must pass, packaged as the
 //!   [`driver_contract!`](crate::driver_contract) macro over a
-//!   [`ContractHarness`].
+//!   [`ContractHarness`]; the fake passes them too (`tests/fake_contract.rs`).
 
 use std::sync::{Mutex, MutexGuard, PoisonError};
 
@@ -20,7 +20,7 @@ pub mod fake_driver;
 pub mod fake_network;
 mod fake_vm;
 
-pub use contract::ContractHarness;
+pub use contract::{ContractHarness, FakeHarness};
 pub use fake_driver::{FakeDriver, FakeDriverBuilder};
 pub use fake_network::FakeNetwork;
 pub use fake_vm::FakeVm;

--- a/virt/arcbox-vm-driver/src/testkit/mod.rs
+++ b/virt/arcbox-vm-driver/src/testkit/mod.rs
@@ -18,6 +18,7 @@ use std::sync::{Mutex, MutexGuard, PoisonError};
 pub mod contract;
 pub mod fake_driver;
 pub mod fake_network;
+mod fake_prepared;
 mod fake_vm;
 mod fake_vsock;
 

--- a/virt/arcbox-vm-driver/tests/fake_contract.rs
+++ b/virt/arcbox-vm-driver/tests/fake_contract.rs
@@ -1,0 +1,17 @@
+//! The fake driver passes its own contract — with everything claimed, and
+//! with nothing claimed (every skip path in the checks).
+
+use arcbox_vm_driver::DriverCapabilities;
+use arcbox_vm_driver::driver_contract;
+use arcbox_vm_driver::testkit::{FakeDriver, FakeHarness};
+
+driver_contract!(full, FakeHarness::new());
+
+driver_contract!(
+    minimal,
+    FakeHarness::with_driver(
+        FakeDriver::builder()
+            .capabilities(DriverCapabilities::default())
+            .build()
+    )
+);


### PR DESCRIPTION
`virt/arcbox-vm-driver` is the VM driver port: the vocabulary of "a VM on this host" — the serializable `VmSpec` family, the object-safe `VmDriver`/`VmHandle` traits, the capability traits, and the `net::GuestNetwork` port — that VMM adapters (Firecracker, VZ, the in-process HV engine, later Cloud Hypervisor) implement and orchestrators consume. No `arcbox-*` dependency; it sits below every adapter.

**Mandatory handle surface vs capabilities.** A handle must only identify (`id`/`record`), observe (`state`/`events`, never blocking; `Exited` broadcast once) and stop (`shutdown`: `Kill` always succeeds, `Graceful{timeout}` falls back to kill; Drop kills unless detached). Everything else is an `Option<&dyn Cap>` accessor — `Vsock`, `VsockListen`, `Checkpoint` (quiescing is its own business: `Resume`/`HoldQuiesced`; there is no pause verb on the handle), `Adopt`/`Detach`, `Prepare`/`PreparedVm` (spawn the VMM ahead of a boot: pid journaled, READY listener bound before the guest starts; `boot` is exactly prepare-then-boot), `Balloon`, `Console`, `DebugSnapshot` — and `capabilities()` must agree with the accessors. There is no `Unsupported` error variant.

**testkit** (feature): `FakeDriver` (real state machine, events, every capability incl. Prepare, scripted failures, `guest_dial`/`push_console`), `FakeNetwork` (10.200.0.0/16 leases, quarantine ledger, `NetworkReconcile` token protocol), and `driver_contract!(mod_name, harness_expr)`, which expands to one `#[tokio::test]` per contract check over a `ContractHarness`; `FakeHarness` is the reference harness. An adapter runs the contract in its own (ignored, hardware-backed) test crate: enable `testkit` in dev-deps, implement `ContractHarness`, `driver_contract!(fc, FcHarness::new())`. `tests/fake_contract.rs` runs it against the fake, fully claimed and with nothing claimed.

No consumer is wired yet, by design — R1 wires `arcbox-vm` through the Firecracker adapter (`virt/arcbox-fc-driver`, in flight). The crate is added to the `linux-engine` CI job (check / test / musl check).

Validation: `cargo fmt --check`; `cargo clippy -p arcbox-vm-driver --all-targets [--all-features] -- -D warnings`; `cargo test -p arcbox-vm-driver --all-features` (30 unit + 28 contract tests); `cargo check --target aarch64-unknown-linux-musl -p arcbox-vm-driver --all-features/--all-targets`; `cargo doc --no-deps --all-features` with zero warnings; `cargo metadata` resolves; `cargo package --no-verify` packages.

Design: company repo `engineering/arcbox/architecture/vm-stack-redesign.md` (charter P4b execution design, D-VM1 / D-VM7 / D-VM9); the `Prepare` capability is the amendment the R1 seam map called for (external-process VMMs are two-phase: warm-pool slots pre-spawn the jailer, the pid is journaled before boot, a boot can be killed mid-staging, READY must be listening before the guest starts).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New library crate and CI coverage only; no production wiring or changes to existing VM execution paths in this PR.
> 
> **Overview**
> Introduces **`virt/arcbox-vm-driver`**, a new port crate with **no `arcbox-*` dependencies** so VMM adapters and orchestrators meet at a shared seam. The crate defines serializable **`VmSpec`** (and related types), object-safe **`VmDriver` / `VmHandle`** with mandatory identify / observe / shutdown, optional capabilities via **`Option<&dyn Cap>`** accessors (vsock, checkpoint, prepare, adopt/detach, balloon, console, debug), and a second **`GuestNetwork`** port with quarantine / reconcile cleanup tokens.
> 
> **`DriverCapabilities`** must align with what handles expose; unsupported behavior is **`None` on accessors**, not a dedicated error variant. The optional **`testkit`** feature adds **`FakeDriver`**, **`FakeNetwork`**, and **`driver_contract!`** contract tests; **`tests/fake_contract.rs`** runs the contract against the fake with full and minimal capability sets.
> 
> Workspace **`Cargo.toml` / `Cargo.lock`** register the crate; the **linux-engine CI** job now **checks, tests, and musl-checks** `arcbox-vm-driver`. **No runtime consumer is wired in this PR** (follow-on adapter work is expected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9e21ba679104d22cdb8340f5f09d91bc989e5e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->