### PR TITLE
feat(agent): export each running container's rootfs over NFS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tokio-vsock",
+ "toml 0.8.23",
  "tonic",
  "tonic-prost",
  "tower",

--- a/guest/arcbox-agent/Cargo.toml
+++ b/guest/arcbox-agent/Cargo.toml
@@ -63,6 +63,7 @@ hyper-util = { version = "0.1.20", features = ["tokio"] }
 [dev-dependencies]
 arcbox-vm.workspace = true
 tempfile = "3"
+toml.workspace = true
 
 [features]
 default = []

--- a/guest/arcbox-agent/Cargo.toml
+++ b/guest/arcbox-agent/Cargo.toml
@@ -22,7 +22,7 @@ tracing-appender = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-nix = { workspace = true, features = ["mount", "process", "resource", "sched", "signal", "feature", "term", "ioctl"] }
+nix = { workspace = true, features = ["mount", "process", "resource", "sched", "signal", "feature", "term", "ioctl", "poll"] }
 libc = { workspace = true }
 prost = { workspace = true }
 uuid = { workspace = true }

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -282,26 +282,37 @@ pub(super) fn ensure_shared_runtime_dirs(notes: &mut Vec<String>) {
 /// already visible there; the merged view a live container sees is not, and
 /// without this the kernel cannot name its inodes to a client.
 ///
-/// `index=on` is not optional alongside it: the kernel rejects
-/// `index=off,nfs_export=on` outright on a read-write mount, and a container
-/// rootfs is read-write. Until arcboxlabs/boot-assets#52 that rejection is
-/// exactly what we got — the stock overlay snapshotter appended `index=off`
-/// after whatever the config asked for, so `index=on` here produced
-/// `index=on,nfs_export=on,index=off`, last-wins, `EINVAL` on every mount.
-/// The patched containerd in boot bundle 0.8.6 is what makes this line take
-/// effect rather than break the guest.
+/// `index=on` is spelled out rather than left to the kernel, because the
+/// kernel's handling of the pair is three-way and only one branch is loud
+/// (`ovl_fs_params_verify`, `fs/overlayfs/params.c`):
+///
+///  - **explicit `index=off` + explicit `nfs_export=on` → `EINVAL`.** This is
+///    our case, and until arcboxlabs/boot-assets#52 it is what we got: the
+///    stock overlay snapshotter appended `index=off` after whatever the config
+///    asked for, so the kernel saw `index=on,nfs_export=on,index=off`,
+///    last-wins, and refused every container's mount. The patched containerd
+///    in boot bundle 0.8.6 is what makes this line take effect rather than
+///    break the guest.
+///  - **`index` left unset → the kernel turns it on itself** and the mount
+///    succeeds. Harmless in isolation, but not a reason to trim `index=on`
+///    from this list: containerd decides whether to append its own `index=off`
+///    by looking at *these* options, so dropping it here puts us straight back
+///    in the first branch.
+///  - **no upper layer, with redirects followed → `nfs_export` is silently
+///    turned off** with only a `pr_info`. That is the one branch that fails
+///    quietly, and it is why a no-upper overlay would need
+///    `redirect_dir=nofollow`.
+///
+/// That last option is absent because nothing here mounts a no-upper overlay:
+/// containerd appends these options only on its overlay mount path, which it
+/// reaches for active snapshots (always with an upperdir) and for
+/// multi-parent views — and `image_snapshot_paths` reads a view's mount *spec*
+/// and removes it without ever mounting. Add it if that changes.
 ///
 /// The cost is one `trusted.overlay.origin` xattr per copy-up; in exchange
 /// `index=on` stops copy-up from breaking hard links, which is a fix in its
 /// own right. It also forbids reusing an upperdir across overlay mounts —
 /// harmless here, since every snapshot owns its upper.
-///
-/// A no-upper overlay would additionally need `redirect_dir=nofollow`, which
-/// is why it is absent: containerd only reaches the overlay mount path (the
-/// only place these options are appended) for active snapshots, which always
-/// carry an upperdir, and for multi-parent views — and nothing in ArcBox
-/// mounts one of those. `image_snapshot_paths` reads a view's mount *spec*
-/// and removes it without ever mounting. Add the option here if that changes.
 const OVERLAY_MOUNT_OPTIONS: &str = r#"["index=on", "nfs_export=on"]"#;
 
 pub(super) fn shared_containerd_config() -> String {

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -274,9 +274,47 @@ pub(super) fn ensure_shared_runtime_dirs(notes: &mut Vec<String>) {
     }
 }
 
+/// Overlay mount options every container rootfs is mounted with.
+///
+/// `nfs_export=on` is what lets the in-kernel nfsd encode file handles for an
+/// overlay mount, which is the precondition for browsing a *running*
+/// container's filesystem through `~/ArcBox` (ABX-424). Committed layers are
+/// already visible there; the merged view a live container sees is not, and
+/// without this the kernel cannot name its inodes to a client.
+///
+/// `index=on` is not optional alongside it: the kernel rejects
+/// `index=off,nfs_export=on` outright on a read-write mount, and a container
+/// rootfs is read-write. Until arcboxlabs/boot-assets#52 that rejection is
+/// exactly what we got — the stock overlay snapshotter appended `index=off`
+/// after whatever the config asked for, so `index=on` here produced
+/// `index=on,nfs_export=on,index=off`, last-wins, `EINVAL` on every mount.
+/// The patched containerd in boot bundle 0.8.6 is what makes this line take
+/// effect rather than break the guest.
+///
+/// The cost is one `trusted.overlay.origin` xattr per copy-up; in exchange
+/// `index=on` stops copy-up from breaking hard links, which is a fix in its
+/// own right. It also forbids reusing an upperdir across overlay mounts —
+/// harmless here, since every snapshot owns its upper.
+///
+/// A no-upper overlay would additionally need `redirect_dir=nofollow`, which
+/// is why it is absent: containerd only reaches the overlay mount path (the
+/// only place these options are appended) for active snapshots, which always
+/// carry an upperdir, and for multi-parent views — and nothing in ArcBox
+/// mounts one of those. `image_snapshot_paths` reads a view's mount *spec*
+/// and removes it without ever mounting. Add the option here if that changes.
+const OVERLAY_MOUNT_OPTIONS: &str = r#"["index=on", "nfs_export=on"]"#;
+
 pub(super) fn shared_containerd_config() -> String {
     format!(
-        "version = 2\n[plugins.\"io.containerd.grpc.v1.cri\".cni]\n  bin_dir = \"{K3S_CNI_BIN_DIR}\"\n  conf_dir = \"{K3S_CNI_CONF_DIR}\"\n  max_conf_num = 1\n"
+        "version = 2\n\
+         \n\
+         [plugins.\"io.containerd.grpc.v1.cri\".cni]\n\
+         \x20 bin_dir = \"{K3S_CNI_BIN_DIR}\"\n\
+         \x20 conf_dir = \"{K3S_CNI_CONF_DIR}\"\n\
+         \x20 max_conf_num = 1\n\
+         \n\
+         [plugins.\"io.containerd.snapshotter.v1.overlayfs\"]\n\
+         \x20 mount_options = {OVERLAY_MOUNT_OPTIONS}\n"
     )
 }
 
@@ -828,6 +866,45 @@ mod tests {
         assert!(config.contains("bin_dir = \"/var/lib/rancher/k3s/data/cni\""));
         assert!(config.contains("conf_dir = \"/var/lib/rancher/k3s/agent/etc/cni/net.d\""));
         assert!(config.contains("max_conf_num = 1"));
+    }
+
+    /// containerd refuses to start on a malformed config, and it does so
+    /// during guest bring-up where the symptom is a readiness timeout rather
+    /// than a parse error. Parsing here is cheap; reading the boot log to
+    /// discover a stray quote is not.
+    #[test]
+    fn shared_containerd_config_is_valid_toml() {
+        let parsed: toml::Value = shared_containerd_config()
+            .parse()
+            .expect("containerd config must be valid TOML");
+        assert_eq!(parsed["version"].as_integer(), Some(2));
+    }
+
+    /// The two options travel together by kernel rule, not by preference:
+    /// `index=off,nfs_export=on` is rejected outright on a read-write mount,
+    /// and a container rootfs is one. Dropping `index=on` while keeping
+    /// `nfs_export=on` would fail every container's overlay mount with
+    /// EINVAL — the failure boot-assets#52's containerd patch exists to
+    /// remove.
+    #[test]
+    fn overlay_mount_options_keep_nfs_export_and_index_together() {
+        let parsed: toml::Value = shared_containerd_config().parse().unwrap();
+        let options = parsed["plugins"]["io.containerd.snapshotter.v1.overlayfs"]["mount_options"]
+            .as_array()
+            .expect("overlayfs snapshotter must declare mount_options")
+            .iter()
+            .map(|value| value.as_str().unwrap().to_owned())
+            .collect::<Vec<_>>();
+
+        assert!(options.contains(&"nfs_export=on".to_owned()));
+        assert!(
+            options.contains(&"index=on".to_owned()),
+            "nfs_export=on without index=on is rejected by the kernel: {options:?}"
+        );
+        assert!(
+            !options.iter().any(|option| option == "index=off"),
+            "index=off would conflict with nfs_export=on: {options:?}"
+        );
     }
 
     #[test]

--- a/guest/arcbox-agent/src/agent/linux/runtime.rs
+++ b/guest/arcbox-agent/src/agent/linux/runtime.rs
@@ -274,61 +274,6 @@ pub(super) fn ensure_shared_runtime_dirs(notes: &mut Vec<String>) {
     }
 }
 
