### PR TITLE
feat(fc-driver): the Firecracker adapter for the VM driver port (R1, part 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,16 +198,16 @@ jobs:
         run: cargo run -p xtask -- check-layers
 
       - name: Check engine-layer crates on Linux
-        run: cargo check --all-targets -p arcbox-atomic-file -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-vm-driver -p arcbox-snapshot -p arcbox-engine -p arcbox-computer
+        run: cargo check --all-targets -p arcbox-atomic-file -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-vm-driver -p arcbox-fc-driver -p arcbox-snapshot -p arcbox-engine -p arcbox-computer
 
       # `--no-fail-fast` so one red run reports every broken crate rather
       # than stopping at the first, which otherwise hides later failures
       # behind a fix-and-rerun loop.
       - name: Test engine-layer crates on Linux
-        run: cargo test --no-fail-fast -p arcbox-atomic-file -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-vm-driver -p arcbox-snapshot -p arcbox-engine -p arcbox-computer
+        run: cargo test --no-fail-fast -p arcbox-atomic-file -p arcbox-image -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-vm-driver -p arcbox-fc-driver -p arcbox-snapshot -p arcbox-engine -p arcbox-computer
 
       - name: Check engine-layer crates on aarch64-unknown-linux-musl
-        run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-atomic-file -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-vm-driver -p arcbox-snapshot
+        run: cargo check --all-targets --target aarch64-unknown-linux-musl -p arcbox-atomic-file -p arcbox-net -p splicetcp -p arcbox-hypervisor -p arcbox-virtio-net -p arcbox-vmm -p arcbox-vm-driver -p arcbox-fc-driver -p arcbox-snapshot
 
   # Pure proto-contract analysis — no Rust toolchain, no build. Runs in
   # parallel with `ci` on a cheap Linux runner. The desktop and agent

--- a/.github/workflows/test-vm-linux.yml
+++ b/.github/workflows/test-vm-linux.yml
@@ -7,6 +7,8 @@ on:
       - "guest/arcbox-agent/**"
       - "virt/arcbox-vm/**"
       - "virt/arcbox-vm-proto/**"
+      - "virt/arcbox-vm-driver/**"
+      - "virt/arcbox-fc-driver/**"
       - "virt/arcbox-vm-agent/**"
       # The snapshot catalog and the device-mapper CoW manager moved out of
       # arcbox-vm; this suite is still the only one that drives dmsetup and
@@ -24,6 +26,8 @@ on:
       - "guest/arcbox-agent/**"
       - "virt/arcbox-vm/**"
       - "virt/arcbox-vm-proto/**"
+      - "virt/arcbox-vm-driver/**"
+      - "virt/arcbox-fc-driver/**"
       - "virt/arcbox-vm-agent/**"
       # The snapshot catalog and the device-mapper CoW manager moved out of
       # arcbox-vm; this suite is still the only one that drives dmsetup and
@@ -73,15 +77,15 @@ jobs:
           restore-keys: linux-cargo-
 
       - name: Check formatting
-        run: cargo fmt -p arcbox-vm -p arcbox-vm-proto -p arcbox-vm-agent -p arcbox-snapshot --check
+        run: cargo fmt -p arcbox-vm -p arcbox-vm-proto -p arcbox-vm-driver -p arcbox-fc-driver -p arcbox-vm-agent -p arcbox-snapshot --check
 
       - name: Clippy
-        run: cargo clippy -p arcbox-vm -p arcbox-vm-proto -p arcbox-vm-agent -p arcbox-snapshot -- -D warnings
+        run: cargo clippy -p arcbox-vm -p arcbox-vm-proto -p arcbox-vm-driver -p arcbox-fc-driver -p arcbox-vm-agent -p arcbox-snapshot -- -D warnings
 
       - name: Unit tests
         # --bins covers the vm-agent guest handlers, whose tests are
         # target_os = "linux" and never run under the macOS workspace job.
-        run: cargo test --lib --bins -p arcbox-vm -p arcbox-vm-proto -p arcbox-vm-agent -p arcbox-snapshot
+        run: cargo test --lib --bins -p arcbox-vm -p arcbox-vm-proto -p arcbox-vm-driver -p arcbox-fc-driver -p arcbox-vm-agent -p arcbox-snapshot
 
   # ---------------------------------------------------------------------------
   # Job 2: integration tests — requires root (TAP interface creation)

--- a/.github/workflows/test-vm-linux.yml
+++ b/.github/workflows/test-vm-linux.yml
@@ -222,6 +222,21 @@ jobs:
             cargo test --test e2e -p arcbox-vm \
             -- --include-ignored --test-threads=1
 
+      # The port's driver contract against the real Firecracker: directly,
+      # and under the jailer firecracker.sh installed next to it.
+      - name: Run the driver contract against Firecracker (direct and jailer)
+        env:
+          FC_BINARY: /tmp/fc-assets/firecracker
+          FC_JAILER: /tmp/fc-assets/jailer
+          FC_KERNEL: /tmp/fc-assets/vmlinux
+          FC_ROOTFS: /tmp/fc-assets/rootfs.ext4
+        run: |
+          sudo env PATH="$PATH" HOME="$HOME" \
+            FC_BINARY="$FC_BINARY" FC_JAILER="$FC_JAILER" \
+            FC_KERNEL="$FC_KERNEL" FC_ROOTFS="$FC_ROOTFS" \
+            cargo test --test contract -p arcbox-fc-driver \
+            -- --include-ignored --test-threads=1
+
   # ---------------------------------------------------------------------------
   # Job 4: agent smoke — SandboxService integration (requires KVM + root + Firecracker + protoc)
   # ---------------------------------------------------------------------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ dependencies = [
  "arcbox-atomic-file",
  "arcbox-error",
  "arcbox-ext4",
+ "arcbox-fc-driver",
  "arcbox-snapshot",
  "arcbox-vm-driver",
  "arcbox-vm-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcbox-fc-driver"
+version = "0.7.0"
+dependencies = [
+ "arcbox-vm-driver",
+ "arcbox-vm-proto",
+ "async-trait",
+ "fc-sdk",
+ "nix 0.29.0",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "arcbox-fleet-agent"
 version = "0.1.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "virt/arcbox-vm",
     "virt/arcbox-vm-proto",
     "virt/arcbox-vm-driver",
+    "virt/arcbox-fc-driver",
     "virt/arcbox-vm-agent",
     "virt/arcbox-fs",
     "virt/arcbox-net",
@@ -271,6 +272,7 @@ arcbox-virtio-balloon = { version = "0.7.0", path = "virt/arcbox-virtio-balloon"
 arcbox-vm = { version = "0.7.0", path = "virt/arcbox-vm" } # x-release-please-version
 arcbox-vm-proto = { version = "0.7.0", path = "virt/arcbox-vm-proto" } # x-release-please-version
 arcbox-vm-driver = { version = "0.7.0", path = "virt/arcbox-vm-driver" } # x-release-please-version
+arcbox-fc-driver = { version = "0.7.0", path = "virt/arcbox-fc-driver" } # x-release-please-version
 arcbox-fs = { version = "0.7.0", path = "virt/arcbox-fs" } # x-release-please-version
 arcbox-net = { version = "0.7.0", path = "virt/arcbox-net" } # x-release-please-version
 arcbox-vmnet = { version = "0.7.0", path = "virt/arcbox-vmnet" } # x-release-please-version

--- a/virt/arcbox-fc-driver/Cargo.toml
+++ b/virt/arcbox-fc-driver/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name              = "arcbox-fc-driver"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description       = "The Firecracker adapter for the arcbox-vm-driver port: renders a VmSpec into Firecracker API payloads and jailer-relative paths, owns the VMM process, and serves vsock, checkpoints, prepare, and adopt over it."
+
+[dependencies]
+arcbox-vm-driver.workspace = true
+async-trait.workspace = true
+fc-sdk.workspace = true
+nix.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+arcbox-vm-driver = { workspace = true, features = ["testkit"] }
+arcbox-vm-proto.workspace = true
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -62,7 +62,12 @@ advertises `checkpoint: false`. A restore loads the image with the guest
 frozen, points every drive at the path *this* restore gives it
 (`PATCH /drives/{id}`, skipped where the image already names it — a
 snapshot records the disk paths of the VM it was taken from, never the fresh
-copy-on-write device a restore runs on), and only then resumes.
+copy-on-write device a restore runs on), and only then resumes. The load
+must find every recorded name first: a staged disk lands at `/{id}.ext4`,
+the name a checkpoint of this driver records, and a disk that already sits
+in the jail under another name is given that name too for the load (a hard
+link, or a device node or copy) and loses it once the drive points at the
+disk itself.
 
 ## Path rules
 

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -47,6 +47,11 @@ let vm = driver.boot(spec, &runtime_dir).await?;   // Box<dyn VmHandle>
 
 The checkpoint format is `firecracker/v1`: a directory holding `vmstate`
 and `mem`. Restoring anything else fails with `Error::ForeignCheckpoint`.
+A restore loads the image with the guest frozen, points every drive at the
+path *this* restore gives it (`PATCH /drives/{id}`, skipped where the image
+already names it — a snapshot records the disk paths of the VM it was taken
+from, never the fresh copy-on-write device a restore runs on), and only then
+resumes.
 
 ## Path rules
 

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -27,7 +27,7 @@ catalog, no engine, no orchestrator.
 | `process` | the process guard: waiter task, exit watch + event, kill / wait, detach |
 | `api` | pause, resume, snapshot, ctrl-alt-del, describe, vm-config over the raw client |
 | `listener` | the port's `VsockListener` over a `{uds}_{port}` socket |
-| `discover` | finding a Firecracker that outlived its booter (recorded pid, `/proc` scan) |
+| `discover` | finding a Firecracker that outlived its booter: the recorded pid and any `/proc` candidate, held to the same `--id` / `--api-sock` / jail-root test |
 | `prepared` | `FcPrepared: PreparedVm` — a spawned VMM waiting for a spec |
 | `handle` | `FcHandle: VmHandle + Vsock + VsockListen + Checkpoint + Detach` |
 | `driver` | `FcDriver: VmDriver + Prepare + Adopt` |

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -1,0 +1,68 @@
+# arcbox-fc-driver
+
+The Firecracker adapter for the [`arcbox-vm-driver`](../arcbox-vm-driver)
+port. It turns a `VmSpec` into Firecracker API payloads and (under the
+jailer) chroot-relative paths, owns the `firecracker`/`jailer` process,
+and serves the port's capabilities over it: `Vsock` and `VsockListen`
+through the hybrid-vsock Unix socket, `Checkpoint` through
+pause → snapshot → resume, `Prepare` for warm pools that spawn ahead of a
+boot, `Adopt`/`Detach` for VMs that outlive the process that booted them.
+
+Nothing above this crate names Firecracker. The sandbox manager
+(`arcbox-vm`) reaches it through `dyn VmDriver` — during the R1 migration
+it also calls the moved staging helpers directly, an edge R3 removes — and
+the only other things it depends on are the port and `fc-sdk`: no snapshot
+catalog, no engine, no orchestrator.
+
+## Layout
+
+| Module | Owns |
+|--------|------|
+| `config` | `FcDriverConfig` — binaries, seccomp, log level, API-socket wait, jailer resource limits |
+| `error` | `FcError`, folded into the port's `Error::Driver { driver: "firecracker", .. }` |
+| `render` | `VmSpec` → `FcPlan`, `RestoreSpec` → `FcRestorePlan`; every path Firecracker sees, and the jailer's relativity, is decided here |
+| `jail` | chroot layout and staging (link-or-copy, copy, block-device node), `apply` for a rendered plan |
+| `spawn` | `firecracker` / `jailer` process spawn from a `SpawnPlan` |
+| `vsock` | the `CONNECT <port>` handshake and the `{uds}_{port}` listener |
+| `process` | the process guard: waiter task, exit watch, kill / graceful shutdown, detach |
+| `prepared` | `FcPrepared: PreparedVm` — a spawned VMM waiting for a spec |
+| `handle` | `FcHandle: VmHandle + Vsock + VsockListen + Checkpoint + Detach` |
+| `driver` | `FcDriver: VmDriver + Prepare + Adopt` |
+
+## Usage
+
+```rust
+use std::sync::Arc;
+use arcbox_fc_driver::{FcDriver, FcDriverConfig};
+use arcbox_vm_driver::VmDriver;
+
+let mut config = FcDriverConfig::new("/usr/bin/firecracker");
+config.jailer_binary = Some("/usr/bin/jailer".into());
+let driver: Arc<dyn VmDriver> = Arc::new(FcDriver::new(config));
+let vm = driver.boot(spec, &runtime_dir).await?;   // Box<dyn VmHandle>
+```
+
+The checkpoint format is `firecracker/v1`: a directory holding `vmstate`
+and `mem`. Restoring anything else fails with `Error::ForeignCheckpoint`.
+
+## Path rules
+
+- **No isolation**: every spec path is passed to Firecracker verbatim; the
+  API socket is `{runtime_dir}/firecracker.sock`, the log and metrics files
+  `{runtime_dir}/firecracker.{log,metrics}` (pre-created), the vsock socket
+  `{runtime_dir}/firecracker.vsock`.
+- **Jailer**: the jail is `{chroot_base}/{firecracker binary name}/{id}/root`
+  and Firecracker sees only paths inside it. A host path already under the
+  jail is passed as `/` + its relative part; anything else is staged first:
+  the kernel to `/vmlinux` (hard link when the jail runs as root, a chowned
+  copy otherwise), a disk `id` to `/{id}.ext4` (a device node for a block
+  device, a copy for a writable file, link-or-copy for a read-only one), a
+  checkpoint to `/snapshots/{image dir name}/{vmstate,mem}`. The API socket
+  is `{jail}/run/firecracker.socket`, the vsock socket
+  `/run/firecracker.vsock` inside and `{jail}/run/firecracker.vsock` outside.
+
+Console files and sockets, virtiofs shares, and the balloon are refused
+with `Error::InvalidSpec` — the driver claims none of those capabilities.
+
+Design: company repo `engineering/arcbox/architecture/vm-stack-redesign.md`
+(Adapters → `virt/arcbox-fc-driver`; D-VM1, D-VM9).

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -69,9 +69,10 @@ resumes.
   is `{jail}/run/firecracker.socket`, the vsock socket
   `/run/firecracker.vsock` inside and `{jail}/run/firecracker.vsock` outside.
 
-A disk `id` must be a plain name: it becomes a device id in the API URL and,
-under a jail, the file the disk is staged as, so anything that could reach
-out of the jail is refused.
+A VM `id` and a disk `id` must each be a plain name: the first is the jail's
+directory, the second a device id in the API URL and the file the disk is
+staged as. Anything that could name a path outside the jail — `.`, `..`, a
+separator — is refused.
 
 Console files and sockets, virtiofs shares, and the balloon are refused
 with `Error::InvalidSpec` — the driver claims none of those capabilities.

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -69,6 +69,10 @@ resumes.
   is `{jail}/run/firecracker.socket`, the vsock socket
   `/run/firecracker.vsock` inside and `{jail}/run/firecracker.vsock` outside.
 
+A disk `id` must be a plain name: it becomes a device id in the API URL and,
+under a jail, the file the disk is staged as, so anything that could reach
+out of the jail is refused.
+
 Console files and sockets, virtiofs shares, and the balloon are refused
 with `Error::InvalidSpec` — the driver claims none of those capabilities.
 

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -47,11 +47,22 @@ let vm = driver.boot(spec, &runtime_dir).await?;   // Box<dyn VmHandle>
 
 The checkpoint format is `firecracker/v1`: a directory holding `vmstate`
 and `mem`. Restoring anything else fails with `Error::ForeignCheckpoint`.
-A restore loads the image with the guest frozen, points every drive at the
-path *this* restore gives it (`PATCH /drives/{id}`, skipped where the image
-already names it — a snapshot records the disk paths of the VM it was taken
-from, never the fresh copy-on-write device a restore runs on), and only then
-resumes.
+
+**Checkpoints are a jailer-mode capability.** `PUT /snapshot/load` reopens
+every drive at the path the checkpoint recorded, with no override, so a
+restored VM can be given other disks only where that path is private to
+it — inside a per-VM chroot, where the driver stages this restore's disks
+under the recorded names. Without a jail the recorded paths are the source
+VM's own host paths, shared with it (the sandbox manager refuses direct-mode
+restores for the same reason). So `capabilities().checkpoint` is `true`
+only with a jailer binary configured, `FcHandle::checkpoint()` is `Some`
+only for a VM under `IsolationSpec::Jailer`, and a `RestoreSpec` without
+jailer isolation is refused with `Error::InvalidSpec` — direct mode
+advertises `checkpoint: false`. A restore loads the image with the guest
+frozen, points every drive at the path *this* restore gives it
+(`PATCH /drives/{id}`, skipped where the image already names it — a
+snapshot records the disk paths of the VM it was taken from, never the fresh
+copy-on-write device a restore runs on), and only then resumes.
 
 ## Path rules
 

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -64,5 +64,26 @@ and `mem`. Restoring anything else fails with `Error::ForeignCheckpoint`.
 Console files and sockets, virtiofs shares, and the balloon are refused
 with `Error::InvalidSpec` — the driver claims none of those capabilities.
 
+## Running the contract
+
+`tests/contract.rs` runs every check of the port's `driver_contract!`
+against a real Firecracker, directly and — when `FC_JAILER` is set —
+under the jailer as uid/gid 0 (production's shape). The tests are
+`#[ignore]`d and skip themselves without their assets; they need
+`/dev/kvm`, and the jailer needs root:
+
+```bash
+FC_BINARY=/tmp/fc-assets/firecracker FC_JAILER=/tmp/fc-assets/jailer \
+FC_KERNEL=/tmp/fc-assets/vmlinux FC_ROOTFS=/tmp/fc-assets/rootfs.ext4 \
+sudo -E cargo test --test contract -p arcbox-fc-driver -- --include-ignored --test-threads=1
+```
+
+`FC_ROOTFS` must carry `vm-agent` at `/sbin/vm-agent` (the harness boots
+`init=/sbin/vm-agent`, dial-polls its exec port to know the guest is up,
+and relies on its READY dial-out for the prepared-listener check). The
+`e2e` job of `.github/workflows/test-vm-linux.yml` runs exactly this after
+the sandbox manager's own e2e suite, on the assets `firecracker.sh
+install` and the S3 CI bucket put under `/tmp/fc-assets`.
+
 Design: company repo `engineering/arcbox/architecture/vm-stack-redesign.md`
 (Adapters → `virt/arcbox-fc-driver`; D-VM1, D-VM9).

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -20,11 +20,14 @@ catalog, no engine, no orchestrator.
 |--------|------|
 | `config` | `FcDriverConfig` — binaries, seccomp, log level, API-socket wait, jailer resource limits |
 | `error` | `FcError`, folded into the port's `Error::Driver { driver: "firecracker", .. }` |
-| `render` | `VmSpec` → `FcPlan`, `RestoreSpec` → `FcRestorePlan`; every path Firecracker sees, and the jailer's relativity, is decided here |
-| `jail` | chroot layout and staging (link-or-copy, copy, block-device node), `apply` for a rendered plan |
+| `render` | `VmLayout` (every path Firecracker sees, and the jailer's relativity), `VmSpec` → `FcPlan`, `RestoreSpec` → `FcRestorePlan` |
+| `jail` | chroot layout and staging (link-or-copy, copy, block-device node), `apply` for a rendered plan, `move_file` out of a jail |
 | `spawn` | `firecracker` / `jailer` process spawn from a `SpawnPlan` |
 | `vsock` | the `CONNECT <port>` handshake and the `{uds}_{port}` listener |
-| `process` | the process guard: waiter task, exit watch, kill / graceful shutdown, detach |
+| `process` | the process guard: waiter task, exit watch + event, kill / wait, detach |
+| `api` | pause, resume, snapshot, ctrl-alt-del, describe, vm-config over the raw client |
+| `listener` | the port's `VsockListener` over a `{uds}_{port}` socket |
+| `discover` | finding a Firecracker that outlived its booter (recorded pid, `/proc` scan) |
 | `prepared` | `FcPrepared: PreparedVm` — a spawned VMM waiting for a spec |
 | `handle` | `FcHandle: VmHandle + Vsock + VsockListen + Checkpoint + Detach` |
 | `driver` | `FcDriver: VmDriver + Prepare + Adopt` |

--- a/virt/arcbox-fc-driver/src/api.rs
+++ b/virt/arcbox-fc-driver/src/api.rs
@@ -6,8 +6,8 @@
 
 use fc_sdk::Client;
 use fc_sdk::types::{
-    FullVmConfiguration, InstanceActionInfoActionType, InstanceInfo, SnapshotCreateParams,
-    SnapshotCreateParamsSnapshotType, VmState,
+    FullVmConfiguration, InstanceActionInfoActionType, InstanceInfo, PartialDrive,
+    SnapshotCreateParams, SnapshotCreateParamsSnapshotType, VmState,
 };
 
 use crate::error::{FcError, Result};
@@ -54,6 +54,26 @@ pub async fn create_snapshot(client: &Client, vmstate: &str, mem: &str) -> Resul
             snapshot_path: vmstate.to_owned(),
             mem_file_path: mem.to_owned(),
             snapshot_type: Some(SnapshotCreateParamsSnapshotType::Full),
+        })
+        .send()
+        .await
+        .map_err(|e| FcError::Api(e.into()))?;
+    Ok(())
+}
+
+/// `PATCH /drives/{id}` — point an existing drive at another host file.
+///
+/// Firecracker reopens the file and re-reads its capacity; the guest sees a
+/// config-change interrupt. A restore uses it while the loaded VM is still
+/// paused, so the guest never touches the path the checkpoint recorded.
+pub async fn update_drive(client: &Client, drive_id: &str, path_on_host: &str) -> Result<()> {
+    client
+        .patch_guest_drive_by_id()
+        .drive_id(drive_id)
+        .body(PartialDrive {
+            drive_id: drive_id.to_owned(),
+            path_on_host: Some(path_on_host.to_owned()),
+            rate_limiter: None,
         })
         .send()
         .await

--- a/virt/arcbox-fc-driver/src/api.rs
+++ b/virt/arcbox-fc-driver/src/api.rs
@@ -6,7 +6,8 @@
 
 use fc_sdk::Client;
 use fc_sdk::types::{
-    InstanceActionInfoActionType, SnapshotCreateParams, SnapshotCreateParamsSnapshotType, VmState,
+    FullVmConfiguration, InstanceActionInfoActionType, InstanceInfo, SnapshotCreateParams,
+    SnapshotCreateParamsSnapshotType, VmState,
 };
 
 use crate::error::{FcError, Result};
@@ -58,4 +59,25 @@ pub async fn create_snapshot(client: &Client, vmstate: &str, mem: &str) -> Resul
         .await
         .map_err(|e| FcError::Api(e.into()))?;
     Ok(())
+}
+
+/// `GET /` — the instance's state (`Running` / `Paused`) among other things.
+pub async fn describe(client: &Client) -> Result<InstanceInfo> {
+    let info = client
+        .describe_instance()
+        .send()
+        .await
+        .map_err(|e| FcError::Api(e.into()))?;
+    Ok(info.into_inner())
+}
+
+/// `GET /vm/config` — the full configuration, including which devices the
+/// VM (booted or restored) actually has.
+pub async fn vm_config(client: &Client) -> Result<FullVmConfiguration> {
+    let config = client
+        .get_export_vm_config()
+        .send()
+        .await
+        .map_err(|e| FcError::Api(e.into()))?;
+    Ok(config.into_inner())
 }

--- a/virt/arcbox-fc-driver/src/api.rs
+++ b/virt/arcbox-fc-driver/src/api.rs
@@ -1,0 +1,61 @@
+//! The few Firecracker API calls a running VM needs, over the raw client.
+//!
+//! `fc_sdk::Vm` wraps the same calls but can only be built by a boot or a
+//! restore; an adopted VM has just the socket, so the handle keeps the
+//! client and calls through here.
+
+use fc_sdk::Client;
+use fc_sdk::types::{
+    InstanceActionInfoActionType, SnapshotCreateParams, SnapshotCreateParamsSnapshotType, VmState,
+};
+
+use crate::error::{FcError, Result};
+
+/// `PATCH /vm {"state": "Paused"}`.
+pub async fn pause(client: &Client) -> Result<()> {
+    client
+        .patch_vm()
+        .body_map(|b| b.state(VmState::Paused))
+        .send()
+        .await
+        .map_err(|e| FcError::Api(e.into()))?;
+    Ok(())
+}
+
+/// `PATCH /vm {"state": "Resumed"}`.
+pub async fn resume(client: &Client) -> Result<()> {
+    client
+        .patch_vm()
+        .body_map(|b| b.state(VmState::Resumed))
+        .send()
+        .await
+        .map_err(|e| FcError::Api(e.into()))?;
+    Ok(())
+}
+
+/// `PUT /actions {"action_type": "SendCtrlAltDel"}` — asks the guest to
+/// reboot, which Firecracker turns into a VM exit.
+pub async fn send_ctrl_alt_del(client: &Client) -> Result<()> {
+    client
+        .create_sync_action()
+        .body_map(|b| b.action_type(InstanceActionInfoActionType::SendCtrlAltDel))
+        .send()
+        .await
+        .map_err(|e| FcError::Api(e.into()))?;
+    Ok(())
+}
+
+/// `PUT /snapshot/create` of a full snapshot; the VM must be paused.
+pub async fn create_snapshot(client: &Client, vmstate: &str, mem: &str) -> Result<()> {
+    client
+        .create_snapshot()
+        .body(SnapshotCreateParams {
+            snapshot_path: vmstate.to_owned(),
+            mem_file_path: mem.to_owned(),
+            snapshot_type: Some(SnapshotCreateParamsSnapshotType::Full),
+        })
+        .send()
+        .await
+        .map_err(|e| FcError::Api(e.into()))?;
+    Ok(())
+}

--- a/virt/arcbox-fc-driver/src/config.rs
+++ b/virt/arcbox-fc-driver/src/config.rs
@@ -1,0 +1,63 @@
+//! Node-wide Firecracker knobs: which binaries to run and how the VMM
+//! process itself is configured.
+//!
+//! Nothing here is per-VM. What a VM is made of is the port's
+//! [`VmSpec`](arcbox_vm_driver::VmSpec); how one VMM process is confined
+//! (uid, gid, chroot base, namespaces) is its
+//! [`IsolationSpec`](arcbox_vm_driver::IsolationSpec). This is what a
+//! composition root reads from its own config file and hands to the
+//! driver once.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// How the driver runs Firecracker on this node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FcDriverConfig {
+    /// The `firecracker` binary.
+    pub firecracker_binary: PathBuf,
+    /// The `jailer` binary; required for
+    /// [`IsolationSpec::Jailer`](arcbox_vm_driver::IsolationSpec::Jailer),
+    /// unused otherwise.
+    pub jailer_binary: Option<PathBuf>,
+    /// Firecracker's log level (`Error`, `Warning`, `Info`, `Debug`,
+    /// `Trace`); Firecracker's own default when `None`.
+    pub log_level: Option<String>,
+    /// Disable seccomp filtering (reduces isolation; testing only).
+    pub no_seccomp: bool,
+    /// A custom seccomp filter BPF file.
+    pub seccomp_filter: Option<PathBuf>,
+    /// Maximum HTTP API payload size in bytes.
+    pub http_api_max_payload_size: Option<usize>,
+    /// MMDS in-memory store size limit in bytes.
+    pub mmds_size_limit: Option<usize>,
+    /// How long a spawn waits for the API socket to appear.
+    pub socket_timeout: Duration,
+    /// Jailer resource limits in `rlimit` form (`"fsize=2048"`), applied to
+    /// every jailed VMM.
+    pub resource_limits: Vec<String>,
+}
+
+impl FcDriverConfig {
+    /// The socket wait a fresh config carries: five seconds, matching
+    /// fc-sdk's own default so the boot handoff bound stays stable across
+    /// SDK upgrades.
+    pub const DEFAULT_SOCKET_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// A config that runs `firecracker_binary` directly with Firecracker's
+    /// defaults: no jailer, default log level, seccomp on, no API or MMDS
+    /// size overrides, a five-second socket wait, no resource limits.
+    pub fn new(firecracker_binary: impl Into<PathBuf>) -> Self {
+        Self {
+            firecracker_binary: firecracker_binary.into(),
+            jailer_binary: None,
+            log_level: None,
+            no_seccomp: false,
+            seccomp_filter: None,
+            http_api_max_payload_size: None,
+            mmds_size_limit: None,
+            socket_timeout: Self::DEFAULT_SOCKET_TIMEOUT,
+            resource_limits: Vec::new(),
+        }
+    }
+}

--- a/virt/arcbox-fc-driver/src/discover.rs
+++ b/virt/arcbox-fc-driver/src/discover.rs
@@ -1,0 +1,255 @@
+//! Finding a Firecracker that outlived the process which booted it.
+//!
+//! The recorded pid may have been recycled since the record was written, so
+//! it counts only while its command name still looks like Firecracker
+//! (`/proc/<pid>/comm` on Linux; elsewhere the check degrades to "process
+//! exists"). On Linux, `/proc` is also scanned for a Firecracker whose
+//! command line names the VM (`--id`) or its API socket (`--api-sock`), or
+//! whose root is the VM's jail — the same three signatures the sandbox
+//! manager's restart sweep keys on.
+
+use std::path::{Path, PathBuf};
+
+use arcbox_vm_driver::{IsolationSpec, VmRecord};
+
+use crate::config::FcDriverConfig;
+
+/// A live Firecracker matching a record, with what a handle needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Found {
+    /// The process.
+    pub pid: u32,
+    /// The API socket as the host connects to it.
+    pub api_socket: PathBuf,
+    /// The confinement the process runs under, as far as `/proc` tells:
+    /// jailed (uid, gid and chroot base read back; namespaces and cgroup
+    /// unknown) or not.
+    pub isolation: IsolationSpec,
+}
+
+/// The Firecracker `record` names, if one is still running.
+pub fn find(config: &FcDriverConfig, record: &VmRecord) -> Option<Found> {
+    let recorded_socket = record.process.as_ref().and_then(|p| p.api_socket.clone());
+    let pid = record
+        .process
+        .as_ref()
+        .map(|p| p.pid)
+        .filter(|pid| process_is_firecracker(*pid))
+        .or_else(|| scan_proc(config, record, recorded_socket.as_deref()))?;
+    let jail_root = jail_root_of(pid);
+    let api_socket = recorded_socket
+        .or_else(|| cmdline_api_socket(pid, jail_root.as_deref()))
+        .unwrap_or_else(|| record.runtime_dir.join("firecracker.sock"));
+    let isolation = match jail_root {
+        Some(root) => {
+            let (uid, gid) = process_ids(pid).unwrap_or((0, 0));
+            // {chroot_base}/{exec}/{id}/root → chroot_base.
+            let chroot_base = root.ancestors().nth(3).map_or_else(
+                || PathBuf::from(crate::jail::DEFAULT_CHROOT_BASE),
+                Path::to_path_buf,
+            );
+            IsolationSpec::Jailer {
+                uid,
+                gid,
+                chroot_base,
+                netns: None,
+                new_pid_ns: false,
+                cgroup: None,
+            }
+        }
+        None => IsolationSpec::None,
+    };
+    Some(Found {
+        pid,
+        api_socket,
+        isolation,
+    })
+}
+
+/// True when `pid` is alive and (on Linux) named like a Firecracker binary.
+fn process_is_firecracker(pid: u32) -> bool {
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "Firecracker pid fits platform pid_t"
+    )]
+    if nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid as i32), None).is_err() {
+        return false;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        match std::fs::read_to_string(format!("/proc/{pid}/comm")) {
+            Ok(comm) => comm.trim_end().starts_with("firecracker"),
+            Err(_) => false,
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        true
+    }
+}
+
+/// The chroot a jailed Firecracker runs in, read from `/proc/<pid>/root`;
+/// `None` for an unjailed process (root is `/`) or off Linux.
+fn jail_root_of(pid: u32) -> Option<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_link(format!("/proc/{pid}/root"))
+            .ok()
+            .filter(|root| root != Path::new("/"))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = pid;
+        None
+    }
+}
+
+/// The `--api-sock` argument of `pid`, made absolute against its jail root
+/// when it is chroot-relative.
+fn cmdline_api_socket(pid: u32, jail_root: Option<&Path>) -> Option<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        let bytes = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+        let socket = cmdline_arg(&bytes, b"--api-sock")?;
+        let socket = PathBuf::from(String::from_utf8_lossy(socket).into_owned());
+        Some(match jail_root {
+            Some(root) => root.join(socket.strip_prefix("/").unwrap_or(&socket)),
+            None => socket,
+        })
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (pid, jail_root);
+        None
+    }
+}
+
+/// The real uid and gid of `pid`, from `/proc/<pid>/status`.
+fn process_ids(pid: u32) -> Option<(u32, u32)> {
+    #[cfg(target_os = "linux")]
+    {
+        let status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+        let field = |name: &str| {
+            status
+                .lines()
+                .find_map(|line| line.strip_prefix(name))
+                .and_then(|rest| rest.split_whitespace().next())
+                .and_then(|value| value.parse::<u32>().ok())
+        };
+        Some((field("Uid:")?, field("Gid:")?))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = pid;
+        None
+    }
+}
+
+/// Scan `/proc` for a Firecracker that names the VM: `--id {id}`,
+/// `--api-sock {socket}`, or a root ending in `{exec}/{id}/root`.
+#[cfg(target_os = "linux")]
+fn scan_proc(config: &FcDriverConfig, record: &VmRecord, socket: Option<&Path>) -> Option<u32> {
+    let direct_socket = socket.map_or_else(
+        || record.runtime_dir.join("firecracker.sock"),
+        Path::to_path_buf,
+    );
+    let jail_tail = config
+        .firecracker_binary
+        .file_name()
+        .map(|exec| Path::new(exec).join(record.id.as_str()).join("root"));
+    let entries = std::fs::read_dir("/proc").ok()?;
+    entries
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let pid = entry.file_name().to_str()?.parse::<u32>().ok()?;
+            process_is_firecracker(pid).then_some((pid, entry.path()))
+        })
+        .find(|(_, proc_dir)| {
+            let direct_match = std::fs::read(proc_dir.join("cmdline"))
+                .ok()
+                .is_some_and(|bytes| cmdline_matches(&bytes, record.id.as_str(), &direct_socket));
+            let jail_match = jail_tail.as_ref().is_some_and(|tail| {
+                std::fs::read_link(proc_dir.join("root"))
+                    .ok()
+                    .is_some_and(|root| root.ends_with(tail))
+            });
+            direct_match || jail_match
+        })
+        .map(|(pid, _)| pid)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn scan_proc(_config: &FcDriverConfig, _record: &VmRecord, _socket: Option<&Path>) -> Option<u32> {
+    None
+}
+
+/// The value following `flag` in a NUL-separated command line.
+#[cfg(any(target_os = "linux", test))]
+fn cmdline_arg<'a>(bytes: &'a [u8], flag: &[u8]) -> Option<&'a [u8]> {
+    let args: Vec<_> = bytes
+        .split(|byte| *byte == 0)
+        .filter(|arg| !arg.is_empty())
+        .collect();
+    args.windows(2)
+        .find(|pair| pair[0] == flag)
+        .map(|pair| pair[1])
+}
+
+/// True when the command line names VM `id` or its direct-mode socket.
+#[cfg(any(target_os = "linux", test))]
+fn cmdline_matches(bytes: &[u8], id: &str, socket: &Path) -> bool {
+    cmdline_arg(bytes, b"--id") == Some(id.as_bytes())
+        || cmdline_arg(bytes, b"--api-sock") == Some(socket.as_os_str().as_encoded_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dead_pid_is_not_firecracker() {
+        // PID 0 targets "the calling process group" for kill(2); use an
+        // implausibly high PID instead.
+        assert!(!process_is_firecracker(
+            u32::try_from(i32::MAX - 1).unwrap()
+        ));
+    }
+
+    #[test]
+    fn firecracker_command_line_matches_only_the_owned_id_or_socket() {
+        let socket = Path::new("/var/lib/arcbox/sandbox/sandboxes/box/firecracker.sock");
+        assert!(cmdline_matches(
+            b"firecracker\0--api-sock\0/var/lib/arcbox/sandbox/sandboxes/box/firecracker.sock\0",
+            "box",
+            socket
+        ));
+        assert!(cmdline_matches(b"firecracker\0--id\0box\0", "box", socket));
+        assert!(!cmdline_matches(
+            b"firecracker\0--id\0other\0",
+            "box",
+            socket
+        ));
+        assert_eq!(
+            cmdline_arg(
+                b"firecracker\0--api-sock\0/run/firecracker.socket\0--id\0box\0",
+                b"--api-sock"
+            ),
+            Some(&b"/run/firecracker.socket"[..])
+        );
+        assert_eq!(cmdline_arg(b"firecracker\0--id\0", b"--id"), None);
+    }
+
+    #[test]
+    fn a_record_whose_pid_is_gone_and_names_no_socket_is_not_found() {
+        let record = VmRecord {
+            id: arcbox_vm_driver::VmId::new("never-booted").unwrap(),
+            driver: crate::NAME.to_owned(),
+            runtime_dir: "/nonexistent/arcbox-fc-driver".into(),
+            process: Some(arcbox_vm_driver::ProcessRecord {
+                pid: u32::try_from(i32::MAX - 1).unwrap(),
+                api_socket: None,
+            }),
+        };
+        assert!(find(&FcDriverConfig::new("/opt/fc/firecracker"), &record).is_none());
+    }
+}

--- a/virt/arcbox-fc-driver/src/discover.rs
+++ b/virt/arcbox-fc-driver/src/discover.rs
@@ -1,12 +1,16 @@
 //! Finding a Firecracker that outlived the process which booted it.
 //!
-//! The recorded pid may have been recycled since the record was written, so
-//! it counts only while its command name still looks like Firecracker
-//! (`/proc/<pid>/comm` on Linux; elsewhere the check degrades to "process
-//! exists"). On Linux, `/proc` is also scanned for a Firecracker whose
-//! command line names the VM (`--id`) or its API socket (`--api-sock`), or
-//! whose root is the VM's jail — the same three signatures the sandbox
-//! manager's restart sweep keys on.
+//! The recorded pid may have been recycled since the record was written —
+//! by another Firecracker, on a busy node — so it is held to the same
+//! identity test as any other candidate: a Firecracker (`/proc/<pid>/comm`)
+//! whose command line names the VM (`--id`) or its API socket
+//! (`--api-sock`), or whose root is the VM's jail. Those are the three
+//! signatures the sandbox manager's restart sweep keys on, and the recorded
+//! pid only saves the `/proc` scan that looks for the same thing.
+//!
+//! All three read `/proc`, so nothing is adopted off Linux: an unverified
+//! pid is a VM this driver would later signal, and Firecracker needs KVM
+//! anyway.
 
 use std::path::{Path, PathBuf};
 
@@ -30,12 +34,13 @@ pub struct Found {
 /// The Firecracker `record` names, if one is still running.
 pub fn find(config: &FcDriverConfig, record: &VmRecord) -> Option<Found> {
     let recorded_socket = record.process.as_ref().and_then(|p| p.api_socket.clone());
+    let identity = Identity::of(config, record, recorded_socket.as_deref());
     let pid = record
         .process
         .as_ref()
         .map(|p| p.pid)
-        .filter(|pid| process_is_firecracker(*pid))
-        .or_else(|| scan_proc(config, record, recorded_socket.as_deref()))?;
+        .filter(|pid| identity.matches(*pid))
+        .or_else(|| identity.scan_proc())?;
     let jail_root = jail_root_of(pid);
     let api_socket = recorded_socket
         .or_else(|| cmdline_api_socket(pid, jail_root.as_deref()))
@@ -145,42 +150,77 @@ fn process_ids(pid: u32) -> Option<(u32, u32)> {
     }
 }
 
-/// Scan `/proc` for a Firecracker that names the VM: `--id {id}`,
-/// `--api-sock {socket}`, or a root ending in `{exec}/{id}/root`.
-#[cfg(target_os = "linux")]
-fn scan_proc(config: &FcDriverConfig, record: &VmRecord, socket: Option<&Path>) -> Option<u32> {
-    let direct_socket = socket.map_or_else(
-        || record.runtime_dir.join("firecracker.sock"),
-        Path::to_path_buf,
-    );
-    let jail_tail = config
-        .firecracker_binary
-        .file_name()
-        .map(|exec| Path::new(exec).join(record.id.as_str()).join("root"));
-    let entries = std::fs::read_dir("/proc").ok()?;
-    entries
-        .filter_map(|entry| entry.ok())
-        .filter_map(|entry| {
-            let pid = entry.file_name().to_str()?.parse::<u32>().ok()?;
-            process_is_firecracker(pid).then_some((pid, entry.path()))
-        })
-        .find(|(_, proc_dir)| {
-            let direct_match = std::fs::read(proc_dir.join("cmdline"))
-                .ok()
-                .is_some_and(|bytes| cmdline_matches(&bytes, record.id.as_str(), &direct_socket));
-            let jail_match = jail_tail.as_ref().is_some_and(|tail| {
-                std::fs::read_link(proc_dir.join("root"))
-                    .ok()
-                    .is_some_and(|root| root.ends_with(tail))
-            });
-            direct_match || jail_match
-        })
-        .map(|(pid, _)| pid)
+/// What makes a running process *this* VM: the id on its command line, the
+/// API socket it was given, or the jail it is chrooted into.
+struct Identity<'a> {
+    id: &'a str,
+    /// The direct-mode API socket: the recorded one, else where a direct
+    /// spawn for this record would have put it.
+    socket: PathBuf,
+    /// `{firecracker binary name}/{id}/root`, the tail of the VM's jail.
+    jail_tail: Option<PathBuf>,
 }
 
-#[cfg(not(target_os = "linux"))]
-fn scan_proc(_config: &FcDriverConfig, _record: &VmRecord, _socket: Option<&Path>) -> Option<u32> {
-    None
+impl<'a> Identity<'a> {
+    fn of(config: &FcDriverConfig, record: &'a VmRecord, socket: Option<&Path>) -> Self {
+        Self {
+            id: record.id.as_str(),
+            socket: socket.map_or_else(
+                || record.runtime_dir.join("firecracker.sock"),
+                Path::to_path_buf,
+            ),
+            jail_tail: config
+                .firecracker_binary
+                .file_name()
+                .map(|exec| Path::new(exec).join(record.id.as_str()).join("root")),
+        }
+    }
+
+    /// True when `pid` is a live Firecracker that this record names.
+    fn matches(&self, pid: u32) -> bool {
+        process_is_firecracker(pid) && self.identifies(Path::new("/proc").join(pid.to_string()))
+    }
+
+    /// True when the `/proc` entry's command line or root names this VM.
+    #[cfg(target_os = "linux")]
+    fn identifies(&self, proc_dir: PathBuf) -> bool {
+        let by_cmdline = std::fs::read(proc_dir.join("cmdline"))
+            .ok()
+            .is_some_and(|bytes| cmdline_matches(&bytes, self.id, &self.socket));
+        let by_jail = self.jail_tail.as_ref().is_some_and(|tail| {
+            std::fs::read_link(proc_dir.join("root"))
+                .ok()
+                .is_some_and(|root| root.ends_with(tail))
+        });
+        by_cmdline || by_jail
+    }
+
+    /// Identity is a `/proc` question; off Linux there is nothing to ask.
+    #[cfg(not(target_os = "linux"))]
+    fn identifies(&self, _proc_dir: PathBuf) -> bool {
+        let _ = (self.id, &self.socket, &self.jail_tail);
+        false
+    }
+
+    /// Scan `/proc` for the VM: `--id {id}`, `--api-sock {socket}`, or a
+    /// root ending in `{exec}/{id}/root`.
+    #[cfg(target_os = "linux")]
+    fn scan_proc(&self) -> Option<u32> {
+        let entries = std::fs::read_dir("/proc").ok()?;
+        entries
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| {
+                let pid = entry.file_name().to_str()?.parse::<u32>().ok()?;
+                process_is_firecracker(pid).then_some((pid, entry.path()))
+            })
+            .find(|(_, proc_dir)| self.identifies(proc_dir.clone()))
+            .map(|(pid, _)| pid)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn scan_proc(&self) -> Option<u32> {
+        None
+    }
 }
 
 /// The value following `flag` in a NUL-separated command line.
@@ -237,6 +277,21 @@ mod tests {
             Some(&b"/run/firecracker.socket"[..])
         );
         assert_eq!(cmdline_arg(b"firecracker\0--id\0", b"--id"), None);
+    }
+
+    #[test]
+    fn a_recorded_pid_that_is_not_this_vm_is_not_adopted() {
+        // The test binary itself: alive, and nothing about it names the VM.
+        let record = VmRecord {
+            id: arcbox_vm_driver::VmId::new("recycled").unwrap(),
+            driver: crate::NAME.to_owned(),
+            runtime_dir: "/nonexistent/arcbox-fc-driver".into(),
+            process: Some(arcbox_vm_driver::ProcessRecord {
+                pid: std::process::id(),
+                api_socket: None,
+            }),
+        };
+        assert!(find(&FcDriverConfig::new("/opt/fc/firecracker"), &record).is_none());
     }
 
     #[test]

--- a/virt/arcbox-fc-driver/src/driver.rs
+++ b/virt/arcbox-fc-driver/src/driver.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 
 use crate::config::FcDriverConfig;
 use crate::handle::FcHandle;
+use crate::listener::VsockEndpoint;
 use crate::prepared::FcPrepared;
 use crate::process::FcProcess;
 use crate::render::VmLayout;
@@ -135,9 +136,9 @@ impl Adopt for FcDriver {
             &self.config,
             &record.runtime_dir,
         )?;
-        let vsock_uds = devices
+        let vsock = devices
             .vsock
-            .map(|vsock| layout.vsock_host_view(&vsock.uds_path));
+            .map(|vsock| VsockEndpoint::new(layout.vsock_host_view(&vsock.uds_path)));
         let process = Arc::new(FcProcess::adopt(found.pid, found.api_socket));
         let quiesced = matches!(info.state, fc_sdk::types::InstanceInfoState::Paused);
         Ok(Some(Box::new(FcHandle::new(
@@ -145,7 +146,7 @@ impl Adopt for FcDriver {
             client,
             layout,
             record.clone(),
-            vsock_uds,
+            vsock,
             quiesced,
         ))))
     }

--- a/virt/arcbox-fc-driver/src/driver.rs
+++ b/virt/arcbox-fc-driver/src/driver.rs
@@ -1,0 +1,257 @@
+//! [`FcDriver`]: the port's [`VmDriver`] for Firecracker, with `Prepare`
+//! and `Adopt`.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use arcbox_vm_driver::{
+    Adopt, CheckpointImage, DriverCapabilities, Error, IsolationSpec, NestedVirt, Prepare,
+    PreparedVm, RestoreSpec, Result, VmDriver, VmHandle, VmId, VmRecord, VmSpec,
+};
+use async_trait::async_trait;
+
+use crate::config::FcDriverConfig;
+use crate::handle::FcHandle;
+use crate::prepared::FcPrepared;
+use crate::process::FcProcess;
+use crate::render::VmLayout;
+use crate::{CHECKPOINT_FORMAT, NAME, api, discover};
+
+/// The Firecracker adapter.
+///
+/// `boot` and `restore` are exactly prepare-then-boot / prepare-then-restore
+/// on a fresh [`FcPrepared`]; a failure on the way drops the prepared VM,
+/// which kills the process it spawned.
+pub struct FcDriver {
+    config: Arc<FcDriverConfig>,
+}
+
+impl FcDriver {
+    /// A driver over `config`.
+    pub fn new(config: FcDriverConfig) -> Self {
+        Self {
+            config: Arc::new(config),
+        }
+    }
+
+    /// The node-wide config this driver runs with.
+    pub fn config(&self) -> &FcDriverConfig {
+        &self.config
+    }
+
+    async fn prepare_vm(
+        &self,
+        id: &VmId,
+        isolation: &IsolationSpec,
+        runtime_dir: &Path,
+    ) -> Result<FcPrepared> {
+        FcPrepared::spawn(Arc::clone(&self.config), id, isolation, runtime_dir).await
+    }
+}
+
+#[async_trait]
+impl VmDriver for FcDriver {
+    fn name(&self) -> &'static str {
+        NAME
+    }
+
+    fn capabilities(&self) -> DriverCapabilities {
+        DriverCapabilities {
+            vsock: true,
+            vsock_listen: true,
+            checkpoint: true,
+            diff_checkpoint: false,
+            adopt: true,
+            prepare: true,
+            balloon: false,
+            console: false,
+            debug: false,
+            nested_virt: nested_virt(),
+        }
+    }
+
+    async fn boot(&self, spec: VmSpec, runtime_dir: &Path) -> Result<Box<dyn VmHandle>> {
+        spec.validate()?;
+        let prepared = self
+            .prepare_vm(&spec.id, &spec.isolation, runtime_dir)
+            .await?;
+        prepared.boot(spec).await
+    }
+
+    async fn restore(
+        &self,
+        image: &CheckpointImage,
+        spec: RestoreSpec,
+        runtime_dir: &Path,
+    ) -> Result<Box<dyn VmHandle>> {
+        // Refuse a foreign image before spawning anything.
+        if image.format.as_str() != CHECKPOINT_FORMAT {
+            return Err(Error::ForeignCheckpoint(image.format.clone()));
+        }
+        let prepared = self
+            .prepare_vm(&spec.id, &spec.isolation, runtime_dir)
+            .await?;
+        prepared.restore(image, spec).await
+    }
+
+    fn adopt(&self) -> Option<&dyn Adopt> {
+        Some(self)
+    }
+
+    fn prepare(&self) -> Option<&dyn Prepare> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl Prepare for FcDriver {
+    async fn prepare(
+        &self,
+        id: &VmId,
+        isolation: &IsolationSpec,
+        runtime_dir: &Path,
+    ) -> Result<Box<dyn PreparedVm>> {
+        Ok(Box::new(self.prepare_vm(id, isolation, runtime_dir).await?))
+    }
+}
+
+#[async_trait]
+impl Adopt for FcDriver {
+    /// Finds the VMM `record` names — the recorded pid when it is still a
+    /// Firecracker, else a `/proc` scan by `--id`, `--api-sock`, or a
+    /// jail root ending in `{firecracker binary name}/{id}/root` — and
+    /// rebuilds a handle over it: the API is reconnected, the VM's devices
+    /// and paused state are read back, and its exit is tracked by probing.
+    async fn adopt(&self, record: &VmRecord) -> Result<Option<Box<dyn VmHandle>>> {
+        let Some(found) = discover::find(&self.config, record) else {
+            return Ok(None);
+        };
+        let client = fc_sdk::connection::connect(&found.api_socket);
+        let info = api::describe(&client).await?;
+        let devices = api::vm_config(&client).await?;
+        let layout = VmLayout::new(
+            &record.id,
+            &found.isolation,
+            &self.config,
+            &record.runtime_dir,
+        )?;
+        let vsock_uds = devices.vsock.map(|vsock| {
+            layout.jail().map_or_else(
+                || vsock.uds_path.clone().into(),
+                |jail| jail.root.join(vsock.uds_path.trim_start_matches('/')),
+            )
+        });
+        let process = Arc::new(FcProcess::adopt(found.pid, found.api_socket));
+        let quiesced = matches!(info.state, fc_sdk::types::InstanceInfoState::Paused);
+        Ok(Some(Box::new(FcHandle::new(
+            process,
+            client,
+            layout,
+            record.clone(),
+            vsock_uds,
+            quiesced,
+        ))))
+    }
+}
+
+/// Whether guests may run their own hypervisor: KVM's `nested` module
+/// parameter on Linux; nowhere else, since Firecracker needs KVM.
+fn nested_virt() -> NestedVirt {
+    #[cfg(target_os = "linux")]
+    {
+        for module in ["kvm_intel", "kvm_amd"] {
+            let path = format!("/sys/module/{module}/parameters/nested");
+            if let Ok(value) = std::fs::read_to_string(&path) {
+                let value = value.trim();
+                return if value == "Y" || value == "1" {
+                    NestedVirt::supported()
+                } else {
+                    NestedVirt::unsupported(format!("{path} is {value}"))
+                };
+            }
+        }
+        NestedVirt::unsupported(
+            "no /sys/module/kvm_{intel,amd}/parameters/nested: kvm not loaded, or not an x86 host",
+        )
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        NestedVirt::unsupported("Firecracker needs Linux KVM")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arcbox_vm_driver::{
+        BootSpec, CheckpointFormat, CheckpointKind, ConsoleSpec, IsolationSpec,
+    };
+
+    use super::*;
+
+    /// A driver whose binary does not exist: anything that reaches a spawn
+    /// fails loudly, so these tests prove what is refused before one.
+    fn driver() -> FcDriver {
+        FcDriver::new(FcDriverConfig::new(
+            "/nonexistent/arcbox-fc-driver/firecracker",
+        ))
+    }
+
+    #[test]
+    fn capabilities_name_what_this_adapter_claims() {
+        let driver = driver();
+        assert_eq!(driver.name(), "firecracker");
+        let caps = driver.capabilities();
+        assert!(caps.vsock && caps.vsock_listen && caps.checkpoint);
+        assert!(caps.adopt && caps.prepare);
+        assert!(!caps.diff_checkpoint && !caps.balloon && !caps.console && !caps.debug);
+        assert!(VmDriver::adopt(&driver).is_some() && VmDriver::prepare(&driver).is_some());
+    }
+
+    #[tokio::test]
+    async fn invalid_specs_and_foreign_images_are_refused_before_a_spawn() {
+        let driver = driver();
+        let dir = tempfile::tempdir().unwrap();
+        let spec = VmSpec {
+            id: VmId::new("box").unwrap(),
+            cpus: 0,
+            memory_mib: 128,
+            boot: BootSpec::Kernel {
+                image: "/vmlinux".into(),
+                cmdline: String::new(),
+                initrd: None,
+            },
+            disks: vec![],
+            nics: vec![],
+            vsock: None,
+            shares: vec![],
+            console: ConsoleSpec::Off,
+            balloon: false,
+            entropy: false,
+            dirty_tracking: false,
+            isolation: IsolationSpec::None,
+        };
+        assert!(matches!(
+            driver.boot(spec, dir.path()).await,
+            Err(Error::InvalidSpec(_))
+        ));
+        let image = CheckpointImage {
+            dir: dir.path().to_path_buf(),
+            format: CheckpointFormat::new("other/v1"),
+            kind: CheckpointKind::Full,
+        };
+        let restore = RestoreSpec {
+            id: VmId::new("box").unwrap(),
+            nics: vec![],
+            disks: vec![],
+            isolation: IsolationSpec::None,
+        };
+        assert!(matches!(
+            driver.restore(&image, restore, dir.path()).await,
+            Err(Error::ForeignCheckpoint(_))
+        ));
+        assert!(
+            !dir.path().join("firecracker.log").exists(),
+            "nothing was spawned"
+        );
+    }
+}

--- a/virt/arcbox-fc-driver/src/driver.rs
+++ b/virt/arcbox-fc-driver/src/driver.rs
@@ -135,12 +135,9 @@ impl Adopt for FcDriver {
             &self.config,
             &record.runtime_dir,
         )?;
-        let vsock_uds = devices.vsock.map(|vsock| {
-            layout.jail().map_or_else(
-                || vsock.uds_path.clone().into(),
-                |jail| jail.root.join(vsock.uds_path.trim_start_matches('/')),
-            )
-        });
+        let vsock_uds = devices
+            .vsock
+            .map(|vsock| layout.vsock_host_view(&vsock.uds_path));
         let process = Arc::new(FcProcess::adopt(found.pid, found.api_socket));
         let quiesced = matches!(info.state, fc_sdk::types::InstanceInfoState::Paused);
         Ok(Some(Box::new(FcHandle::new(

--- a/virt/arcbox-fc-driver/src/driver.rs
+++ b/virt/arcbox-fc-driver/src/driver.rs
@@ -15,7 +15,7 @@ use crate::handle::FcHandle;
 use crate::listener::VsockEndpoint;
 use crate::prepared::FcPrepared;
 use crate::process::FcProcess;
-use crate::render::VmLayout;
+use crate::render::{self, VmLayout};
 use crate::{CHECKPOINT_FORMAT, NAME, api, discover};
 
 /// The Firecracker adapter.
@@ -56,11 +56,15 @@ impl VmDriver for FcDriver {
         NAME
     }
 
+    /// Checkpoints are claimed only with a jailer configured: a restore is
+    /// possible only inside a per-VM chroot
+    /// ([`render::require_jailed_restore`]), and a driver that cannot
+    /// restore does not claim to checkpoint.
     fn capabilities(&self) -> DriverCapabilities {
         DriverCapabilities {
             vsock: true,
             vsock_listen: true,
-            checkpoint: true,
+            checkpoint: self.config.jailer_binary.is_some(),
             diff_checkpoint: false,
             adopt: true,
             prepare: true,
@@ -85,10 +89,12 @@ impl VmDriver for FcDriver {
         spec: RestoreSpec,
         runtime_dir: &Path,
     ) -> Result<Box<dyn VmHandle>> {
-        // Refuse a foreign image before spawning anything.
+        // Refuse a foreign image, and a restore outside a jail, before
+        // spawning anything.
         if image.format.as_str() != CHECKPOINT_FORMAT {
             return Err(Error::ForeignCheckpoint(image.format.clone()));
         }
+        render::require_jailed_restore(&spec.isolation)?;
         let prepared = self
             .prepare_vm(&spec.id, &spec.isolation, runtime_dir)
             .await?;
@@ -138,7 +144,7 @@ impl Adopt for FcDriver {
         )?;
         let vsock = devices
             .vsock
-            .map(|vsock| VsockEndpoint::new(layout.vsock_host_view(&vsock.uds_path)));
+            .map(|vsock| VsockEndpoint::new(layout.host_view(&vsock.uds_path)));
         let process = Arc::new(FcProcess::adopt(found.pid, found.api_socket));
         let quiesced = matches!(info.state, fc_sdk::types::InstanceInfoState::Paused);
         Ok(Some(Box::new(FcHandle::new(
@@ -199,10 +205,16 @@ mod tests {
         let driver = driver();
         assert_eq!(driver.name(), "firecracker");
         let caps = driver.capabilities();
-        assert!(caps.vsock && caps.vsock_listen && caps.checkpoint);
+        assert!(caps.vsock && caps.vsock_listen);
         assert!(caps.adopt && caps.prepare);
         assert!(!caps.diff_checkpoint && !caps.balloon && !caps.console && !caps.debug);
         assert!(VmDriver::adopt(&driver).is_some() && VmDriver::prepare(&driver).is_some());
+        // Checkpoints go with the jailer: without one nothing could be
+        // restored, so nothing is claimed.
+        assert!(!caps.checkpoint);
+        let mut config = FcDriverConfig::new("/nonexistent/arcbox-fc-driver/firecracker");
+        config.jailer_binary = Some("/nonexistent/arcbox-fc-driver/jailer".into());
+        assert!(FcDriver::new(config).capabilities().checkpoint);
     }
 
     #[tokio::test]
@@ -244,8 +256,17 @@ mod tests {
             isolation: IsolationSpec::None,
         };
         assert!(matches!(
-            driver.restore(&image, restore, dir.path()).await,
+            driver.restore(&image, restore.clone(), dir.path()).await,
             Err(Error::ForeignCheckpoint(_))
+        ));
+        // A restore outside a jail is refused before a spawn too.
+        let own = CheckpointImage {
+            format: CheckpointFormat::new(CHECKPOINT_FORMAT),
+            ..image
+        };
+        assert!(matches!(
+            driver.restore(&own, restore, dir.path()).await,
+            Err(Error::InvalidSpec(msg)) if msg.contains("jailer isolation")
         ));
         assert!(
             !dir.path().join("firecracker.log").exists(),

--- a/virt/arcbox-fc-driver/src/error.rs
+++ b/virt/arcbox-fc-driver/src/error.rs
@@ -86,6 +86,43 @@ pub enum FcError {
         what: String,
     },
 
+    /// Connecting to Firecracker's hybrid-vsock Unix socket failed — the
+    /// socket is missing or the VMM is not accepting; final, unlike a guest
+    /// port with no listener yet.
+    #[error("connect to {uds}: {source}")]
+    VsockConnect {
+        /// The Unix socket.
+        uds: PathBuf,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The `CONNECT <port>` / `OK` handshake on the vsock Unix socket
+    /// failed or answered something other than `OK`.
+    #[error("vsock handshake on {uds}: {detail}")]
+    VsockHandshake {
+        /// The Unix socket.
+        uds: PathBuf,
+        /// What went wrong, in the handshake's terms.
+        detail: String,
+        /// The underlying I/O error, when there was one.
+        #[source]
+        source: Option<std::io::Error>,
+    },
+
+    /// A guest-dial-out listener socket could not be bound or accepted on.
+    #[error("{what} {path}: {source}")]
+    VsockListen {
+        /// The step that failed.
+        what: &'static str,
+        /// The listener socket.
+        path: PathBuf,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
     /// Signalling the VMM process failed.
     #[error("kill firecracker {pid}: {source}")]
     Kill {

--- a/virt/arcbox-fc-driver/src/error.rs
+++ b/virt/arcbox-fc-driver/src/error.rs
@@ -39,6 +39,53 @@ pub enum FcError {
         source: nix::Error,
     },
 
+    /// A path that should name a block device could not be inspected.
+    #[error("stat {path}: {source}")]
+    Stat {
+        /// The path.
+        path: PathBuf,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A disk to mirror as a device node is not a block device.
+    #[error("{path} is not a block device")]
+    NotBlockDevice {
+        /// The path.
+        path: PathBuf,
+    },
+
+    /// A block device carries a major or minor number outside `u32` — a
+    /// corrupt node, not something to truncate.
+    #[error("{path}: {what} {value} out of range")]
+    BadDeviceNumber {
+        /// The device node.
+        path: PathBuf,
+        /// `"major"` or `"minor"`.
+        what: &'static str,
+        /// The offending value.
+        value: u64,
+    },
+
+    /// A block-device node could not be created in the jail.
+    #[error("mknod {path}: {source}")]
+    Mknod {
+        /// The node being created.
+        path: PathBuf,
+        /// The underlying errno.
+        #[source]
+        source: nix::Error,
+    },
+
+    /// An operation this host cannot perform: block-device nodes and the
+    /// jailer exist on Linux only.
+    #[error("{what}: Linux-only")]
+    LinuxOnly {
+        /// What was asked for.
+        what: String,
+    },
+
     /// Signalling the VMM process failed.
     #[error("kill firecracker {pid}: {source}")]
     Kill {

--- a/virt/arcbox-fc-driver/src/error.rs
+++ b/virt/arcbox-fc-driver/src/error.rs
@@ -123,6 +123,10 @@ pub enum FcError {
         source: std::io::Error,
     },
 
+    /// The spawn reported no pid, so nothing could own the process.
+    #[error("spawned firecracker reported no pid")]
+    NoPid,
+
     /// Signalling the VMM process failed.
     #[error("kill firecracker {pid}: {source}")]
     Kill {

--- a/virt/arcbox-fc-driver/src/error.rs
+++ b/virt/arcbox-fc-driver/src/error.rs
@@ -1,0 +1,106 @@
+//! What can go wrong inside the adapter, and how it reaches the port.
+//!
+//! The port speaks one [`Error`](arcbox_vm_driver::Error); an adapter's own
+//! failures travel inside its [`Driver`](arcbox_vm_driver::Error::Driver)
+//! variant. [`FcError`] is the typed vocabulary this crate uses internally
+//! — spawn, API, staging, signalling — and [`From<FcError>`] is the one
+//! place it is folded into the port's error, naming the driver and keeping
+//! the original as the `source`.
+
+use std::path::PathBuf;
+
+use crate::NAME;
+
+/// A failure inside the Firecracker adapter.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum FcError {
+    /// The VMM (or jailer) process could not be spawned, or its API socket
+    /// did not appear within the configured wait.
+    #[error("spawn firecracker: {0}")]
+    Spawn(#[source] fc_sdk::Error),
+
+    /// A Firecracker API call failed.
+    #[error("firecracker api: {0}")]
+    Api(#[source] fc_sdk::Error),
+
+    /// Jailer isolation was asked for, but the driver config names no
+    /// jailer binary.
+    #[error("jailer isolation requested but no jailer binary is configured")]
+    NoJailer,
+
+    /// `chown` on a staged file, directory, or socket failed.
+    #[error("chown {path}: {source}")]
+    Chown {
+        /// The path being handed to the jailed uid/gid.
+        path: PathBuf,
+        /// The underlying errno.
+        #[source]
+        source: nix::Error,
+    },
+
+    /// Signalling the VMM process failed.
+    #[error("kill firecracker {pid}: {source}")]
+    Kill {
+        /// The VMM's pid.
+        pid: u32,
+        /// The underlying errno.
+        #[source]
+        source: nix::Error,
+    },
+
+    /// The VMM did not exit within the reap budget after `SIGKILL`.
+    #[error("timed out reaping firecracker {pid}")]
+    ReapTimeout {
+        /// The VMM's pid.
+        pid: u32,
+    },
+}
+
+/// `Result` specialised to [`FcError`].
+pub type Result<T> = std::result::Result<T, FcError>;
+
+impl From<FcError> for arcbox_vm_driver::Error {
+    /// Folds an adapter failure into the port's `Driver` variant: the driver
+    /// name, the failure in this crate's words, and the typed error kept as
+    /// the source.
+    fn from(err: FcError) -> Self {
+        Self::Driver {
+            driver: NAME,
+            message: err.to_string(),
+            source: Some(Box::new(err)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as _;
+
+    use super::*;
+
+    #[test]
+    fn adapter_errors_reach_the_port_as_driver_errors_with_the_source_kept() {
+        let port = arcbox_vm_driver::Error::from(FcError::ReapTimeout { pid: 42 });
+        let arcbox_vm_driver::Error::Driver {
+            driver,
+            message,
+            source,
+        } = &port
+        else {
+            panic!("expected Error::Driver, got {port}");
+        };
+        assert_eq!(*driver, "firecracker");
+        assert_eq!(message, "timed out reaping firecracker 42");
+        let source = source.as_ref().expect("the FcError is kept as the source");
+        assert!(
+            source.downcast_ref::<FcError>().is_some(),
+            "source is the typed FcError"
+        );
+        assert_eq!(
+            port.to_string(),
+            "driver `firecracker`: timed out reaping firecracker 42"
+        );
+        assert!(port.source().is_some());
+    }
+}

--- a/virt/arcbox-fc-driver/src/handle.rs
+++ b/virt/arcbox-fc-driver/src/handle.rs
@@ -1,0 +1,307 @@
+//! [`FcHandle`]: a running Firecracker VM behind the port's [`VmHandle`],
+//! with the vsock, listen, checkpoint, and detach capabilities.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
+
+use arcbox_vm_driver::{
+    AfterCheckpoint, Checkpoint, CheckpointFormat, CheckpointImage, CheckpointKind,
+    CheckpointOptions, Detach, Error, ExitStatus, IoMode, Result, ShutdownMode, VmEvent, VmHandle,
+    VmId, VmRecord, VmState, Vsock, VsockConn, VsockListen, VsockListener,
+};
+use async_trait::async_trait;
+use fc_sdk::Client;
+use nix::unistd::{Gid, Uid, chown};
+use tokio::sync::broadcast;
+
+use crate::error::FcError;
+use crate::process::FcProcess;
+use crate::render::VmLayout;
+use crate::{CHECKPOINT_FORMAT, NAME, api, jail, listener, vsock};
+
+/// How long a graceful shutdown gives the `SendCtrlAltDel` API call itself.
+const CTRL_ALT_DEL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A running (or just-exited) Firecracker VM.
+///
+/// Shares its [`FcProcess`] with the prepared VM it was booted on; dropping
+/// the handle kills the VM unless [`Detach`] released it.
+pub struct FcHandle {
+    process: Arc<FcProcess>,
+    client: Client,
+    layout: VmLayout,
+    record: VmRecord,
+    /// The vsock socket the host dials, when the VM has a vsock device.
+    vsock_uds: Option<PathBuf>,
+    /// Frozen after a checkpoint that asked to hold.
+    quiesced: AtomicBool,
+}
+
+impl FcHandle {
+    /// A handle over a VM that is already running on `process`: the API
+    /// `client` to drive it, its `layout` (jail, sockets), the `record` it
+    /// reports, the vsock socket if the VM has one, and whether the guest
+    /// is currently held paused.
+    pub fn new(
+        process: Arc<FcProcess>,
+        client: Client,
+        layout: VmLayout,
+        record: VmRecord,
+        vsock_uds: Option<PathBuf>,
+        quiesced: bool,
+    ) -> Self {
+        Self {
+            process,
+            client,
+            layout,
+            record,
+            vsock_uds,
+            quiesced: AtomicBool::new(quiesced),
+        }
+    }
+
+    fn require_state(&self, want: VmState, expected: &'static str) -> Result<()> {
+        let state = self.state();
+        if state == want {
+            Ok(())
+        } else {
+            Err(Error::WrongState {
+                id: self.record.id.clone(),
+                state,
+                expected,
+            })
+        }
+    }
+
+    fn require_alive(&self) -> Result<VmState> {
+        match self.state() {
+            state @ VmState::Exited(_) => Err(Error::WrongState {
+                id: self.record.id.clone(),
+                state,
+                expected: "running or quiesced",
+            }),
+            state => Ok(state),
+        }
+    }
+}
+
+impl Drop for FcHandle {
+    fn drop(&mut self) {
+        if !self.process.is_detached() {
+            self.process.kill_now();
+        }
+    }
+}
+
+#[async_trait]
+impl VmHandle for FcHandle {
+    fn id(&self) -> &VmId {
+        &self.record.id
+    }
+
+    fn record(&self) -> VmRecord {
+        self.record.clone()
+    }
+
+    fn state(&self) -> VmState {
+        if let Some(status) = self.process.exit_status() {
+            VmState::Exited(status)
+        } else if self.quiesced.load(Ordering::Acquire) {
+            VmState::Quiesced
+        } else {
+            VmState::Running
+        }
+    }
+
+    fn events(&self) -> broadcast::Receiver<VmEvent> {
+        self.process.events()
+    }
+
+    async fn shutdown(&self, mode: ShutdownMode) -> Result<ExitStatus> {
+        match mode {
+            ShutdownMode::Kill => Ok(self.process.kill().await?),
+            ShutdownMode::Graceful { timeout } => {
+                if let Some(status) = self.process.exit_status() {
+                    return Ok(status);
+                }
+                let deadline = tokio::time::Instant::now() + timeout;
+                // Ask the guest to shut down; errors are ignored — the VM
+                // may already be gone.
+                let _ = tokio::time::timeout(
+                    CTRL_ALT_DEL_TIMEOUT.min(timeout),
+                    api::send_ctrl_alt_del(&self.client),
+                )
+                .await;
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                if let Some(status) = self.process.wait(remaining).await {
+                    return Ok(status);
+                }
+                tracing::warn!(vm = %self.record.id, "guest did not shut down in time; killing firecracker");
+                Ok(self.process.kill().await?)
+            }
+        }
+    }
+
+    fn vsock(&self) -> Option<&dyn Vsock> {
+        self.vsock_uds.is_some().then_some(self)
+    }
+
+    fn checkpoint(&self) -> Option<&dyn Checkpoint> {
+        Some(self)
+    }
+
+    fn vsock_listener(&self) -> Option<&dyn VsockListen> {
+        self.vsock_uds.is_some().then_some(self)
+    }
+
+    fn detach(&self) -> Option<&dyn Detach> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl Vsock for FcHandle {
+    async fn dial(&self, port: u32) -> Result<VsockConn> {
+        self.require_state(VmState::Running, "running")?;
+        let uds = self.vsock_uds.as_deref().ok_or_else(|| Error::Driver {
+            driver: NAME,
+            message: "vm has no vsock device".into(),
+            source: None,
+        })?;
+        let stream = vsock::dial_uds(uds, port).await?;
+        Ok(VsockConn {
+            fd: stream.into_std()?.into(),
+            mode: IoMode::Async,
+        })
+    }
+}
+
+#[async_trait]
+impl VsockListen for FcHandle {
+    async fn listen(&self, port: u32) -> Result<Box<dyn VsockListener>> {
+        listener::bind(&self.layout, &self.process, port)
+    }
+}
+
+#[async_trait]
+impl Detach for FcHandle {
+    async fn detach(&self) -> Result<VmRecord> {
+        self.process.detach();
+        Ok(self.record.clone())
+    }
+}
+
+/// Where a snapshot is written for Firecracker, and how it reaches `dst`.
+enum SnapshotSite {
+    /// Firecracker writes straight into `dst`.
+    Direct { vmstate: String, mem: String },
+    /// Firecracker writes into a jail-local directory, moved to `dst`
+    /// afterwards.
+    Staged {
+        dir: PathBuf,
+        vmstate: String,
+        mem: String,
+    },
+}
+
+static SNAPSHOT_SEQ: AtomicU64 = AtomicU64::new(0);
+
+#[async_trait]
+impl Checkpoint for FcHandle {
+    async fn checkpoint(&self, dst: &Path, opts: CheckpointOptions) -> Result<CheckpointImage> {
+        if opts.kind != CheckpointKind::Full {
+            return Err(Error::InvalidSpec(format!(
+                "{NAME}: diff checkpoints are not supported"
+            )));
+        }
+        let was_quiesced = self.require_alive()? == VmState::Quiesced;
+        tokio::fs::create_dir_all(dst).await?;
+        let site = self.snapshot_site(dst).await?;
+
+        if !was_quiesced {
+            api::pause(&self.client).await?;
+        }
+        // Everything between pause and resume is fallible; its result is
+        // handled only AFTER the guest's state is settled — a bare `?` here
+        // would leave the guest paused forever.
+        let (vmstate, mem) = match &site {
+            SnapshotSite::Direct { vmstate, mem } | SnapshotSite::Staged { vmstate, mem, .. } => {
+                (vmstate.as_str(), mem.as_str())
+            }
+        };
+        let captured = api::create_snapshot(&self.client, vmstate, mem).await;
+        let hold = captured.is_ok() && opts.after == AfterCheckpoint::HoldQuiesced;
+        if hold {
+            self.quiesced.store(true, Ordering::Release);
+        } else if captured.is_ok() || !was_quiesced {
+            // Resume after a successful capture that did not ask to hold,
+            // and after any failure that found the guest running.
+            api::resume(&self.client).await?;
+            self.quiesced.store(false, Ordering::Release);
+        }
+        captured?;
+
+        if let SnapshotSite::Staged { dir, .. } = &site {
+            // The guest is either resumed (files complete, FC flushed them
+            // before returning) or deliberately held, so nothing is still
+            // writing to them.
+            jail::move_file(&dir.join("vmstate"), &dst.join("vmstate")).await?;
+            jail::move_file(&dir.join("mem"), &dst.join("mem")).await?;
+            let _ = tokio::fs::remove_dir_all(dir).await;
+        }
+        Ok(CheckpointImage {
+            dir: dst.to_path_buf(),
+            format: CheckpointFormat::new(CHECKPOINT_FORMAT),
+            kind: CheckpointKind::Full,
+        })
+    }
+}
+
+impl FcHandle {
+    /// Where Firecracker writes the snapshot: `dst` itself without a jail
+    /// or when `dst` is already inside it (chowned so the jailed VMM can
+    /// write there), else a fresh `{jail}/snapshots/<n>` to move from.
+    async fn snapshot_site(&self, dst: &Path) -> Result<SnapshotSite> {
+        let Some(jail) = self.layout.jail() else {
+            return Ok(SnapshotSite::Direct {
+                vmstate: utf8(&dst.join("vmstate"))?,
+                mem: utf8(&dst.join("mem"))?,
+            });
+        };
+        let owned = |dir: &Path| {
+            chown(
+                dir,
+                Some(Uid::from_raw(jail.uid)),
+                Some(Gid::from_raw(jail.gid)),
+            )
+            .map_err(|source| FcError::Chown {
+                path: dir.to_path_buf(),
+                source,
+            })
+        };
+        if let Some(view) = jail.view(dst) {
+            owned(dst)?;
+            return Ok(SnapshotSite::Direct {
+                vmstate: format!("{view}/vmstate"),
+                mem: format!("{view}/mem"),
+            });
+        }
+        let name = format!("ckpt-{}", SNAPSHOT_SEQ.fetch_add(1, Ordering::Relaxed));
+        let dir = jail.root.join("snapshots").join(&name);
+        tokio::fs::create_dir_all(&dir).await?;
+        owned(&dir)?;
+        Ok(SnapshotSite::Staged {
+            dir,
+            vmstate: format!("/snapshots/{name}/vmstate"),
+            mem: format!("/snapshots/{name}/mem"),
+        })
+    }
+}
+
+fn utf8(path: &Path) -> Result<String> {
+    path.to_str()
+        .map(str::to_owned)
+        .ok_or_else(|| Error::InvalidSpec(format!("{NAME}: path {} is not UTF-8", path.display())))
+}

--- a/virt/arcbox-fc-driver/src/handle.rs
+++ b/virt/arcbox-fc-driver/src/handle.rs
@@ -21,6 +21,9 @@ use crate::process::FcProcess;
 use crate::render::VmLayout;
 use crate::{CHECKPOINT_FORMAT, NAME, api, jail, listener, vsock};
 
+#[cfg(test)]
+mod tests;
+
 /// How long a graceful shutdown gives the `SendCtrlAltDel` API call itself.
 const CTRL_ALT_DEL_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -236,6 +239,9 @@ impl Checkpoint for FcHandle {
 
         if !was_quiesced {
             api::pause(&self.client).await?;
+            // The flag tracks the guest, not the intent: a resume that
+            // fails below leaves the VM reporting Quiesced, which it is.
+            self.quiesced.store(true, Ordering::Release);
         }
         // Everything between pause and resume is fallible; its result is
         // handled only AFTER the guest's state is settled — a bare `?` here
@@ -246,12 +252,10 @@ impl Checkpoint for FcHandle {
             }
         };
         let captured = api::create_snapshot(&self.client, vmstate, mem).await;
+        // Resume after a successful capture that did not ask to hold, and
+        // after any failure that found the guest running.
         let hold = captured.is_ok() && opts.after == AfterCheckpoint::HoldQuiesced;
-        if hold {
-            self.quiesced.store(true, Ordering::Release);
-        } else if captured.is_ok() || !was_quiesced {
-            // Resume after a successful capture that did not ask to hold,
-            // and after any failure that found the guest running.
+        if !hold && (captured.is_ok() || !was_quiesced) {
             api::resume(&self.client).await?;
             self.quiesced.store(false, Ordering::Release);
         }
@@ -318,205 +322,4 @@ fn utf8(path: &Path) -> Result<String> {
     path.to_str()
         .map(str::to_owned)
         .ok_or_else(|| Error::InvalidSpec(format!("{NAME}: path {} is not UTF-8", path.display())))
-}
-
-#[cfg(test)]
-mod tests {
-    use std::path::PathBuf;
-
-    use arcbox_vm_driver::{IsolationSpec, ProcessRecord};
-
-    use super::*;
-    use crate::config::FcDriverConfig;
-    use crate::process::testing::{pid_exists, spawn};
-
-    /// A handle over a `sleep` child and an API socket nobody answers on.
-    fn handle(dir: &Path, isolation: IsolationSpec, vsock: bool) -> FcHandle {
-        let id = VmId::new("box").unwrap();
-        let mut config = FcDriverConfig::new("/opt/fc/firecracker");
-        config.jailer_binary = Some("/opt/fc/jailer".into());
-        let layout = VmLayout::new(&id, &isolation, &config, dir).unwrap();
-        let process = Arc::new(spawn("sleep", &["30"]));
-        let record = VmRecord {
-            id,
-            driver: NAME.to_owned(),
-            runtime_dir: dir.to_path_buf(),
-            process: Some(ProcessRecord {
-                pid: process.pid(),
-                api_socket: Some(layout.api_socket()),
-            }),
-        };
-        let vsock_uds = vsock.then(|| layout.vsock_host_uds());
-        FcHandle::new(
-            process,
-            fc_sdk::connection::connect(dir.join("absent.sock")),
-            layout,
-            record,
-            vsock_uds,
-            false,
-        )
-    }
-
-    fn jail(dir: &Path) -> IsolationSpec {
-        IsolationSpec::Jailer {
-            uid: nix::unistd::getuid().as_raw(),
-            gid: nix::unistd::getgid().as_raw(),
-            chroot_base: dir.join("jail"),
-            netns: None,
-            new_pid_ns: false,
-            cgroup: None,
-        }
-    }
-
-    #[tokio::test]
-    async fn state_follows_the_process_and_kill_reports_the_signal() {
-        let dir = tempfile::tempdir().unwrap();
-        let vm = handle(dir.path(), IsolationSpec::None, true);
-        assert_eq!(vm.state(), VmState::Running);
-        assert!(vm.vsock().is_some() && vm.vsock_listener().is_some());
-        assert!(VmHandle::checkpoint(&vm).is_some() && VmHandle::detach(&vm).is_some());
-        let mut events = vm.events();
-        let status = vm.shutdown(ShutdownMode::Kill).await.unwrap();
-        assert_eq!(status, ExitStatus::signaled(9));
-        assert_eq!(vm.state(), VmState::Exited(status));
-        assert_eq!(events.recv().await.unwrap(), VmEvent::Exited(status));
-        assert!(events.try_recv().is_err());
-        // Nothing to dial, listen on, or checkpoint once exited.
-        assert!(matches!(
-            vm.vsock().unwrap().dial(52).await,
-            Err(Error::WrongState { .. })
-        ));
-        assert!(matches!(
-            vm.vsock_listener().unwrap().listen(51).await,
-            Err(Error::WrongState { .. })
-        ));
-        assert!(matches!(
-            VmHandle::checkpoint(&vm)
-                .unwrap()
-                .checkpoint(&dir.path().join("ckpt"), CheckpointOptions::default())
-                .await,
-            Err(Error::WrongState { .. })
-        ));
-    }
-
-    #[tokio::test]
-    async fn graceful_shutdown_kills_at_the_deadline_when_the_guest_ignores_it() {
-        let dir = tempfile::tempdir().unwrap();
-        let vm = handle(dir.path(), IsolationSpec::None, false);
-        assert!(vm.vsock().is_none() && vm.vsock_listener().is_none());
-        let status = vm
-            .shutdown(ShutdownMode::Graceful {
-                timeout: Duration::from_millis(300),
-            })
-            .await
-            .unwrap();
-        assert_eq!(status, ExitStatus::signaled(9));
-        assert_eq!(vm.state(), VmState::Exited(status));
-    }
-
-    #[tokio::test]
-    async fn drop_kills_unless_detached() {
-        let dir = tempfile::tempdir().unwrap();
-        let vm = handle(dir.path(), IsolationSpec::None, false);
-        let pid = vm.record().process.unwrap().pid;
-        drop(vm);
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        assert!(!pid_exists(pid), "a dropped handle kills the vm");
-
-        let vm = handle(dir.path(), IsolationSpec::None, false);
-        let pid = vm.record().process.unwrap().pid;
-        let record = VmHandle::detach(&vm).unwrap().detach().await.unwrap();
-        assert_eq!(record, vm.record());
-        drop(vm);
-        tokio::task::yield_now().await;
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        assert!(pid_exists(pid), "a detached vm keeps running");
-        #[allow(clippy::cast_possible_wrap, reason = "test pid")]
-        nix::sys::signal::kill(
-            nix::unistd::Pid::from_raw(pid as i32),
-            nix::sys::signal::Signal::SIGKILL,
-        )
-        .unwrap();
-    }
-
-    #[tokio::test]
-    async fn diff_checkpoints_are_refused_before_touching_the_guest() {
-        let dir = tempfile::tempdir().unwrap();
-        let vm = handle(dir.path(), IsolationSpec::None, false);
-        let opts = CheckpointOptions {
-            after: AfterCheckpoint::Resume,
-            kind: CheckpointKind::Diff,
-        };
-        assert!(matches!(
-            VmHandle::checkpoint(&vm)
-                .unwrap()
-                .checkpoint(&dir.path().join("ckpt"), opts)
-                .await,
-            Err(Error::InvalidSpec(_))
-        ));
-        assert_eq!(vm.state(), VmState::Running);
-    }
-
-    #[tokio::test]
-    async fn snapshots_are_written_in_place_or_staged_in_the_jail() {
-        let dir = tempfile::tempdir().unwrap();
-        let vm = handle(dir.path(), IsolationSpec::None, false);
-        let dst = dir.path().join("ckpt");
-        match vm.snapshot_site(&dst).await.unwrap() {
-            SnapshotSite::Direct { vmstate, mem } => {
-                assert_eq!(vmstate, dst.join("vmstate").to_str().unwrap());
-                assert_eq!(mem, dst.join("mem").to_str().unwrap());
-            }
-            SnapshotSite::Staged { .. } => panic!("no jail, no staging"),
-        }
-
-        let vm = handle(dir.path(), jail(dir.path()), false);
-        let root = vm.layout.jail().unwrap().root.clone();
-        let inside = root.join("snapshots/abc");
-        tokio::fs::create_dir_all(&inside).await.unwrap();
-        match vm.snapshot_site(&inside).await.unwrap() {
-            SnapshotSite::Direct { vmstate, mem } => {
-                assert_eq!(vmstate, "/snapshots/abc/vmstate");
-                assert_eq!(mem, "/snapshots/abc/mem");
-            }
-            SnapshotSite::Staged { .. } => panic!("inside the jail is written in place"),
-        }
-        let outside = dir.path().join("catalog/ckpt");
-        match vm.snapshot_site(&outside).await.unwrap() {
-            SnapshotSite::Staged { dir, vmstate, mem } => {
-                assert!(dir.starts_with(root.join("snapshots")), "{}", dir.display());
-                assert!(dir.is_dir());
-                let name = dir.file_name().unwrap().to_str().unwrap().to_owned();
-                assert_eq!(vmstate, format!("/snapshots/{name}/vmstate"));
-                assert_eq!(mem, format!("/snapshots/{name}/mem"));
-            }
-            SnapshotSite::Direct { .. } => panic!("outside the jail is staged"),
-        }
-    }
-
-    #[tokio::test]
-    async fn a_listener_fails_once_the_vm_exits() {
-        let dir = tempfile::tempdir().unwrap();
-        let vm = handle(dir.path(), IsolationSpec::None, true);
-        let mut listener = vm.vsock_listener().unwrap().listen(51).await.unwrap();
-        assert!(dir.path().join("firecracker.vsock_51").exists());
-        let killer = {
-            let pid = vm.record().process.unwrap().pid;
-            tokio::spawn(async move {
-                tokio::time::sleep(Duration::from_millis(100)).await;
-                #[allow(clippy::cast_possible_wrap, reason = "test pid")]
-                nix::sys::signal::kill(
-                    nix::unistd::Pid::from_raw(pid as i32),
-                    nix::sys::signal::Signal::SIGKILL,
-                )
-                .unwrap();
-            })
-        };
-        let accepted = tokio::time::timeout(Duration::from_secs(10), listener.accept()).await;
-        assert!(matches!(accepted, Ok(Err(Error::WrongState { .. }))));
-        killer.await.unwrap();
-        drop(listener);
-        assert!(!dir.path().join("firecracker.vsock_51").exists());
-        let _ = PathBuf::new();
-    }
 }

--- a/virt/arcbox-fc-driver/src/handle.rs
+++ b/virt/arcbox-fc-driver/src/handle.rs
@@ -62,6 +62,15 @@ impl FcHandle {
         }
     }
 
+    /// Firecracker leaves its vsock Unix socket behind; once the process is
+    /// gone the file is ours to remove — a restore that re-binds the
+    /// recorded path (direct mode) must find it free.
+    fn unlink_vsock(&self) {
+        if let Some(uds) = &self.vsock_uds {
+            let _ = std::fs::remove_file(uds);
+        }
+    }
+
     fn require_state(&self, want: VmState, expected: &'static str) -> Result<()> {
         let state = self.state();
         if state == want {
@@ -91,6 +100,7 @@ impl Drop for FcHandle {
     fn drop(&mut self) {
         if !self.process.is_detached() {
             self.process.kill_now();
+            self.unlink_vsock();
         }
     }
 }
@@ -120,28 +130,32 @@ impl VmHandle for FcHandle {
     }
 
     async fn shutdown(&self, mode: ShutdownMode) -> Result<ExitStatus> {
-        match mode {
-            ShutdownMode::Kill => Ok(self.process.kill().await?),
-            ShutdownMode::Graceful { timeout } => {
-                if let Some(status) = self.process.exit_status() {
-                    return Ok(status);
+        let status = match mode {
+            ShutdownMode::Kill => self.process.kill().await?,
+            ShutdownMode::Graceful { timeout } => match self.process.exit_status() {
+                Some(status) => status,
+                None => {
+                    let deadline = tokio::time::Instant::now() + timeout;
+                    // Ask the guest to shut down; errors are ignored — the
+                    // VM may already be gone.
+                    let _ = tokio::time::timeout(
+                        CTRL_ALT_DEL_TIMEOUT.min(timeout),
+                        api::send_ctrl_alt_del(&self.client),
+                    )
+                    .await;
+                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    match self.process.wait(remaining).await {
+                        Some(status) => status,
+                        None => {
+                            tracing::warn!(vm = %self.record.id, "guest did not shut down in time; killing firecracker");
+                            self.process.kill().await?
+                        }
+                    }
                 }
-                let deadline = tokio::time::Instant::now() + timeout;
-                // Ask the guest to shut down; errors are ignored — the VM
-                // may already be gone.
-                let _ = tokio::time::timeout(
-                    CTRL_ALT_DEL_TIMEOUT.min(timeout),
-                    api::send_ctrl_alt_del(&self.client),
-                )
-                .await;
-                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-                if let Some(status) = self.process.wait(remaining).await {
-                    return Ok(status);
-                }
-                tracing::warn!(vm = %self.record.id, "guest did not shut down in time; killing firecracker");
-                Ok(self.process.kill().await?)
-            }
-        }
+            },
+        };
+        self.unlink_vsock();
+        Ok(status)
     }
 
     fn vsock(&self) -> Option<&dyn Vsock> {

--- a/virt/arcbox-fc-driver/src/handle.rs
+++ b/virt/arcbox-fc-driver/src/handle.rs
@@ -233,7 +233,8 @@ impl Checkpoint for FcHandle {
                 "{NAME}: diff checkpoints are not supported"
             )));
         }
-        let was_quiesced = self.require_alive()? == VmState::Quiesced;
+        self.require_alive()?;
+        let was_quiesced = self.observe_quiesced().await?;
         tokio::fs::create_dir_all(dst).await?;
         let site = self.snapshot_site(dst).await?;
 
@@ -255,11 +256,26 @@ impl Checkpoint for FcHandle {
         // Resume after a successful capture that did not ask to hold, and
         // after any failure that found the guest running.
         let hold = captured.is_ok() && opts.after == AfterCheckpoint::HoldQuiesced;
-        if !hold && (captured.is_ok() || !was_quiesced) {
-            api::resume(&self.client).await?;
-            self.quiesced.store(false, Ordering::Release);
+        let resumed = if hold || (captured.is_err() && was_quiesced) {
+            Ok(())
+        } else {
+            let resumed = api::resume(&self.client).await;
+            if resumed.is_ok() {
+                self.quiesced.store(false, Ordering::Release);
+            }
+            resumed
+        };
+        // The capture is what the caller asked for, so its failure is the
+        // one reported; a resume that failed on top of it is logged, and the
+        // guest keeps reporting Quiesced, which is what it is.
+        if let Err(captured) = captured {
+            if let Err(resumed) = resumed {
+                tracing::error!(vm = %self.record.id, error = %resumed,
+                    "the guest stays quiesced: it could not be resumed after a failed checkpoint");
+            }
+            return Err(captured.into());
         }
-        captured?;
+        resumed?;
 
         if let SnapshotSite::Staged { dir, .. } = &site {
             // The guest is either resumed (files complete, FC flushed them
@@ -278,6 +294,27 @@ impl Checkpoint for FcHandle {
 }
 
 impl FcHandle {
+    /// Whether the guest is frozen, asked of Firecracker when this handle
+    /// believes it is.
+    ///
+    /// A handle only ever believes that after a checkpoint that held the
+    /// guest, an adopted VM that was already paused, or a resume that failed
+    /// — rare, and each a state the next checkpoint must not take on trust
+    /// (it decides whether to pause). A guest this handle believes is
+    /// running was never quiesced behind its back, so the common path costs
+    /// nothing.
+    async fn observe_quiesced(&self) -> Result<bool> {
+        if !self.quiesced.load(Ordering::Acquire) {
+            return Ok(false);
+        }
+        let paused = matches!(
+            api::describe(&self.client).await?.state,
+            fc_sdk::types::InstanceInfoState::Paused
+        );
+        self.quiesced.store(paused, Ordering::Release);
+        Ok(paused)
+    }
+
     /// Where Firecracker writes the snapshot: `dst` itself without a jail
     /// or when `dst` is already inside it (chowned so the jailed VMM can
     /// write there), else a fresh `{jail}/snapshots/<n>` to move from.

--- a/virt/arcbox-fc-driver/src/handle.rs
+++ b/virt/arcbox-fc-driver/src/handle.rs
@@ -305,3 +305,204 @@ fn utf8(path: &Path) -> Result<String> {
         .map(str::to_owned)
         .ok_or_else(|| Error::InvalidSpec(format!("{NAME}: path {} is not UTF-8", path.display())))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use arcbox_vm_driver::{IsolationSpec, ProcessRecord};
+
+    use super::*;
+    use crate::config::FcDriverConfig;
+    use crate::process::testing::{pid_exists, spawn};
+
+    /// A handle over a `sleep` child and an API socket nobody answers on.
+    fn handle(dir: &Path, isolation: IsolationSpec, vsock: bool) -> FcHandle {
+        let id = VmId::new("box").unwrap();
+        let mut config = FcDriverConfig::new("/opt/fc/firecracker");
+        config.jailer_binary = Some("/opt/fc/jailer".into());
+        let layout = VmLayout::new(&id, &isolation, &config, dir).unwrap();
+        let process = Arc::new(spawn("sleep", &["30"]));
+        let record = VmRecord {
+            id,
+            driver: NAME.to_owned(),
+            runtime_dir: dir.to_path_buf(),
+            process: Some(ProcessRecord {
+                pid: process.pid(),
+                api_socket: Some(layout.api_socket()),
+            }),
+        };
+        let vsock_uds = vsock.then(|| layout.vsock_host_uds());
+        FcHandle::new(
+            process,
+            fc_sdk::connection::connect(dir.join("absent.sock")),
+            layout,
+            record,
+            vsock_uds,
+            false,
+        )
+    }
+
+    fn jail(dir: &Path) -> IsolationSpec {
+        IsolationSpec::Jailer {
+            uid: nix::unistd::getuid().as_raw(),
+            gid: nix::unistd::getgid().as_raw(),
+            chroot_base: dir.join("jail"),
+            netns: None,
+            new_pid_ns: false,
+            cgroup: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn state_follows_the_process_and_kill_reports_the_signal() {
+        let dir = tempfile::tempdir().unwrap();
+        let vm = handle(dir.path(), IsolationSpec::None, true);
+        assert_eq!(vm.state(), VmState::Running);
+        assert!(vm.vsock().is_some() && vm.vsock_listener().is_some());
+        assert!(VmHandle::checkpoint(&vm).is_some() && VmHandle::detach(&vm).is_some());
+        let mut events = vm.events();
+        let status = vm.shutdown(ShutdownMode::Kill).await.unwrap();
+        assert_eq!(status, ExitStatus::signaled(9));
+        assert_eq!(vm.state(), VmState::Exited(status));
+        assert_eq!(events.recv().await.unwrap(), VmEvent::Exited(status));
+        assert!(events.try_recv().is_err());
+        // Nothing to dial, listen on, or checkpoint once exited.
+        assert!(matches!(
+            vm.vsock().unwrap().dial(52).await,
+            Err(Error::WrongState { .. })
+        ));
+        assert!(matches!(
+            vm.vsock_listener().unwrap().listen(51).await,
+            Err(Error::WrongState { .. })
+        ));
+        assert!(matches!(
+            VmHandle::checkpoint(&vm)
+                .unwrap()
+                .checkpoint(&dir.path().join("ckpt"), CheckpointOptions::default())
+                .await,
+            Err(Error::WrongState { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_kills_at_the_deadline_when_the_guest_ignores_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let vm = handle(dir.path(), IsolationSpec::None, false);
+        assert!(vm.vsock().is_none() && vm.vsock_listener().is_none());
+        let status = vm
+            .shutdown(ShutdownMode::Graceful {
+                timeout: Duration::from_millis(300),
+            })
+            .await
+            .unwrap();
+        assert_eq!(status, ExitStatus::signaled(9));
+        assert_eq!(vm.state(), VmState::Exited(status));
+    }
+
+    #[tokio::test]
+    async fn drop_kills_unless_detached() {
+        let dir = tempfile::tempdir().unwrap();
+        let vm = handle(dir.path(), IsolationSpec::None, false);
+        let pid = vm.record().process.unwrap().pid;
+        drop(vm);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(!pid_exists(pid), "a dropped handle kills the vm");
+
+        let vm = handle(dir.path(), IsolationSpec::None, false);
+        let pid = vm.record().process.unwrap().pid;
+        let record = VmHandle::detach(&vm).unwrap().detach().await.unwrap();
+        assert_eq!(record, vm.record());
+        drop(vm);
+        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(pid_exists(pid), "a detached vm keeps running");
+        #[allow(clippy::cast_possible_wrap, reason = "test pid")]
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(pid as i32),
+            nix::sys::signal::Signal::SIGKILL,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn diff_checkpoints_are_refused_before_touching_the_guest() {
+        let dir = tempfile::tempdir().unwrap();
+        let vm = handle(dir.path(), IsolationSpec::None, false);
+        let opts = CheckpointOptions {
+            after: AfterCheckpoint::Resume,
+            kind: CheckpointKind::Diff,
+        };
+        assert!(matches!(
+            VmHandle::checkpoint(&vm)
+                .unwrap()
+                .checkpoint(&dir.path().join("ckpt"), opts)
+                .await,
+            Err(Error::InvalidSpec(_))
+        ));
+        assert_eq!(vm.state(), VmState::Running);
+    }
+
+    #[tokio::test]
+    async fn snapshots_are_written_in_place_or_staged_in_the_jail() {
+        let dir = tempfile::tempdir().unwrap();
+        let vm = handle(dir.path(), IsolationSpec::None, false);
+        let dst = dir.path().join("ckpt");
+        match vm.snapshot_site(&dst).await.unwrap() {
+            SnapshotSite::Direct { vmstate, mem } => {
+                assert_eq!(vmstate, dst.join("vmstate").to_str().unwrap());
+                assert_eq!(mem, dst.join("mem").to_str().unwrap());
+            }
+            SnapshotSite::Staged { .. } => panic!("no jail, no staging"),
+        }
+
+        let vm = handle(dir.path(), jail(dir.path()), false);
+        let root = vm.layout.jail().unwrap().root.clone();
+        let inside = root.join("snapshots/abc");
+        tokio::fs::create_dir_all(&inside).await.unwrap();
+        match vm.snapshot_site(&inside).await.unwrap() {
+            SnapshotSite::Direct { vmstate, mem } => {
+                assert_eq!(vmstate, "/snapshots/abc/vmstate");
+                assert_eq!(mem, "/snapshots/abc/mem");
+            }
+            SnapshotSite::Staged { .. } => panic!("inside the jail is written in place"),
+        }
+        let outside = dir.path().join("catalog/ckpt");
+        match vm.snapshot_site(&outside).await.unwrap() {
+            SnapshotSite::Staged { dir, vmstate, mem } => {
+                assert!(dir.starts_with(root.join("snapshots")), "{}", dir.display());
+                assert!(dir.is_dir());
+                let name = dir.file_name().unwrap().to_str().unwrap().to_owned();
+                assert_eq!(vmstate, format!("/snapshots/{name}/vmstate"));
+                assert_eq!(mem, format!("/snapshots/{name}/mem"));
+            }
+            SnapshotSite::Direct { .. } => panic!("outside the jail is staged"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_listener_fails_once_the_vm_exits() {
+        let dir = tempfile::tempdir().unwrap();
+        let vm = handle(dir.path(), IsolationSpec::None, true);
+        let mut listener = vm.vsock_listener().unwrap().listen(51).await.unwrap();
+        assert!(dir.path().join("firecracker.vsock_51").exists());
+        let killer = {
+            let pid = vm.record().process.unwrap().pid;
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                #[allow(clippy::cast_possible_wrap, reason = "test pid")]
+                nix::sys::signal::kill(
+                    nix::unistd::Pid::from_raw(pid as i32),
+                    nix::sys::signal::Signal::SIGKILL,
+                )
+                .unwrap();
+            })
+        };
+        let accepted = tokio::time::timeout(Duration::from_secs(10), listener.accept()).await;
+        assert!(matches!(accepted, Ok(Err(Error::WrongState { .. }))));
+        killer.await.unwrap();
+        drop(listener);
+        assert!(!dir.path().join("firecracker.vsock_51").exists());
+        let _ = PathBuf::new();
+    }
+}

--- a/virt/arcbox-fc-driver/src/handle.rs
+++ b/virt/arcbox-fc-driver/src/handle.rs
@@ -175,8 +175,11 @@ impl VmHandle for FcHandle {
         self.vsock.is_some().then_some(self)
     }
 
+    /// `Some` for a jailed VM only: a checkpoint is worth taking only where
+    /// it can be restored, and that is inside a per-VM chroot
+    /// ([`crate::render::require_jailed_restore`]).
     fn checkpoint(&self) -> Option<&dyn Checkpoint> {
-        Some(self)
+        self.layout.jail().is_some().then_some(self)
     }
 
     fn vsock_listener(&self) -> Option<&dyn VsockListen> {

--- a/virt/arcbox-fc-driver/src/handle.rs
+++ b/virt/arcbox-fc-driver/src/handle.rs
@@ -17,6 +17,7 @@ use nix::unistd::{Gid, Uid, chown};
 use tokio::sync::broadcast;
 
 use crate::error::FcError;
+use crate::listener::VsockEndpoint;
 use crate::process::FcProcess;
 use crate::render::VmLayout;
 use crate::{CHECKPOINT_FORMAT, NAME, api, jail, listener, vsock};
@@ -36,8 +37,9 @@ pub struct FcHandle {
     client: Client,
     layout: VmLayout,
     record: VmRecord,
-    /// The vsock socket the host dials, when the VM has a vsock device.
-    vsock_uds: Option<PathBuf>,
+    /// The vsock socket the host dials and listens next to, when the VM
+    /// has a vsock device; shared with the prepared VM the handle came from.
+    vsock: Option<VsockEndpoint>,
     /// Frozen after a checkpoint that asked to hold.
     quiesced: AtomicBool,
 }
@@ -52,7 +54,7 @@ impl FcHandle {
         client: Client,
         layout: VmLayout,
         record: VmRecord,
-        vsock_uds: Option<PathBuf>,
+        vsock: Option<VsockEndpoint>,
         quiesced: bool,
     ) -> Self {
         Self {
@@ -60,17 +62,25 @@ impl FcHandle {
             client,
             layout,
             record,
-            vsock_uds,
+            vsock,
             quiesced: AtomicBool::new(quiesced),
         }
+    }
+
+    fn vsock_endpoint(&self) -> Result<&VsockEndpoint> {
+        self.vsock.as_ref().ok_or_else(|| Error::Driver {
+            driver: NAME,
+            message: "vm has no vsock device".into(),
+            source: None,
+        })
     }
 
     /// Firecracker leaves its vsock Unix socket behind; once the process is
     /// gone the file is ours to remove — a restore that re-binds the
     /// recorded path (direct mode) must find it free.
     fn unlink_vsock(&self) {
-        if let Some(uds) = &self.vsock_uds {
-            let _ = std::fs::remove_file(uds);
+        if let Some(vsock) = &self.vsock {
+            let _ = std::fs::remove_file(vsock.path());
         }
     }
 
@@ -162,7 +172,7 @@ impl VmHandle for FcHandle {
     }
 
     fn vsock(&self) -> Option<&dyn Vsock> {
-        self.vsock_uds.is_some().then_some(self)
+        self.vsock.is_some().then_some(self)
     }
 
     fn checkpoint(&self) -> Option<&dyn Checkpoint> {
@@ -170,7 +180,7 @@ impl VmHandle for FcHandle {
     }
 
     fn vsock_listener(&self) -> Option<&dyn VsockListen> {
-        self.vsock_uds.is_some().then_some(self)
+        self.vsock.is_some().then_some(self)
     }
 
     fn detach(&self) -> Option<&dyn Detach> {
@@ -182,12 +192,8 @@ impl VmHandle for FcHandle {
 impl Vsock for FcHandle {
     async fn dial(&self, port: u32) -> Result<VsockConn> {
         self.require_state(VmState::Running, "running")?;
-        let uds = self.vsock_uds.as_deref().ok_or_else(|| Error::Driver {
-            driver: NAME,
-            message: "vm has no vsock device".into(),
-            source: None,
-        })?;
-        let stream = vsock::dial_uds(uds, port).await?;
+        let uds = self.vsock_endpoint()?.path();
+        let stream = vsock::dial_uds(&uds, port).await?;
         Ok(VsockConn {
             fd: stream.into_std()?.into(),
             mode: IoMode::Async,
@@ -197,8 +203,10 @@ impl Vsock for FcHandle {
 
 #[async_trait]
 impl VsockListen for FcHandle {
+    /// Bound next to the same socket [`Vsock::dial`] uses — after a restore
+    /// the one the checkpoint recorded, which is where the guest dials out.
     async fn listen(&self, port: u32) -> Result<Box<dyn VsockListener>> {
-        listener::bind(&self.layout, &self.process, port)
+        listener::bind(&self.layout, self.vsock_endpoint()?, &self.process, port)
     }
 }
 

--- a/virt/arcbox-fc-driver/src/handle/tests.rs
+++ b/virt/arcbox-fc-driver/src/handle/tests.rs
@@ -1,0 +1,199 @@
+//! Handle behavior over plain children and an API socket nobody answers on.
+
+use std::path::PathBuf;
+
+use arcbox_vm_driver::{IsolationSpec, ProcessRecord};
+
+use super::*;
+use crate::config::FcDriverConfig;
+use crate::process::testing::{pid_exists, spawn};
+
+/// A handle over a `sleep` child and an API socket nobody answers on.
+fn handle(dir: &Path, isolation: IsolationSpec, vsock: bool) -> FcHandle {
+    let id = VmId::new("box").unwrap();
+    let mut config = FcDriverConfig::new("/opt/fc/firecracker");
+    config.jailer_binary = Some("/opt/fc/jailer".into());
+    let layout = VmLayout::new(&id, &isolation, &config, dir).unwrap();
+    let process = Arc::new(spawn("sleep", &["30"]));
+    let record = VmRecord {
+        id,
+        driver: NAME.to_owned(),
+        runtime_dir: dir.to_path_buf(),
+        process: Some(ProcessRecord {
+            pid: process.pid(),
+            api_socket: Some(layout.api_socket()),
+        }),
+    };
+    let vsock_uds = vsock.then(|| layout.vsock_host_uds());
+    FcHandle::new(
+        process,
+        fc_sdk::connection::connect(dir.join("absent.sock")),
+        layout,
+        record,
+        vsock_uds,
+        false,
+    )
+}
+
+fn jail(dir: &Path) -> IsolationSpec {
+    IsolationSpec::Jailer {
+        uid: nix::unistd::getuid().as_raw(),
+        gid: nix::unistd::getgid().as_raw(),
+        chroot_base: dir.join("jail"),
+        netns: None,
+        new_pid_ns: false,
+        cgroup: None,
+    }
+}
+
+#[tokio::test]
+async fn state_follows_the_process_and_kill_reports_the_signal() {
+    let dir = tempfile::tempdir().unwrap();
+    let vm = handle(dir.path(), IsolationSpec::None, true);
+    assert_eq!(vm.state(), VmState::Running);
+    assert!(vm.vsock().is_some() && vm.vsock_listener().is_some());
+    assert!(VmHandle::checkpoint(&vm).is_some() && VmHandle::detach(&vm).is_some());
+    let mut events = vm.events();
+    let status = vm.shutdown(ShutdownMode::Kill).await.unwrap();
+    assert_eq!(status, ExitStatus::signaled(9));
+    assert_eq!(vm.state(), VmState::Exited(status));
+    assert_eq!(events.recv().await.unwrap(), VmEvent::Exited(status));
+    assert!(events.try_recv().is_err());
+    // Nothing to dial, listen on, or checkpoint once exited.
+    assert!(matches!(
+        vm.vsock().unwrap().dial(52).await,
+        Err(Error::WrongState { .. })
+    ));
+    assert!(matches!(
+        vm.vsock_listener().unwrap().listen(51).await,
+        Err(Error::WrongState { .. })
+    ));
+    assert!(matches!(
+        VmHandle::checkpoint(&vm)
+            .unwrap()
+            .checkpoint(&dir.path().join("ckpt"), CheckpointOptions::default())
+            .await,
+        Err(Error::WrongState { .. })
+    ));
+}
+
+#[tokio::test]
+async fn graceful_shutdown_kills_at_the_deadline_when_the_guest_ignores_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let vm = handle(dir.path(), IsolationSpec::None, false);
+    assert!(vm.vsock().is_none() && vm.vsock_listener().is_none());
+    let status = vm
+        .shutdown(ShutdownMode::Graceful {
+            timeout: Duration::from_millis(300),
+        })
+        .await
+        .unwrap();
+    assert_eq!(status, ExitStatus::signaled(9));
+    assert_eq!(vm.state(), VmState::Exited(status));
+}
+
+#[tokio::test]
+async fn drop_kills_unless_detached() {
+    let dir = tempfile::tempdir().unwrap();
+    let vm = handle(dir.path(), IsolationSpec::None, false);
+    let pid = vm.record().process.unwrap().pid;
+    drop(vm);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(!pid_exists(pid), "a dropped handle kills the vm");
+
+    let vm = handle(dir.path(), IsolationSpec::None, false);
+    let pid = vm.record().process.unwrap().pid;
+    let record = VmHandle::detach(&vm).unwrap().detach().await.unwrap();
+    assert_eq!(record, vm.record());
+    drop(vm);
+    tokio::task::yield_now().await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(pid_exists(pid), "a detached vm keeps running");
+    #[allow(clippy::cast_possible_wrap, reason = "test pid")]
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(pid as i32),
+        nix::sys::signal::Signal::SIGKILL,
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+async fn diff_checkpoints_are_refused_before_touching_the_guest() {
+    let dir = tempfile::tempdir().unwrap();
+    let vm = handle(dir.path(), IsolationSpec::None, false);
+    let opts = CheckpointOptions {
+        after: AfterCheckpoint::Resume,
+        kind: CheckpointKind::Diff,
+    };
+    assert!(matches!(
+        VmHandle::checkpoint(&vm)
+            .unwrap()
+            .checkpoint(&dir.path().join("ckpt"), opts)
+            .await,
+        Err(Error::InvalidSpec(_))
+    ));
+    assert_eq!(vm.state(), VmState::Running);
+}
+
+#[tokio::test]
+async fn snapshots_are_written_in_place_or_staged_in_the_jail() {
+    let dir = tempfile::tempdir().unwrap();
+    let vm = handle(dir.path(), IsolationSpec::None, false);
+    let dst = dir.path().join("ckpt");
+    match vm.snapshot_site(&dst).await.unwrap() {
+        SnapshotSite::Direct { vmstate, mem } => {
+            assert_eq!(vmstate, dst.join("vmstate").to_str().unwrap());
+            assert_eq!(mem, dst.join("mem").to_str().unwrap());
+        }
+        SnapshotSite::Staged { .. } => panic!("no jail, no staging"),
+    }
+
+    let vm = handle(dir.path(), jail(dir.path()), false);
+    let root = vm.layout.jail().unwrap().root.clone();
+    let inside = root.join("snapshots/abc");
+    tokio::fs::create_dir_all(&inside).await.unwrap();
+    match vm.snapshot_site(&inside).await.unwrap() {
+        SnapshotSite::Direct { vmstate, mem } => {
+            assert_eq!(vmstate, "/snapshots/abc/vmstate");
+            assert_eq!(mem, "/snapshots/abc/mem");
+        }
+        SnapshotSite::Staged { .. } => panic!("inside the jail is written in place"),
+    }
+    let outside = dir.path().join("catalog/ckpt");
+    match vm.snapshot_site(&outside).await.unwrap() {
+        SnapshotSite::Staged { dir, vmstate, mem } => {
+            assert!(dir.starts_with(root.join("snapshots")), "{}", dir.display());
+            assert!(dir.is_dir());
+            let name = dir.file_name().unwrap().to_str().unwrap().to_owned();
+            assert_eq!(vmstate, format!("/snapshots/{name}/vmstate"));
+            assert_eq!(mem, format!("/snapshots/{name}/mem"));
+        }
+        SnapshotSite::Direct { .. } => panic!("outside the jail is staged"),
+    }
+}
+
+#[tokio::test]
+async fn a_listener_fails_once_the_vm_exits() {
+    let dir = tempfile::tempdir().unwrap();
+    let vm = handle(dir.path(), IsolationSpec::None, true);
+    let mut listener = vm.vsock_listener().unwrap().listen(51).await.unwrap();
+    assert!(dir.path().join("firecracker.vsock_51").exists());
+    let killer = {
+        let pid = vm.record().process.unwrap().pid;
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            #[allow(clippy::cast_possible_wrap, reason = "test pid")]
+            nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(pid as i32),
+                nix::sys::signal::Signal::SIGKILL,
+            )
+            .unwrap();
+        })
+    };
+    let accepted = tokio::time::timeout(Duration::from_secs(10), listener.accept()).await;
+    assert!(matches!(accepted, Ok(Err(Error::WrongState { .. }))));
+    killer.await.unwrap();
+    drop(listener);
+    assert!(!dir.path().join("firecracker.vsock_51").exists());
+    let _ = PathBuf::new();
+}

--- a/virt/arcbox-fc-driver/src/handle/tests.rs
+++ b/virt/arcbox-fc-driver/src/handle/tests.rs
@@ -6,6 +6,10 @@ use super::*;
 use crate::config::FcDriverConfig;
 use crate::process::testing::{pid_exists, spawn};
 
+mod fake_fc;
+
+use fake_fc::FakeFc;
+
 /// A handle over a `sleep` child and an API socket nobody answers on.
 fn handle(dir: &Path, isolation: IsolationSpec, vsock: bool) -> FcHandle {
     handle_over(Arc::new(spawn("sleep", &["30"])), dir, isolation, vsock)
@@ -17,6 +21,19 @@ fn handle_over(
     dir: &Path,
     isolation: IsolationSpec,
     vsock: bool,
+) -> FcHandle {
+    let client = fc_sdk::connection::connect(dir.join("absent.sock"));
+    with_client(process, client, dir, isolation, vsock, false)
+}
+
+/// A handle over `process`, talking to `client`.
+fn with_client(
+    process: Arc<FcProcess>,
+    client: fc_sdk::Client,
+    dir: &Path,
+    isolation: IsolationSpec,
+    vsock: bool,
+    quiesced: bool,
 ) -> FcHandle {
     let id = VmId::new("box").unwrap();
     let mut config = FcDriverConfig::new("/opt/fc/firecracker");
@@ -32,14 +49,24 @@ fn handle_over(
         }),
     };
     let vsock_uds = vsock.then(|| layout.vsock_host_uds());
-    FcHandle::new(
-        process,
-        fc_sdk::connection::connect(dir.join("absent.sock")),
-        layout,
-        record,
-        vsock_uds,
-        false,
-    )
+    FcHandle::new(process, client, layout, record, vsock_uds, quiesced)
+}
+
+/// A Firecracker that pauses and describes itself happily, and answers
+/// `snapshot/create` and the resume as the test asks.
+fn scripted(dir: &Path, capture: u16, resume: u16, state: &'static str) -> FakeFc {
+    FakeFc::start(dir, move |route, body| match route {
+        "PATCH /vm" if body.contains("Resumed") => {
+            (resume, r#"{"fault_message":"no resume"}"#.into())
+        }
+        "PATCH /vm" => (204, String::new()),
+        "PUT /snapshot/create" => (capture, r#"{"fault_message":"no capture"}"#.into()),
+        "GET /" => (
+            200,
+            format!(r#"{{"app_name":"fake","id":"box","state":"{state}","vmm_version":"1.10.1"}}"#),
+        ),
+        other => panic!("the driver called {other} unexpectedly"),
+    })
 }
 
 fn jail(dir: &Path) -> IsolationSpec {
@@ -193,6 +220,100 @@ async fn snapshots_are_written_in_place_or_staged_in_the_jail() {
         }
         SnapshotSite::Direct { .. } => panic!("outside the jail is staged"),
     }
+}
+
+#[tokio::test]
+async fn a_failed_capture_is_reported_even_when_the_resume_fails_too() {
+    let dir = tempfile::tempdir().unwrap();
+    let fc = scripted(dir.path(), 400, 400, "Paused");
+    let vm = with_client(
+        Arc::new(spawn("sleep", &["30"])),
+        fc.client(),
+        dir.path(),
+        IsolationSpec::None,
+        false,
+        false,
+    );
+    let failed = VmHandle::checkpoint(&vm)
+        .unwrap()
+        .checkpoint(&dir.path().join("ckpt"), CheckpointOptions::default())
+        .await;
+    match failed {
+        Err(Error::Driver { message, .. }) => {
+            assert!(message.contains("no capture"), "{message}");
+        }
+        other => panic!("expected the capture failure, got {other:?}"),
+    }
+    // The resume was attempted and did not take: the guest really is frozen.
+    assert_eq!(vm.state(), VmState::Quiesced);
+    let calls = fc.calls();
+    assert!(
+        calls.iter().any(|call| call.contains("Paused")),
+        "{calls:?}"
+    );
+    assert!(
+        calls.iter().any(|call| call.contains("Resumed")),
+        "{calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_failed_capture_leaves_a_resumed_guest_running() {
+    let dir = tempfile::tempdir().unwrap();
+    let fc = scripted(dir.path(), 400, 204, "Paused");
+    let vm = with_client(
+        Arc::new(spawn("sleep", &["30"])),
+        fc.client(),
+        dir.path(),
+        IsolationSpec::None,
+        false,
+        false,
+    );
+    assert!(
+        VmHandle::checkpoint(&vm)
+            .unwrap()
+            .checkpoint(&dir.path().join("ckpt"), CheckpointOptions::default())
+            .await
+            .is_err()
+    );
+    assert_eq!(vm.state(), VmState::Running);
+}
+
+#[tokio::test]
+async fn a_guest_the_handle_believes_is_frozen_is_asked_before_the_capture() {
+    let dir = tempfile::tempdir().unwrap();
+    // The handle thinks the guest is quiesced; Firecracker says it runs.
+    let fc = scripted(dir.path(), 204, 204, "Running");
+    let vm = with_client(
+        Arc::new(spawn("sleep", &["30"])),
+        fc.client(),
+        dir.path(),
+        IsolationSpec::None,
+        false,
+        true,
+    );
+    assert_eq!(vm.state(), VmState::Quiesced);
+    let opts = CheckpointOptions {
+        after: AfterCheckpoint::HoldQuiesced,
+        kind: CheckpointKind::Full,
+    };
+    VmHandle::checkpoint(&vm)
+        .unwrap()
+        .checkpoint(&dir.path().join("ckpt"), opts)
+        .await
+        .expect("checkpoint");
+    let calls = fc.calls();
+    assert_eq!(calls[0], "GET /", "{calls:?}");
+    assert!(
+        calls[1].contains("Paused"),
+        "the stale belief was corrected: {calls:?}"
+    );
+    // A hold does not resume, and the guest is frozen for real this time.
+    assert!(
+        !calls.iter().any(|call| call.contains("Resumed")),
+        "{calls:?}"
+    );
+    assert_eq!(vm.state(), VmState::Quiesced);
 }
 
 #[tokio::test]

--- a/virt/arcbox-fc-driver/src/handle/tests.rs
+++ b/virt/arcbox-fc-driver/src/handle/tests.rs
@@ -1,7 +1,5 @@
 //! Handle behavior over plain children and an API socket nobody answers on.
 
-use std::path::PathBuf;
-
 use arcbox_vm_driver::{IsolationSpec, ProcessRecord};
 
 use super::*;
@@ -10,11 +8,20 @@ use crate::process::testing::{pid_exists, spawn};
 
 /// A handle over a `sleep` child and an API socket nobody answers on.
 fn handle(dir: &Path, isolation: IsolationSpec, vsock: bool) -> FcHandle {
+    handle_over(Arc::new(spawn("sleep", &["30"])), dir, isolation, vsock)
+}
+
+/// A handle over `process` and an API socket nobody answers on.
+fn handle_over(
+    process: Arc<FcProcess>,
+    dir: &Path,
+    isolation: IsolationSpec,
+    vsock: bool,
+) -> FcHandle {
     let id = VmId::new("box").unwrap();
     let mut config = FcDriverConfig::new("/opt/fc/firecracker");
     config.jailer_binary = Some("/opt/fc/jailer".into());
     let layout = VmLayout::new(&id, &isolation, &config, dir).unwrap();
-    let process = Arc::new(spawn("sleep", &["30"]));
     let record = VmRecord {
         id,
         driver: NAME.to_owned(),
@@ -115,6 +122,22 @@ async fn drop_kills_unless_detached() {
         nix::sys::signal::Signal::SIGKILL,
     )
     .unwrap();
+
+    // An adopted vm is released the same way: detach, then drop, and it
+    // keeps running for the next adopter.
+    let mut child = tokio::process::Command::new("sleep")
+        .arg("30")
+        .spawn()
+        .unwrap();
+    let pid = child.id().unwrap();
+    let adopted = Arc::new(FcProcess::adopt(pid, dir.path().join("absent.sock")));
+    let vm = handle_over(adopted, dir.path(), IsolationSpec::None, false);
+    VmHandle::detach(&vm).unwrap().detach().await.unwrap();
+    drop(vm);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(pid_exists(pid), "a detached adopted vm keeps running");
+    child.kill().await.unwrap();
+    child.wait().await.unwrap();
 }
 
 #[tokio::test]
@@ -195,5 +218,4 @@ async fn a_listener_fails_once_the_vm_exits() {
     killer.await.unwrap();
     drop(listener);
     assert!(!dir.path().join("firecracker.vsock_51").exists());
-    let _ = PathBuf::new();
 }

--- a/virt/arcbox-fc-driver/src/handle/tests.rs
+++ b/virt/arcbox-fc-driver/src/handle/tests.rs
@@ -48,8 +48,8 @@ fn with_client(
             api_socket: Some(layout.api_socket()),
         }),
     };
-    let vsock_uds = vsock.then(|| layout.vsock_host_uds());
-    FcHandle::new(process, client, layout, record, vsock_uds, quiesced)
+    let vsock = vsock.then(|| VsockEndpoint::new(layout.vsock_host_uds()));
+    FcHandle::new(process, client, layout, record, vsock, quiesced)
 }
 
 /// A Firecracker that pauses and describes itself happily, and answers
@@ -339,4 +339,52 @@ async fn a_listener_fails_once_the_vm_exits() {
     killer.await.unwrap();
     drop(listener);
     assert!(!dir.path().join("firecracker.vsock_51").exists());
+}
+
+#[tokio::test]
+async fn listen_binds_next_to_the_socket_dial_uses_not_the_layout_path() {
+    // A restored (or adopted) VM has its vsock where the checkpoint
+    // recorded it — in direct mode the source VM's runtime dir, not this
+    // one's. Guest dial-outs land next to that socket, so the listener
+    // must be bound there too.
+    let dir = tempfile::tempdir().unwrap();
+    let recorded = dir.path().join("source").join("firecracker.vsock");
+    std::fs::create_dir_all(recorded.parent().unwrap()).unwrap();
+    let id = VmId::new("box").unwrap();
+    let config = FcDriverConfig::new("/opt/fc/firecracker");
+    let layout = VmLayout::new(&id, &IsolationSpec::None, &config, dir.path()).unwrap();
+    assert_ne!(layout.vsock_host_uds(), recorded);
+    let process = Arc::new(spawn("sleep", &["30"]));
+    let record = VmRecord {
+        id,
+        driver: NAME.to_owned(),
+        runtime_dir: dir.path().to_path_buf(),
+        process: Some(ProcessRecord {
+            pid: process.pid(),
+            api_socket: Some(layout.api_socket()),
+        }),
+    };
+    let vm = FcHandle::new(
+        process,
+        fc_sdk::connection::connect(dir.path().join("absent.sock")),
+        layout,
+        record,
+        Some(VsockEndpoint::new(recorded.clone())),
+        false,
+    );
+
+    let listener = vm.vsock_listener().unwrap().listen(51).await.unwrap();
+    assert!(
+        dir.path().join("source/firecracker.vsock_51").exists(),
+        "bound next to the recorded socket"
+    );
+    assert!(
+        !dir.path().join("firecracker.vsock_51").exists(),
+        "not next to the layout's socket"
+    );
+    drop(listener);
+    // And a kill unlinks the recorded socket, not the layout's.
+    std::fs::write(&recorded, b"").unwrap();
+    vm.shutdown(ShutdownMode::Kill).await.unwrap();
+    assert!(!recorded.exists());
 }

--- a/virt/arcbox-fc-driver/src/handle/tests.rs
+++ b/virt/arcbox-fc-driver/src/handle/tests.rs
@@ -52,6 +52,17 @@ fn with_client(
     FcHandle::new(process, client, layout, record, vsock, quiesced)
 }
 
+/// A checkpoint destination inside the VM's jail, so the capture is
+/// written in place and nothing has to be moved out afterwards (the
+/// scripted Firecracker writes no files).
+fn in_jail(vm: &FcHandle) -> PathBuf {
+    vm.layout
+        .jail()
+        .expect("checkpoints are taken on jailed vms")
+        .root
+        .join("snapshots/ckpt")
+}
+
 /// A Firecracker that pauses and describes itself happily, and answers
 /// `snapshot/create` and the resume as the test asks.
 fn scripted(dir: &Path, capture: u16, resume: u16, state: &'static str) -> FakeFc {
@@ -83,7 +94,7 @@ fn jail(dir: &Path) -> IsolationSpec {
 #[tokio::test]
 async fn state_follows_the_process_and_kill_reports_the_signal() {
     let dir = tempfile::tempdir().unwrap();
-    let vm = handle(dir.path(), IsolationSpec::None, true);
+    let vm = handle(dir.path(), jail(dir.path()), true);
     assert_eq!(vm.state(), VmState::Running);
     assert!(vm.vsock().is_some() && vm.vsock_listener().is_some());
     assert!(VmHandle::checkpoint(&vm).is_some() && VmHandle::detach(&vm).is_some());
@@ -105,10 +116,21 @@ async fn state_follows_the_process_and_kill_reports_the_signal() {
     assert!(matches!(
         VmHandle::checkpoint(&vm)
             .unwrap()
-            .checkpoint(&dir.path().join("ckpt"), CheckpointOptions::default())
+            .checkpoint(&in_jail(&vm), CheckpointOptions::default())
             .await,
         Err(Error::WrongState { .. })
     ));
+}
+
+#[tokio::test]
+async fn checkpoints_are_a_jailer_mode_capability() {
+    // Firecracker reopens the recorded drive paths on load, so a checkpoint
+    // can be restored only inside a per-VM chroot; an unjailed VM has no
+    // checkpoint accessor.
+    let dir = tempfile::tempdir().unwrap();
+    let vm = handle(dir.path(), IsolationSpec::None, true);
+    assert!(VmHandle::checkpoint(&vm).is_none());
+    assert!(vm.vsock().is_some() && VmHandle::detach(&vm).is_some());
 }
 
 #[tokio::test]
@@ -170,7 +192,7 @@ async fn drop_kills_unless_detached() {
 #[tokio::test]
 async fn diff_checkpoints_are_refused_before_touching_the_guest() {
     let dir = tempfile::tempdir().unwrap();
-    let vm = handle(dir.path(), IsolationSpec::None, false);
+    let vm = handle(dir.path(), jail(dir.path()), false);
     let opts = CheckpointOptions {
         after: AfterCheckpoint::Resume,
         kind: CheckpointKind::Diff,
@@ -178,7 +200,7 @@ async fn diff_checkpoints_are_refused_before_touching_the_guest() {
     assert!(matches!(
         VmHandle::checkpoint(&vm)
             .unwrap()
-            .checkpoint(&dir.path().join("ckpt"), opts)
+            .checkpoint(&in_jail(&vm), opts)
             .await,
         Err(Error::InvalidSpec(_))
     ));
@@ -230,13 +252,13 @@ async fn a_failed_capture_is_reported_even_when_the_resume_fails_too() {
         Arc::new(spawn("sleep", &["30"])),
         fc.client(),
         dir.path(),
-        IsolationSpec::None,
+        jail(dir.path()),
         false,
         false,
     );
     let failed = VmHandle::checkpoint(&vm)
         .unwrap()
-        .checkpoint(&dir.path().join("ckpt"), CheckpointOptions::default())
+        .checkpoint(&in_jail(&vm), CheckpointOptions::default())
         .await;
     match failed {
         Err(Error::Driver { message, .. }) => {
@@ -265,14 +287,14 @@ async fn a_failed_capture_leaves_a_resumed_guest_running() {
         Arc::new(spawn("sleep", &["30"])),
         fc.client(),
         dir.path(),
-        IsolationSpec::None,
+        jail(dir.path()),
         false,
         false,
     );
     assert!(
         VmHandle::checkpoint(&vm)
             .unwrap()
-            .checkpoint(&dir.path().join("ckpt"), CheckpointOptions::default())
+            .checkpoint(&in_jail(&vm), CheckpointOptions::default())
             .await
             .is_err()
     );
@@ -288,7 +310,7 @@ async fn a_guest_the_handle_believes_is_frozen_is_asked_before_the_capture() {
         Arc::new(spawn("sleep", &["30"])),
         fc.client(),
         dir.path(),
-        IsolationSpec::None,
+        jail(dir.path()),
         false,
         true,
     );
@@ -299,7 +321,7 @@ async fn a_guest_the_handle_believes_is_frozen_is_asked_before_the_capture() {
     };
     VmHandle::checkpoint(&vm)
         .unwrap()
-        .checkpoint(&dir.path().join("ckpt"), opts)
+        .checkpoint(&in_jail(&vm), opts)
         .await
         .expect("checkpoint");
     let calls = fc.calls();

--- a/virt/arcbox-fc-driver/src/handle/tests/fake_fc.rs
+++ b/virt/arcbox-fc-driver/src/handle/tests/fake_fc.rs
@@ -1,0 +1,163 @@
+//! A Firecracker API socket the tests can script.
+//!
+//! The interesting checkpoint paths are the ones where a call fails —
+//! a capture that fails and a resume that fails on top of it, a guest the
+//! handle believes is frozen and is not. None of them are reachable against
+//! a real Firecracker, so this answers its API instead: one closure decides
+//! every reply from the request's method, path and body, and every request
+//! is recorded in order.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::{UnixListener, UnixStream};
+
+/// One request the driver made: `"{METHOD} {path} {body}"`, body trimmed to
+/// nothing when empty.
+pub type Call = String;
+
+/// What to answer: an HTTP status and a JSON body (ignored for 204).
+pub type Reply = (u16, String);
+
+/// A scripted Firecracker API on a Unix socket.
+pub struct FakeFc {
+    socket: PathBuf,
+    calls: Arc<Mutex<Vec<Call>>>,
+    server: tokio::task::JoinHandle<()>,
+}
+
+impl FakeFc {
+    /// Serve `reply` on a fresh socket under `dir` until dropped.
+    pub fn start<R>(dir: &Path, reply: R) -> Self
+    where
+        R: Fn(&str, &str) -> Reply + Send + Sync + 'static,
+    {
+        let socket = dir.join("fake-firecracker.sock");
+        let listener = UnixListener::bind(&socket).expect("bind the fake api socket");
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let server = tokio::spawn(serve(listener, Arc::new(reply), Arc::clone(&calls)));
+        Self {
+            socket,
+            calls,
+            server,
+        }
+    }
+
+    /// A client that talks to this socket.
+    pub fn client(&self) -> fc_sdk::Client {
+        fc_sdk::connection::connect(&self.socket)
+    }
+
+    /// Every request so far, in order.
+    pub fn calls(&self) -> Vec<Call> {
+        self.calls.lock().unwrap_or_else(|e| e.into_inner()).clone()
+    }
+}
+
+impl Drop for FakeFc {
+    fn drop(&mut self) {
+        self.server.abort();
+        let _ = std::fs::remove_file(&self.socket);
+    }
+}
+
+async fn serve<R>(listener: UnixListener, reply: Arc<R>, calls: Arc<Mutex<Vec<Call>>>)
+where
+    R: Fn(&str, &str) -> Reply + Send + Sync + 'static,
+{
+    while let Ok((stream, _)) = listener.accept().await {
+        let reply = Arc::clone(&reply);
+        let calls = Arc::clone(&calls);
+        tokio::spawn(async move {
+            let _ = answer(stream, &*reply, &calls).await;
+        });
+    }
+}
+
+/// Answer every request on one connection until the peer goes away.
+async fn answer<R>(
+    mut stream: UnixStream,
+    reply: &R,
+    calls: &Mutex<Vec<Call>>,
+) -> std::io::Result<()>
+where
+    R: Fn(&str, &str) -> Reply + Sync,
+{
+    let mut buffered = Vec::new();
+    loop {
+        let Some((head, body)) = read_request(&mut stream, &mut buffered).await? else {
+            return Ok(());
+        };
+        let mut parts = head.split_whitespace();
+        let (method, path) = match (parts.next(), parts.next()) {
+            (Some(method), Some(path)) => (method, path),
+            _ => return Ok(()),
+        };
+        let route = format!("{method} {path}");
+        calls
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(format!("{route} {body}").trim_end().to_owned());
+        let (status, payload) = reply(&route, &body);
+        let response = if status == 204 {
+            "HTTP/1.1 204 No Content\r\n\r\n".to_owned()
+        } else {
+            format!(
+                "HTTP/1.1 {status} \r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{payload}",
+                payload.len()
+            )
+        };
+        stream.write_all(response.as_bytes()).await?;
+    }
+}
+
+/// The request line and body of the next request, or `None` at EOF.
+async fn read_request(
+    stream: &mut UnixStream,
+    buffered: &mut Vec<u8>,
+) -> std::io::Result<Option<(String, String)>> {
+    let head_end = loop {
+        if let Some(at) = find(buffered, b"\r\n\r\n") {
+            break at + 4;
+        }
+        if !fill(stream, buffered).await? {
+            return Ok(None);
+        }
+    };
+    let head = String::from_utf8_lossy(&buffered[..head_end]).into_owned();
+    let length = head
+        .lines()
+        .find_map(|line| {
+            let line = line.to_ascii_lowercase();
+            let value = line.strip_prefix("content-length:")?;
+            value.trim().parse::<usize>().ok()
+        })
+        .unwrap_or(0);
+    while buffered.len() < head_end + length {
+        if !fill(stream, buffered).await? {
+            return Ok(None);
+        }
+    }
+    let body = String::from_utf8_lossy(&buffered[head_end..head_end + length]).into_owned();
+    buffered.drain(..head_end + length);
+    let request_line = head.lines().next().unwrap_or_default().to_owned();
+    Ok(Some((request_line, body)))
+}
+
+/// Read more bytes; `false` at EOF.
+async fn fill(stream: &mut UnixStream, buffered: &mut Vec<u8>) -> std::io::Result<bool> {
+    let mut chunk = [0u8; 1024];
+    let read = stream.read(&mut chunk).await?;
+    if read == 0 {
+        return Ok(false);
+    }
+    buffered.extend_from_slice(&chunk[..read]);
+    Ok(true)
+}
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}

--- a/virt/arcbox-fc-driver/src/jail.rs
+++ b/virt/arcbox-fc-driver/src/jail.rs
@@ -277,9 +277,34 @@ pub async fn apply(jail: &Jail, plans: &[StagePlan]) -> Result<()> {
             StageKind::BlockNode => {
                 mknod_for_jailer(&plan.src, &plan.dst, jail.uid, jail.gid).await?;
             }
+            StageKind::Alias => alias_in_jail(&plan.src, &plan.dst, jail.uid, jail.gid).await?,
         }
     }
     Ok(())
+}
+
+/// Give a disk that is already inside the jail a second name there: a hard
+/// link to the same inode (which keeps its ownership); failing that, a
+/// device node for a block device, or a chowned copy.
+pub async fn alias_in_jail(src: &Path, dst: &Path, uid: u32, gid: u32) -> Result<()> {
+    if let Err(e) = tokio::fs::remove_file(dst).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(Error::Io(e));
+    }
+    match tokio::fs::hard_link(src, dst).await {
+        Ok(()) => return Ok(()),
+        Err(e) => {
+            warn!(src = %src.display(), dst = %dst.display(), error = %e,
+                "hard link failed; aliasing by node or copy");
+        }
+    }
+    let metadata = tokio::fs::metadata(src).await.map_err(Error::Io)?;
+    if std::os::unix::fs::FileTypeExt::is_block_device(&metadata.file_type()) {
+        mknod_for_jailer(src, dst, uid, gid).await
+    } else {
+        copy_for_jailer(src, dst, uid, gid).await
+    }
 }
 
 /// Stage a snapshot's vmstate/mem into `{chroot}/snapshots/{snapshot_id}`
@@ -397,6 +422,29 @@ mod tests {
         assert_ne!(
             std::fs::metadata(src.join("rootfs.ext4")).unwrap().ino(),
             std::fs::metadata(root.join("rootfs.ext4")).unwrap().ino()
+        );
+
+        // An alias is the same inode under a second name, and replaces a
+        // stale entry at that name.
+        std::fs::create_dir_all(root.join("pool")).unwrap();
+        std::fs::write(root.join("pool/slot3.ext4"), b"slot").unwrap();
+        std::fs::write(root.join("data.ext4"), b"stale").unwrap();
+        apply(
+            &jail,
+            &[StagePlan {
+                src: root.join("pool/slot3.ext4"),
+                dst: root.join("data.ext4"),
+                kind: StageKind::Alias,
+            }],
+        )
+        .await
+        .unwrap();
+        assert_eq!(std::fs::read(root.join("data.ext4")).unwrap(), b"slot");
+        assert_eq!(
+            std::fs::metadata(root.join("pool/slot3.ext4"))
+                .unwrap()
+                .ino(),
+            std::fs::metadata(root.join("data.ext4")).unwrap().ino()
         );
     }
 }

--- a/virt/arcbox-fc-driver/src/jail.rs
+++ b/virt/arcbox-fc-driver/src/jail.rs
@@ -92,6 +92,25 @@ pub fn vsock_uds_path(chroot_root: &Path) -> PathBuf {
 /// Where the vsock Unix socket lives from inside the jail.
 pub const VSOCK_UDS_IN_JAIL: &str = "/run/firecracker.vsock";
 
+/// Move a file even when source and destination sit on different mounts.
+///
+/// The jailer chroot is its own vfsmount (bind + pivot_root), so a plain
+/// `rename(2)` out of it fails with `EXDEV` regardless of the underlying
+/// filesystem; fall back to copy + remove in that case.
+pub async fn move_file(from: &Path, to: &Path) -> std::io::Result<()> {
+    match tokio::fs::rename(from, to).await {
+        Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
+            tokio::fs::copy(from, to).await?;
+            // fsync the destination before removing the source: a crash between
+            // the copy and the remove must not leave a zero-length/partial
+            // snapshot file registered in the catalog.
+            tokio::fs::File::open(to).await?.sync_all().await?;
+            tokio::fs::remove_file(from).await
+        }
+        other => other,
+    }
+}
+
 /// Stage a read-only file into a jailer chroot: hard-link when possible,
 /// copy otherwise.
 ///

--- a/virt/arcbox-fc-driver/src/jail.rs
+++ b/virt/arcbox-fc-driver/src/jail.rs
@@ -1,0 +1,232 @@
+//! The jailer's chroot: where it is, and how host files get into it.
+//!
+//! Under the jailer, Firecracker runs chrooted into
+//! `{chroot_base}/{firecracker binary name}/{id}/root` and can open only
+//! paths inside it. Everything it needs — the kernel, the disks, a
+//! checkpoint's vmstate and mem — is staged in first, owned by the jailed
+//! uid/gid, and named to Firecracker by its chroot-relative path. This
+//! module is that staging: the layout, and one primitive per way a file
+//! can be brought in (hard link or copy, plain copy, block-device node).
+
+use std::path::{Path, PathBuf};
+
+use arcbox_vm_driver::{Error, Result};
+use nix::unistd::{Gid, Uid, chown};
+use tracing::warn;
+
+use crate::error::FcError;
+
+pub mod blkdev;
+
+/// The jailer's own default chroot base, used when a config names none.
+pub const DEFAULT_CHROOT_BASE: &str = "/srv/jailer";
+
+/// A checkpoint's files on the host, as [`stage_snapshot_files`] stages
+/// them: the directory name they are staged under and the two files.
+#[derive(Debug, Clone, Copy)]
+pub struct SnapshotFiles<'a> {
+    /// The name of the per-checkpoint directory inside the jail
+    /// (`/snapshots/{id}`).
+    pub id: &'a str,
+    /// The host path of the `vmstate` file.
+    pub vmstate: &'a Path,
+    /// The host path of the `mem` file, when the checkpoint has one.
+    pub mem: Option<&'a Path>,
+}
+
+/// Compute the host-side absolute path to the jailer chroot root directory.
+///
+/// Returns `{chroot_base_dir}/{fc_binary_filename}/{id}/root`.
+pub fn chroot_root(
+    fc_binary: impl AsRef<Path>,
+    chroot_base_dir: impl AsRef<Path>,
+    id: &str,
+) -> PathBuf {
+    let exec_name = fc_binary
+        .as_ref()
+        .file_name()
+        .expect("fc_binary must have a filename")
+        .to_string_lossy();
+    chroot_base_dir
+        .as_ref()
+        .join(exec_name.as_ref())
+        .join(id)
+        .join("root")
+}
+
+/// The Firecracker API socket of a jail, as the host sees it:
+/// `{jail}/run/firecracker.socket` (the jailer's fixed location).
+pub fn api_socket_path(chroot_root: &Path) -> PathBuf {
+    chroot_root.join("run/firecracker.socket")
+}
+
+/// The hybrid-vsock Unix socket of a jail, as the host sees it:
+/// `{jail}/run/firecracker.vsock`; Firecracker sees it as
+/// [`VSOCK_UDS_IN_JAIL`].
+pub fn vsock_uds_path(chroot_root: &Path) -> PathBuf {
+    chroot_root.join("run/firecracker.vsock")
+}
+
+/// Where the vsock Unix socket lives from inside the jail.
+pub const VSOCK_UDS_IN_JAIL: &str = "/run/firecracker.vsock";
+
+/// Stage a read-only file into a jailer chroot: hard-link when possible,
+/// copy otherwise.
+///
+/// A hard link shares the inode with the source, so it is only safe for
+/// files FC never writes — the kernel image, a snapshot vmstate, and a
+/// snapshot mem file (mapped MAP_PRIVATE on load). Do NOT use it for the
+/// rootfs copy fallback: FC writes guest blocks into that file. Linking is
+/// also reserved for the root jailer (uid/gid 0), because chown on a link
+/// would mutate the shared source inode; a non-root jailer gets a private
+/// copy with its own ownership.
+pub async fn link_or_copy_for_jailer(src: &Path, dst: &Path, uid: u32, gid: u32) -> Result<()> {
+    // Remove a stale entry first: hard_link fails on an existing dst, and a
+    // leftover from a previous run must not survive by accident.
+    if let Err(e) = tokio::fs::remove_file(dst).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(Error::Io(e));
+    }
+    if uid == 0 && gid == 0 {
+        match tokio::fs::hard_link(src, dst).await {
+            Ok(()) => return Ok(()),
+            // Cross-device (EXDEV) or filesystem quirk. warn, not debug: the
+            // copy fallback silently forfeits the restore fast path, and at
+            // default log levels a misplaced chroot base would only ever be
+            // rediscovered by re-measuring.
+            Err(e) => {
+                warn!(src = %src.display(), dst = %dst.display(), error = %e,
+                    "hard link failed; falling back to copy");
+            }
+        }
+    }
+    tokio::fs::copy(src, dst).await.map_err(Error::Io)?;
+    chown(dst, Some(Uid::from_raw(uid)), Some(Gid::from_raw(gid))).map_err(|source| {
+        FcError::Chown {
+            path: dst.to_path_buf(),
+            source,
+        }
+    })?;
+    Ok(())
+}
+
+/// Stage the kernel into the jailer chroot (link or copy).
+///
+/// Returns the chroot-relative kernel path (e.g. `"/vmlinux"`).
+pub async fn stage_kernel_for_jailer(
+    chroot_root: &Path,
+    kernel_src: impl AsRef<Path>,
+    uid: u32,
+    gid: u32,
+) -> Result<String> {
+    tokio::fs::create_dir_all(chroot_root)
+        .await
+        .map_err(Error::Io)?;
+    let kernel_dst = chroot_root.join("vmlinux");
+    link_or_copy_for_jailer(kernel_src.as_ref(), &kernel_dst, uid, gid).await?;
+    Ok("/vmlinux".to_string())
+}
+
+/// Copy rootfs into the jailer chroot and set ownership.
+///
+/// Returns the chroot-relative rootfs path (e.g. `"/rootfs.ext4"`).
+pub async fn stage_rootfs_copy_for_jailer(
+    chroot_root: &Path,
+    rootfs_src: impl AsRef<Path>,
+    uid: u32,
+    gid: u32,
+) -> Result<String> {
+    tokio::fs::create_dir_all(chroot_root)
+        .await
+        .map_err(Error::Io)?;
+    let rootfs_dst = chroot_root.join("rootfs.ext4");
+    // Remove any stale entry — a previous crash or a failed mknod-then-chown
+    // fallback may have left a block device node here, in which case
+    // `tokio::fs::copy` would write into the device instead of replacing it.
+    if let Err(e) = tokio::fs::remove_file(&rootfs_dst).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(Error::Io(e));
+    }
+    tokio::fs::copy(rootfs_src, &rootfs_dst)
+        .await
+        .map_err(Error::Io)?;
+    chown(
+        &rootfs_dst,
+        Some(Uid::from_raw(uid)),
+        Some(Gid::from_raw(gid)),
+    )
+    .map_err(|source| FcError::Chown {
+        path: rootfs_dst,
+        source,
+    })?;
+    Ok("/rootfs.ext4".to_string())
+}
+
+/// Create a block device node in the jailer chroot pointing to a dm device.
+///
+/// Returns the chroot-relative rootfs path (`"/rootfs.ext4"`).
+pub async fn stage_rootfs_device_for_jailer(
+    chroot_root: &Path,
+    dm_device: impl AsRef<Path>,
+    uid: u32,
+    gid: u32,
+) -> Result<String> {
+    tokio::fs::create_dir_all(chroot_root)
+        .await
+        .map_err(Error::Io)?;
+    let (major, minor) = blkdev::device_major_minor(dm_device.as_ref())?;
+    let node_path = chroot_root.join("rootfs.ext4");
+    // Remove any leftover entry from a previous crash so mknod can succeed
+    // (and so we never end up writing into a stale device node).
+    if let Err(e) = tokio::fs::remove_file(&node_path).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(Error::Io(e));
+    }
+    blkdev::mknod_blkdev(&node_path, major, minor)?;
+    chown(
+        &node_path,
+        Some(Uid::from_raw(uid)),
+        Some(Gid::from_raw(gid)),
+    )
+    .map_err(|source| FcError::Chown {
+        path: node_path,
+        source,
+    })?;
+    Ok("/rootfs.ext4".to_string())
+}
+
+/// Stage a snapshot's vmstate/mem into `{chroot}/snapshots/{snapshot_id}`
+/// via [`link_or_copy_for_jailer`] and return their chroot-relative paths
+/// `(vmstate, mem)` for `SnapshotLoadParams`.
+pub async fn stage_snapshot_files(
+    chroot: &Path,
+    snapshot: &SnapshotFiles<'_>,
+    uid: u32,
+    gid: u32,
+) -> Result<(String, Option<String>)> {
+    let snap_in_chroot = chroot.join("snapshots").join(snapshot.id);
+    std::fs::create_dir_all(&snap_in_chroot).map_err(Error::Io)?;
+    chown(
+        &snap_in_chroot,
+        Some(Uid::from_raw(uid)),
+        Some(Gid::from_raw(gid)),
+    )
+    .map_err(|source| FcError::Chown {
+        path: snap_in_chroot.clone(),
+        source,
+    })?;
+
+    link_or_copy_for_jailer(snapshot.vmstate, &snap_in_chroot.join("vmstate"), uid, gid).await?;
+    let mem = if let Some(mf) = snapshot.mem
+        && mf.exists()
+    {
+        link_or_copy_for_jailer(mf, &snap_in_chroot.join("mem"), uid, gid).await?;
+        Some(format!("/snapshots/{}/mem", snapshot.id))
+    } else {
+        None
+    };
+    Ok((format!("/snapshots/{}/vmstate", snapshot.id), mem))
+}

--- a/virt/arcbox-fc-driver/src/jail.rs
+++ b/virt/arcbox-fc-driver/src/jail.rs
@@ -292,7 +292,9 @@ pub async fn stage_snapshot_files(
     gid: u32,
 ) -> Result<(String, Option<String>)> {
     let snap_in_chroot = chroot.join("snapshots").join(snapshot.id);
-    std::fs::create_dir_all(&snap_in_chroot).map_err(Error::Io)?;
+    tokio::fs::create_dir_all(&snap_in_chroot)
+        .await
+        .map_err(Error::Io)?;
     chown(
         &snap_in_chroot,
         Some(Uid::from_raw(uid)),
@@ -305,7 +307,7 @@ pub async fn stage_snapshot_files(
 
     link_or_copy_for_jailer(snapshot.vmstate, &snap_in_chroot.join("vmstate"), uid, gid).await?;
     let mem = if let Some(mf) = snapshot.mem
-        && mf.exists()
+        && tokio::fs::try_exists(mf).await.unwrap_or(false)
     {
         link_or_copy_for_jailer(mf, &snap_in_chroot.join("mem"), uid, gid).await?;
         Some(format!("/snapshots/{}/mem", snapshot.id))

--- a/virt/arcbox-fc-driver/src/jail.rs
+++ b/virt/arcbox-fc-driver/src/jail.rs
@@ -15,8 +15,30 @@ use nix::unistd::{Gid, Uid, chown};
 use tracing::warn;
 
 use crate::error::FcError;
+use crate::render::{StageKind, StagePlan};
 
 pub mod blkdev;
+
+/// The jail a VM is confined to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Jail {
+    /// The chroot root: `{chroot_base}/{firecracker binary name}/{id}/root`.
+    pub root: PathBuf,
+    /// The uid the VMM runs as.
+    pub uid: u32,
+    /// The gid the VMM runs as.
+    pub gid: u32,
+}
+
+impl Jail {
+    /// `host` as Firecracker sees it, when `host` is already inside the
+    /// jail: `/` + its path relative to the root.
+    pub fn view(&self, host: &Path) -> Option<String> {
+        host.strip_prefix(&self.root)
+            .ok()
+            .map(|rel| format!("/{}", rel.display()))
+    }
+}
 
 /// The jailer's own default chroot base, used when a config names none.
 pub const DEFAULT_CHROOT_BASE: &str = "/srv/jailer";
@@ -141,27 +163,29 @@ pub async fn stage_rootfs_copy_for_jailer(
         .await
         .map_err(Error::Io)?;
     let rootfs_dst = chroot_root.join("rootfs.ext4");
+    copy_for_jailer(rootfs_src.as_ref(), &rootfs_dst, uid, gid).await?;
+    Ok("/rootfs.ext4".to_string())
+}
+
+/// Stage a writable file into the jail as a private copy owned by the
+/// jailed uid/gid — never a hard link: FC writes guest blocks into it.
+pub async fn copy_for_jailer(src: &Path, dst: &Path, uid: u32, gid: u32) -> Result<()> {
     // Remove any stale entry — a previous crash or a failed mknod-then-chown
     // fallback may have left a block device node here, in which case
     // `tokio::fs::copy` would write into the device instead of replacing it.
-    if let Err(e) = tokio::fs::remove_file(&rootfs_dst).await
+    if let Err(e) = tokio::fs::remove_file(dst).await
         && e.kind() != std::io::ErrorKind::NotFound
     {
         return Err(Error::Io(e));
     }
-    tokio::fs::copy(rootfs_src, &rootfs_dst)
-        .await
-        .map_err(Error::Io)?;
-    chown(
-        &rootfs_dst,
-        Some(Uid::from_raw(uid)),
-        Some(Gid::from_raw(gid)),
-    )
-    .map_err(|source| FcError::Chown {
-        path: rootfs_dst,
-        source,
+    tokio::fs::copy(src, dst).await.map_err(Error::Io)?;
+    chown(dst, Some(Uid::from_raw(uid)), Some(Gid::from_raw(gid))).map_err(|source| {
+        FcError::Chown {
+            path: dst.to_path_buf(),
+            source,
+        }
     })?;
-    Ok("/rootfs.ext4".to_string())
+    Ok(())
 }
 
 /// Create a block device node in the jailer chroot pointing to a dm device.
@@ -176,26 +200,67 @@ pub async fn stage_rootfs_device_for_jailer(
     tokio::fs::create_dir_all(chroot_root)
         .await
         .map_err(Error::Io)?;
-    let (major, minor) = blkdev::device_major_minor(dm_device.as_ref())?;
     let node_path = chroot_root.join("rootfs.ext4");
+    mknod_for_jailer(dm_device.as_ref(), &node_path, uid, gid).await?;
+    Ok("/rootfs.ext4".to_string())
+}
+
+/// Mirror the block device at `device` into the jail as a device node at
+/// `node_path`, owned by the jailed uid/gid.
+pub async fn mknod_for_jailer(device: &Path, node_path: &Path, uid: u32, gid: u32) -> Result<()> {
+    let (major, minor) = blkdev::device_major_minor(device)?;
     // Remove any leftover entry from a previous crash so mknod can succeed
     // (and so we never end up writing into a stale device node).
-    if let Err(e) = tokio::fs::remove_file(&node_path).await
+    if let Err(e) = tokio::fs::remove_file(node_path).await
         && e.kind() != std::io::ErrorKind::NotFound
     {
         return Err(Error::Io(e));
     }
-    blkdev::mknod_blkdev(&node_path, major, minor)?;
+    blkdev::mknod_blkdev(node_path, major, minor)?;
     chown(
-        &node_path,
+        node_path,
         Some(Uid::from_raw(uid)),
         Some(Gid::from_raw(gid)),
     )
     .map_err(|source| FcError::Chown {
-        path: node_path,
+        path: node_path.to_path_buf(),
         source,
     })?;
-    Ok("/rootfs.ext4".to_string())
+    Ok(())
+}
+
+/// Execute a rendered staging plan into `jail`.
+///
+/// Creates each destination's parent (handing directories below the root
+/// to the jailed uid/gid, as Firecracker writes its own snapshots next to
+/// them), then link-or-copies, copies, or mknods each entry.
+pub async fn apply(jail: &Jail, plans: &[StagePlan]) -> Result<()> {
+    for plan in plans {
+        if let Some(parent) = plan.dst.parent() {
+            tokio::fs::create_dir_all(parent).await.map_err(Error::Io)?;
+            if parent != jail.root {
+                chown(
+                    parent,
+                    Some(Uid::from_raw(jail.uid)),
+                    Some(Gid::from_raw(jail.gid)),
+                )
+                .map_err(|source| FcError::Chown {
+                    path: parent.to_path_buf(),
+                    source,
+                })?;
+            }
+        }
+        match plan.kind {
+            StageKind::LinkOrCopy => {
+                link_or_copy_for_jailer(&plan.src, &plan.dst, jail.uid, jail.gid).await?;
+            }
+            StageKind::Copy => copy_for_jailer(&plan.src, &plan.dst, jail.uid, jail.gid).await?,
+            StageKind::BlockNode => {
+                mknod_for_jailer(&plan.src, &plan.dst, jail.uid, jail.gid).await?;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Stage a snapshot's vmstate/mem into `{chroot}/snapshots/{snapshot_id}`
@@ -229,4 +294,88 @@ pub async fn stage_snapshot_files(
         None
     };
     Ok((format!("/snapshots/{}/vmstate", snapshot.id), mem))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chroot_root_and_sockets_follow_the_jailer_layout() {
+        let root = chroot_root("/opt/fc/firecracker", "/srv/jailer", "box");
+        assert_eq!(root, Path::new("/srv/jailer/firecracker/box/root"));
+        assert_eq!(
+            api_socket_path(&root),
+            Path::new("/srv/jailer/firecracker/box/root/run/firecracker.socket")
+        );
+        assert_eq!(
+            vsock_uds_path(&root),
+            Path::new("/srv/jailer/firecracker/box/root/run/firecracker.vsock")
+        );
+        let jail = Jail {
+            root: root.clone(),
+            uid: 0,
+            gid: 0,
+        };
+        assert_eq!(
+            jail.view(&root.join("snapshots/abc/vmstate")).as_deref(),
+            Some("/snapshots/abc/vmstate")
+        );
+        assert_eq!(jail.view(Path::new("/images/vmlinux")), None);
+    }
+
+    #[tokio::test]
+    async fn apply_stages_each_plan_under_its_parent_as_the_jail_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("vmlinux"), b"kernel").unwrap();
+        std::fs::write(src.join("rootfs.ext4"), b"disk").unwrap();
+        std::fs::write(src.join("vmstate"), b"state").unwrap();
+        let root = dir.path().join("jail/firecracker/box/root");
+        let jail = Jail {
+            root: root.clone(),
+            uid: nix::unistd::getuid().as_raw(),
+            gid: nix::unistd::getgid().as_raw(),
+        };
+        // A stale entry at a destination is replaced, not written into.
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("rootfs.ext4"), b"stale").unwrap();
+
+        apply(
+            &jail,
+            &[
+                StagePlan {
+                    src: src.join("vmlinux"),
+                    dst: root.join("vmlinux"),
+                    kind: StageKind::LinkOrCopy,
+                },
+                StagePlan {
+                    src: src.join("rootfs.ext4"),
+                    dst: root.join("rootfs.ext4"),
+                    kind: StageKind::Copy,
+                },
+                StagePlan {
+                    src: src.join("vmstate"),
+                    dst: root.join("snapshots/abc/vmstate"),
+                    kind: StageKind::LinkOrCopy,
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(std::fs::read(root.join("vmlinux")).unwrap(), b"kernel");
+        assert_eq!(std::fs::read(root.join("rootfs.ext4")).unwrap(), b"disk");
+        assert_eq!(
+            std::fs::read(root.join("snapshots/abc/vmstate")).unwrap(),
+            b"state"
+        );
+        // A copy never shares the source inode, whoever the jail runs as.
+        use std::os::unix::fs::MetadataExt as _;
+        assert_ne!(
+            std::fs::metadata(src.join("rootfs.ext4")).unwrap().ino(),
+            std::fs::metadata(root.join("rootfs.ext4")).unwrap().ino()
+        );
+    }
 }

--- a/virt/arcbox-fc-driver/src/jail/blkdev.rs
+++ b/virt/arcbox-fc-driver/src/jail/blkdev.rs
@@ -1,0 +1,104 @@
+//! Block-device nodes for the jail: read a device's numbers, mirror it as
+//! a node.
+//!
+//! A twin of `arcbox_snapshot::snapshot_cow::{device_major_minor,
+//! mknod_blkdev}`, kept here so the adapter never depends on the snapshot
+//! catalog: the driver only needs to mirror a device the caller already
+//! created (a dm-snapshot rootfs) into the chroot, not to create one.
+
+use std::path::Path;
+
+use crate::error::{FcError, Result};
+
+/// The `(major, minor)` device numbers of the block device at `path`.
+///
+/// Follows symlinks, so `/dev/mapper/<name>` resolves whether device-mapper
+/// created a node there itself (no udev, the System VM) or udev left a
+/// symlink to `/dev/dm-N` (a stock distro).
+#[cfg(target_os = "linux")]
+pub fn device_major_minor(path: &Path) -> Result<(u32, u32)> {
+    use std::os::unix::fs::{FileTypeExt as _, MetadataExt as _};
+
+    let metadata = std::fs::metadata(path).map_err(|source| FcError::Stat {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !metadata.file_type().is_block_device() {
+        return Err(FcError::NotBlockDevice {
+            path: path.to_path_buf(),
+        });
+    }
+    let dev = metadata.rdev();
+    // Linux packs 12-bit majors and 20-bit minors into `dev_t`; nix hands
+    // them back as `u64`, and a value outside `u32` is a corrupt node, not
+    // something to truncate.
+    let narrow = |what: &'static str, value: u64| {
+        u32::try_from(value).map_err(|_| FcError::BadDeviceNumber {
+            path: path.to_path_buf(),
+            what,
+            value,
+        })
+    };
+    Ok((
+        narrow("major", nix::sys::stat::major(dev))?,
+        narrow("minor", nix::sys::stat::minor(dev))?,
+    ))
+}
+
+/// Create a block device node at `node_path` for `(major, minor)`, mode 0600.
+///
+/// The caller owns the node's ownership: a jailer chroot `chown`s it to the
+/// jailer uid/gid right after, which is why the mode need not be wider.
+#[cfg(target_os = "linux")]
+pub fn mknod_blkdev(node_path: &Path, major: u32, minor: u32) -> Result<()> {
+    use nix::sys::stat::{Mode, SFlag, makedev, mknod};
+
+    mknod(
+        node_path,
+        SFlag::S_IFBLK,
+        Mode::S_IRUSR | Mode::S_IWUSR,
+        makedev(u64::from(major), u64::from(minor)),
+    )
+    .map_err(|source| FcError::Mknod {
+        path: node_path.to_path_buf(),
+        source,
+    })
+}
+
+/// Block device nodes are a Linux concept; off Linux the crate compiles but
+/// the operation is unavailable.
+#[cfg(not(target_os = "linux"))]
+pub fn device_major_minor(path: &Path) -> Result<(u32, u32)> {
+    Err(FcError::LinuxOnly {
+        what: format!("block device numbers for {}", path.display()),
+    })
+}
+
+/// Block device nodes are a Linux concept; off Linux the crate compiles but
+/// the operation is unavailable.
+#[cfg(not(target_os = "linux"))]
+pub fn mknod_blkdev(node_path: &Path, _major: u32, _minor: u32) -> Result<()> {
+    Err(FcError::LinuxOnly {
+        what: format!("mknod {}", node_path.display()),
+    })
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_major_minor_rejects_regular_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("plain");
+        std::fs::write(&file, b"x").unwrap();
+        let err = device_major_minor(&file).unwrap_err();
+        assert!(matches!(err, FcError::NotBlockDevice { .. }), "{err}");
+    }
+
+    #[test]
+    fn device_major_minor_reports_missing_paths() {
+        let err = device_major_minor(Path::new("/nonexistent/arcbox-blkdev")).unwrap_err();
+        assert!(matches!(err, FcError::Stat { .. }), "{err}");
+    }
+}

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -13,9 +13,15 @@
 //!   seccomp, log level, the API-socket wait, jailer resource limits.
 //! - [`error`] — [`FcError`], the adapter's typed failures, folded into the
 //!   port's `Error::Driver` at the boundary.
+//! - [`render`] — [`VmSpec`](arcbox_vm_driver::VmSpec) → [`render::FcPlan`]
+//!   and [`RestoreSpec`](arcbox_vm_driver::RestoreSpec) →
+//!   [`render::FcRestorePlan`]: every path Firecracker sees, and the
+//!   jailer's chroot relativity, is decided there and nowhere else.
 //! - [`jail`] — the jailer's chroot layout and how host files are staged
-//!   into it (link-or-copy, copy, block-device node).
-//! - [`spawn`] — the `firecracker` / `jailer` process spawn.
+//!   into it (link-or-copy, copy, block-device node), including
+//!   [`jail::apply`] for a rendered plan.
+//! - [`spawn`] — the `firecracker` / `jailer` process spawn from a
+//!   [`render::SpawnPlan`].
 //! - [`vsock`] — the hybrid-vsock Unix-socket handshake and the
 //!   `{uds}_{port}` listener for guest dial-outs.
 //!
@@ -39,6 +45,7 @@
 pub mod config;
 pub mod error;
 pub mod jail;
+pub mod render;
 pub mod spawn;
 pub mod vsock;
 

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -30,16 +30,15 @@
 //!   raw client (pause, resume, snapshot, ctrl-alt-del).
 //! - [`listener`] — the port's `VsockListener` over a `{uds}_{port}`
 //!   socket, failing once the VM is gone.
-//! - [`handle`] — [`FcHandle`](handle::FcHandle), the port's `VmHandle`
-//!   over a running VM: state and events from the guard, `Kill` and
-//!   `Graceful` shutdown, and the vsock, listen, checkpoint (pause →
-//!   snapshot → resume or hold), and detach capabilities.
+//! - [`handle`] — [`FcHandle`], the port's `VmHandle` over a running VM:
+//!   state and events from the guard, `Kill` and `Graceful` shutdown, and
+//!   the vsock, listen, checkpoint (pause → snapshot → resume or hold),
+//!   and detach capabilities.
+//! - [`prepared`] — [`FcPrepared`], the port's `PreparedVm`: a spawned
+//!   VMM waiting for a spec, listeners bound before the guest starts.
 //!
-//! The remaining modules — the spec renderer, jail staging, process
-//! spawning and ownership, the vsock handshake, the prepared VM, the
-//! handle, and the driver itself — land one at a time as their code is
-//! moved out of `arcbox-vm` (design: company repo
-//! `engineering/arcbox/architecture/vm-stack-redesign.md`, D-VM1 / D-VM9).
+//! Design: company repo `engineering/arcbox/architecture/vm-stack-redesign.md`
+//! (Adapters → `virt/arcbox-fc-driver`; D-VM1, D-VM9).
 //!
 //! # Rules the crate is held to
 //!
@@ -58,6 +57,7 @@ pub mod error;
 pub mod handle;
 pub mod jail;
 pub mod listener;
+pub mod prepared;
 pub mod process;
 pub mod render;
 pub mod spawn;
@@ -65,6 +65,8 @@ pub mod vsock;
 
 pub use config::FcDriverConfig;
 pub use error::FcError;
+pub use handle::FcHandle;
+pub use prepared::FcPrepared;
 
 /// The driver's name.
 ///

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -13,6 +13,8 @@
 //!   seccomp, log level, the API-socket wait, jailer resource limits.
 //! - [`error`] — [`FcError`], the adapter's typed failures, folded into the
 //!   port's `Error::Driver` at the boundary.
+//! - [`jail`] — the jailer's chroot layout and how host files are staged
+//!   into it (link-or-copy, copy, block-device node).
 //! - [`spawn`] — the `firecracker` / `jailer` process spawn.
 //!
 //! The remaining modules — the spec renderer, jail staging, process
@@ -34,6 +36,7 @@
 
 pub mod config;
 pub mod error;
+pub mod jail;
 pub mod spawn;
 
 pub use config::FcDriverConfig;

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -24,6 +24,8 @@
 //!   [`render::SpawnPlan`].
 //! - [`vsock`] — the hybrid-vsock Unix-socket handshake and the
 //!   `{uds}_{port}` listener for guest dial-outs.
+//! - [`process`] — the VMM process guard: one waiter task reaps the
+//!   child and publishes its exit; kill, wait, and detach never race it.
 //!
 //! The remaining modules — the spec renderer, jail staging, process
 //! spawning and ownership, the vsock handshake, the prepared VM, the
@@ -45,6 +47,7 @@
 pub mod config;
 pub mod error;
 pub mod jail;
+pub mod process;
 pub mod render;
 pub mod spawn;
 pub mod vsock;

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -16,6 +16,8 @@
 //! - [`jail`] — the jailer's chroot layout and how host files are staged
 //!   into it (link-or-copy, copy, block-device node).
 //! - [`spawn`] — the `firecracker` / `jailer` process spawn.
+//! - [`vsock`] — the hybrid-vsock Unix-socket handshake and the
+//!   `{uds}_{port}` listener for guest dial-outs.
 //!
 //! The remaining modules — the spec renderer, jail staging, process
 //! spawning and ownership, the vsock handshake, the prepared VM, the
@@ -38,6 +40,7 @@ pub mod config;
 pub mod error;
 pub mod jail;
 pub mod spawn;
+pub mod vsock;
 
 pub use config::FcDriverConfig;
 pub use error::FcError;

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -1,0 +1,49 @@
+//! `arcbox-fc-driver` — the Firecracker adapter for the VM driver port.
+//!
+//! [`arcbox_vm_driver`] is the vocabulary of "a VM on this host"; this crate
+//! is what makes a [`VmSpec`](arcbox_vm_driver::VmSpec) run under
+//! Firecracker. It is the only crate that names `fc-sdk`, the jailer's
+//! chroot layout, or the hybrid-vsock Unix-socket handshake — everything
+//! above it (the sandbox manager today, the computer runtime tomorrow)
+//! sees a `dyn VmDriver` and never a Firecracker.
+//!
+//! # What lives here
+//!
+//! - [`config`] — [`FcDriverConfig`], the node-wide knobs: binaries,
+//!   seccomp, log level, the API-socket wait, jailer resource limits.
+//! - [`error`] — [`FcError`], the adapter's typed failures, folded into the
+//!   port's `Error::Driver` at the boundary.
+//!
+//! The remaining modules — the spec renderer, jail staging, process
+//! spawning and ownership, the vsock handshake, the prepared VM, the
+//! handle, and the driver itself — land one at a time as their code is
+//! moved out of `arcbox-vm` (design: company repo
+//! `engineering/arcbox/architecture/vm-stack-redesign.md`, D-VM1 / D-VM9).
+//!
+//! # Rules the crate is held to
+//!
+//! - It depends on the port and on `fc-sdk`, never on the snapshot
+//!   catalog, the engine, or any orchestrator.
+//! - Every path Firecracker sees is computed in one place (`render`); the
+//!   jailer's chroot relativity is not re-derived anywhere else.
+//! - Host resources are RAII guards with explicit release: a process is
+//!   killed on drop unless a handle took it and was detached.
+
+#![warn(missing_docs)]
+
+pub mod config;
+pub mod error;
+
+pub use config::FcDriverConfig;
+pub use error::FcError;
+
+/// The driver's name.
+///
+/// [`VmDriver::name`](arcbox_vm_driver::VmDriver::name), recorded in every
+/// [`VmRecord`](arcbox_vm_driver::VmRecord) and named by every
+/// [`Error::Driver`](arcbox_vm_driver::Error::Driver) this crate raises.
+pub const NAME: &str = "firecracker";
+
+/// The on-disk checkpoint format this driver writes and the only one it
+/// restores: Firecracker's `vmstate` + `mem` pair in one directory.
+pub const CHECKPOINT_FORMAT: &str = "firecracker/v1";

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -37,8 +37,8 @@
 //! - [`prepared`] — [`FcPrepared`], the port's `PreparedVm`: a spawned
 //!   VMM waiting for a spec, listeners bound before the guest starts.
 //! - [`discover`] — finding a Firecracker that outlived the process which
-//!   booted it: the recorded pid while it is still a Firecracker, else a
-//!   `/proc` scan by `--id`, `--api-sock`, or jail root.
+//!   booted it: the recorded pid when it is a Firecracker the record names,
+//!   else a `/proc` scan for one, by `--id`, `--api-sock`, or jail root.
 //! - [`driver`] — [`FcDriver`], the port's `VmDriver` with `Prepare` and
 //!   `Adopt`; `boot`/`restore` are prepare-then-boot/restore.
 //!

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -36,6 +36,9 @@
 //!   and detach capabilities.
 //! - [`prepared`] — [`FcPrepared`], the port's `PreparedVm`: a spawned
 //!   VMM waiting for a spec, listeners bound before the guest starts.
+//! - [`discover`] — finding a Firecracker that outlived the process which
+//!   booted it: the recorded pid while it is still a Firecracker, else a
+//!   `/proc` scan by `--id`, `--api-sock`, or jail root.
 //!
 //! Design: company repo `engineering/arcbox/architecture/vm-stack-redesign.md`
 //! (Adapters → `virt/arcbox-fc-driver`; D-VM1, D-VM9).
@@ -53,6 +56,7 @@
 
 pub mod api;
 pub mod config;
+pub mod discover;
 pub mod error;
 pub mod handle;
 pub mod jail;

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -30,6 +30,10 @@
 //!   raw client (pause, resume, snapshot, ctrl-alt-del).
 //! - [`listener`] — the port's `VsockListener` over a `{uds}_{port}`
 //!   socket, failing once the VM is gone.
+//! - [`handle`] — [`FcHandle`](handle::FcHandle), the port's `VmHandle`
+//!   over a running VM: state and events from the guard, `Kill` and
+//!   `Graceful` shutdown, and the vsock, listen, checkpoint (pause →
+//!   snapshot → resume or hold), and detach capabilities.
 //!
 //! The remaining modules — the spec renderer, jail staging, process
 //! spawning and ownership, the vsock handshake, the prepared VM, the
@@ -51,6 +55,7 @@
 pub mod api;
 pub mod config;
 pub mod error;
+pub mod handle;
 pub mod jail;
 pub mod listener;
 pub mod process;

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -13,6 +13,7 @@
 //!   seccomp, log level, the API-socket wait, jailer resource limits.
 //! - [`error`] — [`FcError`], the adapter's typed failures, folded into the
 //!   port's `Error::Driver` at the boundary.
+//! - [`spawn`] — the `firecracker` / `jailer` process spawn.
 //!
 //! The remaining modules — the spec renderer, jail staging, process
 //! spawning and ownership, the vsock handshake, the prepared VM, the
@@ -33,6 +34,7 @@
 
 pub mod config;
 pub mod error;
+pub mod spawn;
 
 pub use config::FcDriverConfig;
 pub use error::FcError;

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -26,6 +26,10 @@
 //!   `{uds}_{port}` listener for guest dial-outs.
 //! - [`process`] — the VMM process guard: one waiter task reaps the
 //!   child and publishes its exit; kill, wait, and detach never race it.
+//! - [`api`] — the few Firecracker API calls a running VM needs, over the
+//!   raw client (pause, resume, snapshot, ctrl-alt-del).
+//! - [`listener`] — the port's `VsockListener` over a `{uds}_{port}`
+//!   socket, failing once the VM is gone.
 //!
 //! The remaining modules — the spec renderer, jail staging, process
 //! spawning and ownership, the vsock handshake, the prepared VM, the
@@ -44,9 +48,11 @@
 
 #![warn(missing_docs)]
 
+pub mod api;
 pub mod config;
 pub mod error;
 pub mod jail;
+pub mod listener;
 pub mod process;
 pub mod render;
 pub mod spawn;

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -53,6 +53,10 @@
 //!   jailer's chroot relativity is not re-derived anywhere else.
 //! - Host resources are RAII guards with explicit release: a process is
 //!   killed on drop unless a handle took it and was detached.
+//! - Checkpoints are a jailer-mode capability: a snapshot load reopens the
+//!   recorded drive paths, so relocation onto other disks is possible only
+//!   inside a per-VM chroot ([`render::require_jailed_restore`]). Direct
+//!   mode advertises `checkpoint: false`.
 
 #![warn(missing_docs)]
 

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -39,6 +39,8 @@
 //! - [`discover`] — finding a Firecracker that outlived the process which
 //!   booted it: the recorded pid while it is still a Firecracker, else a
 //!   `/proc` scan by `--id`, `--api-sock`, or jail root.
+//! - [`driver`] — [`FcDriver`], the port's `VmDriver` with `Prepare` and
+//!   `Adopt`; `boot`/`restore` are prepare-then-boot/restore.
 //!
 //! Design: company repo `engineering/arcbox/architecture/vm-stack-redesign.md`
 //! (Adapters → `virt/arcbox-fc-driver`; D-VM1, D-VM9).
@@ -57,6 +59,7 @@
 pub mod api;
 pub mod config;
 pub mod discover;
+pub mod driver;
 pub mod error;
 pub mod handle;
 pub mod jail;
@@ -68,6 +71,7 @@ pub mod spawn;
 pub mod vsock;
 
 pub use config::FcDriverConfig;
+pub use driver::FcDriver;
 pub use error::FcError;
 pub use handle::FcHandle;
 pub use prepared::FcPrepared;

--- a/virt/arcbox-fc-driver/src/listener.rs
+++ b/virt/arcbox-fc-driver/src/listener.rs
@@ -1,0 +1,77 @@
+//! The port's [`VsockListener`] over a [`UdsListener`]: a guest dial-out
+//! per `accept`, failing once the VM is gone.
+
+use arcbox_vm_driver::{Error, IoMode, Result, VmId, VmState, VsockConn, VsockListener};
+use async_trait::async_trait;
+use nix::unistd::{Gid, Uid, chown};
+use tokio::sync::watch;
+
+use crate::error::FcError;
+use crate::process::FcProcess;
+use crate::render::VmLayout;
+use crate::vsock::UdsListener;
+
+/// Bind the listener for host `port` on the VM's vsock socket, owned by
+/// the jailed uid/gid under a jail (Firecracker `connect(2)`s to it as
+/// that user, which needs write permission on the socket file).
+pub fn bind(layout: &VmLayout, process: &FcProcess, port: u32) -> Result<Box<dyn VsockListener>> {
+    if let Some(status) = process.exit_status() {
+        return Err(Error::WrongState {
+            id: layout.id().clone(),
+            state: VmState::Exited(status),
+            expected: "a live vm",
+        });
+    }
+    let inner = UdsListener::bind(&layout.vsock_host_uds(), port)?;
+    if let Some(jail) = layout.jail() {
+        chown(
+            inner.path(),
+            Some(Uid::from_raw(jail.uid)),
+            Some(Gid::from_raw(jail.gid)),
+        )
+        .map_err(|source| FcError::Chown {
+            path: inner.path().to_path_buf(),
+            source,
+        })?;
+    }
+    Ok(Box::new(FcListener {
+        id: layout.id().clone(),
+        inner,
+        exit: process.subscribe(),
+    }))
+}
+
+struct FcListener {
+    id: VmId,
+    inner: UdsListener,
+    exit: watch::Receiver<Option<arcbox_vm_driver::ExitStatus>>,
+}
+
+#[async_trait]
+impl VsockListener for FcListener {
+    async fn accept(&mut self) -> Result<VsockConn> {
+        let exited = *self.exit.borrow();
+        if let Some(status) = exited {
+            return Err(Error::WrongState {
+                id: self.id.clone(),
+                state: VmState::Exited(status),
+                expected: "running or quiesced",
+            });
+        }
+        let stream = tokio::select! {
+            accepted = self.inner.accept() => accepted?,
+            _ = self.exit.changed() => {
+                let status = self.exit.borrow().unwrap_or(crate::process::UNKNOWN_EXIT);
+                return Err(Error::WrongState {
+                    id: self.id.clone(),
+                    state: VmState::Exited(status),
+                    expected: "running or quiesced",
+                });
+            }
+        };
+        Ok(VsockConn {
+            fd: stream.into_std()?.into(),
+            mode: IoMode::Async,
+        })
+    }
+}

--- a/virt/arcbox-fc-driver/src/listener.rs
+++ b/virt/arcbox-fc-driver/src/listener.rs
@@ -1,20 +1,78 @@
-//! The port's [`VsockListener`] over a [`UdsListener`]: a guest dial-out
-//! per `accept`, failing once the VM is gone.
+//! The port's [`VsockListener`] over [`UdsListener`]s: a guest dial-out
+//! per `accept`, bound next to the vsock socket the VM has *now*, failing
+//! once the VM is gone.
+//!
+//! Firecracker forwards a guest connect to host port `P` to `{uds}_P`
+//! next to its vsock socket — the one it bound, which after a restore is
+//! the path the checkpoint recorded, not the new runtime layout's. The
+//! prepared VM, the handle, and every listener therefore share one
+//! [`VsockEndpoint`]: `dial` reads it, `listen` binds next to it, and a
+//! listener bound before a restore follows it to wherever the restored
+//! guest dials out.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::task::Poll;
 
 use arcbox_vm_driver::{Error, IoMode, Result, VmId, VmState, VsockConn, VsockListener};
 use async_trait::async_trait;
 use nix::unistd::{Gid, Uid, chown};
+use tokio::net::UnixStream;
 use tokio::sync::watch;
 
 use crate::error::FcError;
+use crate::jail::Jail;
 use crate::process::FcProcess;
 use crate::render::VmLayout;
-use crate::vsock::UdsListener;
+use crate::vsock::{UdsListener, listener_socket_path};
 
-/// Bind the listener for host `port` on the VM's vsock socket, owned by
-/// the jailed uid/gid under a jail (Firecracker `connect(2)`s to it as
-/// that user, which needs write permission on the socket file).
-pub fn bind(layout: &VmLayout, process: &FcProcess, port: u32) -> Result<Box<dyn VsockListener>> {
+/// The vsock Unix socket a VM's guest dial-outs are forwarded next to, as
+/// the host sees it.
+///
+/// Created at the layout's path when a VM is prepared and shared with the
+/// handle booted on it; a restore [`relocate`](Self::relocate)s it to the
+/// path the checkpoint recorded before the guest resumes, and listeners
+/// bound earlier follow.
+#[derive(Debug, Clone)]
+pub struct VsockEndpoint(Arc<watch::Sender<PathBuf>>);
+
+impl VsockEndpoint {
+    /// An endpoint at `uds`.
+    pub fn new(uds: PathBuf) -> Self {
+        Self(Arc::new(watch::Sender::new(uds)))
+    }
+
+    /// Where the socket is now.
+    pub fn path(&self) -> PathBuf {
+        self.0.borrow().clone()
+    }
+
+    /// The socket moved: Firecracker bound it at `uds`.
+    pub fn relocate(&self, uds: PathBuf) {
+        self.0.send_if_modified(|current| {
+            if *current == uds {
+                return false;
+            }
+            *current = uds;
+            true
+        });
+    }
+
+    fn subscribe(&self) -> watch::Receiver<PathBuf> {
+        self.0.subscribe()
+    }
+}
+
+/// Bind the listener for host `port` next to the VM's vsock socket.
+///
+/// Under a jail the socket file is owned by the jailed uid/gid: Firecracker
+/// `connect(2)`s to it as that user, which needs write permission on it.
+pub fn bind(
+    layout: &VmLayout,
+    endpoint: &VsockEndpoint,
+    process: &FcProcess,
+    port: u32,
+) -> Result<Box<dyn VsockListener>> {
     if let Some(status) = process.exit_status() {
         return Err(Error::WrongState {
             id: layout.id().clone(),
@@ -22,56 +80,174 @@ pub fn bind(layout: &VmLayout, process: &FcProcess, port: u32) -> Result<Box<dyn
             expected: "a live vm",
         });
     }
-    let inner = UdsListener::bind(&layout.vsock_host_uds(), port)?;
-    if let Some(jail) = layout.jail() {
-        chown(
-            inner.path(),
-            Some(Uid::from_raw(jail.uid)),
-            Some(Gid::from_raw(jail.gid)),
-        )
-        .map_err(|source| FcError::Chown {
-            path: inner.path().to_path_buf(),
-            source,
-        })?;
-    }
+    let mut uds = endpoint.subscribe();
+    let first = bind_at(&uds.borrow_and_update(), port, layout.jail())?;
     Ok(Box::new(FcListener {
         id: layout.id().clone(),
-        inner,
+        port,
+        jail: layout.jail().cloned(),
+        bound: vec![first],
+        uds,
+        follow: true,
         exit: process.subscribe(),
     }))
 }
 
+fn bind_at(uds: &Path, port: u32, jail: Option<&Jail>) -> Result<UdsListener> {
+    let listener = UdsListener::bind(uds, port)?;
+    if let Some(jail) = jail {
+        chown(
+            listener.path(),
+            Some(Uid::from_raw(jail.uid)),
+            Some(Gid::from_raw(jail.gid)),
+        )
+        .map_err(|source| FcError::Chown {
+            path: listener.path().to_path_buf(),
+            source,
+        })?;
+    }
+    Ok(listener)
+}
+
 struct FcListener {
     id: VmId,
-    inner: UdsListener,
+    port: u32,
+    jail: Option<Jail>,
+    /// One per place the VM's socket has been; the first is where it was
+    /// when the listener was bound.
+    bound: Vec<UdsListener>,
+    uds: watch::Receiver<PathBuf>,
+    /// The endpoint is still alive and may move.
+    follow: bool,
     exit: watch::Receiver<Option<arcbox_vm_driver::ExitStatus>>,
+}
+
+impl FcListener {
+    fn exited(&self, status: arcbox_vm_driver::ExitStatus) -> Error {
+        Error::WrongState {
+            id: self.id.clone(),
+            state: VmState::Exited(status),
+            expected: "running or quiesced",
+        }
+    }
+
+    /// Bind next to the socket's current place, if not bound there yet.
+    fn follow_endpoint(&mut self) -> Result<()> {
+        let current = self.uds.borrow_and_update().clone();
+        let target = listener_socket_path(&current, self.port);
+        if !self.bound.iter().any(|l| l.path() == target) {
+            self.bound
+                .push(bind_at(&current, self.port, self.jail.as_ref())?);
+        }
+        Ok(())
+    }
+}
+
+/// The next connection on any of `listeners`.
+async fn accept_any(listeners: &[UdsListener]) -> Result<UnixStream> {
+    std::future::poll_fn(|cx| {
+        for listener in listeners {
+            if let Poll::Ready(accepted) = listener.poll_accept(cx) {
+                return Poll::Ready(accepted);
+            }
+        }
+        Poll::Pending
+    })
+    .await
 }
 
 #[async_trait]
 impl VsockListener for FcListener {
     async fn accept(&mut self) -> Result<VsockConn> {
-        let exited = *self.exit.borrow();
-        if let Some(status) = exited {
-            return Err(Error::WrongState {
-                id: self.id.clone(),
-                state: VmState::Exited(status),
-                expected: "running or quiesced",
+        loop {
+            let exited = *self.exit.borrow();
+            if let Some(status) = exited {
+                return Err(self.exited(status));
+            }
+            self.follow_endpoint()?;
+            let Self {
+                bound,
+                uds,
+                follow,
+                exit,
+                ..
+            } = &mut *self;
+            let stream = tokio::select! {
+                accepted = accept_any(bound) => accepted?,
+                _ = exit.changed() => {
+                    let status = exit.borrow().unwrap_or(crate::process::UNKNOWN_EXIT);
+                    return Err(self.exited(status));
+                }
+                moved = uds.changed(), if *follow => {
+                    // Bound next to the new place on the next turn; a
+                    // dropped endpoint moves no more.
+                    *follow = moved.is_ok();
+                    continue;
+                }
+            };
+            return Ok(VsockConn {
+                fd: stream.into_std()?.into(),
+                mode: IoMode::Async,
             });
         }
-        let stream = tokio::select! {
-            accepted = self.inner.accept() => accepted?,
-            _ = self.exit.changed() => {
-                let status = self.exit.borrow().unwrap_or(crate::process::UNKNOWN_EXIT);
-                return Err(Error::WrongState {
-                    id: self.id.clone(),
-                    state: VmState::Exited(status),
-                    expected: "running or quiesced",
-                });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::io::AsyncWriteExt as _;
+
+    use super::*;
+    use crate::config::FcDriverConfig;
+    use crate::process::testing::spawn;
+
+    #[tokio::test]
+    async fn a_listener_follows_the_endpoint_to_where_the_guest_dials_out() {
+        let dir = tempfile::tempdir().unwrap();
+        let id = VmId::new("box").unwrap();
+        let config = FcDriverConfig::new("/opt/fc/firecracker");
+        let layout = VmLayout::new(
+            &id,
+            &arcbox_vm_driver::IsolationSpec::None,
+            &config,
+            dir.path(),
+        )
+        .unwrap();
+        let process = spawn("sleep", &["30"]);
+        let endpoint = VsockEndpoint::new(layout.vsock_host_uds());
+        let mut listener = bind(&layout, &endpoint, &process, 51).unwrap();
+        assert!(dir.path().join("firecracker.vsock_51").exists());
+
+        // A restore rebinds the vsock where the checkpoint recorded it: the
+        // guest now dials out next to that path.
+        let recorded = dir.path().join("source").join("firecracker.vsock");
+        std::fs::create_dir_all(recorded.parent().unwrap()).unwrap();
+        endpoint.relocate(recorded.clone());
+        let dial = tokio::spawn(async move {
+            let path = listener_socket_path(&recorded, 51);
+            for _ in 0..100 {
+                if let Ok(mut stream) = UnixStream::connect(&path).await {
+                    stream.write_all(&[0]).await.unwrap();
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
             }
-        };
-        Ok(VsockConn {
-            fd: stream.into_std()?.into(),
-            mode: IoMode::Async,
-        })
+            panic!("the relocated listener never came up at {}", path.display());
+        });
+        tokio::time::timeout(Duration::from_secs(10), listener.accept())
+            .await
+            .expect("accept before the deadline")
+            .expect("accept the dial-out at the recorded path");
+        dial.await.unwrap();
+
+        // The original place stays bound too, and both go with the listener.
+        assert!(dir.path().join("firecracker.vsock_51").exists());
+        assert!(dir.path().join("source/firecracker.vsock_51").exists());
+        drop(listener);
+        assert!(!dir.path().join("firecracker.vsock_51").exists());
+        assert!(!dir.path().join("source/firecracker.vsock_51").exists());
+        process.kill().await.unwrap();
     }
 }

--- a/virt/arcbox-fc-driver/src/listener.rs
+++ b/virt/arcbox-fc-driver/src/listener.rs
@@ -197,8 +197,6 @@ impl VsockListener for FcListener {
 mod tests {
     use std::time::Duration;
 
-    use tokio::io::AsyncWriteExt as _;
-
     use super::*;
     use crate::config::FcDriverConfig;
     use crate::process::testing::spawn;
@@ -228,19 +226,20 @@ mod tests {
         let dial = tokio::spawn(async move {
             let path = listener_socket_path(&recorded, 51);
             for _ in 0..100 {
-                if let Ok(mut stream) = UnixStream::connect(&path).await {
-                    stream.write_all(&[0]).await.unwrap();
-                    return;
+                if let Ok(stream) = UnixStream::connect(&path).await {
+                    return stream;
                 }
                 tokio::time::sleep(Duration::from_millis(20)).await;
             }
             panic!("the relocated listener never came up at {}", path.display());
         });
-        tokio::time::timeout(Duration::from_secs(10), listener.accept())
+        let accepted = tokio::time::timeout(Duration::from_secs(10), listener.accept())
             .await
             .expect("accept before the deadline")
             .expect("accept the dial-out at the recorded path");
-        dial.await.unwrap();
+        // The guest end outlives the accept, so nothing races a close.
+        let guest = dial.await.unwrap();
+        drop((accepted, guest));
 
         // The original place stays bound too, and both go with the listener.
         assert!(dir.path().join("firecracker.vsock_51").exists());

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -188,11 +188,15 @@ impl PreparedVm for FcPrepared {
             .await
             .map_err(FcError::Api)?;
         let client = vm.into_client();
-        // The image, not the spec, decides which devices the VM has — and
-        // Firecracker re-binds the vsock socket where the checkpoint
-        // recorded it, so the path is read back rather than assumed.
-        let vsock_uds = api::vm_config(&client)
-            .await?
+        // The image, not the spec, decides which devices the VM has, and it
+        // names them at the paths the checkpoint recorded — so both the
+        // disks and the vsock socket are read back rather than assumed.
+        let loaded = api::vm_config(&client).await?;
+        reattach_disks(&client, &loaded.drives, &plan.drives).await?;
+        // The load left the guest frozen so it could not touch a stale disk;
+        // it runs from here.
+        api::resume(&client).await?;
+        let vsock_uds = loaded
             .vsock
             .map(|vsock| self.layout.vsock_host_view(&vsock.uds_path));
         Ok(Box::new(self.handle(client, vsock_uds)))
@@ -203,9 +207,103 @@ impl PreparedVm for FcPrepared {
     }
 }
 
+/// Point every drive of a freshly loaded image at the path this restore
+/// gives it, skipping the ones the image already names.
+///
+/// A checkpoint records each disk's path, and a restore's disks are never
+/// at those paths — a fresh copy-on-write device, a per-VM copy, a jail of
+/// its own. The VM is still paused here, so the swap happens before the
+/// guest reads a block from the disk it was checkpointed on.
+async fn reattach_disks(
+    client: &fc_sdk::Client,
+    loaded: &[fc_sdk::types::Drive],
+    wanted: &[fc_sdk::types::Drive],
+) -> Result<()> {
+    for drive in wanted {
+        let recorded = loaded
+            .iter()
+            .find(|loaded| loaded.drive_id == drive.drive_id)
+            .ok_or_else(|| {
+                Error::InvalidSpec(format!(
+                    "{NAME}: the checkpoint has no disk `{}`",
+                    drive.drive_id
+                ))
+            })?;
+        if recorded.path_on_host != drive.path_on_host {
+            let path = drive.path_on_host.as_deref().ok_or_else(|| {
+                Error::InvalidSpec(format!("{NAME}: disk `{}` has no path", drive.drive_id))
+            })?;
+            api::update_drive(client, &drive.drive_id, path).await?;
+        }
+    }
+    Ok(())
+}
+
 #[async_trait]
 impl VsockListen for FcPrepared {
     async fn listen(&self, port: u32) -> Result<Box<dyn VsockListener>> {
         listener::bind(&self.layout, &self.process, port)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fc_sdk::types::{DriveCacheType, DriveIoEngine};
+
+    use super::*;
+
+    fn drive(id: &str, path: &str) -> fc_sdk::types::Drive {
+        fc_sdk::types::Drive {
+            drive_id: id.to_owned(),
+            path_on_host: Some(path.to_owned()),
+            is_root_device: true,
+            is_read_only: Some(false),
+            partuuid: None,
+            cache_type: DriveCacheType::Unsafe,
+            rate_limiter: None,
+            io_engine: DriveIoEngine::Sync,
+            socket: None,
+        }
+    }
+
+    /// A client on a socket nobody answers on: any call it makes fails, so
+    /// a call that does not happen is provable.
+    fn unreachable_client() -> fc_sdk::Client {
+        fc_sdk::connection::connect("/nonexistent/arcbox-fc-driver/api.sock")
+    }
+
+    #[tokio::test]
+    async fn a_disk_the_image_already_names_is_not_patched() {
+        reattach_disks(
+            &unreachable_client(),
+            &[drive("rootfs", "/rootfs.ext4")],
+            &[drive("rootfs", "/rootfs.ext4")],
+        )
+        .await
+        .expect("no call is made for a path the image already names");
+    }
+
+    #[tokio::test]
+    async fn a_disk_at_a_new_path_is_patched_and_an_unknown_one_is_refused() {
+        // The patch is attempted — against a socket nobody answers on, so it
+        // fails as a driver error rather than being skipped.
+        let patched = reattach_disks(
+            &unreachable_client(),
+            &[drive("rootfs", "/rootfs.ext4")],
+            &[drive("rootfs", "/restored.ext4")],
+        )
+        .await;
+        assert!(matches!(patched, Err(Error::Driver { .. })), "{patched:?}");
+
+        let unknown = reattach_disks(
+            &unreachable_client(),
+            &[drive("rootfs", "/rootfs.ext4")],
+            &[drive("data", "/data.ext4")],
+        )
+        .await;
+        match unknown {
+            Err(Error::InvalidSpec(message)) => assert!(message.contains("data"), "{message}"),
+            other => panic!("expected InvalidSpec, got {other:?}"),
+        }
     }
 }

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -47,6 +47,11 @@ impl FcPrepared {
         tokio::fs::create_dir_all(runtime_dir).await?;
         let plan = layout.spawn_plan();
         let child = spawn::spawn(&plan, &config).await?;
+        debug_assert_eq!(
+            child.socket_path(),
+            plan.api_socket,
+            "the layout and fc-sdk agree on the API socket"
+        );
         let process = Arc::new(FcProcess::spawn(child, plan.api_socket.clone())?);
         let record = VmRecord {
             id: id.clone(),

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -1,0 +1,203 @@
+//! [`FcPrepared`]: a spawned Firecracker waiting for a spec — the port's
+//! [`PreparedVm`].
+
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use arcbox_vm_driver::{
+    CheckpointImage, Error, ExitStatus, IsolationSpec, PreparedVm, ProcessRecord, RestoreSpec,
+    Result, VmHandle, VmId, VmRecord, VmSpec, VmState, VsockListen, VsockListener,
+};
+use async_trait::async_trait;
+use fc_sdk::VmBuilder;
+
+use crate::config::FcDriverConfig;
+use crate::error::FcError;
+use crate::handle::FcHandle;
+use crate::process::FcProcess;
+use crate::render::{self, VmLayout};
+use crate::{NAME, api, jail, listener, spawn};
+
+/// A spawned VMM process with its API socket up and nothing loaded yet.
+///
+/// Dropping it kills the process unless a `boot` or `restore` succeeded,
+/// after which the returned handle owns it (and shares the guard).
+pub struct FcPrepared {
+    config: Arc<FcDriverConfig>,
+    layout: VmLayout,
+    process: Arc<FcProcess>,
+    record: VmRecord,
+    /// A boot or restore succeeded.
+    consumed: AtomicBool,
+    /// Serializes `boot` / `restore` so at most one can succeed.
+    launch: tokio::sync::Mutex<()>,
+}
+
+impl FcPrepared {
+    /// Spawn the VMM for `id` under `isolation` with `runtime_dir` as its
+    /// scratch space, and wait for its API socket.
+    pub async fn spawn(
+        config: Arc<FcDriverConfig>,
+        id: &VmId,
+        isolation: &IsolationSpec,
+        runtime_dir: &Path,
+    ) -> Result<Self> {
+        let layout = VmLayout::new(id, isolation, &config, runtime_dir)?;
+        tokio::fs::create_dir_all(runtime_dir).await?;
+        let plan = layout.spawn_plan();
+        let child = spawn::spawn(&plan, &config).await?;
+        let process = Arc::new(FcProcess::spawn(child, plan.api_socket.clone())?);
+        let record = VmRecord {
+            id: id.clone(),
+            driver: NAME.to_owned(),
+            runtime_dir: runtime_dir.to_path_buf(),
+            process: Some(ProcessRecord {
+                pid: process.pid(),
+                api_socket: Some(plan.api_socket),
+            }),
+        };
+        Ok(Self {
+            config,
+            layout,
+            process,
+            record,
+            consumed: AtomicBool::new(false),
+            launch: tokio::sync::Mutex::new(()),
+        })
+    }
+
+    fn require_unused(&self) -> Result<()> {
+        if let Some(status) = self.process.exit_status() {
+            return Err(Error::WrongState {
+                id: self.record.id.clone(),
+                state: VmState::Exited(status),
+                expected: "a prepared vm that was not discarded",
+            });
+        }
+        if self.consumed.load(Ordering::Acquire) {
+            return Err(Error::WrongState {
+                id: self.record.id.clone(),
+                state: VmState::Running,
+                expected: "a prepared vm that was not booted yet",
+            });
+        }
+        Ok(())
+    }
+
+    fn require_same_identity(&self, id: &VmId, isolation: &IsolationSpec) -> Result<()> {
+        if *id != self.record.id {
+            return Err(Error::InvalidSpec(format!(
+                "spec id {id} does not match the prepared vm {}",
+                self.record.id
+            )));
+        }
+        if *isolation != *self.layout.isolation() {
+            return Err(Error::InvalidSpec(format!(
+                "spec isolation does not match what vm {} was prepared with",
+                self.record.id
+            )));
+        }
+        Ok(())
+    }
+
+    fn handle(&self, client: fc_sdk::Client, vsock_uds: Option<std::path::PathBuf>) -> FcHandle {
+        self.consumed.store(true, Ordering::Release);
+        FcHandle::new(
+            Arc::clone(&self.process),
+            client,
+            self.layout.clone(),
+            self.record.clone(),
+            vsock_uds,
+            false,
+        )
+    }
+}
+
+impl Drop for FcPrepared {
+    fn drop(&mut self) {
+        if !self.consumed.load(Ordering::Acquire) {
+            self.process.kill_now();
+        }
+    }
+}
+
+#[async_trait]
+impl PreparedVm for FcPrepared {
+    fn id(&self) -> &VmId {
+        &self.record.id
+    }
+
+    fn record(&self) -> VmRecord {
+        self.record.clone()
+    }
+
+    fn alive(&self) -> bool {
+        self.process.alive()
+    }
+
+    fn vsock_listener(&self) -> Option<&dyn VsockListen> {
+        Some(self)
+    }
+
+    async fn boot(&self, spec: VmSpec) -> Result<Box<dyn VmHandle>> {
+        let _launch = self.launch.lock().await;
+        self.require_unused()?;
+        self.require_same_identity(&spec.id, &spec.isolation)?;
+        let plan = render::fc_config(&spec, &self.config, self.layout.runtime_dir())?;
+        if let Some(jail) = self.layout.jail() {
+            jail::apply(jail, &plan.stage).await?;
+        }
+        let mut builder = VmBuilder::new(self.process.api_socket())
+            .boot_source(plan.boot_source)
+            .machine_config(plan.machine);
+        for drive in plan.drives {
+            builder = builder.drive(drive);
+        }
+        for nic in plan.nics {
+            builder = builder.network_interface(nic);
+        }
+        if let Some(vsock) = plan.vsock {
+            builder = builder.vsock(vsock);
+        }
+        if let Some(entropy) = plan.entropy {
+            builder = builder.entropy(entropy);
+        }
+        let vm = builder.start().await.map_err(FcError::Api)?;
+        Ok(Box::new(self.handle(vm.into_client(), plan.vsock_host_uds)))
+    }
+
+    async fn restore(
+        &self,
+        image: &CheckpointImage,
+        spec: RestoreSpec,
+    ) -> Result<Box<dyn VmHandle>> {
+        let _launch = self.launch.lock().await;
+        self.require_unused()?;
+        self.require_same_identity(&spec.id, &spec.isolation)?;
+        let plan = render::fc_restore(image, &spec, &self.config, self.layout.runtime_dir())?;
+        if let Some(jail) = self.layout.jail() {
+            jail::apply(jail, &plan.stage).await?;
+        }
+        let vm = fc_sdk::restore(self.process.api_socket(), plan.load)
+            .await
+            .map_err(FcError::Api)?;
+        let client = vm.into_client();
+        // The image, not the spec, decides which devices the VM has.
+        let has_vsock = api::vm_config(&client).await?.vsock.is_some();
+        Ok(Box::new(
+            self.handle(client, has_vsock.then_some(plan.vsock_host_uds)),
+        ))
+    }
+
+    async fn discard(&self) -> Result<ExitStatus> {
+        Ok(self.process.kill().await?)
+    }
+}
+
+#[async_trait]
+impl VsockListen for FcPrepared {
+    async fn listen(&self, port: u32) -> Result<Box<dyn VsockListener>> {
+        listener::bind(&self.layout, &self.process, port)
+    }
+}

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -207,8 +207,7 @@ impl PreparedVm for FcPrepared {
         // can dial out.
         let has_vsock = loaded.vsock.is_some();
         if let Some(vsock) = loaded.vsock {
-            self.vsock
-                .relocate(self.layout.vsock_host_view(&vsock.uds_path));
+            self.vsock.relocate(self.layout.host_view(&vsock.uds_path));
         }
         // The load left the guest frozen so it could not touch a stale disk;
         // it runs from here.

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -15,6 +15,7 @@ use fc_sdk::VmBuilder;
 use crate::config::FcDriverConfig;
 use crate::error::FcError;
 use crate::handle::FcHandle;
+use crate::listener::VsockEndpoint;
 use crate::process::FcProcess;
 use crate::render::{self, VmLayout};
 use crate::{NAME, api, jail, listener, spawn};
@@ -28,6 +29,10 @@ pub struct FcPrepared {
     layout: VmLayout,
     process: Arc<FcProcess>,
     record: VmRecord,
+    /// Where guest dial-outs land: the layout's vsock socket, until a
+    /// restore learns where the checkpoint had it and moves it. Listeners
+    /// bound before the boot or restore follow.
+    vsock: VsockEndpoint,
     /// A boot or restore succeeded.
     consumed: AtomicBool,
     /// Serializes `boot` / `restore` so at most one can succeed.
@@ -62,11 +67,13 @@ impl FcPrepared {
                 api_socket: Some(plan.api_socket),
             }),
         };
+        let vsock = VsockEndpoint::new(layout.vsock_host_uds());
         Ok(Self {
             config,
             layout,
             process,
             record,
+            vsock,
             consumed: AtomicBool::new(false),
             launch: tokio::sync::Mutex::new(()),
         })
@@ -106,14 +113,14 @@ impl FcPrepared {
         Ok(())
     }
 
-    fn handle(&self, client: fc_sdk::Client, vsock_uds: Option<std::path::PathBuf>) -> FcHandle {
+    fn handle(&self, client: fc_sdk::Client, has_vsock: bool) -> FcHandle {
         self.consumed.store(true, Ordering::Release);
         FcHandle::new(
             Arc::clone(&self.process),
             client,
             self.layout.clone(),
             self.record.clone(),
-            vsock_uds,
+            has_vsock.then(|| self.vsock.clone()),
             false,
         )
     }
@@ -169,7 +176,9 @@ impl PreparedVm for FcPrepared {
             builder = builder.entropy(entropy);
         }
         let vm = builder.start().await.map_err(FcError::Api)?;
-        Ok(Box::new(self.handle(vm.into_client(), plan.vsock_host_uds)))
+        Ok(Box::new(
+            self.handle(vm.into_client(), plan.vsock_host_uds.is_some()),
+        ))
     }
 
     async fn restore(
@@ -193,13 +202,18 @@ impl PreparedVm for FcPrepared {
         // disks and the vsock socket are read back rather than assumed.
         let loaded = api::vm_config(&client).await?;
         reattach_disks(&client, &loaded.drives, &plan.drives).await?;
+        // Firecracker rebound the vsock where the checkpoint recorded it;
+        // listeners bound on this prepared VM move there before the guest
+        // can dial out.
+        let has_vsock = loaded.vsock.is_some();
+        if let Some(vsock) = loaded.vsock {
+            self.vsock
+                .relocate(self.layout.vsock_host_view(&vsock.uds_path));
+        }
         // The load left the guest frozen so it could not touch a stale disk;
         // it runs from here.
         api::resume(&client).await?;
-        let vsock_uds = loaded
-            .vsock
-            .map(|vsock| self.layout.vsock_host_view(&vsock.uds_path));
-        Ok(Box::new(self.handle(client, vsock_uds)))
+        Ok(Box::new(self.handle(client, has_vsock)))
     }
 
     async fn discard(&self) -> Result<ExitStatus> {
@@ -241,8 +255,11 @@ async fn reattach_disks(
 
 #[async_trait]
 impl VsockListen for FcPrepared {
+    /// Bound next to the layout's vsock socket, where a boot puts the
+    /// device; a restore moves the endpoint to the recorded path before
+    /// the guest resumes and the listener follows.
     async fn listen(&self, port: u32) -> Result<Box<dyn VsockListener>> {
-        listener::bind(&self.layout, &self.process, port)
+        listener::bind(&self.layout, &self.vsock, &self.process, port)
     }
 }
 

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -183,11 +183,14 @@ impl PreparedVm for FcPrepared {
             .await
             .map_err(FcError::Api)?;
         let client = vm.into_client();
-        // The image, not the spec, decides which devices the VM has.
-        let has_vsock = api::vm_config(&client).await?.vsock.is_some();
-        Ok(Box::new(
-            self.handle(client, has_vsock.then_some(plan.vsock_host_uds)),
-        ))
+        // The image, not the spec, decides which devices the VM has — and
+        // Firecracker re-binds the vsock socket where the checkpoint
+        // recorded it, so the path is read back rather than assumed.
+        let vsock_uds = api::vm_config(&client)
+            .await?
+            .vsock
+            .map(|vsock| self.layout.vsock_host_view(&vsock.uds_path));
+        Ok(Box::new(self.handle(client, vsock_uds)))
     }
 
     async fn discard(&self) -> Result<ExitStatus> {

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -202,6 +202,16 @@ impl PreparedVm for FcPrepared {
         // disks and the vsock socket are read back rather than assumed.
         let loaded = api::vm_config(&client).await?;
         reattach_disks(&client, &loaded.drives, &plan.drives).await?;
+        // The drives now name the disks themselves; the second names staged
+        // for the load are not needed any more.
+        for alias in &plan.aliases {
+            if let Err(e) = tokio::fs::remove_file(alias).await
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
+                tracing::warn!(vm = %self.record.id, alias = %alias.display(), error = %e,
+                    "a disk alias staged for the load could not be removed");
+            }
+        }
         // Firecracker rebound the vsock where the checkpoint recorded it;
         // listeners bound on this prepared VM move there before the guest
         // can dial out.

--- a/virt/arcbox-fc-driver/src/process.rs
+++ b/virt/arcbox-fc-driver/src/process.rs
@@ -344,12 +344,14 @@ fn probe_alive(pid: u32) -> bool {
     }
 }
 
+/// Plain `tokio` children standing in for Firecracker in this crate's
+/// tests.
 #[cfg(test)]
-mod tests {
+pub(crate) mod testing {
     use super::*;
 
     /// A plain `tokio` child stands in for Firecracker.
-    struct Child(tokio::process::Child);
+    pub struct Child(pub tokio::process::Child);
 
     impl Vmm for Child {
         fn pid(&self) -> Option<u32> {
@@ -365,7 +367,8 @@ mod tests {
         }
     }
 
-    fn spawn(program: &str, args: &[&str]) -> FcProcess {
+    /// An owned [`FcProcess`] over `program args`.
+    pub fn spawn(program: &str, args: &[&str]) -> FcProcess {
         let child = tokio::process::Command::new(program)
             .args(args)
             .spawn()
@@ -373,10 +376,17 @@ mod tests {
         FcProcess::spawn(Child(child), PathBuf::from("/tmp/api.sock")).unwrap()
     }
 
-    fn pid_exists(pid: u32) -> bool {
+    /// `true` while `pid` can be signalled.
+    pub fn pid_exists(pid: u32) -> bool {
         #[allow(clippy::cast_possible_wrap, reason = "test pid")]
         kill(Pid::from_raw(pid as i32), None).is_ok()
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::testing::{pid_exists, spawn};
+    use super::*;
 
     #[tokio::test]
     async fn exit_is_published_once_and_alive_flips_for_good() {

--- a/virt/arcbox-fc-driver/src/process.rs
+++ b/virt/arcbox-fc-driver/src/process.rs
@@ -343,3 +343,118 @@ fn probe_alive(pid: u32) -> bool {
         true
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A plain `tokio` child stands in for Firecracker.
+    struct Child(tokio::process::Child);
+
+    impl Vmm for Child {
+        fn pid(&self) -> Option<u32> {
+            self.0.id()
+        }
+
+        async fn wait(&mut self) -> ExitStatus {
+            self.0.wait().await.map_or(UNKNOWN_EXIT, Into::into)
+        }
+
+        fn release(self) {
+            drop(self.0);
+        }
+    }
+
+    fn spawn(program: &str, args: &[&str]) -> FcProcess {
+        let child = tokio::process::Command::new(program)
+            .args(args)
+            .spawn()
+            .expect("spawn test child");
+        FcProcess::spawn(Child(child), PathBuf::from("/tmp/api.sock")).unwrap()
+    }
+
+    fn pid_exists(pid: u32) -> bool {
+        #[allow(clippy::cast_possible_wrap, reason = "test pid")]
+        kill(Pid::from_raw(pid as i32), None).is_ok()
+    }
+
+    #[tokio::test]
+    async fn exit_is_published_once_and_alive_flips_for_good() {
+        let process = spawn("sh", &["-c", "exit 3"]);
+        let mut events = process.events();
+        let status = process
+            .wait(Duration::from_secs(10))
+            .await
+            .expect("the child exits");
+        assert_eq!(status, ExitStatus::exited(3));
+        assert!(!process.alive());
+        assert_eq!(process.exit_status(), Some(status));
+        assert_eq!(events.recv().await.unwrap(), VmEvent::Exited(status));
+        assert!(events.try_recv().is_err(), "Exited is delivered once");
+        // Killing an exited process just reports the recorded status.
+        assert_eq!(process.kill().await.unwrap(), status);
+    }
+
+    #[tokio::test]
+    async fn kill_reaps_and_reports_the_signal() {
+        let process = spawn("sleep", &["30"]);
+        assert!(process.alive());
+        let status = process.kill().await.unwrap();
+        assert_eq!(status, ExitStatus::signaled(9));
+        assert!(!process.alive());
+        assert_eq!(process.kill().await.unwrap(), status);
+        assert!(!pid_exists(process.pid()), "the child was reaped");
+    }
+
+    #[tokio::test]
+    async fn detach_releases_the_child_without_killing_it() {
+        let process = spawn("sleep", &["30"]);
+        let pid = process.pid();
+        process.detach();
+        assert!(process.is_detached());
+        // Give the waiter a chance to release.
+        tokio::task::yield_now().await;
+        drop(process);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(pid_exists(pid), "a detached child keeps running");
+        #[allow(clippy::cast_possible_wrap, reason = "test pid")]
+        kill(Pid::from_raw(pid as i32), Signal::SIGKILL).unwrap();
+    }
+
+    #[tokio::test]
+    async fn an_adopted_process_is_tracked_by_probing() {
+        let mut child = tokio::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let process = FcProcess::adopt(child.id().unwrap(), PathBuf::from("/tmp/api.sock"));
+        assert!(process.alive());
+        assert!(!process.is_detached());
+        // Killed out from under us and reaped by its real parent, the probe
+        // sees it gone and records an unknown exit — once.
+        child.kill().await.unwrap();
+        child.wait().await.unwrap();
+        let mut events = process.events();
+        assert_eq!(process.exit_status(), Some(UNKNOWN_EXIT));
+        assert!(!process.alive());
+        assert_eq!(events.try_recv().unwrap(), VmEvent::Exited(UNKNOWN_EXIT));
+        assert_eq!(process.exit_status(), Some(UNKNOWN_EXIT));
+        assert!(events.try_recv().is_err(), "the exit is recorded once");
+        assert_eq!(process.kill().await.unwrap(), UNKNOWN_EXIT);
+    }
+
+    #[tokio::test]
+    async fn adopted_kill_signals_and_waits_for_the_pid_to_vanish() {
+        let mut child = tokio::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let process = FcProcess::adopt(child.id().unwrap(), PathBuf::from("/tmp/api.sock"));
+        // The real parent reaps once the signal lands.
+        let reaper = tokio::spawn(async move { child.wait().await.unwrap() });
+        assert_eq!(process.kill().await.unwrap(), UNKNOWN_EXIT);
+        assert!(!process.alive());
+        use std::os::unix::process::ExitStatusExt as _;
+        assert_eq!(reaper.await.unwrap().signal(), Some(9));
+    }
+}

--- a/virt/arcbox-fc-driver/src/process.rs
+++ b/virt/arcbox-fc-driver/src/process.rs
@@ -76,7 +76,8 @@ pub struct FcProcess {
     exit: watch::Sender<Option<ExitStatus>>,
     events: broadcast::Sender<VmEvent>,
     /// Tells the task that observes the process — the waiter or the prober
-    /// — to stand down; taken by `detach`, dropped with the process.
+    /// — to stand down: sent by `detach` (the child is released), dropped
+    /// with the process (the waiter still reaps; the prober stops).
     stand_down: Mutex<Option<oneshot::Sender<()>>>,
     /// Set by `detach`: nothing here kills or observes the process any more.
     detached: AtomicBool,
@@ -310,7 +311,14 @@ async fn waiter<C: Vmm>(
         tokio::pin!(wait);
         tokio::select! {
             status = &mut wait => Some(status),
-            _ = &mut stand_down => None,
+            stood_down = &mut stand_down => match stood_down {
+                // A detach: the child is released, not reaped.
+                Ok(()) => None,
+                // The process value went away without a detach — after a
+                // kill on drop, typically. Nobody is left to tell, but the
+                // child is still ours to reap.
+                Err(_) => Some(wait.await),
+            },
         }
     };
     match outcome {
@@ -457,6 +465,22 @@ mod tests {
         assert!(pid_exists(pid), "a detached child keeps running");
         #[allow(clippy::cast_possible_wrap, reason = "test pid")]
         kill(Pid::from_raw(pid as i32), Signal::SIGKILL).unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_dropped_process_is_still_reaped_after_a_kill_on_drop() {
+        let process = spawn("sleep", &["30"]);
+        let pid = process.pid();
+        // What a handle's drop does: SIGKILL, then the last reference goes.
+        let mut exit = process.subscribe();
+        process.kill_now();
+        drop(process);
+        tokio::time::timeout(Duration::from_secs(5), exit.changed())
+            .await
+            .expect("the waiter reaps and publishes without a live process")
+            .expect("the waiter still holds the exit channel");
+        assert_eq!(*exit.borrow(), Some(ExitStatus::signaled(9)));
+        assert!(!pid_exists(pid), "reaped, not left a zombie");
     }
 
     #[tokio::test]

--- a/virt/arcbox-fc-driver/src/process.rs
+++ b/virt/arcbox-fc-driver/src/process.rs
@@ -9,7 +9,9 @@
 //! on the watch. Because the waiter reaps eagerly, "alive" is answered
 //! from the watch, never from the pid: a reaped pid is never probed or
 //! signalled again. An adopted process (no child to wait on) is the one
-//! exception, tracked by probing `/proc` until it is seen gone.
+//! exception: a prober task watches the pid until it is seen gone and
+//! publishes the exit the same way, so subscribers of an adopted VM are
+//! woken like those of a spawned one.
 
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -28,7 +30,7 @@ use crate::error::{FcError, Result};
 /// may retry.
 pub const REAP_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// How often an adopted process is probed while waiting for it to exit.
+/// How often the prober checks whether an adopted process is still there.
 const PROBE_INTERVAL: Duration = Duration::from_millis(100);
 
 /// The exit status recorded for a process whose real status was never
@@ -73,17 +75,20 @@ pub struct FcProcess {
     api_socket: PathBuf,
     exit: watch::Sender<Option<ExitStatus>>,
     events: broadcast::Sender<VmEvent>,
+    /// Tells the task that observes the process — the waiter or the prober
+    /// — to stand down; taken by `detach`, dropped with the process.
+    stand_down: Mutex<Option<oneshot::Sender<()>>>,
+    /// Set by `detach`: nothing here kills or observes the process any more.
+    detached: AtomicBool,
     ownership: Ownership,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Ownership {
-    /// A waiter task owns the child; `detach` tells it to release.
-    Owned {
-        detach: Mutex<Option<oneshot::Sender<()>>>,
-        detached: AtomicBool,
-    },
+    /// A waiter task owns the child and reaps it.
+    Owned,
     /// Found running; nobody here can reap it, so its exit is inferred by
-    /// probing the pid.
+    /// probing the pid — by a prober task, and on demand.
     Adopted,
 }
 
@@ -95,34 +100,43 @@ impl FcProcess {
     /// signal and must not keep the process.
     pub fn spawn<C: Vmm>(child: C, api_socket: PathBuf) -> Result<Self> {
         let pid = child.pid().ok_or(FcError::NoPid)?;
-        let (exit, _) = watch::channel(None);
-        let (events, _) = broadcast::channel(16);
-        let (detach_tx, detach_rx) = oneshot::channel();
-        let process = Self {
-            pid,
-            api_socket,
-            exit: exit.clone(),
-            events: events.clone(),
-            ownership: Ownership::Owned {
-                detach: Mutex::new(Some(detach_tx)),
-                detached: AtomicBool::new(false),
-            },
-        };
-        tokio::spawn(waiter(child, exit, events, detach_rx));
+        let (process, stand_down) = Self::new(pid, api_socket, Ownership::Owned);
+        tokio::spawn(waiter(
+            child,
+            process.exit.clone(),
+            process.events.clone(),
+            stand_down,
+        ));
         Ok(process)
     }
 
-    /// Track a process this crate did not spawn.
+    /// Track a process this crate did not spawn: a prober task watches the
+    /// pid and publishes its exit once it is gone.
     pub fn adopt(pid: u32, api_socket: PathBuf) -> Self {
+        let (process, stand_down) = Self::new(pid, api_socket, Ownership::Adopted);
+        tokio::spawn(prober(
+            pid,
+            process.exit.clone(),
+            process.events.clone(),
+            stand_down,
+        ));
+        process
+    }
+
+    fn new(pid: u32, api_socket: PathBuf, ownership: Ownership) -> (Self, oneshot::Receiver<()>) {
         let (exit, _) = watch::channel(None);
         let (events, _) = broadcast::channel(16);
-        Self {
+        let (stand_down, stood_down) = oneshot::channel();
+        let process = Self {
             pid,
             api_socket,
             exit,
             events,
-            ownership: Ownership::Adopted,
-        }
+            stand_down: Mutex::new(Some(stand_down)),
+            detached: AtomicBool::new(false),
+            ownership,
+        };
+        (process, stood_down)
     }
 
     /// The VMM's pid.
@@ -135,14 +149,15 @@ impl FcProcess {
         &self.api_socket
     }
 
-    /// How the process ended, once it has. An adopted process is probed
-    /// here; the first probe that finds it gone records [`UNKNOWN_EXIT`].
+    /// How the process ended, once it has. An adopted process is also probed
+    /// here, so the answer is exact between two prober ticks; the first probe
+    /// that finds it gone records [`UNKNOWN_EXIT`].
     pub fn exit_status(&self) -> Option<ExitStatus> {
         let recorded = *self.exit.borrow();
         if let Some(status) = recorded {
             return Some(status);
         }
-        if matches!(self.ownership, Ownership::Adopted) && !probe_alive(self.pid) {
+        if self.ownership == Ownership::Adopted && !self.is_detached() && !probe_alive(self.pid) {
             return Some(publish(&self.exit, &self.events, UNKNOWN_EXIT));
         }
         None
@@ -175,15 +190,8 @@ impl FcProcess {
             if remaining.is_zero() {
                 return None;
             }
-            match self.ownership {
-                Ownership::Owned { .. } => {
-                    if tokio::time::timeout(remaining, rx.changed()).await.is_err() {
-                        return None;
-                    }
-                }
-                Ownership::Adopted => {
-                    tokio::time::sleep(remaining.min(PROBE_INTERVAL)).await;
-                }
+            if tokio::time::timeout(remaining, rx.changed()).await.is_err() {
+                return None;
             }
         }
     }
@@ -208,25 +216,24 @@ impl FcProcess {
         }
     }
 
-    /// Release the child: nothing here kills it any more, and the waiter
-    /// stops reaping. `Exited` is never reported for a detached process.
+    /// Release the process, spawned or adopted: nothing here kills it any
+    /// more, the waiter stops reaping and the prober stops probing. `Exited`
+    /// is never reported for a detached process.
     pub fn detach(&self) {
-        if let Ownership::Owned { detach, detached } = &self.ownership {
-            detached.store(true, Ordering::Release);
-            let tx = detach.lock().unwrap_or_else(|e| e.into_inner()).take();
-            if let Some(tx) = tx {
-                let _ = tx.send(());
-            }
+        self.detached.store(true, Ordering::Release);
+        let tx = self
+            .stand_down
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take();
+        if let Some(tx) = tx {
+            let _ = tx.send(());
         }
     }
 
-    /// `true` after [`detach`](Self::detach) (always `false` for an
-    /// adopted process, which was never owned).
+    /// `true` after [`detach`](Self::detach).
     pub fn is_detached(&self) -> bool {
-        match &self.ownership {
-            Ownership::Owned { detached, .. } => detached.load(Ordering::Acquire),
-            Ownership::Adopted => false,
-        }
+        self.detached.load(Ordering::Acquire)
     }
 
     fn signal(&self, signal: Signal) -> Result<()> {
@@ -291,7 +298,7 @@ async fn waiter<C: Vmm>(
     child: C,
     exit: watch::Sender<Option<ExitStatus>>,
     events: broadcast::Sender<VmEvent>,
-    mut detach: oneshot::Receiver<()>,
+    mut stand_down: oneshot::Receiver<()>,
 ) {
     let mut held = Held {
         child: Some(child),
@@ -303,7 +310,7 @@ async fn waiter<C: Vmm>(
         tokio::pin!(wait);
         tokio::select! {
             status = &mut wait => Some(status),
-            _ = &mut detach => None,
+            _ = &mut stand_down => None,
         }
     };
     match outcome {
@@ -312,6 +319,27 @@ async fn waiter<C: Vmm>(
         }
         None => {
             held.detached = true;
+        }
+    }
+}
+
+/// Watches an adopted pid every [`PROBE_INTERVAL`] and publishes
+/// [`UNKNOWN_EXIT`] once it is gone; told to stand down by `detach`, or by
+/// the process value being dropped (the sender goes with it).
+async fn prober(
+    pid: u32,
+    exit: watch::Sender<Option<ExitStatus>>,
+    events: broadcast::Sender<VmEvent>,
+    mut stand_down: oneshot::Receiver<()>,
+) {
+    loop {
+        tokio::select! {
+            _ = &mut stand_down => return,
+            () = tokio::time::sleep(PROBE_INTERVAL) => {}
+        }
+        if !probe_alive(pid) {
+            publish(&exit, &events, UNKNOWN_EXIT);
+            return;
         }
     }
 }
@@ -440,17 +468,58 @@ mod tests {
         let process = FcProcess::adopt(child.id().unwrap(), PathBuf::from("/tmp/api.sock"));
         assert!(process.alive());
         assert!(!process.is_detached());
+        let mut events = process.events();
         // Killed out from under us and reaped by its real parent, the probe
-        // sees it gone and records an unknown exit — once.
+        // sees it gone and records an unknown exit — once, whether the
+        // on-demand probe or the prober task gets there first.
         child.kill().await.unwrap();
         child.wait().await.unwrap();
-        let mut events = process.events();
         assert_eq!(process.exit_status(), Some(UNKNOWN_EXIT));
         assert!(!process.alive());
-        assert_eq!(events.try_recv().unwrap(), VmEvent::Exited(UNKNOWN_EXIT));
+        assert_eq!(events.recv().await.unwrap(), VmEvent::Exited(UNKNOWN_EXIT));
         assert_eq!(process.exit_status(), Some(UNKNOWN_EXIT));
+        tokio::time::sleep(PROBE_INTERVAL * 2).await;
         assert!(events.try_recv().is_err(), "the exit is recorded once");
         assert_eq!(process.kill().await.unwrap(), UNKNOWN_EXIT);
+    }
+
+    #[tokio::test]
+    async fn an_adopted_process_wakes_its_subscribers_when_it_dies_on_its_own() {
+        let mut child = tokio::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let process = FcProcess::adopt(child.id().unwrap(), PathBuf::from("/tmp/api.sock"));
+        let mut events = process.events();
+        let mut exit = process.subscribe();
+        child.kill().await.unwrap();
+        child.wait().await.unwrap();
+        // Nobody asks `exit_status`; the prober alone must deliver.
+        let event = tokio::time::timeout(Duration::from_secs(5), events.recv())
+            .await
+            .expect("the prober publishes the exit")
+            .unwrap();
+        assert_eq!(event, VmEvent::Exited(UNKNOWN_EXIT));
+        assert!(exit.has_changed().unwrap());
+        assert_eq!(*exit.borrow_and_update(), Some(UNKNOWN_EXIT));
+    }
+
+    #[tokio::test]
+    async fn detach_releases_an_adopted_process_too() {
+        let mut child = tokio::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let process = FcProcess::adopt(child.id().unwrap(), PathBuf::from("/tmp/api.sock"));
+        process.detach();
+        assert!(process.is_detached());
+        // Once released, the process is neither killed nor observed here.
+        let mut events = process.events();
+        child.kill().await.unwrap();
+        child.wait().await.unwrap();
+        tokio::time::sleep(PROBE_INTERVAL * 2).await;
+        assert!(process.alive(), "a detached process is not observed");
+        assert!(events.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/virt/arcbox-fc-driver/src/process.rs
+++ b/virt/arcbox-fc-driver/src/process.rs
@@ -1,0 +1,345 @@
+//! The VMM process guard: one owner of the child, an exit everyone can
+//! observe, and kill / wait / detach that never race the reaper.
+//!
+//! A spawned process is handed to one waiter task that owns the `fc-sdk`
+//! handle and reaps the child the moment it exits, publishing the status on
+//! a `watch` (state) and a `broadcast` (the port's `Exited` event, once).
+//! Everyone else — the prepared VM, the handle, the driver — holds an
+//! [`FcProcess`] and only ever reads the exit, signals the pid, or waits
+//! on the watch. Because the waiter reaps eagerly, "alive" is answered
+//! from the watch, never from the pid: a reaped pid is never probed or
+//! signalled again. An adopted process (no child to wait on) is the one
+//! exception, tracked by probing `/proc` until it is seen gone.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use arcbox_vm_driver::{ExitStatus, VmEvent};
+use nix::sys::signal::{Signal, kill};
+use nix::unistd::Pid;
+use tokio::sync::{broadcast, oneshot, watch};
+
+use crate::error::{FcError, Result};
+
+/// How long `kill` waits for the reaper after `SIGKILL` before giving up
+/// and reporting [`FcError::ReapTimeout`] — the caller keeps its handle and
+/// may retry.
+pub const REAP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How often an adopted process is probed while waiting for it to exit.
+const PROBE_INTERVAL: Duration = Duration::from_millis(100);
+
+/// The exit status recorded for a process whose real status was never
+/// observed: an adopted VMM that vanished, or a `wait` that failed.
+pub const UNKNOWN_EXIT: ExitStatus = ExitStatus {
+    code: None,
+    signal: None,
+};
+
+/// A spawned VMM child the waiter task can own: `fc-sdk`'s process handle
+/// in production, a plain `tokio` child in tests.
+pub trait Vmm: Send + 'static {
+    /// The child's pid, when the spawn reported one.
+    fn pid(&self) -> Option<u32>;
+    /// Wait for the child to exit and reap it.
+    fn wait(&mut self) -> impl std::future::Future<Output = ExitStatus> + Send;
+    /// Give the child up without killing it.
+    fn release(self);
+}
+
+impl Vmm for fc_sdk::FirecrackerProcess {
+    fn pid(&self) -> Option<u32> {
+        Self::pid(self)
+    }
+
+    async fn wait(&mut self) -> ExitStatus {
+        match Self::wait(self).await {
+            Ok(Some(status)) => status.into(),
+            Ok(None) | Err(_) => UNKNOWN_EXIT,
+        }
+    }
+
+    fn release(self) {
+        // The detached handle keeps nothing that would kill on drop.
+        drop(self.detach());
+    }
+}
+
+/// A live VMM process shared by everything that refers to it.
+pub struct FcProcess {
+    pid: u32,
+    api_socket: PathBuf,
+    exit: watch::Sender<Option<ExitStatus>>,
+    events: broadcast::Sender<VmEvent>,
+    ownership: Ownership,
+}
+
+enum Ownership {
+    /// A waiter task owns the child; `detach` tells it to release.
+    Owned {
+        detach: Mutex<Option<oneshot::Sender<()>>>,
+        detached: AtomicBool,
+    },
+    /// Found running; nobody here can reap it, so its exit is inferred by
+    /// probing the pid.
+    Adopted,
+}
+
+impl FcProcess {
+    /// Take ownership of a spawned child: a waiter task reaps it and
+    /// publishes its exit.
+    ///
+    /// Fails when the spawn reported no pid — the caller has nothing to
+    /// signal and must not keep the process.
+    pub fn spawn<C: Vmm>(child: C, api_socket: PathBuf) -> Result<Self> {
+        let pid = child.pid().ok_or(FcError::NoPid)?;
+        let (exit, _) = watch::channel(None);
+        let (events, _) = broadcast::channel(16);
+        let (detach_tx, detach_rx) = oneshot::channel();
+        let process = Self {
+            pid,
+            api_socket,
+            exit: exit.clone(),
+            events: events.clone(),
+            ownership: Ownership::Owned {
+                detach: Mutex::new(Some(detach_tx)),
+                detached: AtomicBool::new(false),
+            },
+        };
+        tokio::spawn(waiter(child, exit, events, detach_rx));
+        Ok(process)
+    }
+
+    /// Track a process this crate did not spawn.
+    pub fn adopt(pid: u32, api_socket: PathBuf) -> Self {
+        let (exit, _) = watch::channel(None);
+        let (events, _) = broadcast::channel(16);
+        Self {
+            pid,
+            api_socket,
+            exit,
+            events,
+            ownership: Ownership::Adopted,
+        }
+    }
+
+    /// The VMM's pid.
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    /// The Firecracker API socket, as the host connects to it.
+    pub fn api_socket(&self) -> &Path {
+        &self.api_socket
+    }
+
+    /// How the process ended, once it has. An adopted process is probed
+    /// here; the first probe that finds it gone records [`UNKNOWN_EXIT`].
+    pub fn exit_status(&self) -> Option<ExitStatus> {
+        let recorded = *self.exit.borrow();
+        if let Some(status) = recorded {
+            return Some(status);
+        }
+        if matches!(self.ownership, Ownership::Adopted) && !probe_alive(self.pid) {
+            return Some(publish(&self.exit, &self.events, UNKNOWN_EXIT));
+        }
+        None
+    }
+
+    /// `true` until the exit has been observed; never flips back.
+    pub fn alive(&self) -> bool {
+        self.exit_status().is_none()
+    }
+
+    /// The port's event stream: `Exited` once, when the process ends.
+    pub fn events(&self) -> broadcast::Receiver<VmEvent> {
+        self.events.subscribe()
+    }
+
+    /// A watch that flips to `Some` when the process exits.
+    pub fn subscribe(&self) -> watch::Receiver<Option<ExitStatus>> {
+        self.exit.subscribe()
+    }
+
+    /// Wait up to `timeout` for the exit; `None` if it did not come.
+    pub async fn wait(&self, timeout: Duration) -> Option<ExitStatus> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut rx = self.exit.subscribe();
+        loop {
+            if let Some(status) = self.exit_status() {
+                return Some(status);
+            }
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return None;
+            }
+            match self.ownership {
+                Ownership::Owned { .. } => {
+                    if tokio::time::timeout(remaining, rx.changed()).await.is_err() {
+                        return None;
+                    }
+                }
+                Ownership::Adopted => {
+                    tokio::time::sleep(remaining.min(PROBE_INTERVAL)).await;
+                }
+            }
+        }
+    }
+
+    /// `SIGKILL` the process unless it already exited, then wait for the
+    /// reaper up to [`REAP_TIMEOUT`]. Idempotent: an exited process just
+    /// reports its status.
+    pub async fn kill(&self) -> Result<ExitStatus> {
+        if let Some(status) = self.exit_status() {
+            return Ok(status);
+        }
+        self.signal(Signal::SIGKILL)?;
+        self.wait(REAP_TIMEOUT)
+            .await
+            .ok_or(FcError::ReapTimeout { pid: self.pid })
+    }
+
+    /// Best-effort `SIGKILL` for drop paths: no wait, no error.
+    pub fn kill_now(&self) {
+        if self.exit_status().is_none() {
+            let _ = self.signal(Signal::SIGKILL);
+        }
+    }
+
+    /// Release the child: nothing here kills it any more, and the waiter
+    /// stops reaping. `Exited` is never reported for a detached process.
+    pub fn detach(&self) {
+        if let Ownership::Owned { detach, detached } = &self.ownership {
+            detached.store(true, Ordering::Release);
+            let tx = detach.lock().unwrap_or_else(|e| e.into_inner()).take();
+            if let Some(tx) = tx {
+                let _ = tx.send(());
+            }
+        }
+    }
+
+    /// `true` after [`detach`](Self::detach) (always `false` for an
+    /// adopted process, which was never owned).
+    pub fn is_detached(&self) -> bool {
+        match &self.ownership {
+            Ownership::Owned { detached, .. } => detached.load(Ordering::Acquire),
+            Ownership::Adopted => false,
+        }
+    }
+
+    fn signal(&self, signal: Signal) -> Result<()> {
+        #[allow(
+            clippy::cast_possible_wrap,
+            reason = "Firecracker pid fits platform pid_t"
+        )]
+        match kill(Pid::from_raw(self.pid as i32), signal) {
+            Ok(()) | Err(nix::errno::Errno::ESRCH) => Ok(()),
+            Err(source) => Err(FcError::Kill {
+                pid: self.pid,
+                source,
+            }),
+        }
+    }
+}
+
+/// Records `status` unless an exit was already recorded, and returns the
+/// one that stands; the `Exited` event is sent for the first only.
+fn publish(
+    exit: &watch::Sender<Option<ExitStatus>>,
+    events: &broadcast::Sender<VmEvent>,
+    status: ExitStatus,
+) -> ExitStatus {
+    let mut first = None;
+    exit.send_if_modified(|slot| {
+        if slot.is_some() {
+            return false;
+        }
+        *slot = Some(status);
+        first = Some(status);
+        true
+    });
+    match first {
+        Some(status) => {
+            // A send error only means nobody is subscribed.
+            let _ = events.send(VmEvent::Exited(status));
+            status
+        }
+        None => exit.borrow().unwrap_or(UNKNOWN_EXIT),
+    }
+}
+
+/// The child, held so a task dropped mid-wait releases a detached child
+/// instead of letting the handle's own drop kill it.
+struct Held<C: Vmm> {
+    child: Option<C>,
+    detached: bool,
+}
+
+impl<C: Vmm> Drop for Held<C> {
+    fn drop(&mut self) {
+        if self.detached
+            && let Some(child) = self.child.take()
+        {
+            child.release();
+        }
+    }
+}
+
+async fn waiter<C: Vmm>(
+    child: C,
+    exit: watch::Sender<Option<ExitStatus>>,
+    events: broadcast::Sender<VmEvent>,
+    mut detach: oneshot::Receiver<()>,
+) {
+    let mut held = Held {
+        child: Some(child),
+        detached: false,
+    };
+    let outcome = {
+        let child = held.child.as_mut().expect("held until the task ends");
+        let wait = child.wait();
+        tokio::pin!(wait);
+        tokio::select! {
+            status = &mut wait => Some(status),
+            _ = &mut detach => None,
+        }
+    };
+    match outcome {
+        Some(status) => {
+            publish(&exit, &events, status);
+        }
+        None => {
+            held.detached = true;
+        }
+    }
+}
+
+/// `true` while `pid` names a live, unreaped process (a zombie counts as
+/// gone on Linux, where its state is readable).
+fn probe_alive(pid: u32) -> bool {
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "Firecracker pid fits platform pid_t"
+    )]
+    if kill(Pid::from_raw(pid as i32), None).is_err() {
+        return false;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // The state letter is the field after the parenthesized comm; comm
+        // may itself contain spaces or parens, so split at the LAST ')'.
+        match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+            Ok(stat) => stat
+                .rsplit_once(')')
+                .and_then(|(_, rest)| rest.split_whitespace().next())
+                .is_some_and(|state| state != "Z" && state != "X"),
+            Err(_) => false,
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        true
+    }
+}

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -293,8 +293,10 @@ pub fn fc_config(spec: &VmSpec, config: &FcDriverConfig, runtime_dir: &Path) -> 
 /// isolation ([`Error::InvalidSpec`], see [`require_jailed_restore`]).
 /// A snapshot load reopens the disk paths the checkpoint recorded — inside
 /// the new jail, where the plan stages this restore's disks under the same
-/// names — so the load is rendered paused and the caller points each drive
-/// at [`FcRestorePlan::drives`] before resuming.
+/// names, `/{id}.ext4`, aliasing a disk that already sits in the jail
+/// elsewhere ([`FcRestorePlan::aliases`]) — so the load is rendered paused
+/// and the caller points each drive at [`FcRestorePlan::drives`] before
+/// resuming and drops the aliases.
 pub fn fc_restore(
     image: &CheckpointImage,
     spec: &RestoreSpec,
@@ -332,10 +334,31 @@ pub fn fc_restore(
         StageKind::LinkOrCopy,
         &mut stage,
     )?;
+    let mut aliases = Vec::new();
     let drives = spec
         .disks
         .iter()
-        .map(|disk| drive(&layout, disk, &mut stage))
+        .map(|disk| {
+            let drive = drive(&layout, disk, &mut stage)?;
+            // The load reopens each drive at the name the checkpoint
+            // recorded — `/{id}.ext4`, where this driver stages a disk. A
+            // disk that already sits in the jail under another name gets
+            // that name too, for the load; the drive is then pointed at the
+            // disk itself and the alias goes.
+            if let Some(jail) = &layout.jail
+                && let Some(view) = jail.view(&disk.path)
+                && view != recorded_name(disk)
+            {
+                let alias = jail.root.join(recorded_file(disk));
+                stage.push(StagePlan {
+                    src: disk.path.clone(),
+                    dst: alias.clone(),
+                    kind: StageKind::Alias,
+                });
+                aliases.push(alias);
+            }
+            Ok(drive)
+        })
         .collect::<Result<Vec<_>>>()?;
     let network_overrides = spec
         .nics
@@ -360,7 +383,19 @@ pub fn fc_restore(
             network_overrides,
         },
         drives,
+        aliases,
     })
+}
+
+/// The file a disk is staged as inside the jail, and so the name a
+/// checkpoint of this driver records for it: `{id}.ext4`.
+fn recorded_file(disk: &DiskSpec) -> String {
+    format!("{}.ext4", disk.id)
+}
+
+/// [`recorded_file`] as Firecracker names it: `/{id}.ext4`.
+fn recorded_name(disk: &DiskSpec) -> String {
+    format!("/{}", recorded_file(disk))
 }
 
 /// Checkpoints are a jailer-mode capability.
@@ -397,7 +432,7 @@ fn drive(layout: &VmLayout, disk: &DiskSpec, stage: &mut Vec<StagePlan>) -> Resu
         Some(_) if disk.read_only => StageKind::LinkOrCopy,
         Some(_) => StageKind::Copy,
     };
-    let path_on_host = layout.place(&disk.path, &format!("{}.ext4", disk.id), kind, stage)?;
+    let path_on_host = layout.place(&disk.path, &recorded_file(disk), kind, stage)?;
     Ok(Drive {
         drive_id: disk.id.clone(),
         path_on_host: Some(path_on_host),

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -154,6 +154,7 @@ impl VmLayout {
         SpawnPlan {
             id: self.id.clone(),
             api_socket: self.api_socket(),
+            vsock_uds: self.vsock_host_uds(),
             mode,
         }
     }

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -1,14 +1,169 @@
 //! From the port's specs to what Firecracker is told.
 //!
-//! The plans a render produces — the process to spawn ([`SpawnPlan`]), the
-//! files a jail needs staged first ([`StagePlan`], executed by
-//! [`jail::apply`](crate::jail::apply)), and the API payloads for a boot
-//! ([`FcPlan`]) or a restore ([`FcRestorePlan`]). The renderer itself, the
-//! one place that decides which path Firecracker sees for every host file,
-//! follows.
+//! One decision lives here and nowhere else: which path Firecracker sees
+//! for every host file. Without a jail, paths pass through verbatim. Under
+//! the jailer, Firecracker is chrooted into
+//! `{chroot_base}/{firecracker binary name}/{id}/root` and every path it
+//! is told is chroot-relative: a host path already under the jail is passed
+//! as `/` + its relative part; anything else is staged in first and named
+//! by where it landed. [`VmLayout`] is that map; the renderers that use it
+//! to produce an [`FcPlan`] / [`FcRestorePlan`] follow, and
+//! [`jail::apply`] executes the staging half.
+
+use std::path::{Path, PathBuf};
+
+use arcbox_vm_driver::{Error, IsolationSpec, Result, VmId};
+
+use crate::NAME;
+use crate::config::FcDriverConfig;
+use crate::jail;
 
 mod plan;
+#[cfg(test)]
+mod tests;
 
 pub use plan::{FcPlan, FcRestorePlan, SpawnMode, SpawnPlan, StageKind, StagePlan};
 
 pub use crate::jail::Jail;
+
+/// The vsock socket name, in the runtime dir (direct) or `run/` (jail).
+const VSOCK_NAME: &str = "firecracker.vsock";
+
+/// Where a VM's files live from the host's and Firecracker's points of
+/// view: the runtime dir, the jail if any, and the sockets in them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VmLayout {
+    id: VmId,
+    runtime_dir: PathBuf,
+    isolation: IsolationSpec,
+    jail: Option<Jail>,
+}
+
+impl VmLayout {
+    /// The layout of VM `id` confined by `isolation`, with `runtime_dir` as
+    /// its private scratch space.
+    pub fn new(
+        id: &VmId,
+        isolation: &IsolationSpec,
+        config: &FcDriverConfig,
+        runtime_dir: &Path,
+    ) -> Result<Self> {
+        let jail = match isolation {
+            IsolationSpec::None => None,
+            IsolationSpec::Jailer {
+                uid,
+                gid,
+                chroot_base,
+                ..
+            } => Some(Jail {
+                root: jail::chroot_root(&config.firecracker_binary, chroot_base, id.as_str()),
+                uid: *uid,
+                gid: *gid,
+            }),
+            other => {
+                return Err(Error::InvalidSpec(format!(
+                    "{NAME}: unsupported isolation {other:?}"
+                )));
+            }
+        };
+        Ok(Self {
+            id: id.clone(),
+            runtime_dir: runtime_dir.to_path_buf(),
+            isolation: isolation.clone(),
+            jail,
+        })
+    }
+
+    /// The VM.
+    pub fn id(&self) -> &VmId {
+        &self.id
+    }
+
+    /// The per-VM scratch directory the driver was given.
+    pub fn runtime_dir(&self) -> &Path {
+        &self.runtime_dir
+    }
+
+    /// The confinement the layout was built for.
+    pub fn isolation(&self) -> &IsolationSpec {
+        &self.isolation
+    }
+
+    /// The jail, when the VM runs under the jailer.
+    pub fn jail(&self) -> Option<&Jail> {
+        self.jail.as_ref()
+    }
+
+    /// The Firecracker API socket, as the host connects to it.
+    pub fn api_socket(&self) -> PathBuf {
+        match &self.jail {
+            Some(jail) => jail::api_socket_path(&jail.root),
+            None => self.runtime_dir.join("firecracker.sock"),
+        }
+    }
+
+    /// The hybrid-vsock Unix socket, as the host dials it.
+    pub fn vsock_host_uds(&self) -> PathBuf {
+        match &self.jail {
+            Some(jail) => jail::vsock_uds_path(&jail.root),
+            None => self.runtime_dir.join(VSOCK_NAME),
+        }
+    }
+
+    /// The hybrid-vsock Unix socket, as Firecracker is told to bind it.
+    pub fn vsock_fc_uds(&self) -> Result<String> {
+        match &self.jail {
+            Some(_) => Ok(jail::VSOCK_UDS_IN_JAIL.to_owned()),
+            None => utf8(&self.runtime_dir.join(VSOCK_NAME)),
+        }
+    }
+
+    /// The process to spawn for this VM.
+    pub fn spawn_plan(&self) -> SpawnPlan {
+        let mode = match &self.jail {
+            Some(jail) => SpawnMode::Jailer {
+                isolation: self.isolation.clone(),
+                jail_root: jail.root.clone(),
+            },
+            None => SpawnMode::Direct {
+                log: self.runtime_dir.join("firecracker.log"),
+                metrics: self.runtime_dir.join("firecracker.metrics"),
+            },
+        };
+        SpawnPlan {
+            id: self.id.clone(),
+            api_socket: self.api_socket(),
+            mode,
+        }
+    }
+
+    /// The path Firecracker is told for `host`, and the staging that makes
+    /// it true: verbatim without a jail; `/` + relative when already inside
+    /// the jail; otherwise staged to `/{in_jail}` by `kind`.
+    pub fn place(
+        &self,
+        host: &Path,
+        in_jail: &str,
+        kind: StageKind,
+        stage: &mut Vec<StagePlan>,
+    ) -> Result<String> {
+        let Some(jail) = &self.jail else {
+            return utf8(host);
+        };
+        if let Some(view) = jail.view(host) {
+            return Ok(view);
+        }
+        stage.push(StagePlan {
+            src: host.to_path_buf(),
+            dst: jail.root.join(in_jail),
+            kind,
+        });
+        Ok(format!("/{in_jail}"))
+    }
+}
+
+fn utf8(path: &Path) -> Result<String> {
+    path.to_str()
+        .map(str::to_owned)
+        .ok_or_else(|| Error::InvalidSpec(format!("{NAME}: path {} is not UTF-8", path.display())))
+}

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -1,21 +1,33 @@
 //! From the port's specs to what Firecracker is told.
 //!
-//! One decision lives here and nowhere else: which path Firecracker sees
-//! for every host file. Without a jail, paths pass through verbatim. Under
-//! the jailer, Firecracker is chrooted into
+//! Two pure decisions live here and nowhere else: which API payloads a
+//! [`VmSpec`] becomes, and which path Firecracker sees for every host
+//! file. Without a jail, paths pass through verbatim. Under the
+//! jailer, Firecracker is chrooted into
 //! `{chroot_base}/{firecracker binary name}/{id}/root` and every path it
 //! is told is chroot-relative: a host path already under the jail is passed
-//! as `/` + its relative part; anything else is staged in first and named
-//! by where it landed. [`VmLayout`] is that map; the renderers that use it
-//! to produce an [`FcPlan`] / [`FcRestorePlan`] follow, and
-//! [`jail::apply`] executes the staging half.
+//! as `/` + its relative part; anything else is staged in first — the
+//! kernel to `/vmlinux`, a disk `id` to `/{id}.ext4`, a checkpoint to
+//! `/snapshots/{image dir name}/{vmstate,mem}` — and named by where it
+//! landed. [`VmLayout`] is that map; [`fc_config`] uses it to produce a
+//! boot plan (the restore renderer follows), and [`jail::apply`] executes
+//! the staging half.
 
+use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
 
-use arcbox_vm_driver::{Error, IsolationSpec, Result, VmId};
+use arcbox_vm_driver::{
+    BootSpec, CacheMode, ConsoleSpec, DiskSpec, Error, IsolationSpec, NicAttachment, NicSpec,
+    Result, VmId, VmSpec,
+};
+use fc_sdk::types::{
+    BootSource, Drive, DriveCacheType, DriveIoEngine, EntropyDevice, MachineConfiguration,
+    NetworkInterface, Vsock,
+};
 
 use crate::NAME;
 use crate::config::FcDriverConfig;
+use crate::error::FcError;
 use crate::jail;
 
 mod plan;
@@ -162,8 +174,148 @@ impl VmLayout {
     }
 }
 
+/// Renders a boot: the API payloads for `spec` and the files a jail needs
+/// staged first.
+///
+/// Refuses, with [`Error::InvalidSpec`], what Firecracker cannot do or this
+/// driver does not expose: firmware and macOS boots, non-TAP NICs, console
+/// files and sockets, virtiofs shares, the balloon.
+pub fn fc_config(spec: &VmSpec, config: &FcDriverConfig, runtime_dir: &Path) -> Result<FcPlan> {
+    spec.validate()?;
+    let layout = VmLayout::new(&spec.id, &spec.isolation, config, runtime_dir)?;
+    if spec.console != ConsoleSpec::Off {
+        return Err(unsupported(
+            "console output is not exposed; use ConsoleSpec::Off",
+        ));
+    }
+    if !spec.shares.is_empty() {
+        return Err(unsupported("virtiofs shares are not available"));
+    }
+    if spec.balloon {
+        return Err(unsupported("the balloon is not exposed"));
+    }
+
+    let mut stage = Vec::new();
+    let boot_source = match &spec.boot {
+        BootSpec::Kernel {
+            image,
+            cmdline,
+            initrd,
+        } => BootSource {
+            kernel_image_path: layout.place(image, "vmlinux", StageKind::LinkOrCopy, &mut stage)?,
+            boot_args: Some(cmdline.clone()),
+            initrd_path: initrd
+                .as_deref()
+                .map(|initrd| layout.place(initrd, "initrd", StageKind::LinkOrCopy, &mut stage))
+                .transpose()?,
+        },
+        other => {
+            return Err(unsupported(&format!(
+                "only direct kernel boots are supported, not {other:?}"
+            )));
+        }
+    };
+    let drives = spec
+        .disks
+        .iter()
+        .map(|disk| drive(&layout, disk, &mut stage))
+        .collect::<Result<Vec<_>>>()?;
+    let nics = spec
+        .nics
+        .iter()
+        .map(network_interface)
+        .collect::<Result<Vec<_>>>()?;
+    let vsock = spec
+        .vsock
+        .map(|vsock| {
+            Ok::<_, Error>(Vsock {
+                guest_cid: i64::from(vsock.guest_cid),
+                uds_path: layout.vsock_fc_uds()?,
+                vsock_id: None,
+            })
+        })
+        .transpose()?;
+    Ok(FcPlan {
+        stage,
+        boot_source,
+        machine: MachineConfiguration {
+            vcpu_count: NonZeroU64::new(u64::from(spec.cpus))
+                .ok_or_else(|| Error::InvalidSpec("cpus must be at least 1".into()))?,
+            mem_size_mib: i64::from(spec.memory_mib),
+            smt: false,
+            track_dirty_pages: spec.dirty_tracking,
+            cpu_template: None,
+            huge_pages: None,
+        },
+        drives,
+        nics,
+        vsock_host_uds: vsock.is_some().then(|| layout.vsock_host_uds()),
+        vsock,
+        entropy: spec.entropy.then_some(EntropyDevice { rate_limiter: None }),
+    })
+}
+
+fn drive(layout: &VmLayout, disk: &DiskSpec, stage: &mut Vec<StagePlan>) -> Result<Drive> {
+    let kind = match &layout.jail {
+        // Verbatim, or already inside the jail: nothing is staged.
+        None => StageKind::Copy,
+        Some(jail) if jail.view(&disk.path).is_some() => StageKind::Copy,
+        Some(_) if is_block_device(&disk.path)? => StageKind::BlockNode,
+        Some(_) if disk.read_only => StageKind::LinkOrCopy,
+        Some(_) => StageKind::Copy,
+    };
+    let path_on_host = layout.place(&disk.path, &format!("{}.ext4", disk.id), kind, stage)?;
+    Ok(Drive {
+        drive_id: disk.id.clone(),
+        path_on_host: Some(path_on_host),
+        is_root_device: disk.root,
+        is_read_only: Some(disk.read_only),
+        partuuid: None,
+        cache_type: match disk.cache {
+            CacheMode::Unsafe => DriveCacheType::Unsafe,
+            CacheMode::Writeback => DriveCacheType::Writeback,
+        },
+        rate_limiter: None,
+        io_engine: DriveIoEngine::Sync,
+        socket: None,
+    })
+}
+
+fn network_interface(nic: &NicSpec) -> Result<NetworkInterface> {
+    Ok(NetworkInterface {
+        iface_id: nic.id.clone(),
+        guest_mac: Some(nic.mac.to_string()),
+        host_dev_name: tap_name(nic)?,
+        rx_rate_limiter: None,
+        tx_rate_limiter: None,
+    })
+}
+
+fn tap_name(nic: &NicSpec) -> Result<String> {
+    match &nic.attachment {
+        NicAttachment::Tap { name } => Ok(name.clone()),
+        other => Err(unsupported(&format!(
+            "nic `{}`: only TAP attachments are supported, not {other:?}",
+            nic.id
+        ))),
+    }
+}
+
+fn is_block_device(path: &Path) -> Result<bool> {
+    use std::os::unix::fs::FileTypeExt as _;
+    let metadata = std::fs::metadata(path).map_err(|source| FcError::Stat {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    Ok(metadata.file_type().is_block_device())
+}
+
 fn utf8(path: &Path) -> Result<String> {
     path.to_str()
         .map(str::to_owned)
         .ok_or_else(|| Error::InvalidSpec(format!("{NAME}: path {} is not UTF-8", path.display())))
+}
+
+fn unsupported(what: &str) -> Error {
+    Error::InvalidSpec(format!("{NAME}: {what}"))
 }

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -423,6 +423,13 @@ fn is_inside_jail(path: &str) -> bool {
         && components.all(|component| matches!(component, std::path::Component::Normal(_)))
 }
 
+/// Whether `path` is a block device — the one thing rendering cannot decide
+/// from the spec alone.
+///
+/// A `stat` inside an otherwise pure function, deliberately: rendering is
+/// synchronous so its rules can be unit-tested as values, and moving the
+/// probe into the staging executor would move a path decision out of this
+/// module, which is the one place they are made.
 fn is_block_device(path: &Path) -> Result<bool> {
     use std::os::unix::fs::FileTypeExt as _;
     let metadata = std::fs::metadata(path).map_err(|source| FcError::Stat {

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -59,6 +59,12 @@ impl VmLayout {
         config: &FcDriverConfig,
         runtime_dir: &Path,
     ) -> Result<Self> {
+        // The id is a directory name here — the jail is `{base}/{exec}/{id}/
+        // root` — and the port allows dots in it, so `.` and `..` would name
+        // another VM's jail, or the base itself.
+        if !is_plain_component(id.as_str()) {
+            return Err(unsupported(&format!("vm id `{id}` must be a plain name")));
+        }
         let jail = match isolation {
             IsolationSpec::None => None,
             IsolationSpec::Jailer {

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -1,0 +1,14 @@
+//! From the port's specs to what Firecracker is told.
+//!
+//! The plans a render produces — the process to spawn ([`SpawnPlan`]), the
+//! files a jail needs staged first ([`StagePlan`], executed by
+//! [`jail::apply`](crate::jail::apply)), and the API payloads for a boot
+//! ([`FcPlan`]) or a restore ([`FcRestorePlan`]). The renderer itself, the
+//! one place that decides which path Firecracker sees for every host file,
+//! follows.
+
+mod plan;
+
+pub use plan::{FcPlan, FcRestorePlan, SpawnMode, SpawnPlan, StageKind, StagePlan};
+
+pub use crate::jail::Jail;

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -128,13 +128,13 @@ impl VmLayout {
         }
     }
 
-    /// The host view of a vsock socket path Firecracker reports (`GET
-    /// /vm/config`, which is what a restored or adopted VM actually bound):
+    /// The host view of a path Firecracker reports (`GET /vm/config` after
+    /// a restore or on adopt — a vsock socket it bound, a disk it opened):
     /// jail-relative under a jail, verbatim otherwise.
-    pub fn vsock_host_view(&self, fc_uds: &str) -> PathBuf {
+    pub fn host_view(&self, fc_path: &str) -> PathBuf {
         match &self.jail {
-            Some(jail) => jail.root.join(fc_uds.trim_start_matches('/')),
-            None => PathBuf::from(fc_uds),
+            Some(jail) => jail.root.join(fc_path.trim_start_matches('/')),
+            None => PathBuf::from(fc_path),
         }
     }
 
@@ -289,10 +289,12 @@ pub fn fc_config(spec: &VmSpec, config: &FcDriverConfig, runtime_dir: &Path) -> 
 /// as Firecracker must see them once the image is loaded.
 ///
 /// Refuses a format this driver did not write
-/// ([`Error::ForeignCheckpoint`]) and a diff image ([`Error::InvalidSpec`]).
-/// A snapshot load reopens the disk paths the checkpoint recorded, which
-/// are never this restore's — so the load is rendered paused and the caller
-/// points each drive at [`FcRestorePlan::drives`] before resuming.
+/// ([`Error::ForeignCheckpoint`]), a diff image, and a spec without jailer
+/// isolation ([`Error::InvalidSpec`], see [`require_jailed_restore`]).
+/// A snapshot load reopens the disk paths the checkpoint recorded — inside
+/// the new jail, where the plan stages this restore's disks under the same
+/// names — so the load is rendered paused and the caller points each drive
+/// at [`FcRestorePlan::drives`] before resuming.
 pub fn fc_restore(
     image: &CheckpointImage,
     spec: &RestoreSpec,
@@ -305,6 +307,7 @@ pub fn fc_restore(
     if image.kind != CheckpointKind::Full {
         return Err(unsupported("diff checkpoints are not restored"));
     }
+    require_jailed_restore(&spec.isolation)?;
     let layout = VmLayout::new(&spec.id, &spec.isolation, config, runtime_dir)?;
     let name = image
         .dir
@@ -358,6 +361,23 @@ pub fn fc_restore(
         },
         drives,
     })
+}
+
+/// Checkpoints are a jailer-mode capability.
+///
+/// `PUT /snapshot/load` reopens every drive at the path the checkpoint
+/// recorded, with no override, so a restored VM can be given other disks
+/// only where that path is private to it — inside a per-VM chroot, where
+/// this driver stages them under the recorded names. Without a jail the
+/// recorded paths are the source VM's own host paths, shared with it, and a
+/// restore is refused.
+pub fn require_jailed_restore(isolation: &IsolationSpec) -> Result<()> {
+    match isolation {
+        IsolationSpec::Jailer { .. } => Ok(()),
+        _ => Err(unsupported(
+            "restore needs jailer isolation: Firecracker reopens the recorded drive paths on load",
+        )),
+    }
 }
 
 fn drive(layout: &VmLayout, disk: &DiskSpec, stage: &mut Vec<StagePlan>) -> Result<Drive> {

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -60,8 +60,9 @@ impl VmLayout {
         runtime_dir: &Path,
     ) -> Result<Self> {
         // The id is a directory name here — the jail is `{base}/{exec}/{id}/
-        // root` — and the port allows dots in it, so `.` and `..` would name
-        // another VM's jail, or the base itself.
+        // root` — so `.` and `..` would name another VM's jail, or the base
+        // itself. The port refuses them at the id; a layout is built from
+        // whatever id it is handed, so the same rule is checked here too.
         if !is_plain_component(id.as_str()) {
             return Err(unsupported(&format!("vm id `{id}` must be a plain name")));
         }

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -1,34 +1,33 @@
 //! From the port's specs to what Firecracker is told.
 //!
 //! Two pure decisions live here and nowhere else: which API payloads a
-//! [`VmSpec`] becomes, and which path Firecracker sees for every host
-//! file. Without a jail, paths pass through verbatim. Under the
+//! [`VmSpec`] / [`RestoreSpec`] becomes, and which path Firecracker sees for
+//! every host file. Without a jail, paths pass through verbatim. Under the
 //! jailer, Firecracker is chrooted into
 //! `{chroot_base}/{firecracker binary name}/{id}/root` and every path it
 //! is told is chroot-relative: a host path already under the jail is passed
 //! as `/` + its relative part; anything else is staged in first — the
 //! kernel to `/vmlinux`, a disk `id` to `/{id}.ext4`, a checkpoint to
 //! `/snapshots/{image dir name}/{vmstate,mem}` — and named by where it
-//! landed. [`VmLayout`] is that map; [`fc_config`] uses it to produce a
-//! boot plan (the restore renderer follows), and [`jail::apply`] executes
-//! the staging half.
+//! landed. [`VmLayout`] is that map; [`fc_config`] and [`fc_restore`] use it
+//! to produce plans, and [`jail::apply`] executes the staging half.
 
 use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
 
 use arcbox_vm_driver::{
-    BootSpec, CacheMode, ConsoleSpec, DiskSpec, Error, IsolationSpec, NicAttachment, NicSpec,
-    Result, VmId, VmSpec,
+    BootSpec, CacheMode, CheckpointImage, CheckpointKind, ConsoleSpec, DiskSpec, Error,
+    IsolationSpec, NicAttachment, NicSpec, RestoreSpec, Result, VmId, VmSpec,
 };
 use fc_sdk::types::{
     BootSource, Drive, DriveCacheType, DriveIoEngine, EntropyDevice, MachineConfiguration,
-    NetworkInterface, Vsock,
+    NetworkInterface, NetworkOverride, SnapshotLoadParams, Vsock,
 };
 
-use crate::NAME;
 use crate::config::FcDriverConfig;
 use crate::error::FcError;
 use crate::jail;
+use crate::{CHECKPOINT_FORMAT, NAME};
 
 mod plan;
 #[cfg(test)]
@@ -252,6 +251,80 @@ pub fn fc_config(spec: &VmSpec, config: &FcDriverConfig, runtime_dir: &Path) -> 
         vsock_host_uds: vsock.is_some().then(|| layout.vsock_host_uds()),
         vsock,
         entropy: spec.entropy.then_some(EntropyDevice { rate_limiter: None }),
+    })
+}
+
+/// Renders a restore of `image` under `spec`: the files a jail needs
+/// staged, and the `PUT /snapshot/load` payload with the image's NICs
+/// retargeted onto `spec.nics`.
+///
+/// Refuses a format this driver did not write
+/// ([`Error::ForeignCheckpoint`]) and a diff image ([`Error::InvalidSpec`]).
+/// The disks in `spec` are staged into the jail at `/{id}.ext4`, the path
+/// a checkpoint of this driver recorded for them; without a jail
+/// Firecracker reopens the recorded host paths itself and the caller must
+/// have put the disks there.
+pub fn fc_restore(
+    image: &CheckpointImage,
+    spec: &RestoreSpec,
+    config: &FcDriverConfig,
+    runtime_dir: &Path,
+) -> Result<FcRestorePlan> {
+    if image.format.as_str() != CHECKPOINT_FORMAT {
+        return Err(Error::ForeignCheckpoint(image.format.clone()));
+    }
+    if image.kind != CheckpointKind::Full {
+        return Err(unsupported("diff checkpoints are not restored"));
+    }
+    let layout = VmLayout::new(&spec.id, &spec.isolation, config, runtime_dir)?;
+    let name = image
+        .dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            Error::InvalidSpec(format!(
+                "checkpoint dir {} has no usable name",
+                image.dir.display()
+            ))
+        })?;
+    let mut stage = Vec::new();
+    let snapshot_path = layout.place(
+        &image.dir.join("vmstate"),
+        &format!("snapshots/{name}/vmstate"),
+        StageKind::LinkOrCopy,
+        &mut stage,
+    )?;
+    let mem_file_path = layout.place(
+        &image.dir.join("mem"),
+        &format!("snapshots/{name}/mem"),
+        StageKind::LinkOrCopy,
+        &mut stage,
+    )?;
+    for disk in &spec.disks {
+        drive(&layout, disk, &mut stage)?;
+    }
+    let network_overrides = spec
+        .nics
+        .iter()
+        .map(|nic| {
+            Ok(NetworkOverride {
+                iface_id: nic.id.clone(),
+                host_dev_name: tap_name(nic)?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(FcRestorePlan {
+        stage,
+        load: SnapshotLoadParams {
+            snapshot_path,
+            mem_file_path: Some(mem_file_path),
+            mem_backend: None,
+            enable_diff_snapshots: None,
+            track_dirty_pages: None,
+            resume_vm: Some(true),
+            network_overrides,
+        },
+        vsock_host_uds: layout.vsock_host_uds(),
     })
 }
 

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -121,6 +121,16 @@ impl VmLayout {
         }
     }
 
+    /// The host view of a vsock socket path Firecracker reports (`GET
+    /// /vm/config`, which is what a restored or adopted VM actually bound):
+    /// jail-relative under a jail, verbatim otherwise.
+    pub fn vsock_host_view(&self, fc_uds: &str) -> PathBuf {
+        match &self.jail {
+            Some(jail) => jail.root.join(fc_uds.trim_start_matches('/')),
+            None => PathBuf::from(fc_uds),
+        }
+    }
+
     /// The hybrid-vsock Unix socket, as Firecracker is told to bind it.
     pub fn vsock_fc_uds(&self) -> Result<String> {
         match &self.jail {
@@ -324,7 +334,6 @@ pub fn fc_restore(
             resume_vm: Some(true),
             network_overrides,
         },
-        vsock_host_uds: layout.vsock_host_uds(),
     })
 }
 

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -162,6 +162,11 @@ impl VmLayout {
     /// The path Firecracker is told for `host`, and the staging that makes
     /// it true: verbatim without a jail; `/` + relative when already inside
     /// the jail; otherwise staged to `/{in_jail}` by `kind`.
+    ///
+    /// `in_jail` must be a relative path of plain components — parts of it
+    /// come from the spec (a disk `id`), and staging writes, replaces, and
+    /// mknods at the destination, so a `..` in it would reach a host file
+    /// outside the jail.
     pub fn place(
         &self,
         host: &Path,
@@ -172,6 +177,11 @@ impl VmLayout {
         let Some(jail) = &self.jail else {
             return utf8(host);
         };
+        if !is_inside_jail(in_jail) {
+            return Err(unsupported(&format!(
+                "`{in_jail}` does not name a path inside the jail"
+            )));
+        }
         if let Some(view) = jail.view(host) {
             return Ok(view);
         }
@@ -344,6 +354,14 @@ pub fn fc_restore(
 }
 
 fn drive(layout: &VmLayout, disk: &DiskSpec, stage: &mut Vec<StagePlan>) -> Result<Drive> {
+    // The id names a Firecracker device (`PUT /drives/{id}`, and the URL a
+    // restore patches) and, under a jail, the file the disk is staged as.
+    if !is_plain_component(&disk.id) {
+        return Err(unsupported(&format!(
+            "disk id `{}` must be a plain name",
+            disk.id
+        )));
+    }
     let kind = match &layout.jail {
         // Verbatim, or already inside the jail: nothing is staged.
         None => StageKind::Copy,
@@ -387,6 +405,22 @@ fn tap_name(nic: &NicSpec) -> Result<String> {
             nic.id
         ))),
     }
+}
+
+/// True when `name` is one plain path component: no separator, no `.` or
+/// `..`, no root, nothing a jail-relative path may not be made of.
+fn is_plain_component(name: &str) -> bool {
+    let mut components = Path::new(name).components();
+    matches!(components.next(), Some(std::path::Component::Normal(_)))
+        && components.next().is_none()
+}
+
+/// True when `path` is relative and made only of plain components, so
+/// joining it onto the jail root lands inside the jail.
+fn is_inside_jail(path: &str) -> bool {
+    let mut components = Path::new(path).components().peekable();
+    components.peek().is_some()
+        && components.all(|component| matches!(component, std::path::Component::Normal(_)))
 }
 
 fn is_block_device(path: &Path) -> Result<bool> {

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -265,16 +265,17 @@ pub fn fc_config(spec: &VmSpec, config: &FcDriverConfig, runtime_dir: &Path) -> 
     })
 }
 
-/// Renders a restore of `image` under `spec`: the files a jail needs
-/// staged, and the `PUT /snapshot/load` payload with the image's NICs
-/// retargeted onto `spec.nics`.
+/// Renders a restore of `image` under `spec`.
+///
+/// The plan carries the files a jail needs staged, the `PUT /snapshot/load`
+/// payload with the image's NICs retargeted onto `spec.nics`, and the disks
+/// as Firecracker must see them once the image is loaded.
 ///
 /// Refuses a format this driver did not write
 /// ([`Error::ForeignCheckpoint`]) and a diff image ([`Error::InvalidSpec`]).
-/// The disks in `spec` are staged into the jail at `/{id}.ext4`, the path
-/// a checkpoint of this driver recorded for them; without a jail
-/// Firecracker reopens the recorded host paths itself and the caller must
-/// have put the disks there.
+/// A snapshot load reopens the disk paths the checkpoint recorded, which
+/// are never this restore's — so the load is rendered paused and the caller
+/// points each drive at [`FcRestorePlan::drives`] before resuming.
 pub fn fc_restore(
     image: &CheckpointImage,
     spec: &RestoreSpec,
@@ -311,9 +312,11 @@ pub fn fc_restore(
         StageKind::LinkOrCopy,
         &mut stage,
     )?;
-    for disk in &spec.disks {
-        drive(&layout, disk, &mut stage)?;
-    }
+    let drives = spec
+        .disks
+        .iter()
+        .map(|disk| drive(&layout, disk, &mut stage))
+        .collect::<Result<Vec<_>>>()?;
     let network_overrides = spec
         .nics
         .iter()
@@ -332,9 +335,11 @@ pub fn fc_restore(
             mem_backend: None,
             enable_diff_snapshots: None,
             track_dirty_pages: None,
-            resume_vm: Some(true),
+            // The guest stays frozen until its disks are reattached.
+            resume_vm: Some(false),
             network_overrides,
         },
+        drives,
     })
 }
 

--- a/virt/arcbox-fc-driver/src/render/plan.rs
+++ b/virt/arcbox-fc-driver/src/render/plan.rs
@@ -16,6 +16,9 @@ pub struct SpawnPlan {
     pub id: VmId,
     /// The API socket the spawned process answers on, as the host sees it.
     pub api_socket: PathBuf,
+    /// The vsock Unix socket the VM will bind, as the host sees it; a stale
+    /// one from an earlier VM in the same place is cleared before the spawn.
+    pub vsock_uds: PathBuf,
     /// Direct or jailed.
     pub mode: SpawnMode,
 }

--- a/virt/arcbox-fc-driver/src/render/plan.rs
+++ b/virt/arcbox-fc-driver/src/render/plan.rs
@@ -66,6 +66,12 @@ pub enum StageKind {
     /// A device node with the source's major/minor — for a block device
     /// (a device-mapper rootfs).
     BlockNode,
+    /// A second name, inside the jail, for a disk that is already in it: a
+    /// hard link (a device node for a block device, a copy when neither is
+    /// possible), owned like the original. A restore uses it so the load
+    /// finds a disk at the name the checkpoint recorded; the alias goes once
+    /// the drive has been pointed at the disk's real name.
+    Alias,
 }
 
 /// Everything a boot needs after the process is up.
@@ -107,4 +113,9 @@ pub struct FcRestorePlan {
     /// `PATCH /drives/{id}` for each whose path the image does not already
     /// name, then resume.
     pub drives: Vec<Drive>,
+    /// Second names staged for the load only ([`StageKind::Alias`]): a disk
+    /// that sits in the jail under a name other than the one the checkpoint
+    /// recorded is linked at the recorded name so the load can reopen it,
+    /// and unlinked again once the drive points at the disk itself.
+    pub aliases: Vec<PathBuf>,
 }

--- a/virt/arcbox-fc-driver/src/render/plan.rs
+++ b/virt/arcbox-fc-driver/src/render/plan.rs
@@ -87,13 +87,15 @@ pub struct FcPlan {
 }
 
 /// Everything a restore needs after the process is up.
+///
+/// Which devices the restored VM has — a vsock, and where its Unix socket
+/// is bound — is the image's to say, not the plan's: Firecracker re-creates
+/// the vsock at the path the checkpoint recorded, so the driver reads it
+/// back from `GET /vm/config` after the load.
 #[derive(Debug, Clone)]
 pub struct FcRestorePlan {
     /// Files to stage into the jail first (empty without a jail).
     pub stage: Vec<StagePlan>,
     /// `PUT /snapshot/load`.
     pub load: SnapshotLoadParams,
-    /// The vsock Unix socket as the host dials it, should the image carry a
-    /// vsock device.
-    pub vsock_host_uds: PathBuf,
 }

--- a/virt/arcbox-fc-driver/src/render/plan.rs
+++ b/virt/arcbox-fc-driver/src/render/plan.rs
@@ -99,6 +99,12 @@ pub struct FcPlan {
 pub struct FcRestorePlan {
     /// Files to stage into the jail first (empty without a jail).
     pub stage: Vec<StagePlan>,
-    /// `PUT /snapshot/load`.
+    /// `PUT /snapshot/load`, rendered paused: the load reopens the disk
+    /// paths the checkpoint recorded, so the guest must not run before the
+    /// drives below have replaced them.
     pub load: SnapshotLoadParams,
+    /// The spec's disks as Firecracker must see them after the load —
+    /// `PATCH /drives/{id}` for each whose path the image does not already
+    /// name, then resume.
+    pub drives: Vec<Drive>,
 }

--- a/virt/arcbox-fc-driver/src/render/plan.rs
+++ b/virt/arcbox-fc-driver/src/render/plan.rs
@@ -1,0 +1,99 @@
+//! What a render produces: the process to spawn, the files to stage, and
+//! the API payloads to send.
+
+use std::path::PathBuf;
+
+use arcbox_vm_driver::{IsolationSpec, VmId};
+use fc_sdk::types::{
+    BootSource, Drive, EntropyDevice, MachineConfiguration, NetworkInterface, SnapshotLoadParams,
+    Vsock,
+};
+
+/// The process a VM runs on, decided before any spec is known.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpawnPlan {
+    /// The VM.
+    pub id: VmId,
+    /// The API socket the spawned process answers on, as the host sees it.
+    pub api_socket: PathBuf,
+    /// Direct or jailed.
+    pub mode: SpawnMode,
+}
+
+/// How the VMM process is started.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpawnMode {
+    /// `firecracker` run directly by the caller.
+    Direct {
+        /// Firecracker's log file, pre-created before the spawn.
+        log: PathBuf,
+        /// Firecracker's metrics file, pre-created before the spawn.
+        metrics: PathBuf,
+    },
+    /// `jailer` confining `firecracker` into a chroot.
+    Jailer {
+        /// The confinement, always [`IsolationSpec::Jailer`].
+        isolation: IsolationSpec,
+        /// The chroot root the jailer will create.
+        jail_root: PathBuf,
+    },
+}
+
+/// One host file to bring into the jail before Firecracker is told about it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StagePlan {
+    /// The file on the host.
+    pub src: PathBuf,
+    /// Where it lands inside the jail (a host path under the jail root).
+    pub dst: PathBuf,
+    /// How it gets there.
+    pub kind: StageKind,
+}
+
+/// How a host file is mirrored into the jail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StageKind {
+    /// Hard link when the jail runs as root, a chowned copy otherwise — for
+    /// files Firecracker only reads (kernel, initrd, vmstate, mem, a
+    /// read-only disk).
+    LinkOrCopy,
+    /// A private, chowned copy — for a writable regular file Firecracker
+    /// will write guest blocks into.
+    Copy,
+    /// A device node with the source's major/minor — for a block device
+    /// (a device-mapper rootfs).
+    BlockNode,
+}
+
+/// Everything a boot needs after the process is up.
+#[derive(Debug, Clone)]
+pub struct FcPlan {
+    /// Files to stage into the jail first (empty without a jail).
+    pub stage: Vec<StagePlan>,
+    /// `PUT /boot-source`.
+    pub boot_source: BootSource,
+    /// `PUT /machine-config`.
+    pub machine: MachineConfiguration,
+    /// `PUT /drives/{id}`, in bus order.
+    pub drives: Vec<Drive>,
+    /// `PUT /network-interfaces/{id}`, in bus order.
+    pub nics: Vec<NetworkInterface>,
+    /// `PUT /vsock`, when the spec asked for one.
+    pub vsock: Option<Vsock>,
+    /// `PUT /entropy`, when the spec asked for one.
+    pub entropy: Option<EntropyDevice>,
+    /// The vsock Unix socket as the host dials it, when there is a vsock.
+    pub vsock_host_uds: Option<PathBuf>,
+}
+
+/// Everything a restore needs after the process is up.
+#[derive(Debug, Clone)]
+pub struct FcRestorePlan {
+    /// Files to stage into the jail first (empty without a jail).
+    pub stage: Vec<StagePlan>,
+    /// `PUT /snapshot/load`.
+    pub load: SnapshotLoadParams,
+    /// The vsock Unix socket as the host dials it, should the image carry a
+    /// vsock device.
+    pub vsock_host_uds: PathBuf,
+}

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -55,6 +55,10 @@ fn direct_layout_names_the_runtime_dir_sockets_and_passes_paths_verbatim() {
         layout.vsock_fc_uds().unwrap(),
         "/run/vms/box/firecracker.vsock"
     );
+    assert_eq!(
+        layout.vsock_host_view("/run/vms/other/firecracker.vsock"),
+        Path::new("/run/vms/other/firecracker.vsock")
+    );
     let plan = layout.spawn_plan();
     assert_eq!(plan.api_socket, Path::new("/run/vms/box/firecracker.sock"));
     let SpawnMode::Direct { log, metrics } = plan.mode else {
@@ -87,6 +91,10 @@ fn jailer_layout_relativizes_inside_paths_and_stages_outside_ones() {
     assert_eq!(layout.api_socket(), root.join("run/firecracker.socket"));
     assert_eq!(layout.vsock_host_uds(), root.join("run/firecracker.vsock"));
     assert_eq!(layout.vsock_fc_uds().unwrap(), "/run/firecracker.vsock");
+    assert_eq!(
+        layout.vsock_host_view("/run/firecracker.vsock"),
+        root.join("run/firecracker.vsock")
+    );
     let plan = layout.spawn_plan();
     assert_eq!(plan.api_socket, root.join("run/firecracker.socket"));
     let SpawnMode::Jailer {
@@ -408,10 +416,6 @@ fn restore_loads_the_image_and_retargets_nics_onto_the_new_taps() {
     assert_eq!(plan.load.network_overrides.len(), 1);
     assert_eq!(plan.load.network_overrides[0].iface_id, "eth0");
     assert_eq!(plan.load.network_overrides[0].host_dev_name, "tap7");
-    assert_eq!(
-        plan.vsock_host_uds,
-        Path::new("/run/vms/box2/firecracker.vsock")
-    );
 }
 
 #[test]
@@ -453,7 +457,6 @@ fn restore_stages_the_image_and_disks_into_a_jail_by_name() {
             },
         ]
     );
-    assert_eq!(plan.vsock_host_uds, root.join("run/firecracker.vsock"));
 
     // An image the caller already staged into the jail is loaded in place.
     let staged = root.join("snapshots/abc");

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -3,8 +3,9 @@
 use std::path::{Path, PathBuf};
 
 use arcbox_vm_driver::{
-    BootSpec, CacheMode, ConsoleSpec, DiskSpec, Error, IsolationSpec, MacAddr, NicAttachment,
-    NicSpec, ShareSpec, VmId, VmSpec, VsockSpec,
+    BootSpec, CacheMode, CheckpointFormat, CheckpointImage, CheckpointKind, ConsoleSpec, DiskSpec,
+    Error, IsolationSpec, MacAddr, NicAttachment, NicSpec, RestoreSpec, ShareSpec, VmId, VmSpec,
+    VsockSpec,
 };
 use fc_sdk::types::{DriveCacheType, DriveIoEngine};
 
@@ -367,4 +368,135 @@ fn what_firecracker_cannot_do_is_refused_before_anything_runs() {
     assert!(base(|s| s.nics[0].attachment = NicAttachment::HostNat).contains("TAP"));
     // Spec validation runs first.
     assert!(base(|s| s.cpus = 0).contains("cpus"));
+}
+
+fn image(dir: &Path) -> CheckpointImage {
+    CheckpointImage {
+        dir: dir.to_path_buf(),
+        format: CheckpointFormat::new(CHECKPOINT_FORMAT),
+        kind: CheckpointKind::Full,
+    }
+}
+
+fn restore_spec(id: &str, isolation: IsolationSpec, rootfs: PathBuf) -> RestoreSpec {
+    let s = spec(id, isolation, rootfs);
+    RestoreSpec {
+        id: s.id,
+        nics: s.nics,
+        disks: s.disks,
+        isolation: s.isolation,
+    }
+}
+
+#[test]
+fn restore_loads_the_image_and_retargets_nics_onto_the_new_taps() {
+    let plan = fc_restore(
+        &image(Path::new("/snaps/abc")),
+        &restore_spec(
+            "box2",
+            IsolationSpec::None,
+            "/run/vms/box2/rootfs.link".into(),
+        ),
+        &config(),
+        Path::new("/run/vms/box2"),
+    )
+    .unwrap();
+    assert!(plan.stage.is_empty());
+    assert_eq!(plan.load.snapshot_path, "/snaps/abc/vmstate");
+    assert_eq!(plan.load.mem_file_path.as_deref(), Some("/snaps/abc/mem"));
+    assert_eq!(plan.load.resume_vm, Some(true));
+    assert_eq!(plan.load.network_overrides.len(), 1);
+    assert_eq!(plan.load.network_overrides[0].iface_id, "eth0");
+    assert_eq!(plan.load.network_overrides[0].host_dev_name, "tap7");
+    assert_eq!(
+        plan.vsock_host_uds,
+        Path::new("/run/vms/box2/firecracker.vsock")
+    );
+}
+
+#[test]
+fn restore_stages_the_image_and_disks_into_a_jail_by_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().join("jail");
+    let root = base.join("firecracker/box2/root");
+    let rootfs = dir.path().join("rootfs.ext4");
+    std::fs::write(&rootfs, b"disk").unwrap();
+    let plan = fc_restore(
+        &image(Path::new("/snaps/abc")),
+        &restore_spec("box2", jailed(&base), rootfs.clone()),
+        &config(),
+        Path::new("/run/vms/box2"),
+    )
+    .unwrap();
+    assert_eq!(plan.load.snapshot_path, "/snapshots/abc/vmstate");
+    assert_eq!(
+        plan.load.mem_file_path.as_deref(),
+        Some("/snapshots/abc/mem")
+    );
+    assert_eq!(
+        plan.stage,
+        vec![
+            StagePlan {
+                src: "/snaps/abc/vmstate".into(),
+                dst: root.join("snapshots/abc/vmstate"),
+                kind: StageKind::LinkOrCopy,
+            },
+            StagePlan {
+                src: "/snaps/abc/mem".into(),
+                dst: root.join("snapshots/abc/mem"),
+                kind: StageKind::LinkOrCopy,
+            },
+            StagePlan {
+                src: rootfs,
+                dst: root.join("rootfs.ext4"),
+                kind: StageKind::Copy,
+            },
+        ]
+    );
+    assert_eq!(plan.vsock_host_uds, root.join("run/firecracker.vsock"));
+
+    // An image the caller already staged into the jail is loaded in place.
+    let staged = root.join("snapshots/abc");
+    let plan = fc_restore(
+        &image(&staged),
+        &restore_spec("box2", jailed(&base), root.join("rootfs.ext4")),
+        &config(),
+        Path::new("/run/vms/box2"),
+    )
+    .unwrap();
+    assert!(plan.stage.is_empty());
+    assert_eq!(plan.load.snapshot_path, "/snapshots/abc/vmstate");
+}
+
+#[test]
+fn restore_refuses_foreign_and_diff_images() {
+    let mut foreign = image(Path::new("/snaps/abc"));
+    foreign.format = CheckpointFormat::new("fake/v1");
+    let spec = restore_spec("box2", IsolationSpec::None, "/x".into());
+    match fc_restore(&foreign, &spec, &config(), Path::new("/run/vms/box2")) {
+        Err(Error::ForeignCheckpoint(format)) => assert_eq!(format.as_str(), "fake/v1"),
+        other => panic!("expected ForeignCheckpoint, got {other:?}"),
+    }
+    let mut diff = image(Path::new("/snaps/abc"));
+    diff.kind = CheckpointKind::Diff;
+    assert!(
+        invalid(fc_restore(
+            &diff,
+            &spec,
+            &config(),
+            Path::new("/run/vms/box2")
+        ))
+        .contains("diff")
+    );
+    let mut spec = spec;
+    spec.nics[0].attachment = NicAttachment::HostNat;
+    assert!(
+        invalid(fc_restore(
+            &image(Path::new("/snaps/abc")),
+            &spec,
+            &config(),
+            Path::new("/run/vms/box2")
+        ))
+        .contains("TAP")
+    );
 }

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -414,10 +414,20 @@ fn restore_loads_the_image_and_retargets_nics_onto_the_new_taps() {
     assert!(plan.stage.is_empty());
     assert_eq!(plan.load.snapshot_path, "/snaps/abc/vmstate");
     assert_eq!(plan.load.mem_file_path.as_deref(), Some("/snaps/abc/mem"));
-    assert_eq!(plan.load.resume_vm, Some(true));
+    // The load leaves the guest frozen until the disks below replace the
+    // ones the checkpoint recorded.
+    assert_eq!(plan.load.resume_vm, Some(false));
     assert_eq!(plan.load.network_overrides.len(), 1);
     assert_eq!(plan.load.network_overrides[0].iface_id, "eth0");
     assert_eq!(plan.load.network_overrides[0].host_dev_name, "tap7");
+    // Without a jail nothing is staged, so the disks reach Firecracker only
+    // as the paths to patch onto the loaded drives.
+    assert_eq!(plan.drives.len(), 1);
+    assert_eq!(plan.drives[0].drive_id, "rootfs");
+    assert_eq!(
+        plan.drives[0].path_on_host.as_deref(),
+        Some("/run/vms/box2/rootfs.link")
+    );
 }
 
 #[test]
@@ -459,6 +469,7 @@ fn restore_stages_the_image_and_disks_into_a_jail_by_name() {
             },
         ]
     );
+    assert_eq!(plan.drives[0].path_on_host.as_deref(), Some("/rootfs.ext4"));
 
     // An image the caller already staged into the jail is loaded in place.
     let staged = root.join("snapshots/abc");
@@ -471,6 +482,23 @@ fn restore_stages_the_image_and_disks_into_a_jail_by_name() {
     .unwrap();
     assert!(plan.stage.is_empty());
     assert_eq!(plan.load.snapshot_path, "/snapshots/abc/vmstate");
+    assert_eq!(plan.drives[0].path_on_host.as_deref(), Some("/rootfs.ext4"));
+
+    // A disk the caller placed in the jail somewhere else than the canonical
+    // name is named where it is: the drive is patched, not staged.
+    let elsewhere = root.join("pool/slot3.ext4");
+    let plan = fc_restore(
+        &image(&staged),
+        &restore_spec("box2", jailed(&base), elsewhere),
+        &config(),
+        Path::new("/run/vms/box2"),
+    )
+    .unwrap();
+    assert!(plan.stage.is_empty());
+    assert_eq!(
+        plan.drives[0].path_on_host.as_deref(),
+        Some("/pool/slot3.ext4")
+    );
 }
 
 #[test]

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -2,7 +2,11 @@
 
 use std::path::{Path, PathBuf};
 
-use arcbox_vm_driver::{IsolationSpec, VmId};
+use arcbox_vm_driver::{
+    BootSpec, CacheMode, ConsoleSpec, DiskSpec, Error, IsolationSpec, MacAddr, NicAttachment,
+    NicSpec, ShareSpec, VmId, VmSpec, VsockSpec,
+};
+use fc_sdk::types::{DriveCacheType, DriveIoEngine};
 
 use super::*;
 use crate::config::FcDriverConfig;
@@ -128,4 +132,239 @@ fn jailer_layout_relativizes_inside_paths_and_stages_outside_ones() {
             kind: StageKind::LinkOrCopy,
         }]
     );
+}
+
+fn spec(id: &str, isolation: IsolationSpec, rootfs: PathBuf) -> VmSpec {
+    VmSpec {
+        id: VmId::new(id).unwrap(),
+        cpus: 2,
+        memory_mib: 512,
+        boot: BootSpec::Kernel {
+            image: "/images/vmlinux".into(),
+            cmdline: "console=ttyS0 ip=1.2.3.4::1.2.3.1:255.255.255.0".into(),
+            initrd: None,
+        },
+        disks: vec![DiskSpec {
+            id: "rootfs".into(),
+            path: rootfs,
+            read_only: false,
+            root: true,
+            cache: CacheMode::Unsafe,
+        }],
+        nics: vec![NicSpec {
+            id: "eth0".into(),
+            mac: MacAddr::new([0x02, 0, 0, 0, 0, 1]),
+            attachment: NicAttachment::Tap {
+                name: "tap7".into(),
+            },
+        }],
+        vsock: Some(VsockSpec { guest_cid: 3 }),
+        shares: vec![],
+        console: ConsoleSpec::Off,
+        balloon: false,
+        entropy: false,
+        dirty_tracking: true,
+        isolation,
+    }
+}
+
+fn invalid(result: Result<impl std::fmt::Debug>) -> String {
+    match result {
+        Err(Error::InvalidSpec(msg)) => msg,
+        other => panic!("expected InvalidSpec, got {other:?}"),
+    }
+}
+
+#[test]
+fn direct_mode_passes_paths_verbatim() {
+    let plan = fc_config(
+        &spec("box", IsolationSpec::None, "/images/rootfs.ext4".into()),
+        &config(),
+        Path::new("/run/vms/box"),
+    )
+    .unwrap();
+    assert!(plan.stage.is_empty(), "nothing is staged without a jail");
+    assert_eq!(plan.boot_source.kernel_image_path, "/images/vmlinux");
+    assert_eq!(
+        plan.boot_source.boot_args.as_deref(),
+        Some("console=ttyS0 ip=1.2.3.4::1.2.3.1:255.255.255.0")
+    );
+    assert_eq!(
+        plan.drives[0].path_on_host.as_deref(),
+        Some("/images/rootfs.ext4")
+    );
+    let vsock = plan.vsock.unwrap();
+    assert_eq!(vsock.guest_cid, 3);
+    assert_eq!(vsock.uds_path, "/run/vms/box/firecracker.vsock");
+    assert_eq!(
+        plan.vsock_host_uds.as_deref(),
+        Some(Path::new("/run/vms/box/firecracker.vsock"))
+    );
+}
+
+#[test]
+fn machine_config_and_devices_follow_the_spec() {
+    let mut s = spec("box", IsolationSpec::None, "/images/rootfs.ext4".into());
+    s.entropy = true;
+    s.disks.push(DiskSpec {
+        id: "data".into(),
+        path: "/images/data.ext4".into(),
+        read_only: true,
+        root: false,
+        cache: CacheMode::Writeback,
+    });
+    let plan = fc_config(&s, &config(), Path::new("/run/vms/box")).unwrap();
+    assert_eq!(plan.machine.vcpu_count.get(), 2);
+    assert_eq!(plan.machine.mem_size_mib, 512);
+    assert!(!plan.machine.smt);
+    assert!(plan.machine.track_dirty_pages);
+    let root = &plan.drives[0];
+    assert!(root.is_root_device);
+    assert_eq!(root.is_read_only, Some(false));
+    assert!(matches!(root.cache_type, DriveCacheType::Unsafe));
+    assert!(matches!(root.io_engine, DriveIoEngine::Sync));
+    let data = &plan.drives[1];
+    assert_eq!(data.drive_id, "data");
+    assert!(!data.is_root_device);
+    assert_eq!(data.is_read_only, Some(true));
+    assert!(matches!(data.cache_type, DriveCacheType::Writeback));
+    let nic = &plan.nics[0];
+    assert_eq!(nic.iface_id, "eth0");
+    assert_eq!(nic.guest_mac.as_deref(), Some("02:00:00:00:00:01"));
+    assert_eq!(nic.host_dev_name, "tap7");
+    assert!(plan.entropy.is_some());
+
+    let mut s = spec("box", IsolationSpec::None, "/images/rootfs.ext4".into());
+    s.dirty_tracking = false;
+    s.vsock = None;
+    let plan = fc_config(&s, &config(), Path::new("/run/vms/box")).unwrap();
+    assert!(!plan.machine.track_dirty_pages);
+    assert!(plan.vsock.is_none() && plan.vsock_host_uds.is_none());
+    assert!(plan.entropy.is_none());
+}
+
+#[test]
+fn jailer_mode_stages_outside_files_and_relativizes_inside_ones() {
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().join("jail");
+    let root = base.join("firecracker/box/root");
+    // A rootfs the caller already put in the jail (a mknod'ed dm device).
+    std::fs::create_dir_all(&root).unwrap();
+    let inside = root.join("rootfs.ext4");
+    std::fs::write(&inside, b"disk").unwrap();
+    let outside = dir.path().join("rootfs.ext4");
+    std::fs::write(&outside, b"disk").unwrap();
+
+    let plan = fc_config(
+        &spec("box", jailed(&base), inside),
+        &config(),
+        Path::new("/run/vms/box"),
+    )
+    .unwrap();
+    assert_eq!(plan.boot_source.kernel_image_path, "/vmlinux");
+    assert_eq!(plan.drives[0].path_on_host.as_deref(), Some("/rootfs.ext4"));
+    assert_eq!(
+        plan.stage,
+        vec![StagePlan {
+            src: "/images/vmlinux".into(),
+            dst: root.join("vmlinux"),
+            kind: StageKind::LinkOrCopy,
+        }],
+        "the kernel is staged; the in-jail rootfs is not"
+    );
+    assert_eq!(plan.vsock.unwrap().uds_path, "/run/firecracker.vsock");
+    assert_eq!(
+        plan.vsock_host_uds.as_deref(),
+        Some(root.join("run/firecracker.vsock").as_path())
+    );
+
+    // A writable disk outside the jail is copied to /{id}.ext4; a read-only
+    // one is link-or-copied.
+    let mut s = spec("box", jailed(&base), outside.clone());
+    s.disks.push(DiskSpec {
+        id: "data".into(),
+        path: outside.clone(),
+        read_only: true,
+        root: false,
+        cache: CacheMode::Unsafe,
+    });
+    let plan = fc_config(&s, &config(), Path::new("/run/vms/box")).unwrap();
+    assert_eq!(plan.drives[0].path_on_host.as_deref(), Some("/rootfs.ext4"));
+    assert_eq!(plan.drives[1].path_on_host.as_deref(), Some("/data.ext4"));
+    assert_eq!(
+        plan.stage[1..],
+        [
+            StagePlan {
+                src: outside.clone(),
+                dst: root.join("rootfs.ext4"),
+                kind: StageKind::Copy,
+            },
+            StagePlan {
+                src: outside,
+                dst: root.join("data.ext4"),
+                kind: StageKind::LinkOrCopy,
+            }
+        ]
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn jailer_mode_mirrors_a_block_device_as_a_node() {
+    use std::os::unix::fs::FileTypeExt as _;
+    let Some(device) = std::fs::read_dir("/dev")
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .find(|entry| {
+            entry
+                .metadata()
+                .is_ok_and(|m| m.file_type().is_block_device())
+        })
+        .map(|entry| entry.path())
+    else {
+        eprintln!("no block device under /dev; skipping");
+        return;
+    };
+    let base = PathBuf::from("/srv/jailer");
+    let plan = fc_config(
+        &spec("box", jailed(&base), device.clone()),
+        &config(),
+        Path::new("/run/vms/box"),
+    )
+    .unwrap();
+    assert_eq!(plan.drives[0].path_on_host.as_deref(), Some("/rootfs.ext4"));
+    assert!(plan.stage.contains(&StagePlan {
+        src: device,
+        dst: base.join("firecracker/box/root/rootfs.ext4"),
+        kind: StageKind::BlockNode,
+    }));
+}
+
+#[test]
+fn what_firecracker_cannot_do_is_refused_before_anything_runs() {
+    let base = |mutate: fn(&mut VmSpec)| {
+        let mut s = spec("box", IsolationSpec::None, "/images/rootfs.ext4".into());
+        mutate(&mut s);
+        invalid(fc_config(&s, &config(), Path::new("/run/vms/box")))
+    };
+    assert!(base(|s| s.console = ConsoleSpec::File("/tmp/c.log".into())).contains("console"));
+    assert!(base(|s| s.console = ConsoleSpec::Socket("/tmp/c.sock".into())).contains("console"));
+    assert!(
+        base(|s| s.shares.push(ShareSpec {
+            tag: "src".into(),
+            host_path: "/src".into(),
+            read_only: false,
+        }))
+        .contains("shares")
+    );
+    assert!(base(|s| s.balloon = true).contains("balloon"));
+    assert!(
+        base(|s| s.boot = BootSpec::Firmware {
+            image: "/fw/OVMF.fd".into()
+        })
+        .contains("kernel"),
+    );
+    assert!(base(|s| s.nics[0].attachment = NicAttachment::HostNat).contains("TAP"));
+    // Spec validation runs first.
+    assert!(base(|s| s.cpus = 0).contains("cpus"));
 }

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -351,6 +351,31 @@ fn jailer_mode_mirrors_a_block_device_as_a_node() {
 }
 
 #[test]
+fn a_vm_id_cannot_name_another_jail() {
+    // The port allows dots in an id, and the jail is `{base}/{exec}/{id}/root`.
+    for id in [".", ".."] {
+        let id = VmId::new(id).expect("the port accepts it");
+        let error = VmLayout::new(
+            &id,
+            &jailed(Path::new("/srv/jailer")),
+            &config(),
+            Path::new("/run/vms/box"),
+        );
+        assert!(invalid(error).contains("vm id"), "`{id}` is refused");
+    }
+    // A dot inside a name is not a component of its own.
+    assert!(
+        VmLayout::new(
+            &VmId::new("box.1").unwrap(),
+            &jailed(Path::new("/srv/jailer")),
+            &config(),
+            Path::new("/run/vms/box"),
+        )
+        .is_ok()
+    );
+}
+
+#[test]
 fn a_disk_id_cannot_reach_out_of_the_jail() {
     let base = PathBuf::from("/srv/jailer");
     for isolation in [IsolationSpec::None, jailed(&base)] {

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -528,20 +528,31 @@ fn restore_stages_the_image_and_disks_into_a_jail_by_name() {
     )
     .unwrap();
     assert!(plan.stage.is_empty());
+    assert!(plan.aliases.is_empty(), "at the recorded name already");
     assert_eq!(plan.load.snapshot_path, "/snapshots/abc/vmstate");
     assert_eq!(plan.drives[0].path_on_host.as_deref(), Some("/rootfs.ext4"));
 
-    // A disk the caller placed in the jail somewhere else than the canonical
-    // name is named where it is: the drive is patched, not staged.
+    // A disk the caller placed in the jail somewhere else than the recorded
+    // name is named where it is — but the load reopens `/rootfs.ext4`, so
+    // it is aliased there for the load and the alias goes once the drive
+    // is patched onto the disk itself.
     let elsewhere = root.join("pool/slot3.ext4");
     let plan = fc_restore(
         &image(&staged),
-        &restore_spec("box2", jailed(&base), elsewhere),
+        &restore_spec("box2", jailed(&base), elsewhere.clone()),
         &config(),
         Path::new("/run/vms/box2"),
     )
     .unwrap();
-    assert!(plan.stage.is_empty());
+    assert_eq!(
+        plan.stage,
+        vec![StagePlan {
+            src: elsewhere,
+            dst: root.join("rootfs.ext4"),
+            kind: StageKind::Alias,
+        }]
+    );
+    assert_eq!(plan.aliases, vec![root.join("rootfs.ext4")]);
     assert_eq!(
         plan.drives[0].path_on_host.as_deref(),
         Some("/pool/slot3.ext4")

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -333,8 +333,7 @@ fn jailer_mode_mirrors_a_block_device_as_a_node() {
         })
         .map(|entry| entry.path())
     else {
-        eprintln!("no block device under /dev; skipping");
-        return;
+        panic!("no block device under /dev: this host cannot exercise the mknod staging rule");
     };
     let base = PathBuf::from("/srv/jailer");
     let plan = fc_config(

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -352,6 +352,37 @@ fn jailer_mode_mirrors_a_block_device_as_a_node() {
 }
 
 #[test]
+fn a_disk_id_cannot_reach_out_of_the_jail() {
+    let base = PathBuf::from("/srv/jailer");
+    for isolation in [IsolationSpec::None, jailed(&base)] {
+        let mut s = spec("box", isolation, "/images/rootfs.ext4".into());
+        // Staging joins `{id}.ext4` onto the jail root and replaces whatever
+        // is there — with a copy, or a device node.
+        s.disks[0].id = "../../etc/shadow".into();
+        assert!(
+            invalid(fc_config(&s, &config(), Path::new("/run/vms/box"))).contains("disk id"),
+            "a traversing disk id is refused"
+        );
+        s.disks[0].id = "nested/name".into();
+        assert!(invalid(fc_config(&s, &config(), Path::new("/run/vms/box"))).contains("disk id"));
+    }
+
+    // The same guard covers every staged name, whoever supplies it.
+    let layout = layout(&jailed(&base));
+    let mut stage = Vec::new();
+    assert!(
+        invalid(layout.place(
+            Path::new("/images/vmlinux"),
+            "../vmlinux",
+            StageKind::LinkOrCopy,
+            &mut stage,
+        ))
+        .contains("inside the jail")
+    );
+    assert!(stage.is_empty());
+}
+
+#[test]
 fn what_firecracker_cannot_do_is_refused_before_anything_runs() {
     let base = |mutate: fn(&mut VmSpec)| {
         let mut s = spec("box", IsolationSpec::None, "/images/rootfs.ext4".into());

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -56,7 +56,7 @@ fn direct_layout_names_the_runtime_dir_sockets_and_passes_paths_verbatim() {
         "/run/vms/box/firecracker.vsock"
     );
     assert_eq!(
-        layout.vsock_host_view("/run/vms/other/firecracker.vsock"),
+        layout.host_view("/run/vms/other/firecracker.vsock"),
         Path::new("/run/vms/other/firecracker.vsock")
     );
     let plan = layout.spawn_plan();
@@ -93,7 +93,7 @@ fn jailer_layout_relativizes_inside_paths_and_stages_outside_ones() {
     assert_eq!(layout.vsock_host_uds(), root.join("run/firecracker.vsock"));
     assert_eq!(layout.vsock_fc_uds().unwrap(), "/run/firecracker.vsock");
     assert_eq!(
-        layout.vsock_host_view("/run/firecracker.vsock"),
+        layout.host_view("/run/firecracker.vsock"),
         root.join("run/firecracker.vsock")
     );
     let plan = layout.spawn_plan();
@@ -453,8 +453,10 @@ fn restore_spec(id: &str, isolation: IsolationSpec, rootfs: PathBuf) -> RestoreS
 }
 
 #[test]
-fn restore_loads_the_image_and_retargets_nics_onto_the_new_taps() {
-    let plan = fc_restore(
+fn restore_is_a_jailer_mode_capability() {
+    // Without a jail the load would reopen the source VM's own host paths;
+    // the restore is refused before anything is planned.
+    let error = fc_restore(
         &image(Path::new("/snaps/abc")),
         &restore_spec(
             "box2",
@@ -463,25 +465,10 @@ fn restore_loads_the_image_and_retargets_nics_onto_the_new_taps() {
         ),
         &config(),
         Path::new("/run/vms/box2"),
-    )
-    .unwrap();
-    assert!(plan.stage.is_empty());
-    assert_eq!(plan.load.snapshot_path, "/snaps/abc/vmstate");
-    assert_eq!(plan.load.mem_file_path.as_deref(), Some("/snaps/abc/mem"));
-    // The load leaves the guest frozen until the disks below replace the
-    // ones the checkpoint recorded.
-    assert_eq!(plan.load.resume_vm, Some(false));
-    assert_eq!(plan.load.network_overrides.len(), 1);
-    assert_eq!(plan.load.network_overrides[0].iface_id, "eth0");
-    assert_eq!(plan.load.network_overrides[0].host_dev_name, "tap7");
-    // Without a jail nothing is staged, so the disks reach Firecracker only
-    // as the paths to patch onto the loaded drives.
-    assert_eq!(plan.drives.len(), 1);
-    assert_eq!(plan.drives[0].drive_id, "rootfs");
-    assert_eq!(
-        plan.drives[0].path_on_host.as_deref(),
-        Some("/run/vms/box2/rootfs.link")
     );
+    assert!(invalid(error).contains("jailer isolation"));
+    assert!(require_jailed_restore(&IsolationSpec::None).is_err());
+    assert!(require_jailed_restore(&jailed(Path::new("/srv/jailer"))).is_ok());
 }
 
 #[test]
@@ -503,6 +490,12 @@ fn restore_stages_the_image_and_disks_into_a_jail_by_name() {
         plan.load.mem_file_path.as_deref(),
         Some("/snapshots/abc/mem")
     );
+    // The load leaves the guest frozen until the drives below replace the
+    // ones the checkpoint recorded, and lands each NIC on its new TAP.
+    assert_eq!(plan.load.resume_vm, Some(false));
+    assert_eq!(plan.load.network_overrides.len(), 1);
+    assert_eq!(plan.load.network_overrides[0].iface_id, "eth0");
+    assert_eq!(plan.load.network_overrides[0].host_dev_name, "tap7");
     assert_eq!(
         plan.stage,
         vec![
@@ -559,11 +552,19 @@ fn restore_stages_the_image_and_disks_into_a_jail_by_name() {
 fn restore_refuses_foreign_and_diff_images() {
     let mut foreign = image(Path::new("/snaps/abc"));
     foreign.format = CheckpointFormat::new("fake/v1");
-    let spec = restore_spec("box2", IsolationSpec::None, "/x".into());
-    match fc_restore(&foreign, &spec, &config(), Path::new("/run/vms/box2")) {
+    // A foreign format is refused first, whatever the isolation.
+    let unjailed = restore_spec("box2", IsolationSpec::None, "/x".into());
+    match fc_restore(&foreign, &unjailed, &config(), Path::new("/run/vms/box2")) {
         Err(Error::ForeignCheckpoint(format)) => assert_eq!(format.as_str(), "fake/v1"),
         other => panic!("expected ForeignCheckpoint, got {other:?}"),
     }
+    // A disk already inside the jail, so nothing is stat'ed on the way to
+    // the checks below.
+    let spec = restore_spec(
+        "box2",
+        jailed(Path::new("/srv/jailer")),
+        "/srv/jailer/firecracker/box2/root/rootfs.ext4".into(),
+    );
     let mut diff = image(Path::new("/snaps/abc"));
     diff.kind = CheckpointKind::Diff;
     assert!(

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -61,6 +61,7 @@ fn direct_layout_names_the_runtime_dir_sockets_and_passes_paths_verbatim() {
     );
     let plan = layout.spawn_plan();
     assert_eq!(plan.api_socket, Path::new("/run/vms/box/firecracker.sock"));
+    assert_eq!(plan.vsock_uds, Path::new("/run/vms/box/firecracker.vsock"));
     let SpawnMode::Direct { log, metrics } = plan.mode else {
         panic!("direct spawn");
     };
@@ -97,6 +98,7 @@ fn jailer_layout_relativizes_inside_paths_and_stages_outside_ones() {
     );
     let plan = layout.spawn_plan();
     assert_eq!(plan.api_socket, root.join("run/firecracker.socket"));
+    assert_eq!(plan.vsock_uds, root.join("run/firecracker.vsock"));
     let SpawnMode::Jailer {
         isolation,
         jail_root,

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -352,16 +352,15 @@ fn jailer_mode_mirrors_a_block_device_as_a_node() {
 
 #[test]
 fn a_vm_id_cannot_name_another_jail() {
-    // The port allows dots in an id, and the jail is `{base}/{exec}/{id}/root`.
+    // The jail is `{base}/{exec}/{id}/root`, so `.` and `..` would name the
+    // binary's or the base's own `root`. The port refuses them at the id;
+    // the layout's guard is the second lock on the same door.
     for id in [".", ".."] {
-        let id = VmId::new(id).expect("the port accepts it");
-        let error = VmLayout::new(
-            &id,
-            &jailed(Path::new("/srv/jailer")),
-            &config(),
-            Path::new("/run/vms/box"),
+        assert!(
+            matches!(VmId::new(id), Err(Error::InvalidSpec(_))),
+            "`{id}` is refused by the port"
         );
-        assert!(invalid(error).contains("vm id"), "`{id}` is refused");
+        assert!(!is_plain_component(id), "`{id}` is refused by the layout");
     }
     // A dot inside a name is not a component of its own.
     assert!(

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -1,0 +1,131 @@
+//! Pins every path and payload rule of the renderer.
+
+use std::path::{Path, PathBuf};
+
+use arcbox_vm_driver::{IsolationSpec, VmId};
+
+use super::*;
+use crate::config::FcDriverConfig;
+
+fn config() -> FcDriverConfig {
+    let mut config = FcDriverConfig::new("/opt/fc/firecracker");
+    config.jailer_binary = Some("/opt/fc/jailer".into());
+    config
+}
+
+fn jailed(chroot_base: &Path) -> IsolationSpec {
+    IsolationSpec::Jailer {
+        uid: 1000,
+        gid: 1000,
+        chroot_base: chroot_base.to_path_buf(),
+        netns: None,
+        new_pid_ns: false,
+        cgroup: None,
+    }
+}
+
+fn layout(isolation: &IsolationSpec) -> VmLayout {
+    VmLayout::new(
+        &VmId::new("box").unwrap(),
+        isolation,
+        &config(),
+        Path::new("/run/vms/box"),
+    )
+    .unwrap()
+}
+
+#[test]
+fn direct_layout_names_the_runtime_dir_sockets_and_passes_paths_verbatim() {
+    let layout = layout(&IsolationSpec::None);
+    assert!(layout.jail().is_none());
+    assert_eq!(
+        layout.api_socket(),
+        Path::new("/run/vms/box/firecracker.sock")
+    );
+    assert_eq!(
+        layout.vsock_host_uds(),
+        Path::new("/run/vms/box/firecracker.vsock")
+    );
+    assert_eq!(
+        layout.vsock_fc_uds().unwrap(),
+        "/run/vms/box/firecracker.vsock"
+    );
+    let plan = layout.spawn_plan();
+    assert_eq!(plan.api_socket, Path::new("/run/vms/box/firecracker.sock"));
+    let SpawnMode::Direct { log, metrics } = plan.mode else {
+        panic!("direct spawn");
+    };
+    assert_eq!(log, Path::new("/run/vms/box/firecracker.log"));
+    assert_eq!(metrics, Path::new("/run/vms/box/firecracker.metrics"));
+
+    let mut stage = Vec::new();
+    assert_eq!(
+        layout
+            .place(
+                Path::new("/images/vmlinux"),
+                "vmlinux",
+                StageKind::LinkOrCopy,
+                &mut stage
+            )
+            .unwrap(),
+        "/images/vmlinux"
+    );
+    assert!(stage.is_empty(), "nothing is staged without a jail");
+}
+
+#[test]
+fn jailer_layout_relativizes_inside_paths_and_stages_outside_ones() {
+    let base = PathBuf::from("/srv/jailer");
+    let layout = layout(&jailed(&base));
+    let root = base.join("firecracker/box/root");
+    assert_eq!(layout.jail().unwrap().root, root);
+    assert_eq!(layout.api_socket(), root.join("run/firecracker.socket"));
+    assert_eq!(layout.vsock_host_uds(), root.join("run/firecracker.vsock"));
+    assert_eq!(layout.vsock_fc_uds().unwrap(), "/run/firecracker.vsock");
+    let plan = layout.spawn_plan();
+    assert_eq!(plan.api_socket, root.join("run/firecracker.socket"));
+    let SpawnMode::Jailer {
+        isolation,
+        jail_root,
+    } = plan.mode
+    else {
+        panic!("jailer spawn");
+    };
+    assert_eq!(isolation, jailed(&base));
+    assert_eq!(jail_root, root);
+
+    let mut stage = Vec::new();
+    // Already inside the jail: `/` + relative, nothing staged.
+    assert_eq!(
+        layout
+            .place(
+                &root.join("rootfs.ext4"),
+                "rootfs.ext4",
+                StageKind::Copy,
+                &mut stage
+            )
+            .unwrap(),
+        "/rootfs.ext4"
+    );
+    assert!(stage.is_empty());
+    // Outside: staged to `/{name}` by the given kind.
+    assert_eq!(
+        layout
+            .place(
+                Path::new("/images/vmlinux"),
+                "vmlinux",
+                StageKind::LinkOrCopy,
+                &mut stage
+            )
+            .unwrap(),
+        "/vmlinux"
+    );
+    assert_eq!(
+        stage,
+        vec![StagePlan {
+            src: "/images/vmlinux".into(),
+            dst: root.join("vmlinux"),
+            kind: StageKind::LinkOrCopy,
+        }]
+    );
+}

--- a/virt/arcbox-fc-driver/src/spawn.rs
+++ b/virt/arcbox-fc-driver/src/spawn.rs
@@ -22,9 +22,9 @@ pub async fn spawn(
     fc_cfg: &FcDriverConfig,
 ) -> Result<fc_sdk::FirecrackerProcess> {
     if let Some(parent) = plan.vsock_uds.parent() {
-        std::fs::create_dir_all(parent).map_err(Error::Io)?;
+        tokio::fs::create_dir_all(parent).await.map_err(Error::Io)?;
     }
-    if let Err(e) = std::fs::remove_file(&plan.vsock_uds)
+    if let Err(e) = tokio::fs::remove_file(&plan.vsock_uds).await
         && e.kind() != std::io::ErrorKind::NotFound
     {
         return Err(Error::Io(e));
@@ -32,7 +32,7 @@ pub async fn spawn(
     match &plan.mode {
         SpawnMode::Direct { log, metrics } => {
             for target in [log, metrics] {
-                std::fs::File::create(target).map_err(Error::Io)?;
+                tokio::fs::File::create(target).await.map_err(Error::Io)?;
             }
             spawn_direct(fc_cfg, plan.id.as_str(), &plan.api_socket, log, metrics).await
         }

--- a/virt/arcbox-fc-driver/src/spawn.rs
+++ b/virt/arcbox-fc-driver/src/spawn.rs
@@ -8,39 +8,35 @@ use fc_sdk::process::{FirecrackerProcessBuilder, JailerProcessBuilder};
 
 use crate::config::FcDriverConfig;
 use crate::error::FcError;
-use crate::jail;
 use crate::render::{SpawnMode, SpawnPlan};
 
 /// Spawn the process a plan describes and wait for its API socket.
 ///
-/// Direct mode pre-creates the log and metrics files (some Firecracker
-/// builds expect `--log-path`/`--metrics-path` targets to exist). Jailer
-/// mode pre-creates `{jail}/run` and clears a stale vsock socket there, so
-/// a restore can bind its vsock device where the plan says.
+/// The vsock socket's directory (`{runtime_dir}`, or `{jail}/run`) is
+/// created and a stale socket from an earlier VM in the same place is
+/// cleared first, so the device can bind where the plan says. Direct mode
+/// also pre-creates the log and metrics files (some Firecracker builds
+/// expect `--log-path`/`--metrics-path` targets to exist).
 pub async fn spawn(
     plan: &SpawnPlan,
     fc_cfg: &FcDriverConfig,
 ) -> Result<fc_sdk::FirecrackerProcess> {
+    if let Some(parent) = plan.vsock_uds.parent() {
+        std::fs::create_dir_all(parent).map_err(Error::Io)?;
+    }
+    if let Err(e) = std::fs::remove_file(&plan.vsock_uds)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(Error::Io(e));
+    }
     match &plan.mode {
         SpawnMode::Direct { log, metrics } => {
             for target in [log, metrics] {
-                if let Some(parent) = target.parent() {
-                    std::fs::create_dir_all(parent).map_err(Error::Io)?;
-                }
                 std::fs::File::create(target).map_err(Error::Io)?;
             }
             spawn_direct(fc_cfg, plan.id.as_str(), &plan.api_socket, log, metrics).await
         }
-        SpawnMode::Jailer {
-            isolation,
-            jail_root,
-        } => {
-            std::fs::create_dir_all(jail_root.join("run")).map_err(Error::Io)?;
-            if let Err(e) = std::fs::remove_file(jail::vsock_uds_path(jail_root))
-                && e.kind() != std::io::ErrorKind::NotFound
-            {
-                return Err(Error::Io(e));
-            }
+        SpawnMode::Jailer { isolation, .. } => {
             spawn_jailer(fc_cfg, isolation, plan.id.as_str()).await
         }
     }

--- a/virt/arcbox-fc-driver/src/spawn.rs
+++ b/virt/arcbox-fc-driver/src/spawn.rs
@@ -1,4 +1,5 @@
-//! Firecracker process spawn helpers — shared between `manager` and `sandbox`.
+//! Firecracker process spawn helpers — from a rendered [`SpawnPlan`], or
+//! directly by mode.
 
 use std::path::Path;
 
@@ -7,6 +8,43 @@ use fc_sdk::process::{FirecrackerProcessBuilder, JailerProcessBuilder};
 
 use crate::config::FcDriverConfig;
 use crate::error::FcError;
+use crate::jail;
+use crate::render::{SpawnMode, SpawnPlan};
+
+/// Spawn the process a plan describes and wait for its API socket.
+///
+/// Direct mode pre-creates the log and metrics files (some Firecracker
+/// builds expect `--log-path`/`--metrics-path` targets to exist). Jailer
+/// mode pre-creates `{jail}/run` and clears a stale vsock socket there, so
+/// a restore can bind its vsock device where the plan says.
+pub async fn spawn(
+    plan: &SpawnPlan,
+    fc_cfg: &FcDriverConfig,
+) -> Result<fc_sdk::FirecrackerProcess> {
+    match &plan.mode {
+        SpawnMode::Direct { log, metrics } => {
+            for target in [log, metrics] {
+                if let Some(parent) = target.parent() {
+                    std::fs::create_dir_all(parent).map_err(Error::Io)?;
+                }
+                std::fs::File::create(target).map_err(Error::Io)?;
+            }
+            spawn_direct(fc_cfg, plan.id.as_str(), &plan.api_socket, log, metrics).await
+        }
+        SpawnMode::Jailer {
+            isolation,
+            jail_root,
+        } => {
+            std::fs::create_dir_all(jail_root.join("run")).map_err(Error::Io)?;
+            if let Err(e) = std::fs::remove_file(jail::vsock_uds_path(jail_root))
+                && e.kind() != std::io::ErrorKind::NotFound
+            {
+                return Err(Error::Io(e));
+            }
+            spawn_jailer(fc_cfg, isolation, plan.id.as_str()).await
+        }
+    }
+}
 
 /// Configure and spawn a Firecracker process via the Jailer.
 ///

--- a/virt/arcbox-fc-driver/src/spawn.rs
+++ b/virt/arcbox-fc-driver/src/spawn.rs
@@ -1,63 +1,66 @@
 //! Firecracker process spawn helpers — shared between `manager` and `sandbox`.
 
 use std::path::Path;
-use std::time::Duration;
 
+use arcbox_vm_driver::{Error, IsolationSpec, Result};
 use fc_sdk::process::{FirecrackerProcessBuilder, JailerProcessBuilder};
 
-use crate::config::{FirecrackerConfig, JailerConfig};
-use crate::error::{Result, VmmError};
-
-// Match fc-sdk 0.2.3 while keeping ArcBox's boot handoff bound stable across upgrades.
-const DEFAULT_SOCKET_TIMEOUT_SECS: u64 = 5;
+use crate::config::FcDriverConfig;
+use crate::error::FcError;
 
 /// Configure and spawn a Firecracker process via the Jailer.
 ///
 /// Returns the spawned process. The caller can query `process.socket_path()`
 /// to obtain the API socket inside the chroot.
 pub async fn spawn_jailer(
-    jc: &JailerConfig,
-    fc_cfg: &FirecrackerConfig,
+    fc_cfg: &FcDriverConfig,
+    isolation: &IsolationSpec,
     id: &str,
 ) -> Result<fc_sdk::FirecrackerProcess> {
-    let mut jb = JailerProcessBuilder::new(&jc.binary, &fc_cfg.binary, id, jc.uid, jc.gid);
-    if let Some(ref base) = jc.chroot_base_dir {
-        jb = jb.chroot_base_dir(base);
+    let IsolationSpec::Jailer {
+        uid,
+        gid,
+        chroot_base,
+        netns,
+        new_pid_ns,
+        cgroup,
+    } = isolation
+    else {
+        return Err(Error::InvalidSpec(
+            "a jailer spawn needs IsolationSpec::Jailer".into(),
+        ));
+    };
+    let jailer = fc_cfg.jailer_binary.as_deref().ok_or(FcError::NoJailer)?;
+    let mut jb = JailerProcessBuilder::new(jailer, &fc_cfg.firecracker_binary, id, *uid, *gid);
+    jb = jb.chroot_base_dir(chroot_base);
+    if let Some(ns) = netns {
+        jb = jb.netns(ns.display().to_string());
     }
-    if let Some(ref ns) = jc.netns {
-        jb = jb.netns(ns);
-    }
-    if jc.new_pid_ns {
+    if *new_pid_ns {
         jb = jb.new_pid_ns(true);
     }
-    if let Some(ref ver) = jc.cgroup_version {
-        jb = jb.cgroup_version(ver);
+    if let Some(cg) = cgroup {
+        jb = jb.cgroup_version(cg.version.to_string());
+        if let Some(parent) = &cg.parent {
+            jb = jb.parent_cgroup(parent);
+        }
     }
-    if let Some(ref parent) = jc.parent_cgroup {
-        jb = jb.parent_cgroup(parent);
-    }
-    for limit in &jc.resource_limits {
+    for limit in &fc_cfg.resource_limits {
         jb = jb.resource_limit(limit);
     }
-    jb = jb.socket_timeout(Duration::from_secs(
-        fc_cfg
-            .socket_timeout_secs
-            .unwrap_or(DEFAULT_SOCKET_TIMEOUT_SECS),
-    ));
-    jb.spawn()
-        .await
-        .map_err(|e| VmmError::Process(e.to_string()))
+    jb = jb.socket_timeout(fc_cfg.socket_timeout);
+    jb.spawn().await.map_err(|e| Error::from(FcError::Spawn(e)))
 }
 
 /// Configure and spawn a Firecracker process directly (no Jailer).
 pub async fn spawn_direct(
-    fc_cfg: &FirecrackerConfig,
+    fc_cfg: &FcDriverConfig,
     id: &str,
     socket_path: &Path,
     log_path: &Path,
     metrics_path: &Path,
 ) -> Result<fc_sdk::FirecrackerProcess> {
-    let mut fb = FirecrackerProcessBuilder::new(&fc_cfg.binary, socket_path).id(id);
+    let mut fb = FirecrackerProcessBuilder::new(&fc_cfg.firecracker_binary, socket_path).id(id);
     fb = fb.log_path(log_path).metrics_path(metrics_path);
     if let Some(ref level) = fc_cfg.log_level {
         fb = fb.log_level(level);
@@ -74,20 +77,14 @@ pub async fn spawn_direct(
     if let Some(size) = fc_cfg.mmds_size_limit {
         fb = fb.mmds_size_limit(size);
     }
-    fb = fb.socket_timeout(Duration::from_secs(
-        fc_cfg
-            .socket_timeout_secs
-            .unwrap_or(DEFAULT_SOCKET_TIMEOUT_SECS),
-    ));
+    fb = fb.socket_timeout(fc_cfg.socket_timeout);
     tracing::debug!(
         id,
         socket = %socket_path.display(),
         log = %log_path.display(),
         metrics = %metrics_path.display(),
-        binary = %fc_cfg.binary,
+        binary = %fc_cfg.firecracker_binary.display(),
         "spawning firecracker (direct mode)"
     );
-    fb.spawn()
-        .await
-        .map_err(|e| VmmError::Process(e.to_string()))
+    fb.spawn().await.map_err(|e| Error::from(FcError::Spawn(e)))
 }

--- a/virt/arcbox-fc-driver/src/vsock.rs
+++ b/virt/arcbox-fc-driver/src/vsock.rs
@@ -1,0 +1,258 @@
+//! Firecracker's hybrid vsock: a Unix socket in both directions.
+//!
+//! Firecracker exposes a Unix domain socket (`uds_path`) that acts as a proxy
+//! for host-initiated connections to guest vsock ports.  The handshake:
+//!
+//! 1. Connect to `uds_path`.
+//! 2. Write `"CONNECT {port}\n"`.
+//! 3. Read until `'\n'` — the response is `"OK {host_ephemeral_port}\n"`.
+//! 4. The socket is now a bidirectional pipe to the guest's vsock port.
+//!
+//! In the other direction, a guest-initiated connect to host port `P` is
+//! forwarded by Firecracker to a host Unix socket at `{uds_path}_{P}`; a
+//! [`UdsListener`] pre-binds there before the guest starts.
+
+use std::path::{Path, PathBuf};
+
+use arcbox_vm_driver::{Error, Result};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+
+use crate::error::FcError;
+
+/// Single attempt: connect to the Firecracker vsock UDS and complete the
+/// `CONNECT {port}` / `OK` handshake.
+///
+/// Firecracker closes the connection without answering when no listener is
+/// active on the guest port yet (kernel still booting, agent not started);
+/// that outcome is [`Error::Io`] of kind
+/// [`ConnectionRefused`](std::io::ErrorKind::ConnectionRefused), the one a
+/// caller retries on. Every other failure is final.
+pub async fn dial_uds(uds_path: &Path, port: u32) -> Result<UnixStream> {
+    let mut stream =
+        UnixStream::connect(uds_path)
+            .await
+            .map_err(|source| FcError::VsockConnect {
+                uds: uds_path.to_path_buf(),
+                source,
+            })?;
+    let handshake = |detail: &str, source: std::io::Error| FcError::VsockHandshake {
+        uds: uds_path.to_path_buf(),
+        detail: detail.to_owned(),
+        source: Some(source),
+    };
+    let malformed = |detail: &str| FcError::VsockHandshake {
+        uds: uds_path.to_path_buf(),
+        detail: detail.to_owned(),
+        source: None,
+    };
+
+    // Firecracker vsock host-initiated handshake.
+    stream
+        .write_all(format!("CONNECT {port}\n").as_bytes())
+        .await
+        .map_err(|e| handshake("CONNECT write", e))?;
+
+    // Read "OK {port}\n".
+    let mut buf = [0u8; 64];
+    let mut i = 0usize;
+    loop {
+        let n = stream
+            .read(&mut buf[i..=i])
+            .await
+            .map_err(|e| handshake("response read", e))?;
+        if n == 0 {
+            return Err(Error::Io(std::io::Error::new(
+                std::io::ErrorKind::ConnectionRefused,
+                format!("vsock port {port}: connection closed during handshake"),
+            )));
+        }
+        if buf[i] == b'\n' {
+            break;
+        }
+        i += 1;
+        if i >= buf.len() - 1 {
+            return Err(malformed("response too long").into());
+        }
+    }
+    let resp = std::str::from_utf8(&buf[..=i]).map_err(|_| malformed("non-UTF-8 response"))?;
+    if !resp.starts_with("OK") {
+        return Err(malformed(&format!("unexpected response: {resp:?}")).into());
+    }
+    Ok(stream)
+}
+
+/// Derive the host Unix-socket path Firecracker forwards guest-initiated
+/// connections to host `port` to: `{uds_path}_{port}`.
+///
+/// The suffix convention is Firecracker's hybrid-vsock contract ("a guest
+/// connection to port 52 will get forwarded to `./v.sock_52`", FC
+/// docs/vsock.md). FC resolves the path against its own filesystem view,
+/// which matches the host view here: in jailer mode both are the same file
+/// under the chroot root, in direct mode the same absolute path.
+pub fn listener_socket_path(uds_path: &Path, port: u32) -> PathBuf {
+    let mut path = uds_path.as_os_str().to_owned();
+    path.push(format!("_{port}"));
+    PathBuf::from(path)
+}
+
+/// Pre-bound listener for a guest dial-out to one host port.
+///
+/// Must be bound BEFORE Firecracker `InstanceStart` for a boot-time
+/// dial-out: FC forwards the guest's connect only to an already-listening
+/// socket and resets the guest otherwise, losing the event. The socket file
+/// is per-boot; dropping the listener removes it.
+pub struct UdsListener {
+    listener: UnixListener,
+    path: PathBuf,
+}
+
+impl UdsListener {
+    /// Bind the listener socket for `port` on `uds_path`, replacing any
+    /// stale socket file left behind by a previous boot of the same VM
+    /// directory.
+    pub fn bind(uds_path: &Path, port: u32) -> Result<Self> {
+        let path = listener_socket_path(uds_path, port);
+        if let Err(e) = std::fs::remove_file(&path)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(FcError::VsockListen {
+                what: "remove stale listener socket",
+                path,
+                source: e,
+            }
+            .into());
+        }
+        let listener = UnixListener::bind(&path).map_err(|source| FcError::VsockListen {
+            what: "bind listener socket",
+            path: path.clone(),
+            source,
+        })?;
+        Ok(Self { listener, path })
+    }
+
+    /// The bound socket path (so jailer boots can grant FC connect access).
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Wait for the next guest connection.
+    pub async fn accept(&self) -> Result<UnixStream> {
+        let (stream, _) = self
+            .listener
+            .accept()
+            .await
+            .map_err(|source| FcError::VsockListen {
+                what: "accept on listener socket",
+                path: self.path.clone(),
+                source,
+            })?;
+        Ok(stream)
+    }
+}
+
+impl Drop for UdsListener {
+    fn drop(&mut self) {
+        // The socket file is meaningful only to the boot that bound it.
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn listener_socket_path_appends_the_port_suffix() {
+        // Pins the Firecracker hybrid-vsock naming contract: a guest
+        // dialing host port 51 lands on `{uds}_51`.
+        assert_eq!(
+            listener_socket_path(Path::new("/vm/dir/firecracker.vsock"), 51),
+            Path::new("/vm/dir/firecracker.vsock_51")
+        );
+    }
+
+    #[tokio::test]
+    async fn listener_accepts_the_dial_out_and_cleans_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let uds = dir.path().join("fc.vsock");
+        // A stale socket file from a previous boot must not fail the bind.
+        std::fs::write(listener_socket_path(&uds, 51), b"stale").unwrap();
+
+        let listener = UdsListener::bind(&uds, 51).unwrap();
+        let dial_path = listener.path().to_owned();
+        let dial = tokio::spawn(async move {
+            let mut stream = UnixStream::connect(&dial_path).await.unwrap();
+            stream.write_all(&[0u8]).await.unwrap();
+        });
+        let mut stream = listener.accept().await.unwrap();
+        let mut byte = [0u8; 1];
+        stream.read_exact(&mut byte).await.unwrap();
+        dial.await.unwrap();
+
+        let path = listener.path().to_owned();
+        drop(listener);
+        assert!(!path.exists(), "drop must remove the per-boot socket file");
+    }
+
+    #[tokio::test]
+    async fn dial_completes_the_connect_handshake() {
+        let dir = tempfile::tempdir().unwrap();
+        let uds = dir.path().join("fc.vsock");
+        let proxy = UnixListener::bind(&uds).unwrap();
+        let fc = tokio::spawn(async move {
+            let (mut stream, _) = proxy.accept().await.unwrap();
+            let mut req = vec![0u8; "CONNECT 52\n".len()];
+            stream.read_exact(&mut req).await.unwrap();
+            assert_eq!(req, b"CONNECT 52\n");
+            stream.write_all(b"OK 1024\n").await.unwrap();
+            stream
+        });
+        let stream = dial_uds(&uds, 52).await.unwrap();
+        drop(stream);
+        fc.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dial_reports_a_closed_handshake_as_connection_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let uds = dir.path().join("fc.vsock");
+        let proxy = UnixListener::bind(&uds).unwrap();
+        // Firecracker's answer when nothing listens on the guest port: it
+        // reads the CONNECT and closes without a reply.
+        let fc = tokio::spawn(async move {
+            let (mut stream, _) = proxy.accept().await.unwrap();
+            let mut req = [0u8; 16];
+            let _ = stream.read(&mut req).await.unwrap();
+            drop(stream);
+        });
+        match dial_uds(&uds, 52).await {
+            Err(Error::Io(e)) => assert_eq!(e.kind(), std::io::ErrorKind::ConnectionRefused),
+            other => panic!("expected Io(ConnectionRefused), got {other:?}"),
+        }
+        fc.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dial_rejects_a_non_ok_reply_and_a_missing_socket_as_final() {
+        let dir = tempfile::tempdir().unwrap();
+        let uds = dir.path().join("fc.vsock");
+        let proxy = UnixListener::bind(&uds).unwrap();
+        let fc = tokio::spawn(async move {
+            let (mut stream, _) = proxy.accept().await.unwrap();
+            let mut req = [0u8; 16];
+            let _ = stream.read(&mut req).await.unwrap();
+            stream.write_all(b"ERR nope\n").await.unwrap();
+        });
+        assert!(matches!(
+            dial_uds(&uds, 52).await,
+            Err(Error::Driver { .. })
+        ));
+        fc.await.unwrap();
+
+        assert!(matches!(
+            dial_uds(&dir.path().join("absent.vsock"), 52).await,
+            Err(Error::Driver { .. })
+        ));
+    }
+}

--- a/virt/arcbox-fc-driver/src/vsock.rs
+++ b/virt/arcbox-fc-driver/src/vsock.rs
@@ -138,16 +138,24 @@ impl UdsListener {
 
     /// Wait for the next guest connection.
     pub async fn accept(&self) -> Result<UnixStream> {
-        let (stream, _) = self
-            .listener
-            .accept()
-            .await
-            .map_err(|source| FcError::VsockListen {
-                what: "accept on listener socket",
-                path: self.path.clone(),
-                source,
-            })?;
-        Ok(stream)
+        std::future::poll_fn(|cx| self.poll_accept(cx)).await
+    }
+
+    /// Poll for the next guest connection.
+    pub fn poll_accept(
+        &self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<UnixStream>> {
+        self.listener.poll_accept(cx).map(|accepted| {
+            accepted.map(|(stream, _)| stream).map_err(|source| {
+                FcError::VsockListen {
+                    what: "accept on listener socket",
+                    path: self.path.clone(),
+                    source,
+                }
+                .into()
+            })
+        })
     }
 }
 

--- a/virt/arcbox-fc-driver/tests/contract.rs
+++ b/virt/arcbox-fc-driver/tests/contract.rs
@@ -68,13 +68,16 @@ struct FcHarness {
 }
 
 impl FcHarness {
-    /// Firecracker run directly; `None` without the assets.
+    /// Firecracker run directly; `None` without the assets. No jailer, so
+    /// the driver claims no checkpoints and the contract's checkpoint and
+    /// restore checks skip themselves.
     fn direct() -> Option<Self> {
         Some(Self::new(Assets::from_env()?, None))
     }
 
-    /// Firecracker under the jailer as uid/gid 0 (production's shape);
-    /// `None` without the assets or `FC_JAILER`.
+    /// Firecracker under the jailer as uid/gid 0 (production's shape), the
+    /// mode checkpoints and restores are possible in; `None` without the
+    /// assets or `FC_JAILER`.
     fn jailer() -> Option<Self> {
         let jailer: PathBuf = std::env::var_os("FC_JAILER")?.into();
         Some(Self::new(Assets::from_env()?, Some(jailer)))

--- a/virt/arcbox-fc-driver/tests/contract.rs
+++ b/virt/arcbox-fc-driver/tests/contract.rs
@@ -1,0 +1,249 @@
+//! The driver contract against a real Firecracker.
+//!
+//! Every check the port's `driver_contract!` runs against the fake runs
+//! here against `FcDriver` — directly, and under the jailer when
+//! `FC_JAILER` is set — from `arcbox_vm_driver::testkit::contract`, one
+//! `#[ignore]`d test each. The list below mirrors `driver_contract!`; a
+//! check added to the port is added here.
+//!
+//! ## Prerequisites
+//!
+//! | Variable    | Description                                                |
+//! |-------------|------------------------------------------------------------|
+//! | `FC_BINARY` | Path to the `firecracker` binary                           |
+//! | `FC_KERNEL` | Path to the kernel image (`vmlinux`)                       |
+//! | `FC_ROOTFS` | Path to a root filesystem with `vm-agent` at `/sbin/vm-agent` |
+//! | `FC_JAILER` | Path to the `jailer` binary; enables the `jailer` module    |
+//!
+//! Tests without their variables return early. Both modes need `/dev/kvm`;
+//! the jailer needs root.
+//!
+//! ## Running
+//!
+//! ```bash
+//! sudo -E cargo test --test contract -p arcbox-fc-driver -- --include-ignored --test-threads=1
+//! ```
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use arcbox_fc_driver::{FcDriver, FcDriverConfig, jail};
+use arcbox_vm_driver::testkit::ContractHarness;
+use arcbox_vm_driver::{
+    BootSpec, CacheMode, ConsoleSpec, DiskSpec, Error, IsolationSpec, VmDriver, VmHandle, VmId,
+    VmSpec, VsockSpec,
+};
+use arcbox_vm_proto::exec::{AGENT_PORT, READY_PORT};
+use async_trait::async_trait;
+
+/// How long `ready` dial-polls the agent port before giving up.
+const READY_DEADLINE: Duration = Duration::from_secs(60);
+
+/// The Firecracker assets the environment names.
+struct Assets {
+    binary: PathBuf,
+    kernel: PathBuf,
+    rootfs: PathBuf,
+}
+
+impl Assets {
+    fn from_env() -> Option<Self> {
+        Some(Self {
+            binary: std::env::var_os("FC_BINARY")?.into(),
+            kernel: std::env::var_os("FC_KERNEL")?.into(),
+            rootfs: std::env::var_os("FC_ROOTFS")?.into(),
+        })
+    }
+}
+
+/// `FcDriver` over temporary directories, in one isolation mode.
+struct FcHarness {
+    driver: Arc<FcDriver>,
+    assets: Assets,
+    isolation: IsolationSpec,
+    root: tempfile::TempDir,
+    dirs: AtomicUsize,
+}
+
+impl FcHarness {
+    /// Firecracker run directly; `None` without the assets.
+    fn direct() -> Option<Self> {
+        Some(Self::new(Assets::from_env()?, None))
+    }
+
+    /// Firecracker under the jailer as uid/gid 0 (production's shape);
+    /// `None` without the assets or `FC_JAILER`.
+    fn jailer() -> Option<Self> {
+        let jailer: PathBuf = std::env::var_os("FC_JAILER")?.into();
+        Some(Self::new(Assets::from_env()?, Some(jailer)))
+    }
+
+    fn new(assets: Assets, jailer: Option<PathBuf>) -> Self {
+        let root = tempfile::Builder::new()
+            .prefix("fc-contract-")
+            .tempdir()
+            .expect("temporary directory for the harness");
+        let mut config = FcDriverConfig::new(&assets.binary);
+        config.log_level = Some("Error".into());
+        config.no_seccomp = true;
+        config.socket_timeout = Duration::from_secs(15);
+        let isolation = match &jailer {
+            Some(_) => IsolationSpec::Jailer {
+                uid: 0,
+                gid: 0,
+                chroot_base: root.path().join("jail"),
+                netns: None,
+                new_pid_ns: false,
+                cgroup: None,
+            },
+            None => IsolationSpec::None,
+        };
+        config.jailer_binary = jailer;
+        Self {
+            driver: Arc::new(FcDriver::new(config)),
+            assets,
+            isolation,
+            root,
+            dirs: AtomicUsize::new(0),
+        }
+    }
+
+    /// A private, writable copy of the rootfs for `id`: next to the runtime
+    /// dirs when running directly, inside the VM's jail (where the sandbox
+    /// manager stages it, and where the driver passes it through as
+    /// `/rootfs.ext4`) under the jailer.
+    fn rootfs_for(&self, id: &VmId) -> PathBuf {
+        let path = match &self.isolation {
+            IsolationSpec::Jailer { chroot_base, .. } => {
+                jail::chroot_root(&self.assets.binary, chroot_base, id.as_str()).join("rootfs.ext4")
+            }
+            _ => self.root.path().join(format!("{id}.ext4")),
+        };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("rootfs parent");
+        }
+        std::fs::copy(&self.assets.rootfs, &path).expect("copy the rootfs for the vm");
+        path
+    }
+}
+
+#[async_trait]
+impl ContractHarness for FcHarness {
+    fn driver(&self) -> Arc<dyn VmDriver> {
+        self.driver.clone()
+    }
+
+    fn spec(&self, id: &VmId) -> VmSpec {
+        VmSpec {
+            id: id.clone(),
+            cpus: 1,
+            memory_mib: 256,
+            boot: BootSpec::Kernel {
+                image: self.assets.kernel.clone(),
+                cmdline: "console=ttyS0 reboot=k panic=1 pci=off init=/sbin/vm-agent".into(),
+                initrd: None,
+            },
+            disks: vec![DiskSpec {
+                id: "rootfs".into(),
+                path: self.rootfs_for(id),
+                read_only: false,
+                root: true,
+                cache: CacheMode::Unsafe,
+            }],
+            // No NIC: the contract exercises no network, and a TAP would
+            // need root even in direct mode.
+            nics: vec![],
+            vsock: Some(VsockSpec { guest_cid: 3 }),
+            shares: vec![],
+            console: ConsoleSpec::Off,
+            balloon: false,
+            entropy: false,
+            dirty_tracking: true,
+            isolation: self.isolation.clone(),
+        }
+    }
+
+    fn runtime_dir(&self) -> PathBuf {
+        let n = self.dirs.fetch_add(1, Ordering::Relaxed);
+        let dir = self.root.path().join(format!("vm{n}"));
+        std::fs::create_dir_all(&dir).expect("runtime dir under the harness root");
+        dir
+    }
+
+    fn dial_port(&self) -> Option<u32> {
+        Some(AGENT_PORT)
+    }
+
+    fn guest_dial_out_port(&self) -> Option<u32> {
+        Some(READY_PORT)
+    }
+
+    /// vm-agent is up once its exec port answers a dial; it dials the
+    /// READY port right after bringing that listener up.
+    async fn ready(&self, handle: &dyn VmHandle) {
+        let vsock = handle.vsock().expect("the contract spec asks for vsock");
+        let deadline = tokio::time::Instant::now() + READY_DEADLINE;
+        loop {
+            match vsock.dial(AGENT_PORT).await {
+                Ok(_) => return,
+                Err(Error::Io(e)) if e.kind() == std::io::ErrorKind::ConnectionRefused => {}
+                Err(e) => panic!("dial the agent port of {}: {e}", handle.id()),
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "vm-agent in {} did not come up within {READY_DEADLINE:?}",
+                handle.id()
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+}
+
+/// `driver_contract!` with every test `#[ignore]`d and skipped when the
+/// harness has no assets: the port's macro cannot ignore, and these need
+/// KVM, a Firecracker, and a rootfs.
+macro_rules! ignored_contract {
+    ($mod:ident, $harness:expr; $($check:ident),* $(,)?) => {
+        mod $mod {
+            use super::*;
+            $(
+                #[tokio::test]
+                #[ignore = "needs FC_BINARY, FC_KERNEL, FC_ROOTFS (and FC_JAILER for the jailer) plus /dev/kvm"]
+                async fn $check() {
+                    let Some(harness) = $harness else {
+                        eprintln!("skipping: assets not configured");
+                        return;
+                    };
+                    arcbox_vm_driver::testkit::contract::$check(&harness).await;
+                }
+            )*
+        }
+    };
+}
+
+macro_rules! contract_modes {
+    ($($check:ident),* $(,)?) => {
+        ignored_contract!(direct, FcHarness::direct(); $($check),*);
+        ignored_contract!(jailer, FcHarness::jailer(); $($check),*);
+    };
+}
+
+// Keep in step with `driver_contract!` in arcbox-vm-driver's testkit.
+contract_modes! {
+    boot_reports_running_then_exits_on_kill,
+    events_deliver_exit_exactly_once,
+    capabilities_agree_with_accessors,
+    checkpoint_resume_keeps_running,
+    checkpoint_hold_quiesces,
+    restore_yields_a_live_vm,
+    detach_then_adopt_round_trip,
+    vsock_dial_reaches_the_guest,
+    foreign_checkpoint_is_refused,
+    record_is_stable,
+    prepare_then_boot_matches_boot,
+    prepared_listener_is_live_before_boot,
+    discard_kills_a_prepared_vm,
+    restore_reattaches_disks,
+}

--- a/virt/arcbox-vm/Cargo.toml
+++ b/virt/arcbox-vm/Cargo.toml
@@ -14,6 +14,7 @@ arcbox-vm-driver.workspace = true
 arcbox-error.workspace = true
 arcbox-snapshot.workspace = true
 fc-sdk.workspace       = true
+arcbox-fc-driver.workspace = true
 tokio.workspace        = true
 thiserror.workspace    = true
 anyhow.workspace       = true

--- a/virt/arcbox-vm/src/config/jailer.rs
+++ b/virt/arcbox-vm/src/config/jailer.rs
@@ -1,4 +1,9 @@
+use std::path::{Path, PathBuf};
+
+use arcbox_vm_driver::{CgroupSpec, IsolationSpec};
 use serde::{Deserialize, Serialize};
+
+use crate::error::VmmError;
 
 /// Configuration for running Firecracker under the Jailer sandbox.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -23,4 +28,136 @@ pub struct JailerConfig {
     /// Resource limits in `rlimit` format (e.g., `"fsize=2048"`).
     #[serde(default)]
     pub resource_limits: Vec<String>,
+}
+
+impl JailerConfig {
+    /// The jailer's default chroot base, used when the config names none.
+    pub const DEFAULT_CHROOT_BASE: &'static str = "/srv/jailer";
+
+    /// The chroot base the jailer actually uses: the configured directory,
+    /// or the jailer's own default.
+    pub fn chroot_base(&self) -> &Path {
+        Path::new(
+            self.chroot_base_dir
+                .as_deref()
+                .unwrap_or(Self::DEFAULT_CHROOT_BASE),
+        )
+    }
+}
+
+impl TryFrom<&JailerConfig> for IsolationSpec {
+    type Error = VmmError;
+
+    /// The per-VM half of the jailer config: who the VMM runs as, where its
+    /// chroot lives, which namespaces and cgroup it enters. The jailer
+    /// binary and the resource limits are node-wide and belong to the
+    /// driver config instead.
+    ///
+    /// A `parent_cgroup` without a `cgroup_version` keeps the jailer's own
+    /// default, version 1, made explicit here because the spec's
+    /// [`CgroupSpec`] always names a version.
+    fn try_from(jc: &JailerConfig) -> Result<Self, VmmError> {
+        let cgroup = match (jc.cgroup_version.as_deref(), jc.parent_cgroup.as_deref()) {
+            (None, None) => None,
+            (version, parent) => Some(CgroupSpec {
+                version: match version {
+                    None => 1,
+                    Some("1") => 1,
+                    Some("2") => 2,
+                    Some(other) => {
+                        return Err(VmmError::Config(format!(
+                            "jailer cgroup_version must be \"1\" or \"2\", got {other:?}"
+                        )));
+                    }
+                },
+                parent: parent.map(str::to_owned),
+            }),
+        };
+        Ok(Self::Jailer {
+            uid: jc.uid,
+            gid: jc.gid,
+            chroot_base: jc.chroot_base().to_path_buf(),
+            netns: jc.netns.as_deref().map(PathBuf::from),
+            new_pid_ns: jc.new_pid_ns,
+            cgroup,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn jailer() -> JailerConfig {
+        JailerConfig {
+            binary: "/usr/bin/jailer".into(),
+            uid: 1000,
+            gid: 1000,
+            chroot_base_dir: None,
+            netns: None,
+            new_pid_ns: false,
+            cgroup_version: None,
+            parent_cgroup: None,
+            resource_limits: vec!["fsize=2048".into()],
+        }
+    }
+
+    #[test]
+    fn isolation_defaults_the_chroot_base_and_carries_no_cgroup_when_unset() {
+        let spec = IsolationSpec::try_from(&jailer()).unwrap();
+        assert_eq!(
+            spec,
+            IsolationSpec::Jailer {
+                uid: 1000,
+                gid: 1000,
+                chroot_base: PathBuf::from("/srv/jailer"),
+                netns: None,
+                new_pid_ns: false,
+                cgroup: None,
+            }
+        );
+    }
+
+    #[test]
+    fn isolation_maps_the_cgroup_fields_and_the_jailer_default_version() {
+        let mut jc = jailer();
+        jc.chroot_base_dir = Some("/jail".into());
+        jc.netns = Some("/var/run/netns/x".into());
+        jc.new_pid_ns = true;
+        jc.cgroup_version = Some("2".into());
+        jc.parent_cgroup = Some("arcbox".into());
+        let IsolationSpec::Jailer {
+            chroot_base,
+            netns,
+            new_pid_ns,
+            cgroup,
+            ..
+        } = IsolationSpec::try_from(&jc).unwrap()
+        else {
+            panic!("jailer config converts to jailer isolation");
+        };
+        assert_eq!(chroot_base, PathBuf::from("/jail"));
+        assert_eq!(netns, Some(PathBuf::from("/var/run/netns/x")));
+        assert!(new_pid_ns);
+        assert_eq!(
+            cgroup,
+            Some(CgroupSpec {
+                version: 2,
+                parent: Some("arcbox".into())
+            })
+        );
+
+        // A parent alone rides on the jailer's default cgroup version.
+        jc.cgroup_version = None;
+        let IsolationSpec::Jailer { cgroup, .. } = IsolationSpec::try_from(&jc).unwrap() else {
+            unreachable!()
+        };
+        assert_eq!(cgroup.map(|c| c.version), Some(1));
+
+        jc.cgroup_version = Some("v2".into());
+        assert!(matches!(
+            IsolationSpec::try_from(&jc),
+            Err(VmmError::Config(_))
+        ));
+    }
 }

--- a/virt/arcbox-vm/src/config/vmm.rs
+++ b/virt/arcbox-vm/src/config/vmm.rs
@@ -1,3 +1,7 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use arcbox_fc_driver::FcDriverConfig;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Result, VmmError};
@@ -74,6 +78,32 @@ pub struct FirecrackerConfig {
     /// used exactly as written, so `[]` is how a config disables CoW.
     #[serde(default)]
     pub dmsetup_candidates: Option<Vec<String>>,
+}
+
+impl From<&FirecrackerConfig> for FcDriverConfig {
+    /// The node-wide half of the Firecracker config: the binaries and the
+    /// process-level flags. The data dir, datapath, pool and warm-create
+    /// knobs stay with the manager; the jailer's per-VM fields become an
+    /// [`arcbox_vm_driver::IsolationSpec`] via [`JailerConfig`].
+    fn from(fc: &FirecrackerConfig) -> Self {
+        Self {
+            firecracker_binary: PathBuf::from(&fc.binary),
+            jailer_binary: fc.jailer.as_ref().map(|jc| PathBuf::from(&jc.binary)),
+            log_level: fc.log_level.clone(),
+            no_seccomp: fc.no_seccomp,
+            seccomp_filter: fc.seccomp_filter.as_deref().map(PathBuf::from),
+            http_api_max_payload_size: fc.http_api_max_payload_size,
+            mmds_size_limit: fc.mmds_size_limit,
+            socket_timeout: fc
+                .socket_timeout_secs
+                .map_or(Self::DEFAULT_SOCKET_TIMEOUT, Duration::from_secs),
+            resource_limits: fc
+                .jailer
+                .as_ref()
+                .map(|jc| jc.resource_limits.clone())
+                .unwrap_or_default(),
+        }
+    }
 }
 
 fn default_pool_size() -> usize {
@@ -266,6 +296,45 @@ mod tests {
         )
         .unwrap();
         assert_eq!(cfg.sandbox_datapath, SandboxDatapath::Iptables);
+    }
+
+    #[test]
+    fn driver_config_takes_the_process_flags_and_the_jailer_binary() {
+        let mut fc = VmmConfig::default().firecracker;
+        assert_eq!(
+            FcDriverConfig::from(&fc),
+            FcDriverConfig::new("/usr/bin/firecracker")
+        );
+
+        fc.jailer = Some(JailerConfig {
+            binary: "/usr/bin/jailer".into(),
+            uid: 0,
+            gid: 0,
+            chroot_base_dir: None,
+            netns: None,
+            new_pid_ns: false,
+            cgroup_version: None,
+            parent_cgroup: None,
+            resource_limits: vec!["fsize=2048".into()],
+        });
+        fc.log_level = Some("Error".into());
+        fc.no_seccomp = true;
+        fc.seccomp_filter = Some("/etc/fc/seccomp.bpf".into());
+        fc.http_api_max_payload_size = Some(1 << 20);
+        fc.mmds_size_limit = Some(4096);
+        fc.socket_timeout_secs = Some(15);
+        let driver = FcDriverConfig::from(&fc);
+        assert_eq!(driver.jailer_binary, Some(PathBuf::from("/usr/bin/jailer")));
+        assert_eq!(driver.log_level.as_deref(), Some("Error"));
+        assert!(driver.no_seccomp);
+        assert_eq!(
+            driver.seccomp_filter,
+            Some(PathBuf::from("/etc/fc/seccomp.bpf"))
+        );
+        assert_eq!(driver.http_api_max_payload_size, Some(1 << 20));
+        assert_eq!(driver.mmds_size_limit, Some(4096));
+        assert_eq!(driver.socket_timeout, Duration::from_secs(15));
+        assert_eq!(driver.resource_limits, vec!["fsize=2048".to_string()]);
     }
 
     #[test]

--- a/virt/arcbox-vm/src/lib.rs
+++ b/virt/arcbox-vm/src/lib.rs
@@ -49,7 +49,6 @@ pub mod file_io;
 pub mod network;
 pub mod rootfs;
 pub mod sandbox;
-pub mod spawn;
 pub mod vsock;
 
 /// Boot-parameter vocabulary shared with `vm-agent` (`arcbox_vm_proto::boot`).

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -20,6 +20,7 @@ use arcbox_fc_driver::jail::{
     stage_rootfs_copy_for_jailer, stage_rootfs_device_for_jailer, stage_snapshot_files,
 };
 use arcbox_fc_driver::spawn::{spawn_direct, spawn_jailer};
+use arcbox_fc_driver::vsock::UdsListener;
 use arcbox_vm_driver::IsolationSpec;
 use chrono::{DateTime, Utc};
 use fc_sdk::VmBuilder;

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -14,6 +14,9 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
+use arcbox_fc_driver::FcDriverConfig;
+use arcbox_fc_driver::spawn::{spawn_direct, spawn_jailer};
+use arcbox_vm_driver::IsolationSpec;
 use chrono::{DateTime, Utc};
 use fc_sdk::VmBuilder;
 use fc_sdk::types::{BootSource, Drive, NetworkInterface, Vsock};
@@ -29,7 +32,6 @@ use crate::error::{Result, VmmError};
 use crate::network::{NetworkAllocation, NetworkManager};
 use crate::snapshot::{SnapshotCatalog, SnapshotDraft};
 use crate::snapshot_cow::{CowHandle, CowManager, CowOptions};
-use crate::spawn::{spawn_direct, spawn_jailer};
 use crate::template_catalog::TemplateCatalog;
 use crate::vsock::{self, ExecInputMsg, ExitStatus, OutputChunk, StartCommand};
 

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use arcbox_fc_driver::FcDriverConfig;
 use arcbox_fc_driver::jail::{
-    SnapshotFiles, chroot_root, link_or_copy_for_jailer, stage_kernel_for_jailer,
+    SnapshotFiles, chroot_root, link_or_copy_for_jailer, move_file, stage_kernel_for_jailer,
     stage_rootfs_copy_for_jailer, stage_rootfs_device_for_jailer, stage_snapshot_files,
 };
 use arcbox_fc_driver::spawn::{spawn_direct, spawn_jailer};

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -15,6 +15,10 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
 use arcbox_fc_driver::FcDriverConfig;
+use arcbox_fc_driver::jail::{
+    SnapshotFiles, chroot_root, link_or_copy_for_jailer, stage_kernel_for_jailer,
+    stage_rootfs_copy_for_jailer, stage_rootfs_device_for_jailer, stage_snapshot_files,
+};
 use arcbox_fc_driver::spawn::{spawn_direct, spawn_jailer};
 use arcbox_vm_driver::IsolationSpec;
 use chrono::{DateTime, Utc};

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -646,143 +646,6 @@ pub(super) async fn run_initial_cmd(
     }
 }
 
-/// Compute the host-side absolute path to the jailer chroot root directory.
-///
-/// Returns `{chroot_base_dir}/{fc_binary_filename}/{id}/root`.
-pub(super) fn chroot_root(fc_binary: &str, chroot_base_dir: &str, id: &str) -> PathBuf {
-    let exec_name = Path::new(fc_binary)
-        .file_name()
-        .expect("fc_binary must have a filename")
-        .to_string_lossy();
-    PathBuf::from(chroot_base_dir)
-        .join(exec_name.as_ref())
-        .join(id)
-        .join("root")
-}
-
-/// Stage a read-only file into a jailer chroot: hard-link when possible,
-/// copy otherwise.
-///
-/// A hard link shares the inode with the source, so it is only safe for
-/// files FC never writes — the kernel image, a snapshot vmstate, and a
-/// snapshot mem file (mapped MAP_PRIVATE on load). Do NOT use it for the
-/// rootfs copy fallback: FC writes guest blocks into that file. Linking is
-/// also reserved for the root jailer (uid/gid 0), because chown on a link
-/// would mutate the shared source inode; a non-root jailer gets a private
-/// copy with its own ownership.
-pub(super) async fn link_or_copy_for_jailer(
-    src: &Path,
-    dst: &Path,
-    uid: u32,
-    gid: u32,
-) -> Result<()> {
-    // Remove a stale entry first: hard_link fails on an existing dst, and a
-    // leftover from a previous run must not survive by accident.
-    if let Err(e) = tokio::fs::remove_file(dst).await
-        && e.kind() != std::io::ErrorKind::NotFound
-    {
-        return Err(VmmError::Io(e));
-    }
-    if uid == 0 && gid == 0 {
-        match tokio::fs::hard_link(src, dst).await {
-            Ok(()) => return Ok(()),
-            // Cross-device (EXDEV) or filesystem quirk. warn, not debug: the
-            // copy fallback silently forfeits the restore fast path, and at
-            // default log levels a misplaced chroot base would only ever be
-            // rediscovered by re-measuring.
-            Err(e) => {
-                warn!(src = %src.display(), dst = %dst.display(), error = %e,
-                    "hard link failed; falling back to copy");
-            }
-        }
-    }
-    tokio::fs::copy(src, dst).await.map_err(VmmError::Io)?;
-    chown(dst, Some(Uid::from_raw(uid)), Some(Gid::from_raw(gid)))
-        .map_err(|e| VmmError::Process(format!("chown {}: {e}", dst.display())))?;
-    Ok(())
-}
-
-/// Stage the kernel into the jailer chroot (link or copy).
-///
-/// Returns the chroot-relative kernel path (e.g. `"/vmlinux"`).
-pub(super) async fn stage_kernel_for_jailer(
-    chroot_root: &Path,
-    kernel_src: &str,
-    uid: u32,
-    gid: u32,
-) -> Result<String> {
-    tokio::fs::create_dir_all(chroot_root)
-        .await
-        .map_err(VmmError::Io)?;
-    let kernel_dst = chroot_root.join("vmlinux");
-    link_or_copy_for_jailer(Path::new(kernel_src), &kernel_dst, uid, gid).await?;
-    Ok("/vmlinux".to_string())
-}
-
-/// Copy rootfs into the jailer chroot and set ownership.
-///
-/// Returns the chroot-relative rootfs path (e.g. `"/rootfs.ext4"`).
-pub(super) async fn stage_rootfs_copy_for_jailer(
-    chroot_root: &Path,
-    rootfs_src: &str,
-    uid: u32,
-    gid: u32,
-) -> Result<String> {
-    tokio::fs::create_dir_all(chroot_root)
-        .await
-        .map_err(VmmError::Io)?;
-    let rootfs_dst = chroot_root.join("rootfs.ext4");
-    // Remove any stale entry — a previous crash or a failed mknod-then-chown
-    // fallback may have left a block device node here, in which case
-    // `tokio::fs::copy` would write into the device instead of replacing it.
-    if let Err(e) = tokio::fs::remove_file(&rootfs_dst).await
-        && e.kind() != std::io::ErrorKind::NotFound
-    {
-        return Err(VmmError::Io(e));
-    }
-    tokio::fs::copy(rootfs_src, &rootfs_dst)
-        .await
-        .map_err(VmmError::Io)?;
-    chown(
-        &rootfs_dst,
-        Some(Uid::from_raw(uid)),
-        Some(Gid::from_raw(gid)),
-    )
-    .map_err(|e| VmmError::Process(format!("chown rootfs: {e}")))?;
-    Ok("/rootfs.ext4".to_string())
-}
-
-/// Create a block device node in the jailer chroot pointing to a dm device.
-///
-/// Returns the chroot-relative rootfs path (`"/rootfs.ext4"`).
-pub(super) async fn stage_rootfs_device_for_jailer(
-    chroot_root: &Path,
-    dm_device: &str,
-    uid: u32,
-    gid: u32,
-) -> Result<String> {
-    tokio::fs::create_dir_all(chroot_root)
-        .await
-        .map_err(VmmError::Io)?;
-    let (major, minor) = crate::snapshot_cow::device_major_minor(dm_device)?;
-    let node_path = chroot_root.join("rootfs.ext4");
-    // Remove any leftover entry from a previous crash so mknod can succeed
-    // (and so we never end up writing into a stale device node).
-    if let Err(e) = tokio::fs::remove_file(&node_path).await
-        && e.kind() != std::io::ErrorKind::NotFound
-    {
-        return Err(VmmError::Io(e));
-    }
-    crate::snapshot_cow::mknod_blkdev(&node_path, major, minor)?;
-    chown(
-        &node_path,
-        Some(Uid::from_raw(uid)),
-        Some(Gid::from_raw(gid)),
-    )
-    .map_err(|e| VmmError::Process(format!("chown rootfs device: {e}")))?;
-    Ok("/rootfs.ext4".to_string())
-}
-
 /// A failed restore-staging step, carrying whichever CoW resources were
 /// acquired before the failure so the caller can roll them back.
 pub(super) struct StageError {
@@ -827,7 +690,7 @@ pub(super) async fn stage_rootfs_cow_or_copy(
                     journal(None).map_err(|error| fail(error, None))?;
                     stage_rootfs_copy_for_jailer(chroot, rootfs, uid, gid)
                         .await
-                        .map_err(|error| fail(error, None))?;
+                        .map_err(|error| fail(error.into(), None))?;
                     Ok(None)
                 }
             }
@@ -841,46 +704,10 @@ pub(super) async fn stage_rootfs_cow_or_copy(
             );
             stage_rootfs_copy_for_jailer(chroot, rootfs, uid, gid)
                 .await
-                .map_err(|error| fail(error, None))?;
+                .map_err(|error| fail(error.into(), None))?;
             Ok(None)
         }
     }
-}
-
-/// Stage a snapshot's vmstate/mem into `{chroot}/snapshots/{snapshot_id}`
-/// via [`link_or_copy_for_jailer`] and return their chroot-relative paths
-/// `(vmstate, mem)` for `SnapshotLoadParams`.
-pub(super) async fn stage_snapshot_files(
-    chroot: &Path,
-    snapshot: &crate::snapshot::SnapshotMeta,
-    uid: u32,
-    gid: u32,
-) -> Result<(String, Option<String>)> {
-    let snap_in_chroot = chroot.join("snapshots").join(&snapshot.id);
-    std::fs::create_dir_all(&snap_in_chroot).map_err(VmmError::Io)?;
-    chown(
-        &snap_in_chroot,
-        Some(Uid::from_raw(uid)),
-        Some(Gid::from_raw(gid)),
-    )
-    .map_err(|e| VmmError::Process(format!("chown snap dir: {e}")))?;
-
-    link_or_copy_for_jailer(
-        &snapshot.vmstate_path,
-        &snap_in_chroot.join("vmstate"),
-        uid,
-        gid,
-    )
-    .await?;
-    let mem = if let Some(ref mf) = snapshot.mem_path
-        && mf.exists()
-    {
-        link_or_copy_for_jailer(mf, &snap_in_chroot.join("mem"), uid, gid).await?;
-        Some(format!("/snapshots/{}/mem", snapshot.id))
-    } else {
-        None
-    };
-    Ok((format!("/snapshots/{}/vmstate", snapshot.id), mem))
 }
 
 /// Create a stable `{vm_dir}/rootfs.link` symlink pointing at the dm-snapshot

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -999,11 +999,15 @@ async fn do_boot(
     }
 
     // Spawn the Firecracker process (direct or via Jailer).
-    let process_result = if let Some(ref jc) = fc_cfg.jailer {
-        spawn_jailer(jc, fc_cfg, id).await
-    } else {
-        spawn_direct(fc_cfg, id, &socket_path, &log_path, &metrics_path).await
-    };
+    let process_result: Result<fc_sdk::FirecrackerProcess> = async {
+        let driver_config = FcDriverConfig::from(fc_cfg);
+        Ok(if let Some(ref jc) = fc_cfg.jailer {
+            spawn_jailer(&driver_config, &IsolationSpec::try_from(jc)?, id).await?
+        } else {
+            spawn_direct(&driver_config, id, &socket_path, &log_path, &metrics_path).await?
+        })
+    }
+    .await;
     let process = match process_result {
         Ok(process) => process,
         Err(error) => {

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -3,7 +3,7 @@ use super::types::action;
 use super::*;
 use arcbox_snapshot::SnapshotError;
 
-type BootOutput = (Arc<fc_sdk::Vm>, PathBuf, vsock::ReadyListener);
+type BootOutput = (Arc<fc_sdk::Vm>, PathBuf, UdsListener);
 
 /// How long the readiness gate waits for vm-agent's dial-out (the guest
 /// connect to [`vsock::READY_PORT`]) before the boot is declared failed.
@@ -74,16 +74,19 @@ pub(super) async fn boot_sandbox(
             // (the vm-agent binary among them) rebuild the default template
             // and re-inject it into docker templates automatically, so a
             // guest always carries the agent from the same build as its host.
-            let agent_ready = match tokio::time::timeout(AGENT_GATE_TIMEOUT, ready_listener.wait())
-                .await
-            {
-                Ok(Ok(())) => Ok(()),
-                Ok(Err(error)) => Err(VmmError::Vsock(format!("agent readiness gate: {error}"))),
-                Err(_) => Err(VmmError::Vsock(format!(
-                    "agent readiness gate: vm-agent did not dial the ready port within {}s",
-                    AGENT_GATE_TIMEOUT.as_secs()
-                ))),
-            };
+            let agent_ready =
+                match tokio::time::timeout(AGENT_GATE_TIMEOUT, vsock::wait_ready(&ready_listener))
+                    .await
+                {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(error)) => {
+                        Err(VmmError::Vsock(format!("agent readiness gate: {error}")))
+                    }
+                    Err(_) => Err(VmmError::Vsock(format!(
+                        "agent readiness gate: vm-agent did not dial the ready port within {}s",
+                        AGENT_GATE_TIMEOUT.as_secs()
+                    ))),
+                };
             // The socket file is per-boot; the gate has consumed its one event.
             drop(ready_listener);
             if let Err(gate_error) = agent_ready {
@@ -1082,11 +1085,11 @@ async fn do_boot(
     // that guest-initiated connect to `{uds_path}_{READY_PORT}` only if
     // someone is already listening there — otherwise the guest is reset and
     // the one readiness event is lost.
-    let ready_listener = match vsock::ReadyListener::bind(&vsock_host_path) {
+    let ready_listener = match UdsListener::bind(&vsock_host_path, vsock::READY_PORT) {
         Ok(listener) => listener,
         Err(error) => {
             return Err(BootFailure {
-                error,
+                error: error.into(),
                 process: None,
                 cow_handle: None,
             });

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -1,7 +1,4 @@
-use super::boot::{
-    StageError, chroot_root, stage_kernel_for_jailer, stage_rootfs_cow_or_copy,
-    stage_snapshot_files,
-};
+use super::boot::{StageError, stage_rootfs_cow_or_copy};
 use super::persistence::{ProvisionIntent, SandboxProvisionOutcome, SandboxTransition};
 use super::pool::PreparedSlot;
 use super::types::action;
@@ -773,7 +770,14 @@ impl SandboxManager {
                     // FC (mem is mapped MAP_PRIVATE on load), so the root jailer
                     // hard-links them instead of copying — the mem file is the
                     // sandbox's full memory size (CORE-75).
-                    stage_snapshot_files(&cr, &snap_meta, jc.uid, jc.gid).await
+                    let files = SnapshotFiles {
+                        id: &snap_meta.id,
+                        vmstate: &snap_meta.vmstate_path,
+                        mem: snap_meta.mem_path.as_deref(),
+                    };
+                    stage_snapshot_files(&cr, &files, jc.uid, jc.gid)
+                        .await
+                        .map_err(VmmError::from)
                 }
                 .await;
 

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -6,27 +6,9 @@ use super::*;
 
 /// The image format this path writes — a Firecracker `vmstate` + `mem`
 /// pair — recorded on every catalog entry so a restore can tell which
-/// driver may read it.
-pub(super) const CHECKPOINT_FORMAT: &str = "firecracker/v1";
-
-/// Move a file even when source and destination sit on different mounts.
-///
-/// The jailer chroot is its own vfsmount (bind + pivot_root), so a plain
-/// `rename(2)` out of it fails with `EXDEV` regardless of the underlying
-/// filesystem; fall back to copy + remove in that case.
-pub(super) async fn move_file(from: &Path, to: &Path) -> std::io::Result<()> {
-    match tokio::fs::rename(from, to).await {
-        Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
-            tokio::fs::copy(from, to).await?;
-            // fsync the destination before removing the source: a crash between
-            // the copy and the remove must not leave a zero-length/partial
-            // snapshot file registered in the catalog.
-            tokio::fs::File::open(to).await?.sync_all().await?;
-            tokio::fs::remove_file(from).await
-        }
-        other => other,
-    }
-}
+/// driver may read it. The Firecracker driver names it; a restore through
+/// the driver refuses any other.
+pub(super) const CHECKPOINT_FORMAT: &str = arcbox_fc_driver::CHECKPOINT_FORMAT;
 
 /// Parameters for the internal restore path
 /// ([`SandboxManager::restore_from_snapshot`]), shared by the Restore RPC

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -681,7 +681,12 @@ impl SandboxManager {
                     let vsock_path = cr.join("run/firecracker.vsock");
                     let _ = std::fs::remove_file(&vsock_path);
 
-                    let proc = spawn_jailer(jailer, fc_cfg, &new_id).await?;
+                    let proc = spawn_jailer(
+                        &FcDriverConfig::from(fc_cfg),
+                        &IsolationSpec::try_from(jailer)?,
+                        &new_id,
+                    )
+                    .await?;
                     Ok((proc, vsock_path))
                 }
                 .await;

--- a/virt/arcbox-vm/src/sandbox/cleanup.rs
+++ b/virt/arcbox-vm/src/sandbox/cleanup.rs
@@ -1,4 +1,3 @@
-use super::boot::chroot_root;
 use super::persistence::{SandboxRecordStore, SandboxTransition};
 use super::types::{SandboxBootTask, action};
 use super::*;
@@ -840,16 +839,8 @@ mod tests {
             parent_cgroup: None,
             resource_limits: vec![],
         });
-        let slot_chroot = chroot_root(
-            &config.firecracker.binary,
-            &chroot_base.to_string_lossy(),
-            "pool-slot",
-        );
-        let sandbox_chroot = chroot_root(
-            &config.firecracker.binary,
-            &chroot_base.to_string_lossy(),
-            "job",
-        );
+        let slot_chroot = chroot_root(&config.firecracker.binary, &chroot_base, "pool-slot");
+        let sandbox_chroot = chroot_root(&config.firecracker.binary, &chroot_base, "job");
         std::fs::create_dir_all(&slot_chroot).unwrap();
         std::fs::create_dir_all(&sandbox_chroot).unwrap();
 

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -28,9 +28,6 @@
 //! onwards every resource is keyed by the sandbox id again and resume,
 //! reconciliation, and `Remove` all see one naming scheme.
 
-use super::boot::{
-    chroot_root, link_or_copy_for_jailer, stage_kernel_for_jailer, stage_rootfs_device_for_jailer,
-};
 use super::checkpoint::{CheckpointRequest, checkpoint_impl, move_file};
 use super::persistence::SandboxTransition;
 use super::types::action;

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -28,7 +28,7 @@
 //! onwards every resource is keyed by the sandbox id again and resume,
 //! reconciliation, and `Remove` all see one naming scheme.
 
-use super::checkpoint::{CheckpointRequest, checkpoint_impl, move_file};
+use super::checkpoint::{CheckpointRequest, checkpoint_impl};
 use super::persistence::SandboxTransition;
 use super::types::action;
 use super::*;

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -595,7 +595,12 @@ impl SandboxManager {
             std::fs::create_dir_all(&run_dir).map_err(VmmError::Io)?;
             let vsock_path = cr.join("run/firecracker.vsock");
             let _ = std::fs::remove_file(&vsock_path);
-            let spawned = spawn_jailer(jailer, fc_cfg, id).await?;
+            let spawned = spawn_jailer(
+                &FcDriverConfig::from(fc_cfg),
+                &IsolationSpec::try_from(jailer)?,
+                id,
+            )
+            .await?;
             #[allow(
                 clippy::cast_possible_wrap,
                 reason = "Firecracker pid fits platform pid_t"

--- a/virt/arcbox-vm/src/sandbox/pool.rs
+++ b/virt/arcbox-vm/src/sandbox/pool.rs
@@ -343,7 +343,13 @@ async fn stage_slot(
     std::fs::create_dir_all(cr.join("run")).map_err(VmmError::Io)?;
     let vsock_path = cr.join("run/firecracker.vsock");
 
-    let process = spawn_jailer(jc, fc_cfg, slot_id).await?;
+    let process = spawn_jailer(
+        &FcDriverConfig::from(fc_cfg),
+        &IsolationSpec::try_from(jc)?,
+        slot_id,
+    )
+    .await
+    .map_err(VmmError::from)?;
     #[allow(
         clippy::cast_possible_wrap,
         reason = "Firecracker pid fits platform pid_t"

--- a/virt/arcbox-vm/src/sandbox/pool.rs
+++ b/virt/arcbox-vm/src/sandbox/pool.rs
@@ -13,10 +13,7 @@
 //! LoadSnapshot time binds a claimed slot to its TAP, which keeps slots
 //! network-agnostic (the seam CORE-81 builds on).
 
-use super::boot::{
-    StageError, chroot_root, kill_and_reap_fc_checked, stage_kernel_for_jailer,
-    stage_rootfs_cow_or_copy, stage_snapshot_files,
-};
+use super::boot::{StageError, kill_and_reap_fc_checked, stage_rootfs_cow_or_copy};
 use super::reconcile::{self, POOL_SLOT_PREFIX, SandboxStateRecord};
 use super::*;
 use crate::config::JailerConfig;
@@ -372,7 +369,7 @@ async fn stage_slot(
 
     if let Some(kernel) = snapshot.kernel_path.as_deref() {
         if let Err(error) = stage_kernel_for_jailer(&cr, kernel, jc.uid, jc.gid).await {
-            return Err(carry(error, Some(process), None));
+            return Err(carry(error.into(), Some(process), None));
         }
     }
 
@@ -389,11 +386,16 @@ async fn stage_slot(
         }
     }
 
-    match stage_snapshot_files(&cr, snapshot, jc.uid, jc.gid).await {
+    let files = SnapshotFiles {
+        id: &snapshot.id,
+        vmstate: &snapshot.vmstate_path,
+        mem: snapshot.mem_path.as_deref(),
+    };
+    match stage_snapshot_files(&cr, &files, jc.uid, jc.gid).await {
         Ok((vmstate_path, mem_path)) => {
             Ok((process, cow_handle, vmstate_path, mem_path, vsock_path))
         }
-        Err(error) => Err(carry(error, Some(process), cow_handle)),
+        Err(error) => Err(carry(error.into(), Some(process), cow_handle)),
     }
 }
 

--- a/virt/arcbox-vm/src/sandbox/reconcile.rs
+++ b/virt/arcbox-vm/src/sandbox/reconcile.rs
@@ -286,8 +286,11 @@ pub(super) async fn sweep_orphans(
             && let Some(ref jc) = config.firecracker.jailer
         {
             let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-            let chroot =
-                super::boot::chroot_root(&config.firecracker.binary, base, record.resource_owner());
+            let chroot = arcbox_fc_driver::jail::chroot_root(
+                &config.firecracker.binary,
+                base,
+                record.resource_owner(),
+            );
             if let Some(parent) = chroot.parent() {
                 remove_dir_if_present(parent).await?;
             }
@@ -544,7 +547,11 @@ fn discover_firecracker_pids(
         .join("firecracker.sock");
     let jailer_root = config.firecracker.jailer.as_ref().map(|jailer| {
         let base = jailer.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-        super::boot::chroot_root(&config.firecracker.binary, base, record.resource_owner())
+        arcbox_fc_driver::jail::chroot_root(
+            &config.firecracker.binary,
+            base,
+            record.resource_owner(),
+        )
     });
 
     for entry in std::fs::read_dir("/proc")? {

--- a/virt/arcbox-vm/src/vsock.rs
+++ b/virt/arcbox-vm/src/vsock.rs
@@ -23,7 +23,8 @@
 //!
 //! In the other direction, a guest-initiated connect to host port `P` is
 //! forwarded by Firecracker to a host Unix socket at `{uds_path}_{P}`; the
-//! boot readiness gate pre-listens there (see [`ReadyListener`]).
+//! boot readiness gate pre-listens there ([`arcbox_fc_driver::vsock::UdsListener`]
+//! + [`wait_ready`]).
 //!
 //! ## Frame format
 //!
@@ -32,12 +33,12 @@
 //! [`arcbox_vm_proto::exec`], re-exported here; the net-reconfig timing
 //! suffix on `MSG_EXIT` is decoded by [`ReconfigTimings`].
 
-use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use arcbox_fc_driver::vsock::UdsListener;
 use arcbox_vm_driver::{IoMode, Vsock, VsockConn};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{UnixListener, UnixStream};
+use tokio::net::UnixStream;
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 
@@ -212,118 +213,20 @@ fn into_unix_stream(conn: VsockConn) -> Result<UnixStream> {
     }
 }
 
-/// Single attempt: connect to the Firecracker vsock UDS and complete the
-/// `CONNECT {port}` / `OK` handshake.
-async fn try_vsock_handshake(uds_path: &Path, port: u32) -> Result<UnixStream> {
-    let mut stream = UnixStream::connect(uds_path)
+/// Wait for the guest agent's readiness dial-out on a pre-bound listener:
+/// `accept()` one connection and read (and discard) its single byte.
+/// Completion is the readiness event.
+pub(crate) async fn wait_ready(listener: &UdsListener) -> Result<()> {
+    let mut stream = listener
+        .accept()
         .await
-        .map_err(|e| VmmError::Vsock(format!("connect to {}: {e}", uds_path.display())))?;
-
-    // Firecracker vsock host-initiated handshake.
+        .map_err(|e| VmmError::Vsock(format!("accept on ready socket: {e}")))?;
+    let mut byte = [0u8; 1];
     stream
-        .write_all(format!("CONNECT {port}\n").as_bytes())
+        .read(&mut byte)
         .await
-        .map_err(|e| VmmError::Vsock(format!("vsock CONNECT write: {e}")))?;
-
-    // Read "OK {port}\n".
-    let mut buf = [0u8; 64];
-    let mut i = 0usize;
-    loop {
-        let n = stream
-            .read(&mut buf[i..=i])
-            .await
-            .map_err(|e| VmmError::Vsock(format!("vsock handshake read: {e}")))?;
-        if n == 0 {
-            return Err(VmmError::Vsock("vsock handshake: connection closed".into()));
-        }
-        if buf[i] == b'\n' {
-            break;
-        }
-        i += 1;
-        if i >= buf.len() - 1 {
-            return Err(VmmError::Vsock("vsock handshake: response too long".into()));
-        }
-    }
-    let resp = std::str::from_utf8(&buf[..=i])
-        .map_err(|_| VmmError::Vsock("vsock handshake: non-UTF-8 response".into()))?;
-    if !resp.starts_with("OK") {
-        return Err(VmmError::Vsock(format!(
-            "vsock handshake: unexpected response: {resp:?}"
-        )));
-    }
-    Ok(stream)
-}
-
-/// Derive the host Unix-socket path Firecracker forwards guest-initiated
-/// [`READY_PORT`] connections to: `{uds_path}_{READY_PORT}`.
-///
-/// The suffix convention is Firecracker's hybrid-vsock contract ("a guest
-/// connection to port 52 will get forwarded to `./v.sock_52`", FC
-/// docs/vsock.md). FC resolves the path against its own filesystem view,
-/// which matches the host view here: in jailer mode both are the same file
-/// under the chroot root, in direct mode the same absolute path.
-fn ready_socket_path(uds_path: &Path) -> PathBuf {
-    let mut path = uds_path.as_os_str().to_owned();
-    path.push(format!("_{READY_PORT}"));
-    PathBuf::from(path)
-}
-
-/// Pre-bound listener for the guest agent's readiness dial-out.
-///
-/// Must be bound BEFORE Firecracker `InstanceStart`: FC forwards the guest's
-/// connect only to an already-listening socket and resets the guest
-/// otherwise, losing the event. The socket file is per-boot; dropping the
-/// listener removes it.
-pub(crate) struct ReadyListener {
-    listener: UnixListener,
-    path: PathBuf,
-}
-
-impl ReadyListener {
-    /// Bind the readiness socket for `uds_path`, replacing any stale socket
-    /// file left behind by a previous boot of the same VM directory.
-    pub(crate) fn bind(uds_path: &Path) -> Result<Self> {
-        let path = ready_socket_path(uds_path);
-        if let Err(e) = std::fs::remove_file(&path)
-            && e.kind() != std::io::ErrorKind::NotFound
-        {
-            return Err(VmmError::Vsock(format!(
-                "remove stale ready socket {}: {e}",
-                path.display()
-            )));
-        }
-        let listener = UnixListener::bind(&path)
-            .map_err(|e| VmmError::Vsock(format!("bind ready socket {}: {e}", path.display())))?;
-        Ok(Self { listener, path })
-    }
-
-    /// The bound socket path (so jailer boots can grant FC connect access).
-    pub(crate) fn path(&self) -> &Path {
-        &self.path
-    }
-
-    /// Wait for the guest's dial-out: `accept()` one connection and read
-    /// (and discard) its single byte. Completion is the readiness event.
-    pub(crate) async fn wait(&self) -> Result<()> {
-        let (mut stream, _) = self
-            .listener
-            .accept()
-            .await
-            .map_err(|e| VmmError::Vsock(format!("accept on ready socket: {e}")))?;
-        let mut byte = [0u8; 1];
-        stream
-            .read(&mut byte)
-            .await
-            .map_err(|e| VmmError::Vsock(format!("read ready byte: {e}")))?;
-        Ok(())
-    }
-}
-
-impl Drop for ReadyListener {
-    fn drop(&mut self) {
-        // The socket file is meaningful only to the boot that bound it.
-        let _ = std::fs::remove_file(&self.path);
-    }
+        .map_err(|e| VmmError::Vsock(format!("read ready byte: {e}")))?;
+    Ok(())
 }
 
 /// Write a single frame to any `AsyncWrite`.
@@ -750,6 +653,7 @@ mod tests {
     use std::os::fd::OwnedFd;
 
     use async_trait::async_trait;
+    use tokio::net::UnixListener;
 
     use super::*;
 
@@ -760,37 +664,6 @@ mod tests {
         buf.extend_from_slice(&(payload.len() as u32).to_le_bytes());
         buf.extend_from_slice(payload);
         buf
-    }
-
-    #[test]
-    fn ready_socket_path_appends_the_port_suffix() {
-        // Pins the Firecracker hybrid-vsock naming contract AND the port
-        // value: the guest dials 51, so the host must listen at `..._51`.
-        assert_eq!(
-            ready_socket_path(Path::new("/vm/dir/firecracker.vsock")),
-            Path::new("/vm/dir/firecracker.vsock_51")
-        );
-    }
-
-    #[tokio::test]
-    async fn ready_listener_accepts_the_dial_out_and_cleans_up() {
-        let dir = tempfile::tempdir().unwrap();
-        let uds = dir.path().join("fc.vsock");
-        // A stale socket file from a previous boot must not fail the bind.
-        std::fs::write(ready_socket_path(&uds), b"stale").unwrap();
-
-        let listener = ReadyListener::bind(&uds).unwrap();
-        let dial_path = listener.path().to_owned();
-        let dial = tokio::spawn(async move {
-            let mut stream = UnixStream::connect(&dial_path).await.unwrap();
-            stream.write_all(&[0u8]).await.unwrap();
-        });
-        listener.wait().await.unwrap();
-        dial.await.unwrap();
-
-        let path = listener.path().to_owned();
-        drop(listener);
-        assert!(!path.exists(), "drop must remove the per-boot socket file");
     }
 
     #[test]

--- a/virt/arcbox-vm/src/vsock/uds.rs
+++ b/virt/arcbox-vm/src/vsock/uds.rs
@@ -12,36 +12,23 @@ use std::path::PathBuf;
 use arcbox_vm_driver::{IoMode, Vsock, VsockConn};
 use async_trait::async_trait;
 
-use crate::error::VmmError;
-
 /// Transitional [`Vsock`] over Firecracker's hybrid-vsock Unix socket.
 ///
 /// Dials by running the `CONNECT {port}` handshake on the wrapped
-/// `uds_path`. Firecracker closes the proxied connection without an `OK`
-/// when the guest has no listener on the port yet; that is the port's
-/// `ConnectionRefused`, so callers retry it. Goes away once the Firecracker
-/// driver's handle exposes [`Vsock`] itself.
+/// `uds_path` — the adapter's own [`arcbox_fc_driver::vsock::dial_uds`],
+/// which already answers the port's `ConnectionRefused` when Firecracker
+/// closes the proxied connection because the guest has no listener on the
+/// port yet, so callers retry it. Goes away once the manager takes the
+/// capability from the Firecracker driver's handle.
 pub struct UdsVsock(pub PathBuf);
 
 #[async_trait]
 impl Vsock for UdsVsock {
     async fn dial(&self, port: u32) -> arcbox_vm_driver::Result<VsockConn> {
-        match super::try_vsock_handshake(&self.0, port).await {
-            Ok(stream) => Ok(VsockConn {
-                fd: OwnedFd::from(stream.into_std()?),
-                mode: IoMode::Async,
-            }),
-            Err(VmmError::Vsock(message)) if message.contains("connection closed") => {
-                Err(std::io::Error::new(std::io::ErrorKind::ConnectionRefused, message).into())
-            }
-            Err(error) => Err(arcbox_vm_driver::Error::Driver {
-                driver: "firecracker",
-                message: match error {
-                    VmmError::Vsock(message) => message,
-                    other => other.to_string(),
-                },
-                source: None,
-            }),
-        }
+        let stream = arcbox_fc_driver::vsock::dial_uds(&self.0, port).await?;
+        Ok(VsockConn {
+            fd: OwnedFd::from(stream.into_std()?),
+            mode: IoMode::Async,
+        })
     }
 }


### PR DESCRIPTION
R1 track D of the VM stack redesign (D-VM1, D-VM9; stacked on #656 — retarget to `master` once R0 merges): `virt/arcbox-fc-driver`, the Firecracker adapter behind `arcbox-vm-driver`, extracted from `arcbox-vm`.

- **Pure moves out of the manager** (each its own commit, rename-detectable): `spawn.rs`; the jail layout/staging block of `boot.rs` (+ a `jail/blkdev.rs` twin of the two mknod helpers so the adapter never depends on `arcbox-snapshot`); the vsock `CONNECT` handshake and READY listener from `vsock.rs`; `move_file` from `checkpoint.rs`. The manager keeps working through the moved code (`cargo test -p arcbox-vm` green at every commit); `arcbox-vm → arcbox-fc-driver` is a temporary composition-root edge that R3 removes.
- **New**: `render` (`VmLayout` — the one map of every path Firecracker sees, and the jailer's chroot relativity, decided in one place; `fc_config`/`fc_restore`; tests pin every rule incl. `InvalidSpec` for console/shares/balloon and `Diff`), `jail::apply`, `spawn::spawn(&SpawnPlan)`, the `process` guard (waiter task owns the child; exit watch + event; `Kill` = SIGKILL + bounded 5 s reap that errors exactly like today's `kill_and_reap`; `Graceful{timeout}` = ctrl-alt-del then kill; Drop kills unless detached/exited; `alive()` never signals a reaped pid), `api` (raw calls over `fc_sdk::Client`, needed for adopted VMs), `listener`, `FcHandle` (`VmHandle + Vsock + VsockListen + Checkpoint + Detach`; checkpoint format `firecracker/v1`, `Resume` / `HoldQuiesced`), `FcPrepared` (`PreparedVm`: pid + API socket known before boot, READY listener bound before the guest starts), `discover` (the `/proc` orphan scan, copied from `reconcile.rs` until commit 18 replaces the manager's copy with `Adopt`), and `FcDriver` (`VmDriver + Prepare + Adopt`; capabilities: vsock, vsock_listen, checkpoint, adopt, prepare; nested_virt from KVM's `nested` parameter).
- **Manager prerequisites**: `VmmError::Driver`, `FcDriverConfig: From<&FirecrackerConfig>`, `IsolationSpec: TryFrom<&JailerConfig>` (`cgroup_version` must parse; a `parent_cgroup` without a version now passes the jailer's own default `--cgroup-version 1` explicitly). Identical `Driver` variant to the vsock-capability PR; dedupe at merge.
- **Two fixes found while writing the contract harness**: a restored VM dials the vsock socket the image recorded (Firecracker re-binds it there; the handle unlinks it on exit so a re-bind never hits `EADDRINUSE`), and a stale vsock socket is cleared before every spawn, not only under the jailer.
- **Six fixes from review** (each its own commit): `detach` releases an adopted VM and an adopted process gets a prober so its exit wakes `events()`/`accept()`; a restore reattaches the disks it was given (`resume_vm: false` → `GET /vm/config` → `PATCH /drives/{id}` → resume) instead of silently reopening the image's; a disk id can no longer name a path outside the jail; the recorded pid is held to the same `--id`/`--api-sock`/jail-root identity test as a `/proc` scan (so a recycled pid cannot adopt a sibling VM); a failed capture — not the resume that failed on top of it — is the error a checkpoint reports, and a handle that believes the guest is frozen re-derives it before deciding to pause; the async spawn path no longer calls blocking `std::fs`. The checkpoint interleavings are unreachable against a real Firecracker, so `handle/tests/fake_fc.rs` scripts an API socket for them.
- **CI**: crate added to `linux-engine` (check/test/musl) and to `test-vm-linux`'s unit job and path filters; the e2e job runs the port's 14 driver-contract checks against real Firecracker in direct and jailer mode (`tests/contract.rs`, `--include-ignored`; the file mirrors the port's `driver_contract!` list because the macro cannot emit `#[ignore]`).

Validation (macOS host): `cargo fmt --check`; `cargo clippy -p arcbox-fc-driver -p arcbox-vm --all-targets --all-features -- -D warnings`; `cargo test -p arcbox-fc-driver -p arcbox-vm` (33 + 167 unit tests; the 28 contract tests are ignored without FC); `cargo test -p arcbox-vm-driver --all-features` (port untouched); `cargo check --target aarch64-unknown-linux-musl -p arcbox-fc-driver -p arcbox-vm --all-targets`; `cargo doc -p arcbox-fc-driver --no-deps` zero warnings. The contract against real Firecracker runs for the first time in this PR's `test-vm-linux` e2e job once retargeted — the risk to watch there is the jailer accepting a pre-placed `rootfs.ext4` in the chroot (the manager already relies on it). The `GET /vm/config` read-back after a snapshot load is no longer a guess: FC 1.10.1 feeds every restored device back through `vm_resources.update_from_restored_device`, and its own endpoint warning names boot-source, `smt` and `cpu_template` as the only fields that come back empty — drives and vsock are reported, and the restore now depends on both.

Design: company repo `engineering/arcbox/architecture/vm-stack-redesign.md`; plan commits 1–10 of the R1 execution plan. Follow-up (track F): plan commits 11, 15–19 — the manager holds `dyn PreparedVm`/`dyn VmHandle` and `arcbox-vm` stops naming Firecracker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new code on the VM boot/restore/checkpoint path and jailer chroot staging, but behavior is bounded by the driver port, path/id validation, and contract tests on KVM in CI.
> 
> **Overview**
> Adds **`virt/arcbox-fc-driver`**, a new crate that implements **`arcbox-vm-driver`** for Firecracker: **`FcDriver`** (boot, restore, prepare, adopt), **`VmLayout`/`render`** for all API paths and jailer chroot staging, jail staging, spawn, vsock dial/listen, process lifecycle, checkpoints (`firecracker/v1`, jailer-only restore with disk reattach), and **`/proc`** discovery for adopted VMs.
> 
> **`arcbox-vm`** now depends on the crate (R1 composition edge); workspace **`Cargo.toml`/`Cargo.lock`** register the package. **CI** includes `arcbox-fc-driver` in engine-layer check/test/musl jobs, expands **`test-vm-linux`** path filters and fmt/clippy/unit targets, and adds an e2e step that runs **`contract`** tests against real Firecracker (direct and jailer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2da40b34882b85c6ff79945414f45658365f7fb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

