### PR TITLE
feat(agent): mount container rootfs with nfs-exportable overlay options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tokio-vsock",
+ "toml 0.8.23",
  "tonic",
  "tonic-prost",
  "tower",

--- a/guest/arcbox-agent/Cargo.toml
+++ b/guest/arcbox-agent/Cargo.toml
@@ -63,6 +63,7 @@ hyper-util = { version = "0.1.20", features = ["tokio"] }
 [dev-dependencies]
 arcbox-vm.workspace = true
 tempfile = "3"
+toml.workspace = true
 
 [features]
 default = []

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -282,26 +282,37 @@ pub(super) fn ensure_shared_runtime_dirs(notes: &mut Vec<String>) {
 /// already visible there; the merged view a live container sees is not, and
 /// without this the kernel cannot name its inodes to a client.
 ///
-/// `index=on` is not optional alongside it: the kernel rejects
-/// `index=off,nfs_export=on` outright on a read-write mount, and a container
-/// rootfs is read-write. Until arcboxlabs/boot-assets#52 that rejection is
-/// exactly what we got — the stock overlay snapshotter appended `index=off`
-/// after whatever the config asked for, so `index=on` here produced
-/// `index=on,nfs_export=on,index=off`, last-wins, `EINVAL` on every mount.
-/// The patched containerd in boot bundle 0.8.6 is what makes this line take
-/// effect rather than break the guest.
+/// `index=on` is spelled out rather than left to the kernel, because the
+/// kernel's handling of the pair is three-way and only one branch is loud
+/// (`ovl_fs_params_verify`, `fs/overlayfs/params.c`):
+///
+///  - **explicit `index=off` + explicit `nfs_export=on` → `EINVAL`.** This is
+///    our case, and until arcboxlabs/boot-assets#52 it is what we got: the
+///    stock overlay snapshotter appended `index=off` after whatever the config
+///    asked for, so the kernel saw `index=on,nfs_export=on,index=off`,
+///    last-wins, and refused every container's mount. The patched containerd
+///    in boot bundle 0.8.6 is what makes this line take effect rather than
+///    break the guest.
+///  - **`index` left unset → the kernel turns it on itself** and the mount
+///    succeeds. Harmless in isolation, but not a reason to trim `index=on`
+///    from this list: containerd decides whether to append its own `index=off`
+///    by looking at *these* options, so dropping it here puts us straight back
+///    in the first branch.
+///  - **no upper layer, with redirects followed → `nfs_export` is silently
+///    turned off** with only a `pr_info`. That is the one branch that fails
+///    quietly, and it is why a no-upper overlay would need
+///    `redirect_dir=nofollow`.
+///
+/// That last option is absent because nothing here mounts a no-upper overlay:
+/// containerd appends these options only on its overlay mount path, which it
+/// reaches for active snapshots (always with an upperdir) and for
+/// multi-parent views — and `image_snapshot_paths` reads a view's mount *spec*
+/// and removes it without ever mounting. Add it if that changes.
 ///
 /// The cost is one `trusted.overlay.origin` xattr per copy-up; in exchange
 /// `index=on` stops copy-up from breaking hard links, which is a fix in its
 /// own right. It also forbids reusing an upperdir across overlay mounts —
 /// harmless here, since every snapshot owns its upper.
-///
-/// A no-upper overlay would additionally need `redirect_dir=nofollow`, which
-/// is why it is absent: containerd only reaches the overlay mount path (the
-/// only place these options are appended) for active snapshots, which always
-/// carry an upperdir, and for multi-parent views — and nothing in ArcBox
-/// mounts one of those. `image_snapshot_paths` reads a view's mount *spec*
-/// and removes it without ever mounting. Add the option here if that changes.
 const OVERLAY_MOUNT_OPTIONS: &str = r#"["index=on", "nfs_export=on"]"#;
 
 pub(super) fn shared_containerd_config() -> String {

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -274,9 +274,47 @@ pub(super) fn ensure_shared_runtime_dirs(notes: &mut Vec<String>) {
     }
 }
 
+/// Overlay mount options every container rootfs is mounted with.
+///
+/// `nfs_export=on` is what lets the in-kernel nfsd encode file handles for an
+/// overlay mount, which is the precondition for browsing a *running*
+/// container's filesystem through `~/ArcBox` (ABX-424). Committed layers are
+/// already visible there; the merged view a live container sees is not, and
+/// without this the kernel cannot name its inodes to a client.
+///
+/// `index=on` is not optional alongside it: the kernel rejects
+/// `index=off,nfs_export=on` outright on a read-write mount, and a container
+/// rootfs is read-write. Until arcboxlabs/boot-assets#52 that rejection is
+/// exactly what we got — the stock overlay snapshotter appended `index=off`
+/// after whatever the config asked for, so `index=on` here produced
+/// `index=on,nfs_export=on,index=off`, last-wins, `EINVAL` on every mount.
+/// The patched containerd in boot bundle 0.8.6 is what makes this line take
+/// effect rather than break the guest.
+///
+/// The cost is one `trusted.overlay.origin` xattr per copy-up; in exchange
+/// `index=on` stops copy-up from breaking hard links, which is a fix in its
+/// own right. It also forbids reusing an upperdir across overlay mounts —
+/// harmless here, since every snapshot owns its upper.
+///
+/// A no-upper overlay would additionally need `redirect_dir=nofollow`, which
+/// is why it is absent: containerd only reaches the overlay mount path (the
+/// only place these options are appended) for active snapshots, which always
+/// carry an upperdir, and for multi-parent views — and nothing in ArcBox
+/// mounts one of those. `image_snapshot_paths` reads a view's mount *spec*
+/// and removes it without ever mounting. Add the option here if that changes.
+const OVERLAY_MOUNT_OPTIONS: &str = r#"["index=on", "nfs_export=on"]"#;
+
 pub(super) fn shared_containerd_config() -> String {
     format!(
-        "version = 2\n[plugins.\"io.containerd.grpc.v1.cri\".cni]\n  bin_dir = \"{K3S_CNI_BIN_DIR}\"\n  conf_dir = \"{K3S_CNI_CONF_DIR}\"\n  max_conf_num = 1\n"
+        "version = 2\n\
+         \n\
+         [plugins.\"io.containerd.grpc.v1.cri\".cni]\n\
+         \x20 bin_dir = \"{K3S_CNI_BIN_DIR}\"\n\
+         \x20 conf_dir = \"{K3S_CNI_CONF_DIR}\"\n\
+         \x20 max_conf_num = 1\n\
+         \n\
+         [plugins.\"io.containerd.snapshotter.v1.overlayfs\"]\n\
+         \x20 mount_options = {OVERLAY_MOUNT_OPTIONS}\n"
     )
 }
 
@@ -828,6 +866,45 @@ mod tests {
         assert!(config.contains("bin_dir = \"/var/lib/rancher/k3s/data/cni\""));
         assert!(config.contains("conf_dir = \"/var/lib/rancher/k3s/agent/etc/cni/net.d\""));
         assert!(config.contains("max_conf_num = 1"));
+    }
+
+    /// containerd refuses to start on a malformed config, and it does so
+    /// during guest bring-up where the symptom is a readiness timeout rather
+    /// than a parse error. Parsing here is cheap; reading the boot log to
+    /// discover a stray quote is not.
+    #[test]
+    fn shared_containerd_config_is_valid_toml() {
+        let parsed: toml::Value = shared_containerd_config()
+            .parse()
+            .expect("containerd config must be valid TOML");
+        assert_eq!(parsed["version"].as_integer(), Some(2));
+    }
+
+    /// The two options travel together by kernel rule, not by preference:
+    /// `index=off,nfs_export=on` is rejected outright on a read-write mount,
+    /// and a container rootfs is one. Dropping `index=on` while keeping
+    /// `nfs_export=on` would fail every container's overlay mount with
+    /// EINVAL — the failure boot-assets#52's containerd patch exists to
+    /// remove.
+    #[test]
+    fn overlay_mount_options_keep_nfs_export_and_index_together() {
+        let parsed: toml::Value = shared_containerd_config().parse().unwrap();
+        let options = parsed["plugins"]["io.containerd.snapshotter.v1.overlayfs"]["mount_options"]
+            .as_array()
+            .expect("overlayfs snapshotter must declare mount_options")
+            .iter()
+            .map(|value| value.as_str().unwrap().to_owned())
+            .collect::<Vec<_>>();
+
+        assert!(options.contains(&"nfs_export=on".to_owned()));
+        assert!(
+            options.contains(&"index=on".to_owned()),
+            "nfs_export=on without index=on is rejected by the kernel: {options:?}"
+        );
+        assert!(
+            !options.iter().any(|option| option == "index=off"),
+            "index=off would conflict with nfs_export=on: {options:?}"
+        );
     }
 
     #[test]

--- a/tests/e2e/tests/overlay_options_probe.rs
+++ b/tests/e2e/tests/overlay_options_probe.rs
@@ -1,0 +1,117 @@
+//! Proves the overlayfs snapshotter's configured mount options reach the
+//! kernel, rather than merely reaching `/etc/containerd/config.toml`.
+//!
+//! A container's rootfs must be mounted with `index=on,nfs_export=on` for the
+//! in-kernel nfsd to be able to encode file handles for it — the precondition
+//! for browsing a live container through `~/ArcBox` (ABX-424). Configuring
+//! them is not the same as getting them: until arcboxlabs/boot-assets#52 the
+//! stock overlay snapshotter appended `index=off` after the configured
+//! options, and the kernel rejects `index=off,nfs_export=on` on a read-write
+//! mount outright.
+//!
+//! This reads the guest's own `/proc/mounts` through a privileged container in
+//! the host PID namespace, because that is the only place the *effective*
+//! options are visible. Note `/proc/mounts` omits options equal to the
+//! kernel default, which is why the assertions target `index=on` and
+//! `nfs_export=on` (both non-default) rather than the absence of `index=off`.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+use arcbox_e2e::docker::docker_output;
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+const DOCKER_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[test]
+#[ignore = "boots a System VM through a real daemon"]
+fn container_rootfs_is_mounted_with_nfs_exportable_options() -> Result<()> {
+    let root = arcbox_e2e::repo_root();
+    if !arcbox_e2e::env_flag("SKIP_BUILD") {
+        let shell = xshell::Shell::new()?;
+        shell.change_dir(&root);
+        xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+    }
+
+    let version = resolve_boot_version(&root)?;
+    let data_dir = tempfile::Builder::new()
+        .prefix("arcbox-overlay-opts-")
+        .tempdir()?;
+    stage_dev_boot_assets(&root, data_dir.path(), &version)?;
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: data_dir.path().to_owned(),
+        args: vec![],
+        env: vec![("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version)],
+    })?;
+    daemon
+        .wait_ready_blocking(READY_TIMEOUT)
+        .context("daemon not ready")?;
+
+    let result = scenario(data_dir.path());
+    if result.is_err() {
+        let kept = data_dir.keep();
+        eprintln!("preserving test directory path={}", kept.display());
+    }
+    drop(daemon);
+    result
+}
+
+fn scenario(data_dir: &Path) -> Result<()> {
+    let image = std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+
+    docker_output(
+        data_dir,
+        &[
+            "run", "-d", "--name", "ovl-probe", &image, "sleep", "300",
+        ],
+        DOCKER_TIMEOUT,
+    )?;
+
+    // Read PID 1's mount table rather than our own: a container's
+    // `/proc/mounts` shows its rootfs as `/` with the overlay options already
+    // stripped. `--pid=host` makes `/proc/1` the guest init, and `/proc/N/mounts`
+    // is readable without entering its mount namespace — which matters,
+    // because `nsenter -m` would resolve every subsequent binary against the
+    // guest's EROFS root instead of this image.
+    let mounts = docker_output(
+        data_dir,
+        &[
+            "run",
+            "--rm",
+            "--privileged",
+            "--pid=host",
+            &image,
+            "cat",
+            "/proc/1/mounts",
+        ],
+        DOCKER_TIMEOUT,
+    )?;
+
+    println!("guest overlay mounts:\n{mounts}");
+
+    let overlay_lines: Vec<&str> = mounts
+        .lines()
+        .filter(|line| line.starts_with("overlay "))
+        .collect();
+    if overlay_lines.is_empty() {
+        bail!("no overlay mount in the guest's /proc/mounts:\n{mounts}");
+    }
+
+    for option in ["index=on", "nfs_export=on"] {
+        if !overlay_lines.iter().any(|line| line.contains(option)) {
+            bail!(
+                "no overlay mount carries {option}; the snapshotter's configured \
+                 mount_options did not reach the kernel:\n{}",
+                overlay_lines.join("\n")
+            );
+        }
+    }
+
+    let _ = docker_output(data_dir, &["rm", "-f", "ovl-probe"], DOCKER_TIMEOUT);
+    Ok(())
+}

--- a/tests/e2e/tests/overlay_options_probe.rs
+++ b/tests/e2e/tests/overlay_options_probe.rs
@@ -66,9 +66,7 @@ fn scenario(data_dir: &Path) -> Result<()> {
 
     docker_output(
         data_dir,
-        &[
-            "run", "-d", "--name", "ovl-probe", &image, "sleep", "300",
-        ],
+        &["run", "-d", "--name", "ovl-probe", &image, "sleep", "300"],
         DOCKER_TIMEOUT,
     )?;
 

--- a/tests/e2e/tests/overlay_options_probe.rs
+++ b/tests/e2e/tests/overlay_options_probe.rs
@@ -18,7 +18,7 @@
 use std::path::Path;
 use std::time::Duration;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
 use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
 use arcbox_e2e::docker::docker_output;
@@ -34,6 +34,16 @@ fn container_rootfs_is_mounted_with_nfs_exportable_options() -> Result<()> {
         let shell = xshell::Shell::new()?;
         shell.change_dir(&root);
         xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+        // The subject of this test is config the *guest agent* writes, and
+        // `stage_dev_boot_assets` stages whichever agent has the newest mtime
+        // across the dev tree, the musl target and ~/.arcbox/bin. Without
+        // building it here, a machine holding any older agent can boot one
+        // that predates the change entirely (ABX-385 class).
+        xshell::cmd!(
+            shell,
+            "cargo build -p arcbox-agent --target aarch64-unknown-linux-musl --release"
+        )
+        .run()?;
     }
 
     let version = resolve_boot_version(&root)?;
@@ -48,9 +58,17 @@ fn container_rootfs_is_mounted_with_nfs_exportable_options() -> Result<()> {
         args: vec![],
         env: vec![("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version)],
     })?;
-    daemon
-        .wait_ready_blocking(READY_TIMEOUT)
-        .context("daemon not ready")?;
+    // Readiness failures need the same forensics as scenario failures: the
+    // daemon log explaining why boot stalled lives in the data dir, and `?`
+    // here would drop it (tests/e2e/AGENTS.md).
+    if let Err(error) = daemon.wait_ready_blocking(READY_TIMEOUT) {
+        let kept = data_dir.keep();
+        drop(daemon);
+        bail!(
+            "daemon not ready: {error:#} (data dir preserved at {})",
+            kept.display()
+        );
+    }
 
     let result = scenario(data_dir.path());
     if result.is_err() {
@@ -100,14 +118,22 @@ fn scenario(data_dir: &Path) -> Result<()> {
         bail!("no overlay mount in the guest's /proc/mounts:\n{mounts}");
     }
 
-    for option in ["index=on", "nfs_export=on"] {
-        if !overlay_lines.iter().any(|line| line.contains(option)) {
-            bail!(
-                "no overlay mount carries {option}; the snapshotter's configured \
-                 mount_options did not reach the kernel:\n{}",
-                overlay_lines.join("\n")
-            );
-        }
+    // Both options on *one* mount. Scanning for each independently would pass
+    // when one mount carries `index=on` and a different one carries
+    // `nfs_export=on` — never checking the pairing this exists to guarantee.
+    // It also masks the sharpest signature there is: a mount with `index=on`
+    // and no `nfs_export=on` is what the kernel leaves behind when it drops
+    // nfs_export on its own.
+    let paired = overlay_lines
+        .iter()
+        .any(|line| line.contains("index=on") && line.contains("nfs_export=on"));
+    if !paired {
+        bail!(
+            "no single overlay mount carries both index=on and nfs_export=on; \
+             the snapshotter's configured mount_options did not reach the kernel \
+             intact:\n{}",
+            overlay_lines.join("\n")
+        );
     }
 
     let _ = docker_output(data_dir, &["rm", "-f", "ovl-probe"], DOCKER_TIMEOUT);


### PR DESCRIPTION
First of two steps for ABX-424 (browse a **running** container through `~/ArcBox`). This one lands the capability; nothing exports a live container yet.

## What and why

The in-kernel nfsd can only encode file handles for an overlay mounted with `nfs_export=on`. Committed layers are already visible under `~/ArcBox/containerd` via the child export — the merged view a live container actually sees is not, and without this option the kernel cannot name its inodes to a client at all.

`index=on` is not a preference, it is a kernel rule: `index=off,nfs_export=on` is **rejected outright on a read-write mount**, and a container rootfs is one. That rejection is precisely what this config produced until boot bundle 0.8.6 — the stock overlay snapshotter appended `index=off` after whatever the config asked for, so the kernel saw `index=on,nfs_export=on,index=off`, last-wins, `EINVAL` on every container. #654 pinned the containerd carrying containerd#13805, which is what lets this line take effect instead of breaking the guest. **Do not revert that pin without reverting this.**

## Verified on hardware, not inferred from the config file

The new `overlay_options_probe` reads the guest init's own mount table:

```
overlay /var/lib/docker/rootfs/overlayfs/b756b21… overlay rw,relatime,
  lowerdir=…/snapshots/2/fs:…/snapshots/1/fs,
  upperdir=…/snapshots/3/fs, workdir=…/snapshots/3/work,
  index=on,nfs_export=on
```

Two things about how it reads that, both learned the hard way:

- it reads **`/proc/1/mounts`**, not its own `/proc/mounts` — a container sees its rootfs as `/` with the overlay options already stripped;
- it gets there with **`--pid=host`**, not `nsenter -t 1 -m`. Entering the mount namespace resolves every subsequent binary against the guest's EROFS root, where the first attempt died on `nsenter: can't execute 'grep'`.

The probe exists because "the config file says so" and "the kernel accepted it" are different claims, and only the second one matters. A future edit that gets the option silently dropped would otherwise still show a green `boot_assets`.

`boot_assets` also passes with the change (75.7s, full Docker lifecycle). Phase timings against the same bundle without it: `image_pull` 9.78s → 10.34s, everything else within noise. Single sample, so read it as "no visible regression", not as a measurement of `index=on`'s cost.

## Scope and cost

The options apply to every container rootfs, so the cost is paid whether or not `~/ArcBox` is in use: one `trusted.overlay.origin` xattr per copy-up. In exchange `index=on` stops copy-up from breaking hard links, which is a correctness fix in its own right. It also forbids reusing an upperdir across overlay mounts — harmless here, since every snapshot owns its upper.

No `redirect_dir=nofollow`, deliberately: the kernel only requires it for an overlay with **no upper layer**, and nothing in ArcBox mounts one. containerd appends these options only on its overlay mount path — single-parent views return a plain bind mount — and `image_snapshot_paths` reads a view's mount *spec* and removes it without ever mounting. The doc comment says so at the constant, so the next person who adds a real view mount knows what to add.

## Note on the unit tests

`shared_containerd_config`'s tests do not run on a macOS dev host: `mod linux` is `#[cfg(target_os = "linux")]`, and CI excludes `arcbox-agent` from build/test/clippy entirely (`guest/AGENTS.md`). That is true of the test that was already there. Moving the function somewhere they would run means a new binary→lib dependency in a crate another branch is actively splitting (CORE-127), so it stays put — and the e2e probe, not the unit tests, is what actually gates this.

## Next

Per-container `/etc/exports` entries plus the teardown ordering (`exportfs -u` + `exportfs -f` in the init netns *before* dockerd unmounts, since an exported child pins its mount). Separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes containerd overlay mount options for every container rootfs; misconfiguration could cause EINVAL on all overlay mounts, though the change is paired with boot-assets containerd and guarded by unit and e2e checks.
> 
> **Overview**
> **Configures containerd’s overlayfs snapshotter** so every container rootfs is mounted with **`index=on` and `nfs_export=on`** — the kernel precondition for nfsd to encode handles on a live container’s merged overlay (ABX-424 / `~/ArcBox`). The guest agent’s generated **`/etc/containerd/config.toml`** now includes a **`io.containerd.snapshotter.v1.overlayfs`** section with those **`mount_options`**, alongside the existing CNI paths.
> 
> **Why both options together:** the kernel rejects read-write overlays with **`index=off,nfs_export=on`**; stock containerd used to append **`index=off`** after config, breaking every mount until the boot-assets containerd patch (bundle 0.8.6). The new constant and comments document that pairing and the **`redirect_dir=nofollow`** caveat for no-upper overlays.
> 
> **Verification:** unit tests parse the generated TOML and assert **`nfs_export=on`**, **`index=on`**, and no **`index=off`**. A new **ignored e2e** (`overlay_options_probe`) boots a real System VM, runs a container, and reads **`/proc/1/mounts`** via **`--pid=host`** to prove both options appear on the **same** overlay line—not only in config. **`toml`** is added as a **dev-dependency** for those tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbd637b0318faecf9a1a617ed3687b1d24355a01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->