-/// Overlay mount options every container rootfs is mounted with.
-///
-/// `nfs_export=on` is what lets the in-kernel nfsd encode file handles for an
-/// overlay mount, which is the precondition for browsing a *running*
-/// container's filesystem through `~/ArcBox` (ABX-424). Committed layers are
-/// already visible there; the merged view a live container sees is not, and
-/// without this the kernel cannot name its inodes to a client.
-///
-/// `index=on` is spelled out rather than left to the kernel, because the
-/// kernel's handling of the pair is three-way and only one branch is loud
-/// (`ovl_fs_params_verify`, `fs/overlayfs/params.c`):
-///
-///  - **explicit `index=off` + explicit `nfs_export=on` → `EINVAL`.** This is
-///    our case, and until arcboxlabs/boot-assets#52 it is what we got: the
-///    stock overlay snapshotter appended `index=off` after whatever the config
-///    asked for, so the kernel saw `index=on,nfs_export=on,index=off`,
-///    last-wins, and refused every container's mount. The patched containerd
-///    in boot bundle 0.8.6 is what makes this line take effect rather than
-///    break the guest.
-///  - **`index` left unset → the kernel turns it on itself** and the mount
-///    succeeds. Harmless in isolation, but not a reason to trim `index=on`
-///    from this list: containerd decides whether to append its own `index=off`
-///    by looking at *these* options, so dropping it here puts us straight back
-///    in the first branch.
-///  - **no upper layer, with redirects followed → `nfs_export` is silently
-///    turned off** with only a `pr_info`. That is the one branch that fails
-///    quietly, and it is why a no-upper overlay would need
-///    `redirect_dir=nofollow`.
-///
-/// That last option is absent because nothing here mounts a no-upper overlay:
-/// containerd appends these options only on its overlay mount path, which it
-/// reaches for active snapshots (always with an upperdir) and for
-/// multi-parent views — and `image_snapshot_paths` reads a view's mount *spec*
-/// and removes it without ever mounting. Add it if that changes.
-///
-/// The cost is one `trusted.overlay.origin` xattr per copy-up; in exchange
-/// `index=on` stops copy-up from breaking hard links, which is a fix in its
-/// own right. It also forbids reusing an upperdir across overlay mounts —
-/// harmless here, since every snapshot owns its upper.
-const OVERLAY_MOUNT_OPTIONS: &str = r#"["index=on", "nfs_export=on"]"#;
-
-pub(super) fn shared_containerd_config() -> String {
-    format!(
-        "version = 2\n\
-         \n\
-         [plugins.\"io.containerd.grpc.v1.cri\".cni]\n\
-         \x20 bin_dir = \"{K3S_CNI_BIN_DIR}\"\n\
-         \x20 conf_dir = \"{K3S_CNI_CONF_DIR}\"\n\
-         \x20 max_conf_num = 1\n\
-         \n\
-         [plugins.\"io.containerd.snapshotter.v1.overlayfs\"]\n\
-         \x20 mount_options = {OVERLAY_MOUNT_OPTIONS}\n"
-    )
-}
-
 pub(super) async fn ensure_containerd_ready(
     runtime_bin_dir: &Path,
     notes: &mut Vec<String>,
@@ -338,7 +283,7 @@ pub(super) async fn ensure_containerd_ready(
     }
 
     let containerd_config = "/etc/containerd/config.toml";
-    let config_toml = shared_containerd_config();
+    let config_toml = crate::containerd_config::render();
     if let Err(e) = std::fs::write(containerd_config, config_toml) {
         notes.push(format!("write containerd config failed({})", e));
     }
@@ -869,54 +814,7 @@ mod tests {
     use arcbox_constants::container_network::ContainerNetwork;
     use arcbox_constants::status::{SERVICE_ERROR, SERVICE_NOT_READY, SERVICE_READY};
 
-    use super::{DockerProbe, direct_routing_rule, shared_containerd_config};
-
-    #[test]
-    fn shared_containerd_config_uses_k3s_cni_paths() {
-        let config = shared_containerd_config();
-        assert!(config.contains("bin_dir = \"/var/lib/rancher/k3s/data/cni\""));
-        assert!(config.contains("conf_dir = \"/var/lib/rancher/k3s/agent/etc/cni/net.d\""));
-        assert!(config.contains("max_conf_num = 1"));
-    }
-
-    /// containerd refuses to start on a malformed config, and it does so
-    /// during guest bring-up where the symptom is a readiness timeout rather
-    /// than a parse error. Parsing here is cheap; reading the boot log to
-    /// discover a stray quote is not.
-    #[test]
-    fn shared_containerd_config_is_valid_toml() {
-        let parsed: toml::Value = shared_containerd_config()
-            .parse()
-            .expect("containerd config must be valid TOML");
-        assert_eq!(parsed["version"].as_integer(), Some(2));
-    }
-
-    /// The two options travel together by kernel rule, not by preference:
-    /// `index=off,nfs_export=on` is rejected outright on a read-write mount,
-    /// and a container rootfs is one. Dropping `index=on` while keeping
-    /// `nfs_export=on` would fail every container's overlay mount with
-    /// EINVAL — the failure boot-assets#52's containerd patch exists to
-    /// remove.
-    #[test]
-    fn overlay_mount_options_keep_nfs_export_and_index_together() {
-        let parsed: toml::Value = shared_containerd_config().parse().unwrap();
-        let options = parsed["plugins"]["io.containerd.snapshotter.v1.overlayfs"]["mount_options"]
-            .as_array()
-            .expect("overlayfs snapshotter must declare mount_options")
-            .iter()
-            .map(|value| value.as_str().unwrap().to_owned())
-            .collect::<Vec<_>>();
-
-        assert!(options.contains(&"nfs_export=on".to_owned()));
-        assert!(
-            options.contains(&"index=on".to_owned()),
-            "nfs_export=on without index=on is rejected by the kernel: {options:?}"
-        );
-        assert!(
-            !options.iter().any(|option| option == "index=off"),
-            "index=off would conflict with nfs_export=on: {options:?}"
-        );
-    }
+    use super::{DockerProbe, direct_routing_rule};
 
     #[test]
     fn cmdline_container_network_drives_the_firewall_destination() {

--- a/guest/arcbox-agent/src/containerd-config.toml
+++ b/guest/arcbox-agent/src/containerd-config.toml
@@ -1,0 +1,25 @@
+# containerd configuration written to /etc/containerd/config.toml at runtime.
+#
+# `@NAME@` placeholders are substituted by `containerd_config::render()` from
+# `arcbox_constants::paths`, so the paths here stay the same ones the agent
+# uses to create those directories. Anything not templated is literal.
+#
+# This file is `include_str!`d into the agent rather than shipped in the guest
+# rootfs on purpose: the rootfs is a separate release train, and a config that
+# can lag the agent depending on it would drop options silently — the exact
+# failure mode the overlayfs section below is most vulnerable to.
+
+version = 2
+
+[plugins."io.containerd.grpc.v1.cri".cni]
+  bin_dir = "@CNI_BIN_DIR@"
+  conf_dir = "@CNI_CONF_DIR@"
+  max_conf_num = 1
+
+# Makes a running container's rootfs exportable over NFS, which is what lets
+# the host browse it live at ~/ArcBox (ABX-424). The two options are coupled by
+# the kernel, not by preference — see OVERLAY_MOUNT_OPTIONS in containerd_config.rs for
+# which of the three branches in `ovl_fs_params_verify` each spelling lands in,
+# and which one fails silently.
+[plugins."io.containerd.snapshotter.v1.overlayfs"]
+  mount_options = @OVERLAY_MOUNT_OPTIONS@

--- a/guest/arcbox-agent/src/containerd_config.rs
+++ b/guest/arcbox-agent/src/containerd_config.rs
@@ -1,0 +1,139 @@
+//! The containerd configuration the agent writes at runtime.
+//!
+//! Lives outside `agent/linux/` for one concrete reason: everything in that
+//! module is `#[cfg(target_os = "linux")]`, so its unit tests never compile on
+//! a macOS dev host — and CI excludes this crate from build, test and clippy
+//! entirely (`guest/AGENTS.md`). Rendering a config file is pure string work
+//! with no Linux in it, so keeping it here is what makes the tests below
+//! actually run somewhere.
+
+use arcbox_constants::paths::{K3S_CNI_BIN_DIR, K3S_CNI_CONF_DIR};
+
+/// Overlay mount options every container rootfs is mounted with.
+///
+/// `nfs_export=on` is what lets the in-kernel nfsd encode file handles for an
+/// overlay mount, which is the precondition for browsing a *running*
+/// container's filesystem through `~/ArcBox` (ABX-424). Committed layers are
+/// already visible there; the merged view a live container sees is not, and
+/// without this the kernel cannot name its inodes to a client.
+///
+/// `index=on` is spelled out rather than left to the kernel, because the
+/// kernel's handling of the pair is three-way and only one branch is loud
+/// (`ovl_fs_params_verify`, `fs/overlayfs/params.c`):
+///
+///  - **explicit `index=off` + explicit `nfs_export=on` → `EINVAL`.** This is
+///    our case, and until arcboxlabs/boot-assets#52 it is what we got: the
+///    stock overlay snapshotter appended `index=off` after whatever the config
+///    asked for, so the kernel saw `index=on,nfs_export=on,index=off`,
+///    last-wins, and refused every container's mount. The patched containerd
+///    in boot bundle 0.8.6 is what makes this line take effect rather than
+///    break the guest.
+///  - **`index` left unset → the kernel turns it on itself** and the mount
+///    succeeds. Harmless in isolation, but not a reason to trim `index=on`
+///    from this list: containerd decides whether to append its own `index=off`
+///    by looking at *these* options, so dropping it here puts us straight back
+///    in the first branch.
+///  - **no upper layer, with redirects followed → `nfs_export` is silently
+///    turned off** with only a `pr_info`. That is the one branch that fails
+///    quietly, and it is why a no-upper overlay would need
+///    `redirect_dir=nofollow`.
+///
+/// That last option is absent because nothing here mounts a no-upper overlay:
+/// containerd appends these options only on its overlay mount path, which it
+/// reaches for active snapshots (always with an upperdir) and for
+/// multi-parent views — and `image_snapshot_paths` reads a view's mount *spec*
+/// and removes it without ever mounting. Add it if that changes.
+///
+/// The cost is one `trusted.overlay.origin` xattr per copy-up; in exchange
+/// `index=on` stops copy-up from breaking hard links, which is a fix in its
+/// own right. It also forbids reusing an upperdir across overlay mounts —
+/// harmless here, since every snapshot owns its upper.
+const OVERLAY_MOUNT_OPTIONS: &str = r#"["index=on", "nfs_export=on"]"#;
+
+/// The config as authored, with `@NAME@` placeholders still in it.
+///
+/// Kept as a real `.toml` file so it reads as the thing it is: escaped quotes
+/// and `\x20` indentation inside a Rust string literal were the sign that the
+/// previous form was fighting the language rather than expressing it.
+/// `include_str!` rather than a runtime read, so the config cannot lag the
+/// agent that depends on it.
+const CONTAINERD_CONFIG_TEMPLATE: &str = include_str!("containerd-config.toml");
+
+pub fn render() -> String {
+    CONTAINERD_CONFIG_TEMPLATE
+        .replace("@CNI_BIN_DIR@", K3S_CNI_BIN_DIR)
+        .replace("@CNI_CONF_DIR@", K3S_CNI_CONF_DIR)
+        .replace("@OVERLAY_MOUNT_OPTIONS@", OVERLAY_MOUNT_OPTIONS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cni_paths_come_from_the_shared_constants() {
+        let config = render();
+        assert!(config.contains(&format!("bin_dir = \"{K3S_CNI_BIN_DIR}\"")));
+        assert!(config.contains(&format!("conf_dir = \"{K3S_CNI_CONF_DIR}\"")));
+        assert!(config.contains("max_conf_num = 1"));
+    }
+
+    /// A template's own failure mode: a placeholder nobody substitutes.
+    ///
+    /// It is not always loud. `mount_options = @OVERLAY_MOUNT_OPTIONS@` is a
+    /// parse error and would at least stop containerd, but
+    /// `bin_dir = "@CNI_BIN_DIR@"` is perfectly valid TOML carrying a nonsense
+    /// path — a silent misconfiguration. Nothing downstream would say so.
+    ///
+    /// Comments are exempt: the file documents its own placeholder convention,
+    /// and prose about the `@NAME@` form is not a setting anyone reads. (This
+    /// exemption is not hypothetical — the first run of this test failed on
+    /// exactly that sentence.)
+    #[test]
+    fn no_placeholder_survives_rendering_outside_comments() {
+        let config = render();
+        let leftovers: Vec<&str> = config
+            .lines()
+            .filter(|line| !line.trim_start().starts_with('#'))
+            .filter(|line| line.contains('@'))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "unsubstituted placeholder left in the rendered config: {leftovers:?}"
+        );
+    }
+
+    /// containerd refuses to start on a malformed config, and it does so during
+    /// guest bring-up where the symptom is a readiness timeout rather than a
+    /// parse error. Parsing here is cheap; reading the boot log to find a stray
+    /// quote is not.
+    #[test]
+    fn the_rendered_config_is_valid_toml() {
+        let parsed: toml::Value = render().parse().expect("config must be valid TOML");
+        assert_eq!(parsed["version"].as_integer(), Some(2));
+    }
+
+    /// The two options travel together by kernel rule, not by preference:
+    /// explicit `index=off` alongside `nfs_export=on` is rejected outright on a
+    /// read-write mount, and a container rootfs is one.
+    #[test]
+    fn overlay_mount_options_keep_nfs_export_and_index_together() {
+        let parsed: toml::Value = render().parse().unwrap();
+        let options = parsed["plugins"]["io.containerd.snapshotter.v1.overlayfs"]["mount_options"]
+            .as_array()
+            .expect("overlayfs snapshotter must declare mount_options")
+            .iter()
+            .map(|value| value.as_str().unwrap().to_owned())
+            .collect::<Vec<_>>();
+
+        assert!(options.contains(&"nfs_export=on".to_owned()));
+        assert!(
+            options.contains(&"index=on".to_owned()),
+            "nfs_export=on without index=on is rejected by the kernel: {options:?}"
+        );
+        assert!(
+            !options.iter().any(|option| option == "index=off"),
+            "index=off would conflict with nfs_export=on: {options:?}"
+        );
+    }
+}

--- a/guest/arcbox-agent/src/live_exports.rs
+++ b/guest/arcbox-agent/src/live_exports.rs
@@ -1,0 +1,169 @@
+//! Discovery half of the live-container NFS view (ABX-424).
+//!
+//! A running container's merged rootfs is an overlay mount, and the docker
+//! data mount is bind-propagated into the NFS export root, so every container
+//! already appears at
+//! `/run/arcbox/nfs-export/docker/rootfs/overlayfs/<container id>` without any
+//! bind of its own. What it does *not* have is an `/etc/exports` entry, and
+//! NFSv4 will not cross into an unexported child mount — the host sees the
+//! empty directory the overlay is mounted over, which reads as "the container
+//! has no files" rather than as an error.
+//!
+//! `crossmnt` would cross automatically and is banned: it SIGSEGVs the
+//! shipped `rpc.mountd`, leaving a zombie whose name still satisfies the
+//! respawn guard, after which every export upcall goes unanswered and the
+//! host's `mount_nfs` wedges in uninterruptible sleep with no diagnostics. So
+//! each mount gets an explicit entry, and something has to notice them coming
+//! and going.
+//!
+//! **Departures need no ordering.** Measured 2026-08-17: an export entry does
+//! not pin its mount — `docker rm -f` unmounts a currently-exported rootfs
+//! without complaint. So this can be driven entirely by watching the mount
+//! table, with no container-lifecycle event source and no requirement to
+//! unexport before dockerd tears a container down. (An earlier spike concluded
+//! the opposite, but that was with `crossmnt` in play.)
+//!
+//! This module is the pure half — parsing and naming — kept out of
+//! `agent/linux/` on purpose so its tests run on a macOS dev host too.
+
+/// Where container rootfs overlays surface inside the export root.
+pub const EXPORT_ROOTFS_PREFIX: &str = "/run/arcbox/nfs-export/docker/rootfs/overlayfs/";
+
+/// Mountpoints of the container rootfs overlays currently inside the export
+/// root, in a stable order.
+///
+/// Reads `/proc/self/mountinfo` rather than `/proc/self/mounts` because only
+/// the former can be `poll()`ed for changes, and parsing whatever we watch
+/// avoids the two disagreeing. Its fstype lives after the ` - ` separator,
+/// which is also what makes the separator load-bearing: optional fields sit
+/// before it and their count varies per mount.
+#[must_use]
+pub fn rootfs_mountpoints(mountinfo: &str) -> Vec<String> {
+    let mut found: Vec<String> = mountinfo
+        .lines()
+        .filter_map(parse_overlay_mountpoint)
+        .filter(|mountpoint| mountpoint.starts_with(EXPORT_ROOTFS_PREFIX))
+        .map(str::to_owned)
+        .collect();
+    found.sort();
+    found.dedup();
+    found
+}
+
+fn parse_overlay_mountpoint(line: &str) -> Option<&str> {
+    let (before, after) = line.split_once(" - ")?;
+    // fstype is the first field after the separator.
+    if after.split_whitespace().next()? != "overlay" {
+        return None;
+    }
+    // mountpoint is the 5th field of the fixed prefix.
+    before.split_whitespace().nth(4)
+}
+
+/// A stable, collision-resistant `fsid` for an export entry.
+///
+/// Every export needs its own fsid, and the obvious counter would need
+/// allocation state that survives an agent restart and container churn. A
+/// digest of the mountpoint needs none: it is identical across restarts,
+/// distinct per container, and computable by anyone holding the path.
+///
+/// Rendered in UUID shape because `exportfs` accepts `fsid=<uuid>` alongside
+/// the small-integer form, which is what makes a stateless 128-bit id usable
+/// at all — verified against the shipped nfs-utils and kernel before this was
+/// built on.
+#[must_use]
+pub fn fsid_for(mountpoint: &str) -> String {
+    use sha2::{Digest, Sha256};
+
+    let digest = Sha256::digest(mountpoint.as_bytes());
+    let hex: String = digest
+        .iter()
+        .take(16)
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    format!(
+        "{}-{}-{}-{}-{}",
+        &hex[0..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..32]
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Real lines, including the two shapes that matter: a container rootfs
+    /// inside the export root, and its twin under `/var/lib/docker` which must
+    /// not be exported (it is the same filesystem, reachable through the
+    /// export root already).
+    const MOUNTINFO: &str = "\
+25 24 0:23 / /proc rw,nosuid,nodev,noexec,relatime shared:5 - proc proc rw
+71 30 0:52 / /var/lib/docker/rootfs/overlayfs/9aa873fd rw,relatime - overlay overlay rw,lowerdir=/a:/b,upperdir=/c,workdir=/d,index=on,nfs_export=on
+72 31 0:52 / /run/arcbox/nfs-export/docker/rootfs/overlayfs/9aa873fd rw,relatime - overlay overlay rw,lowerdir=/a:/b,upperdir=/c,workdir=/d,index=on,nfs_export=on
+73 31 0:11 / /run/arcbox/nfs-export/docker/containerd ro,noatime - btrfs /dev/vdb ro,subvol=/@containerd
+";
+
+    #[test]
+    fn only_overlays_inside_the_export_root_are_returned() {
+        assert_eq!(
+            rootfs_mountpoints(MOUNTINFO),
+            vec!["/run/arcbox/nfs-export/docker/rootfs/overlayfs/9aa873fd".to_owned()]
+        );
+    }
+
+    /// The optional-field count before ` - ` varies per mount (`shared:5`
+    /// above, nothing on the overlays), so the fstype must be read from after
+    /// the separator rather than at a fixed offset.
+    #[test]
+    fn optional_fields_do_not_shift_the_fstype() {
+        let with_optionals = "\
+72 31 0:52 / /run/arcbox/nfs-export/docker/rootfs/overlayfs/abc rw,relatime shared:9 master:2 - overlay overlay rw,index=on
+";
+        assert_eq!(
+            rootfs_mountpoints(with_optionals),
+            vec!["/run/arcbox/nfs-export/docker/rootfs/overlayfs/abc".to_owned()]
+        );
+    }
+
+    /// A btrfs mount whose *source* string contains "overlay" must not be
+    /// mistaken for an overlay mount.
+    #[test]
+    fn the_fstype_decides_not_the_source_string() {
+        let misleading = "\
+74 31 0:11 / /run/arcbox/nfs-export/docker/rootfs/overlayfs/abc ro,noatime - btrfs /dev/overlay ro
+";
+        assert!(rootfs_mountpoints(misleading).is_empty());
+    }
+
+    #[test]
+    fn fsid_is_uuid_shaped_stable_and_distinct() {
+        let one = fsid_for("/run/arcbox/nfs-export/docker/rootfs/overlayfs/aaa");
+        let two = fsid_for("/run/arcbox/nfs-export/docker/rootfs/overlayfs/bbb");
+
+        assert_eq!(
+            one,
+            fsid_for("/run/arcbox/nfs-export/docker/rootfs/overlayfs/aaa")
+        );
+        assert_ne!(one, two);
+        assert_eq!(one.len(), 36);
+        assert_eq!(
+            one.split('-').map(str::len).collect::<Vec<_>>(),
+            vec![8, 4, 4, 4, 12]
+        );
+        assert!(one.chars().all(|c| c.is_ascii_hexdigit() || c == '-'));
+    }
+
+    /// fsid 0 and 1 are taken by the docker and containerd exports; a derived
+    /// id must never render as one of those.
+    #[test]
+    fn a_derived_fsid_never_collides_with_the_static_exports() {
+        for id in ["/x", "/y", EXPORT_ROOTFS_PREFIX] {
+            let fsid = fsid_for(id);
+            assert_ne!(fsid, "0");
+            assert_ne!(fsid, "1");
+        }
+    }
+}

--- a/guest/arcbox-agent/src/live_exports.rs
+++ b/guest/arcbox-agent/src/live_exports.rs
@@ -73,14 +73,15 @@ fn parse_overlay_mountpoint(line: &str) -> Option<&str> {
 /// built on.
 #[must_use]
 pub fn fsid_for(mountpoint: &str) -> String {
+    use std::fmt::Write as _;
+
     use sha2::{Digest, Sha256};
 
     let digest = Sha256::digest(mountpoint.as_bytes());
-    let hex: String = digest
-        .iter()
-        .take(16)
-        .map(|byte| format!("{byte:02x}"))
-        .collect();
+    let mut hex = String::with_capacity(32);
+    for byte in digest.iter().take(16) {
+        let _ = write!(hex, "{byte:02x}");
+    }
     format!(
         "{}-{}-{}-{}-{}",
         &hex[0..8],

--- a/guest/arcbox-agent/src/main.rs
+++ b/guest/arcbox-agent/src/main.rs
@@ -21,6 +21,10 @@ mod boot_done;
 mod init;
 // Discovery half of the live-container NFS view. Pure parsing and
 // naming, gated like `boot_done` so the tests run on a host build too.
+// The containerd config the agent writes at runtime. Gated like
+// `live_exports` so its tests run on a host build too.
+#[cfg(any(target_os = "linux", test))]
+mod containerd_config;
 #[cfg(any(target_os = "linux", test))]
 mod live_exports;
 #[cfg(any(target_os = "linux", test))]

--- a/guest/arcbox-agent/src/main.rs
+++ b/guest/arcbox-agent/src/main.rs
@@ -19,6 +19,10 @@ mod agent;
 #[cfg(any(target_os = "linux", test))]
 mod boot_done;
 mod init;
+// Discovery half of the live-container NFS view. Pure parsing and
+// naming, gated like `boot_done` so the tests run on a host build too.
+#[cfg(any(target_os = "linux", test))]
+mod live_exports;
 #[cfg(any(target_os = "linux", test))]
 pub(crate) mod runtime_materialize;
 mod supervisor;

--- a/guest/arcbox-agent/src/nfs.rs
+++ b/guest/arcbox-agent/src/nfs.rs
@@ -52,8 +52,15 @@ mod platform {
     const NFSD_MOUNTPOINT: &str = "/proc/fs/nfsd";
     const NFS_STATE_DIR: &str = "/var/lib/nfs";
     const EXPORTS_PATH: &str = "/etc/exports";
+    /// Watched for mount-table changes; also the table the live export
+    /// entries are derived from, so the two can never disagree.
+    const MOUNTINFO_PATH: &str = "/proc/self/mountinfo";
     const NETCONFIG_PATH: &str = "/etc/netconfig";
     const NFSD_THREADS: &str = "4";
+
+    /// Guards the single mount-table watcher against repeated
+    /// `ensure_docker_export` calls.
+    static WATCHER_ARMED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
     /// Minimal libtirpc netconfig. The guest rootfs ships none, and without it
     /// `rpc.mountd` logs "No V2 or V3 listeners created" and serves nothing;
@@ -143,8 +150,10 @@ local      tpi_cots_ord  -     loopback  -       -       -
             Err(e) => tracing::warn!(error = %e, "nfs export: volume icon install failed"),
         }
 
-        write_exports(&cfg).map_err(|e| format!("write {} failed({e})", cfg.exports_path))?;
-        refresh_exports()?;
+        // Renders any already-running containers too: on a warm restart
+        // the mount table is populated before this runs, and waiting for
+        // the next mount change would leave them invisible until one.
+        reconcile_exports(&cfg)?;
         notes.push("refreshed exportfs".to_string());
 
         ensure_netconfig()?;
@@ -156,6 +165,13 @@ local      tpi_cots_ord  -     loopback  -       -       -
 
         ensure_nfsd_threads(&cfg)?;
         notes.push(format!("ensured nfsd threads={}", cfg.threads));
+
+        // Once: this runs again on every EnsureNfsExport, and a thread
+        // per call would pile up watchers that all rewrite the same file.
+        if !WATCHER_ARMED.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            spawn_export_watcher();
+            notes.push("armed live-export watcher".to_string());
+        }
 
         tracing::info!(
             export_ready = export_ready(),
@@ -252,10 +268,6 @@ local      tpi_cots_ord  -     loopback  -       -       -
             ));
         }
         Ok(())
-    }
-
-    fn write_exports(cfg: &ExportConfig<'_>) -> io::Result<()> {
-        fs::write(cfg.exports_path, render_exports(cfg))
     }
 
     fn refresh_exports() -> Result<(), String> {
@@ -461,12 +473,106 @@ local      tpi_cots_ord  -     loopback  -       -       -
     ///   restarts, and marks the NFSv4 pseudo-root. The containerd child
     ///   export gets its own fixed `fsid=1` — it is a separate btrfs
     ///   subvolume, and nfsd cannot derive a stable id for those on its own.
-    fn render_exports(cfg: &ExportConfig<'_>) -> String {
+    ///
+    /// Running containers add one entry each, because NFSv4 does not cross
+    /// into an unexported child mount and `crossmnt` — which would — is
+    /// banned. Their fsids are derived from the mountpoint rather than
+    /// allocated, so nothing has to be remembered across an agent restart or
+    /// reconciled against container churn.
+    fn render_exports(cfg: &ExportConfig<'_>, live: &[String]) -> String {
         const OPTS: &str = "no_subtree_check,insecure,all_squash,anonuid=0,anongid=0";
-        let docker = format!("{} 127.0.0.1/32(ro,fsid=0,{OPTS})\n", cfg.export_docker);
-        match cfg.export_containerd {
-            Some(child) => format!("{docker}{child} 127.0.0.1/32(ro,fsid=1,{OPTS})\n"),
-            None => docker,
+        let mut rendered = format!("{} 127.0.0.1/32(ro,fsid=0,{OPTS})\n", cfg.export_docker);
+        if let Some(child) = cfg.export_containerd {
+            rendered.push_str(&format!("{child} 127.0.0.1/32(ro,fsid=1,{OPTS})\n"));
+        }
+        for mountpoint in live {
+            let fsid = crate::live_exports::fsid_for(mountpoint);
+            rendered.push_str(&format!(
+                "{mountpoint} 127.0.0.1/32(ro,fsid={fsid},{OPTS})\n"
+            ));
+        }
+        rendered
+    }
+
+    /// Current container rootfs overlays, or none if the mount table is
+    /// unreadable.
+    ///
+    /// A failure here degrades the live view rather than the export: the
+    /// static docker and containerd exports still render, so `~/ArcBox` keeps
+    /// working and only running containers go missing from it.
+    fn live_rootfs_exports() -> Vec<String> {
+        match fs::read_to_string(MOUNTINFO_PATH) {
+            Ok(mountinfo) => crate::live_exports::rootfs_mountpoints(&mountinfo),
+            Err(e) => {
+                tracing::warn!(error = %e, path = MOUNTINFO_PATH, "nfs export: cannot read mount table");
+                Vec::new()
+            }
+        }
+    }
+
+    /// Rewrites `/etc/exports` from the current mount table and reloads it.
+    fn reconcile_exports(cfg: &ExportConfig<'_>) -> Result<(), String> {
+        let live = live_rootfs_exports();
+        fs::write(cfg.exports_path, render_exports(cfg, &live))
+            .map_err(|e| format!("write {} failed({e})", cfg.exports_path))?;
+        refresh_exports()?;
+        tracing::debug!(containers = live.len(), "nfs export: reconciled");
+        Ok(())
+    }
+
+    /// Keeps the per-container entries in step with the mount table, for the
+    /// life of the agent.
+    ///
+    /// Blocks in `poll()` rather than polling on a timer: the guest is idle
+    /// most of the time and this repo has already paid once for a busy
+    /// watcher (ABX-517's 1 kHz vmnet poll cost about half the daemon's idle
+    /// CPU). `/proc/self/mountinfo` reports mount-table changes as `POLLPRI`,
+    /// so an idle guest wakes this thread exactly never.
+    ///
+    /// Departures need no urgency and no ordering: an export entry does not
+    /// pin its mount, so dockerd can unmount a container's rootfs while it is
+    /// still exported. A stale entry is therefore cosmetic until the next
+    /// change wakes us.
+    fn spawn_export_watcher() {
+        std::thread::spawn(move || {
+            let file = match fs::File::open(MOUNTINFO_PATH) {
+                Ok(file) => file,
+                Err(e) => {
+                    tracing::warn!(error = %e, "nfs export: live view disabled, cannot watch mounts");
+                    return;
+                }
+            };
+
+            loop {
+                if let Err(e) = wait_for_mount_change(&file) {
+                    tracing::warn!(error = %e, "nfs export: mount watch failed, live view stops here");
+                    return;
+                }
+                if let Err(e) = reconcile_exports(&ExportConfig::default()) {
+                    // Keep watching: a transient exportfs failure should not
+                    // cost every later container its entry.
+                    tracing::warn!(error = %e, "nfs export: reconcile failed");
+                }
+            }
+        });
+    }
+
+    /// Blocks until the mount table changes.
+    fn wait_for_mount_change(file: &fs::File) -> Result<(), String> {
+        use std::os::fd::AsFd;
+
+        use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
+
+        // POLLPRI is how procfs signals a mount-table change; POLLERR arrives
+        // with it. A revents of neither means a spurious wake, which is
+        // harmless — the caller just reconciles against an unchanged table.
+        let mut fds = [PollFd::new(file.as_fd(), PollFlags::POLLPRI)];
+        loop {
+            match poll(&mut fds, PollTimeout::NONE) {
+                Ok(_) => return Ok(()),
+                Err(nix::errno::Errno::EINTR) => continue,
+                Err(e) => return Err(format!("poll({MOUNTINFO_PATH}) failed({e})")),
+            }
         }
     }
 
@@ -505,7 +611,7 @@ local      tpi_cots_ord  -     loopback  -       -       -
 
         #[test]
         fn render_exports_is_readonly_and_localhost_only() {
-            let rendered = render_exports(&ExportConfig::default());
+            let rendered = render_exports(&ExportConfig::default(), &[]);
             assert!(rendered.starts_with("/run/arcbox/nfs-export/docker 127.0.0.1/32("));
             assert!(rendered.contains("ro,"));
             assert!(rendered.contains("fsid=0"));
@@ -518,7 +624,7 @@ local      tpi_cots_ord  -     loopback  -       -       -
 
         #[test]
         fn containerd_child_export_is_inside_the_v4_root_with_its_own_fsid() {
-            let rendered = render_exports(&ExportConfig::default());
+            let rendered = render_exports(&ExportConfig::default(), &[]);
             let child = rendered
                 .lines()
                 .nth(1)
@@ -536,7 +642,7 @@ local      tpi_cots_ord  -     loopback  -       -       -
                 export_containerd: None,
                 ..ExportConfig::default()
             };
-            let rendered = render_exports(&cfg);
+            let rendered = render_exports(&cfg, &[]);
             assert_eq!(rendered.lines().count(), 1);
             assert!(!rendered.contains("containerd"));
         }

--- a/guest/arcbox-agent/src/nfs.rs
+++ b/guest/arcbox-agent/src/nfs.rs
@@ -58,9 +58,10 @@ mod platform {
     const NETCONFIG_PATH: &str = "/etc/netconfig";
     const NFSD_THREADS: &str = "4";
 
-    /// Guards the single mount-table watcher against repeated
-    /// `ensure_docker_export` calls.
-    static WATCHER_ARMED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    /// Backoff after a `poll()` failure on the mount table. Long, because
+    /// there is no realistic persistent error here — this exists so a
+    /// surprising one cannot become a spin.
+    const WATCH_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
 
     /// Minimal libtirpc netconfig. The guest rootfs ships none, and without it
     /// `rpc.mountd` logs "No V2 or V3 listeners created" and serves nothing;
@@ -181,16 +182,12 @@ local      tpi_cots_ord  -     loopback  -       -       -
         ensure_nfsd_threads(&cfg)?;
         notes.push(format!("ensured nfsd threads={}", cfg.threads));
 
-        // Once: this runs again on every EnsureNfsExport, and a thread per call
-        // would pile up watchers all rewriting the same file. The flag is
-        // cleared if the watcher ever exits, so a later pass can replace it.
-        if let Some(mountinfo) = mountinfo {
-            if WATCHER_ARMED.swap(true, std::sync::atomic::Ordering::SeqCst) {
-                drop(mountinfo);
-            } else {
-                spawn_export_watcher(mountinfo, WatchedExports::from(&cfg));
-                notes.push("armed live-export watcher".to_string());
-            }
+        // Idempotent: this runs again on every EnsureNfsExport, and a thread
+        // per call would pile up watchers all rewriting the same file.
+        if let Some(mountinfo) = mountinfo
+            && ensure_export_watcher(mountinfo, WatchedExports::from(&cfg))
+        {
+            notes.push("armed live-export watcher".to_string());
         }
 
         tracing::info!(
@@ -616,35 +613,54 @@ local      tpi_cots_ord  -     loopback  -       -       -
     /// between, and it would stay dropped until some unrelated mount woke us.
     /// The caller opens first, reconciles second, and hands the descriptor
     /// over, which leaves no gap between the snapshot and the watch.
-    fn spawn_export_watcher(mountinfo: fs::File, watched: WatchedExports) {
-        std::thread::spawn(move || {
-            // Whatever ends this thread, let a later EnsureNfsExport start a
-            // replacement: staying "armed" after the watcher is gone would
-            // leave every future container unexported until the agent restarts.
-            let _disarm = Disarm;
-
-            loop {
-                if let Err(e) = wait_for_mount_change(&mountinfo) {
-                    tracing::warn!(error = %e, "nfs export: mount watch failed, live view stops here");
-                    return;
-                }
-                if let Err(e) = reconcile_exports(&watched.as_config()) {
-                    // Keep watching: a transient exportfs failure should not
-                    // cost every later container its entry.
-                    tracing::warn!(error = %e, "nfs export: reconcile failed");
-                }
+    ///
+    /// **This loop does not return.** Neither failure it can meet is worth
+    /// ending the live view for: a failing `exportfs` is usually transient,
+    /// and `poll()` on a procfs descriptor we own has no realistic persistent
+    /// error. Retrying both is also what makes the supervision below sound —
+    /// a thread that can exit on its own turns every "is it still alive?"
+    /// check into a race with its own last instruction.
+    fn watch_exports(mountinfo: &fs::File, watched: &WatchedExports) -> ! {
+        loop {
+            if let Err(e) = wait_for_mount_change(mountinfo) {
+                tracing::warn!(error = %e, "nfs export: mount watch failed, retrying");
+                std::thread::sleep(WATCH_RETRY_DELAY);
+                continue;
             }
-        });
+            if let Err(e) = reconcile_exports(&watched.as_config()) {
+                // A transient exportfs failure should not cost every later
+                // container its entry.
+                tracing::warn!(error = %e, "nfs export: reconcile failed");
+            }
+        }
     }
 
-    /// Clears [`WATCHER_ARMED`] however the watcher thread ends, including a
-    /// panic.
-    struct Disarm;
+    /// Starts the watcher if one is not already running.
+    ///
+    /// Returns whether it started one. Holding the slot across the check makes
+    /// this atomic against a concurrent `EnsureNfsExport`, and because
+    /// [`watch_exports`] never returns, `is_finished()` means the thread
+    /// panicked rather than "is about to stop" — so there is no window where a
+    /// caller sees a live watcher that is really on its way out and declines to
+    /// replace it. An earlier version used an `AtomicBool` cleared by a `Drop`
+    /// guard and had exactly that window: the ensure call would observe
+    /// "armed", skip the respawn, and only then would the flag clear, leaving
+    /// the guest with no watcher and the host with no reason to ask again.
+    fn ensure_export_watcher(mountinfo: fs::File, watched: WatchedExports) -> bool {
+        static WATCHER: std::sync::Mutex<Option<std::thread::JoinHandle<()>>> =
+            std::sync::Mutex::new(None);
 
-    impl Drop for Disarm {
-        fn drop(&mut self) {
-            WATCHER_ARMED.store(false, std::sync::atomic::Ordering::SeqCst);
+        let mut slot = WATCHER.lock().unwrap_or_else(|e| e.into_inner());
+        if slot.as_ref().is_some_and(|handle| !handle.is_finished()) {
+            return false;
         }
+        if slot.is_some() {
+            tracing::warn!("nfs export: watcher had died, starting a replacement");
+        }
+        *slot = Some(std::thread::spawn(move || {
+            watch_exports(&mountinfo, &watched);
+        }));
+        true
     }
 
     /// Blocks until the mount table changes.

--- a/guest/arcbox-agent/src/nfs.rs
+++ b/guest/arcbox-agent/src/nfs.rs
@@ -35,8 +35,8 @@ pub const MOUNTD_PORT: u16 = 20048;
 
 #[cfg(target_os = "linux")]
 mod platform {
+    use std::fmt::Write as _;
     use std::fs;
-    use std::io;
     use std::path::Path;
     use std::process::{Command, Stdio};
 
@@ -150,6 +150,21 @@ local      tpi_cots_ord  -     loopback  -       -       -
             Err(e) => tracing::warn!(error = %e, "nfs export: volume icon install failed"),
         }
 
+        // Open the watch descriptor *before* the reconcile below reads the
+        // table. Procfs reports a change only to descriptors that were already
+        // open, so opening afterwards leaves a window whose containers are
+        // both missed by the snapshot and never announced — invisible until
+        // some later, unrelated mount. Opening first makes the two overlap
+        // instead of gap.
+        let mountinfo = match fs::File::open(MOUNTINFO_PATH) {
+            Ok(file) => Some(file),
+            Err(e) => {
+                tracing::warn!(error = %e, path = MOUNTINFO_PATH, "nfs export: live container view disabled");
+                notes.push("live-export watcher unavailable".to_string());
+                None
+            }
+        };
+
         // Renders any already-running containers too: on a warm restart
         // the mount table is populated before this runs, and waiting for
         // the next mount change would leave them invisible until one.
@@ -166,11 +181,16 @@ local      tpi_cots_ord  -     loopback  -       -       -
         ensure_nfsd_threads(&cfg)?;
         notes.push(format!("ensured nfsd threads={}", cfg.threads));
 
-        // Once: this runs again on every EnsureNfsExport, and a thread
-        // per call would pile up watchers that all rewrite the same file.
-        if !WATCHER_ARMED.swap(true, std::sync::atomic::Ordering::SeqCst) {
-            spawn_export_watcher();
-            notes.push("armed live-export watcher".to_string());
+        // Once: this runs again on every EnsureNfsExport, and a thread per call
+        // would pile up watchers all rewriting the same file. The flag is
+        // cleared if the watcher ever exits, so a later pass can replace it.
+        if let Some(mountinfo) = mountinfo {
+            if WATCHER_ARMED.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                drop(mountinfo);
+            } else {
+                spawn_export_watcher(mountinfo, WatchedExports::from(&cfg));
+                notes.push("armed live-export watcher".to_string());
+            }
         }
 
         tracing::info!(
@@ -483,13 +503,11 @@ local      tpi_cots_ord  -     loopback  -       -       -
         const OPTS: &str = "no_subtree_check,insecure,all_squash,anonuid=0,anongid=0";
         let mut rendered = format!("{} 127.0.0.1/32(ro,fsid=0,{OPTS})\n", cfg.export_docker);
         if let Some(child) = cfg.export_containerd {
-            rendered.push_str(&format!("{child} 127.0.0.1/32(ro,fsid=1,{OPTS})\n"));
+            let _ = writeln!(rendered, "{child} 127.0.0.1/32(ro,fsid=1,{OPTS})");
         }
         for mountpoint in live {
             let fsid = crate::live_exports::fsid_for(mountpoint);
-            rendered.push_str(&format!(
-                "{mountpoint} 127.0.0.1/32(ro,fsid={fsid},{OPTS})\n"
-            ));
+            let _ = writeln!(rendered, "{mountpoint} 127.0.0.1/32(ro,fsid={fsid},{OPTS})");
         }
         rendered
     }
@@ -511,13 +529,71 @@ local      tpi_cots_ord  -     loopback  -       -       -
     }
 
     /// Rewrites `/etc/exports` from the current mount table and reloads it.
+    ///
+    /// Serialized, because two writers exist: `ensure_docker_export` (once per
+    /// `EnsureNfsExport`) and the watcher thread (once per mount change), and
+    /// a container starting during an ensure pass puts them in the same
+    /// instant. Without the lock they can interleave a `write` with the other's
+    /// `exportfs -ra`, which reads whatever half of the table is on disk.
+    ///
+    /// The file is replaced by rename rather than truncated in place for the
+    /// same reason: `exportfs` may be reading it. `/etc` is a tmpfs, so no
+    /// fsync is warranted — there is nothing here to survive a power cut, only
+    /// a concurrent reader to keep whole.
     fn reconcile_exports(cfg: &ExportConfig<'_>) -> Result<(), String> {
+        static EXPORTS_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        // A panicking writer leaves the table as it found it (rename is
+        // all-or-nothing), so a poisoned lock is safe to take over.
+        let _guard = EXPORTS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
         let live = live_rootfs_exports();
-        fs::write(cfg.exports_path, render_exports(cfg, &live))
-            .map_err(|e| format!("write {} failed({e})", cfg.exports_path))?;
+        let staged = format!("{}.arcbox-tmp", cfg.exports_path);
+        fs::write(&staged, render_exports(cfg, &live))
+            .map_err(|e| format!("write {staged} failed({e})"))?;
+        if let Err(e) = fs::rename(&staged, cfg.exports_path) {
+            let _ = fs::remove_file(&staged);
+            return Err(format!(
+                "rename {staged} -> {} failed({e})",
+                cfg.exports_path
+            ));
+        }
         refresh_exports()?;
         tracing::debug!(containers = live.len(), "nfs export: reconciled");
         Ok(())
+    }
+
+    /// The parts of an [`ExportConfig`] the watcher has to carry.
+    ///
+    /// Owned, because the thread outlives the borrow — and carried at all
+    /// because `ensure_docker_export` may have *resolved* the containerd child
+    /// away on a guest with no `/var/lib/containerd`. Rebuilding a default
+    /// inside the watcher would quietly reinstate that path on the next mount
+    /// change and hand `exportfs -ra` an entry for a directory that is not
+    /// there.
+    #[derive(Clone)]
+    struct WatchedExports {
+        export_docker: String,
+        export_containerd: Option<String>,
+        exports_path: String,
+    }
+
+    impl WatchedExports {
+        fn from(cfg: &ExportConfig<'_>) -> Self {
+            Self {
+                export_docker: cfg.export_docker.to_owned(),
+                export_containerd: cfg.export_containerd.map(str::to_owned),
+                exports_path: cfg.exports_path.to_owned(),
+            }
+        }
+
+        fn as_config(&self) -> ExportConfig<'_> {
+            ExportConfig {
+                export_docker: &self.export_docker,
+                export_containerd: self.export_containerd.as_deref(),
+                exports_path: &self.exports_path,
+                ..ExportConfig::default()
+            }
+        }
     }
 
     /// Keeps the per-container entries in step with the mount table, for the
@@ -533,28 +609,42 @@ local      tpi_cots_ord  -     loopback  -       -       -
     /// pin its mount, so dockerd can unmount a container's rootfs while it is
     /// still exported. A stale entry is therefore cosmetic until the next
     /// change wakes us.
-    fn spawn_export_watcher() {
+    ///
+    /// Takes an already-open `mountinfo`. Procfs reports a change only to
+    /// descriptors open when it happened, so opening here — after the caller's
+    /// first reconcile — would silently drop every container that appeared in
+    /// between, and it would stay dropped until some unrelated mount woke us.
+    /// The caller opens first, reconciles second, and hands the descriptor
+    /// over, which leaves no gap between the snapshot and the watch.
+    fn spawn_export_watcher(mountinfo: fs::File, watched: WatchedExports) {
         std::thread::spawn(move || {
-            let file = match fs::File::open(MOUNTINFO_PATH) {
-                Ok(file) => file,
-                Err(e) => {
-                    tracing::warn!(error = %e, "nfs export: live view disabled, cannot watch mounts");
-                    return;
-                }
-            };
+            // Whatever ends this thread, let a later EnsureNfsExport start a
+            // replacement: staying "armed" after the watcher is gone would
+            // leave every future container unexported until the agent restarts.
+            let _disarm = Disarm;
 
             loop {
-                if let Err(e) = wait_for_mount_change(&file) {
+                if let Err(e) = wait_for_mount_change(&mountinfo) {
                     tracing::warn!(error = %e, "nfs export: mount watch failed, live view stops here");
                     return;
                 }
-                if let Err(e) = reconcile_exports(&ExportConfig::default()) {
+                if let Err(e) = reconcile_exports(&watched.as_config()) {
                     // Keep watching: a transient exportfs failure should not
                     // cost every later container its entry.
                     tracing::warn!(error = %e, "nfs export: reconcile failed");
                 }
             }
         });
+    }
+
+    /// Clears [`WATCHER_ARMED`] however the watcher thread ends, including a
+    /// panic.
+    struct Disarm;
+
+    impl Drop for Disarm {
+        fn drop(&mut self) {
+            WATCHER_ARMED.store(false, std::sync::atomic::Ordering::SeqCst);
+        }
     }
 
     /// Blocks until the mount table changes.
@@ -570,7 +660,9 @@ local      tpi_cots_ord  -     loopback  -       -       -
         loop {
             match poll(&mut fds, PollTimeout::NONE) {
                 Ok(_) => return Ok(()),
-                Err(nix::errno::Errno::EINTR) => continue,
+                // A signal is not a watch failure — resume the wait rather
+                // than tearing the live view down for the agent's lifetime.
+                Err(nix::errno::Errno::EINTR) => {}
                 Err(e) => return Err(format!("poll({MOUNTINFO_PATH}) failed({e})")),
             }
         }

--- a/tests/e2e/tests/live_container_fs.rs
+++ b/tests/e2e/tests/live_container_fs.rs
@@ -62,9 +62,17 @@ fn a_running_containers_filesystem_is_readable_from_the_host() -> Result<()> {
         args: vec![],
         env: vec![("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version)],
     })?;
-    daemon
-        .wait_ready_blocking(READY_TIMEOUT)
-        .context("daemon not ready")?;
+    // Readiness failures need the same forensics as scenario failures: the
+    // daemon log explaining why boot stalled lives in the data dir, and `?`
+    // here would drop it (tests/e2e/AGENTS.md).
+    if let Err(error) = daemon.wait_ready_blocking(READY_TIMEOUT) {
+        let kept = data_dir.keep();
+        drop(daemon);
+        bail!(
+            "daemon not ready: {error:#} (data dir preserved at {})",
+            kept.display()
+        );
+    }
 
     let result = scenario(data_dir.path());
     if result.is_err() {

--- a/tests/e2e/tests/live_container_fs.rs
+++ b/tests/e2e/tests/live_container_fs.rs
@@ -1,0 +1,192 @@
+//! ABX-424 acceptance: a **running** container's filesystem is browsable from
+//! the macOS host through `~/ArcBox`, live.
+//!
+//! Committed layers have been visible under `~/ArcBox/containerd` since
+//! ABX-425, but those are the immutable parents. What a running container
+//! actually sees — its merged overlay, including everything it has written
+//! since it started — was not reachable at all: the in-kernel nfsd could not
+//! encode file handles for an overlay mounted without `nfs_export=on`, and the
+//! mountpoint had no export entry of its own.
+//!
+//! The test deliberately does no `exportfs` work itself. Everything it needs
+//! must come from the guest agent reconciling exports on its own, which is the
+//! behaviour under test; a version of this that set up its own export would
+//! pass without the feature existing.
+//!
+//! Three properties, in order of what they would tell you when one breaks:
+//!
+//! 1. the host can read a file the container wrote **before** the read — the
+//!    view exists at all;
+//! 2. the host can read a file the container writes **after** that — it is a
+//!    live view rather than a one-shot snapshot;
+//! 3. `docker rm -f` still succeeds afterwards — exporting a container's
+//!    rootfs has not made it un-removable, which is the regression this
+//!    feature could plausibly introduce.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+use arcbox_e2e::docker::docker_output;
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+const DOCKER_TIMEOUT: Duration = Duration::from_secs(120);
+/// The agent reconciles exports off a mount-table change and the host mount
+/// caches attributes (`actimeo=10`), so a read needs a window before it counts
+/// as a failure.
+const VISIBLE_TIMEOUT: Duration = Duration::from_secs(60);
+const BOOT_MARKER: &str = "arcbox-live-fs-at-start";
+const LIVE_MARKER: &str = "arcbox-live-fs-after-start";
+
+#[test]
+#[ignore = "boots a System VM through a real daemon"]
+fn a_running_containers_filesystem_is_readable_from_the_host() -> Result<()> {
+    let root = arcbox_e2e::repo_root();
+    if !arcbox_e2e::env_flag("SKIP_BUILD") {
+        let shell = xshell::Shell::new()?;
+        shell.change_dir(&root);
+        xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+    }
+
+    let version = resolve_boot_version(&root)?;
+    let data_dir = tempfile::Builder::new()
+        .prefix("arcbox-live-fs-")
+        .tempdir()?;
+    stage_dev_boot_assets(&root, data_dir.path(), &version)?;
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: data_dir.path().to_owned(),
+        args: vec![],
+        env: vec![("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version)],
+    })?;
+    daemon
+        .wait_ready_blocking(READY_TIMEOUT)
+        .context("daemon not ready")?;
+
+    let result = scenario(data_dir.path());
+    if result.is_err() {
+        let kept = data_dir.keep();
+        println!("preserving test directory path={}", kept.display());
+    }
+    drop(daemon);
+    result
+}
+
+fn scenario(data_dir: &Path) -> Result<()> {
+    let image = std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+
+    docker_output(
+        data_dir,
+        &[
+            "run",
+            "-d",
+            "--name",
+            "live-fs",
+            &image,
+            "sh",
+            "-c",
+            &format!("echo {BOOT_MARKER} > /at-start.txt && sleep 300"),
+        ],
+        DOCKER_TIMEOUT,
+    )?;
+    let container_id = docker_output(
+        data_dir,
+        &["inspect", "-f", "{{.Id}}", "live-fs"],
+        DOCKER_TIMEOUT,
+    )?
+    .trim()
+    .to_owned();
+
+    let host_root = live_fs_root(data_dir, &container_id);
+    println!("expecting the live rootfs at {}", host_root.display());
+
+    // (1) exists at all
+    let at_start = read_with_retry(&host_root.join("at-start.txt")).with_context(|| {
+        format!(
+            "the live rootfs of {container_id} was not readable through the host mount.\n\
+             guest overlay mounts were:\n{}",
+            overlay_mounts(data_dir, &image).unwrap_or_else(|e| format!("<unavailable: {e:#}>"))
+        )
+    })?;
+    if !at_start.contains(BOOT_MARKER) {
+        bail!("at-start.txt read back as {at_start:?}, expected {BOOT_MARKER}");
+    }
+
+    // (2) live, not a snapshot taken when the export was created
+    docker_output(
+        data_dir,
+        &[
+            "exec",
+            "live-fs",
+            "sh",
+            "-c",
+            &format!("echo {LIVE_MARKER} > /after-start.txt"),
+        ],
+        DOCKER_TIMEOUT,
+    )?;
+    let after_start = read_with_retry(&host_root.join("after-start.txt"))
+        .context("a file written after the export existed never became visible")?;
+    if !after_start.contains(LIVE_MARKER) {
+        bail!("after-start.txt read back as {after_start:?}, expected {LIVE_MARKER}");
+    }
+
+    // (3) exporting it has not made the container un-removable
+    docker_output(data_dir, &["rm", "-f", "live-fs"], DOCKER_TIMEOUT)
+        .context("docker rm -f failed while the rootfs was exported")?;
+
+    Ok(())
+}
+
+/// Where the host sees a container's live rootfs.
+///
+/// The guest mounts it inside the NFS export root at
+/// `/run/arcbox/nfs-export/docker/rootfs/overlayfs/<id>`, and that export root
+/// is `fsid=0` — the NFSv4 pseudo-root — so the host path is the same tail
+/// under the mount. Asserting the ID is the container's own, rather than
+/// discovering the path by scanning, is deliberate: a path a caller cannot
+/// derive from something it already knows is not a browsable view, and the
+/// desktop Files tabs would have nothing to open.
+fn live_fs_root(data_dir: &Path, container_id: &str) -> PathBuf {
+    data_dir
+        .join("ArcBox")
+        .join("rootfs/overlayfs")
+        .join(container_id)
+}
+
+fn overlay_mounts(data_dir: &Path, image: &str) -> Result<String> {
+    let mounts = docker_output(
+        data_dir,
+        &[
+            "run",
+            "--rm",
+            "--privileged",
+            "--pid=host",
+            image,
+            "cat",
+            "/proc/1/mounts",
+        ],
+        DOCKER_TIMEOUT,
+    )?;
+    Ok(mounts
+        .lines()
+        .filter(|line| line.starts_with("overlay "))
+        .collect::<Vec<_>>()
+        .join("\n"))
+}
+
+fn read_with_retry(path: &Path) -> Result<String> {
+    let deadline = Instant::now() + VISIBLE_TIMEOUT;
+    loop {
+        let last = match std::fs::read_to_string(path) {
+            Ok(contents) => return Ok(contents),
+            Err(error) => error,
+        };
+        if Instant::now() >= deadline {
+            bail!("{} never became readable: {last}", path.display());
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+}

--- a/tests/e2e/tests/overlay_options_probe.rs
+++ b/tests/e2e/tests/overlay_options_probe.rs
@@ -1,0 +1,117 @@
+//! Proves the overlayfs snapshotter's configured mount options reach the
+//! kernel, rather than merely reaching `/etc/containerd/config.toml`.
+//!
+//! A container's rootfs must be mounted with `index=on,nfs_export=on` for the
+//! in-kernel nfsd to be able to encode file handles for it — the precondition
+//! for browsing a live container through `~/ArcBox` (ABX-424). Configuring
+//! them is not the same as getting them: until arcboxlabs/boot-assets#52 the
+//! stock overlay snapshotter appended `index=off` after the configured
+//! options, and the kernel rejects `index=off,nfs_export=on` on a read-write
+//! mount outright.
+//!
+//! This reads the guest's own `/proc/mounts` through a privileged container in
+//! the host PID namespace, because that is the only place the *effective*
+//! options are visible. Note `/proc/mounts` omits options equal to the
+//! kernel default, which is why the assertions target `index=on` and
+//! `nfs_export=on` (both non-default) rather than the absence of `index=off`.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
+use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
+use arcbox_e2e::docker::docker_output;
+
+const READY_TIMEOUT: Duration = Duration::from_secs(180);
+const DOCKER_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[test]
+#[ignore = "boots a System VM through a real daemon"]
+fn container_rootfs_is_mounted_with_nfs_exportable_options() -> Result<()> {
+    let root = arcbox_e2e::repo_root();
+    if !arcbox_e2e::env_flag("SKIP_BUILD") {
+        let shell = xshell::Shell::new()?;
+        shell.change_dir(&root);
+        xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+    }
+
+    let version = resolve_boot_version(&root)?;
+    let data_dir = tempfile::Builder::new()
+        .prefix("arcbox-overlay-opts-")
+        .tempdir()?;
+    stage_dev_boot_assets(&root, data_dir.path(), &version)?;
+
+    let mut daemon = DaemonHandle::spawn(DaemonConfig {
+        binary: root.join("target/release/arcbox-daemon"),
+        data_dir: data_dir.path().to_owned(),
+        args: vec![],
+        env: vec![("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version)],
+    })?;
+    daemon
+        .wait_ready_blocking(READY_TIMEOUT)
+        .context("daemon not ready")?;
+
+    let result = scenario(data_dir.path());
+    if result.is_err() {
+        let kept = data_dir.keep();
+        eprintln!("preserving test directory path={}", kept.display());
+    }
+    drop(daemon);
+    result
+}
+
+fn scenario(data_dir: &Path) -> Result<()> {
+    let image = std::env::var("ARCBOX_E2E_IMAGE").unwrap_or_else(|_| "alpine:latest".to_owned());
+
+    docker_output(
+        data_dir,
+        &[
+            "run", "-d", "--name", "ovl-probe", &image, "sleep", "300",
+        ],
+        DOCKER_TIMEOUT,
+    )?;
+
+    // Read PID 1's mount table rather than our own: a container's
+    // `/proc/mounts` shows its rootfs as `/` with the overlay options already
+    // stripped. `--pid=host` makes `/proc/1` the guest init, and `/proc/N/mounts`
+    // is readable without entering its mount namespace — which matters,
+    // because `nsenter -m` would resolve every subsequent binary against the
+    // guest's EROFS root instead of this image.
+    let mounts = docker_output(
+        data_dir,
+        &[
+            "run",
+            "--rm",
+            "--privileged",
+            "--pid=host",
+            &image,
+            "cat",
+            "/proc/1/mounts",
+        ],
+        DOCKER_TIMEOUT,
+    )?;
+
+    println!("guest overlay mounts:\n{mounts}");
+
+    let overlay_lines: Vec<&str> = mounts
+        .lines()
+        .filter(|line| line.starts_with("overlay "))
+        .collect();
+    if overlay_lines.is_empty() {
+        bail!("no overlay mount in the guest's /proc/mounts:\n{mounts}");
+    }
+
+    for option in ["index=on", "nfs_export=on"] {
+        if !overlay_lines.iter().any(|line| line.contains(option)) {
+            bail!(
+                "no overlay mount carries {option}; the snapshotter's configured \
+                 mount_options did not reach the kernel:\n{}",
+                overlay_lines.join("\n")
+            );
+        }
+    }
+
+    let _ = docker_output(data_dir, &["rm", "-f", "ovl-probe"], DOCKER_TIMEOUT);
+    Ok(())
+}

--- a/tests/e2e/tests/overlay_options_probe.rs
+++ b/tests/e2e/tests/overlay_options_probe.rs
@@ -66,9 +66,7 @@ fn scenario(data_dir: &Path) -> Result<()> {
 
     docker_output(
         data_dir,
-        &[
-            "run", "-d", "--name", "ovl-probe", &image, "sleep", "300",
-        ],
+        &["run", "-d", "--name", "ovl-probe", &image, "sleep", "300"],
         DOCKER_TIMEOUT,
     )?;
 

--- a/tests/e2e/tests/overlay_options_probe.rs
+++ b/tests/e2e/tests/overlay_options_probe.rs
@@ -18,7 +18,7 @@
 use std::path::Path;
 use std::time::Duration;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use arcbox_e2e::boot_assets::{resolve_boot_version, stage_dev_boot_assets};
 use arcbox_e2e::daemon::{DaemonConfig, DaemonHandle};
 use arcbox_e2e::docker::docker_output;
@@ -34,6 +34,16 @@ fn container_rootfs_is_mounted_with_nfs_exportable_options() -> Result<()> {
         let shell = xshell::Shell::new()?;
         shell.change_dir(&root);
         xshell::cmd!(shell, "cargo build --release -p arcbox-daemon").run()?;
+        // The subject of this test is config the *guest agent* writes, and
+        // `stage_dev_boot_assets` stages whichever agent has the newest mtime
+        // across the dev tree, the musl target and ~/.arcbox/bin. Without
+        // building it here, a machine holding any older agent can boot one
+        // that predates the change entirely (ABX-385 class).
+        xshell::cmd!(
+            shell,
+            "cargo build -p arcbox-agent --target aarch64-unknown-linux-musl --release"
+        )
+        .run()?;
     }
 
     let version = resolve_boot_version(&root)?;
@@ -48,9 +58,17 @@ fn container_rootfs_is_mounted_with_nfs_exportable_options() -> Result<()> {
         args: vec![],
         env: vec![("ARCBOX_BOOT_ASSET_VERSION".to_owned(), version)],
     })?;
-    daemon
-        .wait_ready_blocking(READY_TIMEOUT)
-        .context("daemon not ready")?;
+    // Readiness failures need the same forensics as scenario failures: the
+    // daemon log explaining why boot stalled lives in the data dir, and `?`
+    // here would drop it (tests/e2e/AGENTS.md).
+    if let Err(error) = daemon.wait_ready_blocking(READY_TIMEOUT) {
+        let kept = data_dir.keep();
+        drop(daemon);
+        bail!(
+            "daemon not ready: {error:#} (data dir preserved at {})",
+            kept.display()
+        );
+    }
 
     let result = scenario(data_dir.path());
     if result.is_err() {
@@ -100,14 +118,22 @@ fn scenario(data_dir: &Path) -> Result<()> {
         bail!("no overlay mount in the guest's /proc/mounts:\n{mounts}");
     }
 
-    for option in ["index=on", "nfs_export=on"] {
-        if !overlay_lines.iter().any(|line| line.contains(option)) {
-            bail!(
-                "no overlay mount carries {option}; the snapshotter's configured \
-                 mount_options did not reach the kernel:\n{}",
-                overlay_lines.join("\n")
-            );
-        }
+    // Both options on *one* mount. Scanning for each independently would pass
+    // when one mount carries `index=on` and a different one carries
+    // `nfs_export=on` — never checking the pairing this exists to guarantee.
+    // It also masks the sharpest signature there is: a mount with `index=on`
+    // and no `nfs_export=on` is what the kernel leaves behind when it drops
+    // nfs_export on its own.
+    let paired = overlay_lines
+        .iter()
+        .any(|line| line.contains("index=on") && line.contains("nfs_export=on"));
+    if !paired {
+        bail!(
+            "no single overlay mount carries both index=on and nfs_export=on; \
+             the snapshotter's configured mount_options did not reach the kernel \
+             intact:\n{}",
+            overlay_lines.join("\n")
+        );
     }
 
     let _ = docker_output(data_dir, &["rm", "-f", "ovl-probe"], DOCKER_TIMEOUT);


### PR DESCRIPTION
Completes **ABX-424**. Stacked on #659 — merge that first.

A running container's filesystem is now browsable from the host at **`~/ArcBox/rootfs/overlayfs/<container id>`**, live. Committed layers have been visible since ABX-425, but those are the immutable parents; what a container has written since it started was not reachable at all.

## Why it was invisible

Two things were missing and only one of them was code:

1. the overlay had to be mounted `nfs_export=on` before nfsd could encode file handles for it — #659;
2. the mountpoint needed an `/etc/exports` entry of its own. NFSv4 does not cross into an unexported child mount, so the host was seeing the **empty directory the overlay is mounted over** — which reads as "this container has no files" rather than as an error. `crossmnt` would cross automatically and stays banned: it SIGSEGVs the shipped `rpc.mountd`, leaving a zombie whose name still satisfies the respawn guard, after which the host's `mount_nfs` wedges in uninterruptible sleep with no diagnostics.

## The design shrank once it was measured

The plan of record wanted a container-lifecycle event source, because an exported child was believed to **pin** its mount — meaning the unexport had to happen *before* dockerd tore the container down, and a mount-table watcher could only ever learn about a departure too late.

Measured on hardware: **it does not pin.** `docker rm -f` unmounts a currently-exported rootfs without complaint, and the mount is genuinely gone afterwards. The earlier observation was made with `crossmnt` in play. So there is no ordering constraint, no event source, and unexport is tidiness rather than correctness. Watching the mount table is sufficient on its own — and it also covers containers this agent did not start.

Two deliberate mechanism choices:

- **`poll()` on `/proc/self/mountinfo`, not a timer.** An idle guest wakes the thread exactly never. This repo has already paid to learn that once: ABX-517's 1 kHz vmnet poll cost about half the daemon's idle CPU.
- **fsids derived from the mountpoint, not allocated.** Every export needs a distinct fsid; a counter would need state surviving agent restarts and container churn. A digest needs none. `exportfs` accepts the UUID form alongside small integers, which is what makes a stateless 128-bit id usable at all — verified against the shipped nfs-utils and kernel *before* the design leaned on it, rather than discovering it in the implementation.

## Acceptance

`tests/e2e/tests/live_container_fs.rs` was written **before** the implementation and failed for the right reason (`at-start.txt … No such file or directory`, with the guest's overlay mounts printed alongside). It now passes. It does no `exportfs` work itself — a version that set up its own export would pass without the feature existing.

Three properties, ordered by what each tells you when it breaks:

1. the host reads a file written **before** the read — the view exists;
2. the host reads a file written **after** that — it is live, not a snapshot taken when the export appeared;
3. `docker rm -f` still succeeds — exporting a rootfs has not made containers un-removable.

It also pins the path as **derivable from the container ID** rather than discovering it by scanning: a path a caller cannot compute from something it already holds is not a browsable view, and the desktop Files tabs would have nothing to open.

`boot_assets` passes unchanged (78.5s). The five `live_exports` unit tests run on a macOS dev host — the parsing and naming live outside `agent/linux/` for exactly that reason, since everything in that module is invisible to both a host build and CI.

## Not in scope

Unexport currently happens on the next mount-table change rather than immediately, which is cosmetic given the above. Finder ESTALE behaviour when a browsed container exits, and the cost of `index=on` under heavy copy-up, are both open and unmeasured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes guest NFS export reconciliation and containerd overlay mount options on the critical path for host filesystem visibility; failures surface as missing live views or readiness timeouts rather than isolated UI bugs.
> 
> **Overview**
> Completes **ABX-424**: running containers become browsable on the macOS host at **`~/ArcBox/rootfs/overlayfs/<container id>`**, with files written before and after export visible live.
> 
> **Containerd config** moves from an inline string in `runtime.rs` to a templated `containerd-config.toml` rendered by `containerd_config::render()`, embedding overlay snapshotter `mount_options` **`index=on,nfs_export=on`** so nfsd can encode handles for live overlay rootfs (paired by kernel rules; avoids silent `index=off` conflicts).
> 
> **NFS `/etc/exports`** now adds one read-only localhost entry per container overlay under the export root, with **UUID-shaped fsids** derived from the mountpoint (`live_exports`). **`reconcile_exports`** stages via rename, runs `exportfs -ra`, and is mutex-serialized against concurrent writers. A background thread **`poll()`s** an already-open `/proc/self/mountinfo` (`POLLPRI`) instead of timer polling; mountinfo is opened before the first reconcile to avoid missing containers that appear in the gap.
> 
> **Tests**: host-runnable unit tests for config rendering and mountinfo parsing; ignored e2e `live_container_fs` (host read + live write + `docker rm -f`) and `overlay_options_probe` (effective kernel mount options).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0689dd47445144c222f6fdf26af304ce322905ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->