### PR TITLE
fix(vm-driver): refuse path-shaped ids and make the restore contract check distinguishing

### DIFF
--- a/virt/arcbox-vm-driver/src/spec.rs
+++ b/virt/arcbox-vm-driver/src/spec.rs
@@ -16,10 +16,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
 
-/// The identity of a VM: non-empty, at most 64 characters, `[A-Za-z0-9._-]`.
+/// The identity of a VM: a plain name — non-empty, at most 64 characters,
+/// `[A-Za-z0-9._-]`, and not `.` or `..`.
 ///
 /// Drivers use it as a runtime-directory and socket-name component, which is
-/// what the character set protects.
+/// what the rule protects; [`DiskSpec::id`] is held to the same one.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct VmId(String);
@@ -31,23 +32,7 @@ impl VmId {
     /// Validates `id` and wraps it.
     pub fn new(id: impl Into<String>) -> Result<Self> {
         let id = id.into();
-        if id.is_empty() {
-            return Err(Error::InvalidSpec("vm id must not be empty".into()));
-        }
-        if id.len() > Self::MAX_LEN {
-            return Err(Error::InvalidSpec(format!(
-                "vm id `{id}` exceeds {} characters",
-                Self::MAX_LEN
-            )));
-        }
-        if let Some(bad) = id
-            .chars()
-            .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')))
-        {
-            return Err(Error::InvalidSpec(format!(
-                "vm id `{id}` contains `{bad}`; allowed: A-Z a-z 0-9 . _ -"
-            )));
-        }
+        require_plain_name("vm id", &id)?;
         Ok(Self(id))
     }
 
@@ -283,6 +268,35 @@ impl VmSpec {
 fn require_path(what: &str, path: &Path) -> Result<()> {
     if path.as_os_str().is_empty() {
         return Err(Error::InvalidSpec(format!("{what} must not be empty")));
+    }
+    Ok(())
+}
+
+/// The rule for anything a driver may turn into a path component, a socket
+/// name, or a URL segment: non-empty, at most [`VmId::MAX_LEN`] bytes,
+/// `[A-Za-z0-9._-]`, and not the `.` / `..` traversal names.
+fn require_plain_name(what: &str, name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(Error::InvalidSpec(format!("{what} must not be empty")));
+    }
+    if name.len() > VmId::MAX_LEN {
+        return Err(Error::InvalidSpec(format!(
+            "{what} `{name}` exceeds {} characters",
+            VmId::MAX_LEN
+        )));
+    }
+    if let Some(bad) = name
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')))
+    {
+        return Err(Error::InvalidSpec(format!(
+            "{what} `{name}` contains `{bad}`; allowed: A-Z a-z 0-9 . _ -"
+        )));
+    }
+    if name == "." || name == ".." {
+        return Err(Error::InvalidSpec(format!(
+            "{what} `{name}` is a path traversal name"
+        )));
     }
     Ok(())
 }
@@ -534,11 +548,24 @@ mod tests {
     fn vm_id_accepts_the_documented_alphabet_and_nothing_else() {
         assert!(VmId::new("a.b_c-D9").is_ok());
         assert!(VmId::new("x".repeat(VmId::MAX_LEN)).is_ok());
+        assert!(VmId::new(".hidden").is_ok());
+        assert!(VmId::new("...").is_ok());
         assert!(VmId::new("").is_err());
         assert!(VmId::new("x".repeat(VmId::MAX_LEN + 1)).is_err());
         assert!(VmId::new("has space").is_err());
         assert!(VmId::new("slash/y").is_err());
         assert!(VmId::new("ünïcode").is_err());
+    }
+
+    #[test]
+    fn vm_id_refuses_the_traversal_names() {
+        for bad in [".", ".."] {
+            match VmId::new(bad) {
+                Err(Error::InvalidSpec(msg)) => assert!(msg.contains("traversal"), "{msg}"),
+                other => panic!("`{bad}` gave {other:?}"),
+            }
+            assert!(serde_json::from_str::<VmId>(&format!("\"{bad}\"")).is_err());
+        }
     }
 
     #[test]

--- a/virt/arcbox-vm-driver/src/spec.rs
+++ b/virt/arcbox-vm-driver/src/spec.rs
@@ -194,10 +194,11 @@ pub struct VmSpec {
 impl VmSpec {
     /// Checks the invariants no driver can repair.
     ///
-    /// CPU and memory are at least 1; disk ids, NIC ids and share tags are
-    /// non-empty and unique; at most one disk is the root; every MAC is a
-    /// non-nil unicast address; every boot, disk and share path is
-    /// non-empty; the vsock guest CID is 3 or above.
+    /// CPU and memory are at least 1; disk ids are plain names under the
+    /// [`VmId`] rule and unique; NIC ids and share tags are non-empty and
+    /// unique; at most one disk is the root; every MAC is a non-nil unicast
+    /// address; every boot, disk and share path is non-empty; the vsock
+    /// guest CID is 3 or above.
     pub fn validate(&self) -> Result<()> {
         if self.cpus == 0 {
             return Err(Error::InvalidSpec("cpus must be at least 1".into()));
@@ -208,9 +209,7 @@ impl VmSpec {
         self.boot.validate()?;
         let mut disk_ids = HashSet::new();
         for disk in &self.disks {
-            if disk.id.is_empty() {
-                return Err(Error::InvalidSpec("disk id must not be empty".into()));
-            }
+            require_plain_name("disk id", &disk.id)?;
             if !disk_ids.insert(disk.id.as_str()) {
                 return Err(Error::InvalidSpec(format!(
                     "duplicate disk id `{}`",
@@ -350,7 +349,9 @@ impl BootSpec {
 /// One block device.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DiskSpec {
-    /// Unique within the spec; drivers use it as the device's name.
+    /// Unique within the spec; drivers use it as the device's name, and as
+    /// a file name or URL segment, so it is held to the [`VmId`] rule
+    /// (`[A-Za-z0-9._-]`, at most 64 characters, not `.` or `..`).
     pub id: String,
     /// The backing file on the host.
     pub path: PathBuf,
@@ -637,6 +638,24 @@ mod tests {
         let mut s = spec();
         s.disks[0].path = PathBuf::new();
         assert!(invalid(&s).contains("disk path"));
+    }
+
+    #[test]
+    fn disk_ids_are_plain_names() {
+        for bad in [
+            ".",
+            "..",
+            "a/b",
+            "has space",
+            "x".repeat(VmId::MAX_LEN + 1).as_str(),
+        ] {
+            let mut s = spec();
+            s.disks[0].id = bad.into();
+            assert!(invalid(&s).contains("disk id"), "`{bad}` accepted");
+        }
+        let mut s = spec();
+        s.disks[0].id = "root.fs_v2-a".into();
+        s.validate().unwrap();
     }
 
     #[test]

--- a/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
@@ -377,10 +377,29 @@ pub async fn discard_kills_a_prepared_vm(h: &dyn ContractHarness) {
 
 /// A restore names the image's disks at new host paths (a copy here, a
 /// fresh CoW device in production) and comes up under the new id.
+///
+/// The source boots from private copies of the harness's disks, and those
+/// copies are removed once they have been copied again for the restore, so
+/// a driver that reopens the paths recorded in the checkpoint instead of
+/// the ones in `RestoreSpec::disks` fails here rather than passing by
+/// accident.
 pub async fn restore_reattaches_disks(h: &dyn ContractHarness) {
-    let source = boot(h, "reattach-src").await;
+    let driver = h.driver();
+    let mut source_spec = h.spec(&id("reattach-src"));
+    let source_dir = h.runtime_dir();
+    for disk in &mut source_spec.disks {
+        let private = source_dir.join(format!("{}.src", disk.id));
+        std::fs::copy(&disk.path, &private).expect("copy the disk for the source");
+        disk.path = private;
+    }
+    let source = driver
+        .boot(source_spec.clone(), &source_dir)
+        .await
+        .expect("boot");
+    h.ready(&*source).await;
     let Some(cp) = source.checkpoint() else {
-        assert!(!h.driver().capabilities().checkpoint);
+        assert!(!driver.capabilities().checkpoint);
+        source.shutdown(ShutdownMode::Kill).await.expect("kill");
         return;
     };
     let opts = CheckpointOptions {
@@ -388,7 +407,7 @@ pub async fn restore_reattaches_disks(h: &dyn ContractHarness) {
         kind: CheckpointKind::Full,
     };
     let image = cp
-        .checkpoint(&h.runtime_dir().join("checkpoint"), opts)
+        .checkpoint(&source_dir.join("checkpoint"), opts)
         .await
         .expect("checkpoint");
     source
@@ -396,27 +415,27 @@ pub async fn restore_reattaches_disks(h: &dyn ContractHarness) {
         .await
         .expect("kill source");
 
-    let template = h.spec(&id("reattach-dst"));
-    let copies = h.runtime_dir();
-    let disks = template
+    let restore_dir = h.runtime_dir();
+    let disks = source_spec
         .disks
         .into_iter()
         .map(|mut disk| {
-            let copy = copies.join(format!("{}.restored", disk.id));
+            let copy = restore_dir.join(format!("{}.restored", disk.id));
             std::fs::copy(&disk.path, &copy).expect("copy the disk for the restore");
+            std::fs::remove_file(&disk.path).expect("remove the source disk");
             disk.path = copy;
             disk
         })
         .collect();
+    let template = h.spec(&id("reattach-dst"));
     let restore = RestoreSpec {
         id: id("reattach-dst"),
         nics: template.nics,
         disks,
         isolation: template.isolation,
     };
-    let restored = h
-        .driver()
-        .restore(&image, restore, &h.runtime_dir())
+    let restored = driver
+        .restore(&image, restore, &restore_dir)
         .await
         .expect("restore onto the copied disks");
     assert_eq!(*restored.id(), id("reattach-dst"));

--- a/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
@@ -385,6 +385,12 @@ pub async fn discard_kills_a_prepared_vm(h: &dyn ContractHarness) {
 /// accident.
 pub async fn restore_reattaches_disks(h: &dyn ContractHarness) {
     let driver = h.driver();
+    if !driver.capabilities().checkpoint {
+        // Nothing to restore from; skip before copying disks a hardware
+        // harness may measure in gigabytes. The accessor half of the
+        // agreement is `capabilities_agree_with_accessors`'s job.
+        return;
+    }
     let mut source_spec = h.spec(&id("reattach-src"));
     let source_dir = h.runtime_dir();
     for disk in &mut source_spec.disks {


### PR DESCRIPTION
Three port-crate follow-ups surfaced by the fc-driver review on #658 (threads PRRT_kwDOQzhFzc6Zqj_t and PRRT_kwDOQzhFzc6ZqPJd). Stacked on `feat/vm-driver-port` (#656); to be retargeted to `master` once that merges.

## What

- **`VmId` refuses `.` and `..`** (015d31b8). The charset rule already excluded `/`, but the two traversal names passed, and every path-shaped adapter inherited the hazard (the FC adapter had to refuse them itself in `VmLayout::new`). The rule now lives in one private helper, `require_plain_name` — non-empty, ≤ 64, `[A-Za-z0-9._-]`, not `.`/`..` — and `VmId::new` (and thus its `Deserialize`) goes through it.
- **`DiskSpec.id` is held to the same rule** (602bdf73). Adapters use it as a URL path segment and a file name, so `VmSpec::validate` now applies `require_plain_name` to disk ids instead of an emptiness check; NIC ids and share tags keep the emptiness/uniqueness check (drivers use them as device names only).
- **`restore_reattaches_disks` is distinguishing** (2e2fdef3). The check used to leave the source disk in place, so a driver that ignored `RestoreSpec::disks` and reopened the checkpoint's recorded paths passed anyway. The source now boots from private copies of the harness's disks; after the checkpoint those copies are copied again for the restore and the originals removed, so reopening the recorded paths fails. The harness's own images are never touched (the copies live under fresh runtime dirs). `FakeDriver` still passes: it never opens disk paths and already refuses a mismatched disk-id set.

## Tests

`vm_id_refuses_the_traversal_names`, `disk_ids_are_plain_names`; the contract runs green against the fake both fully claimed and unclaimed (`tests/fake_contract.rs`).

Checks before each commit: `cargo fmt --all`, `cargo clippy -p arcbox-vm-driver --all-targets --all-features -- -D warnings`, `cargo test -p arcbox-vm-driver --all-features`, `cargo check --target aarch64-unknown-linux-musl -p arcbox-vm-driver --all-targets --all-features`, `cargo doc -p arcbox-vm-driver --no-deps --all-features`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stricter id validation may reject specs that previously passed (e.g. disk ids with slashes or traversal names), and the restore contract change affects how real drivers must wire disk reattachment on restore.
> 
> **Overview**
> **Centralizes “plain name” validation** for anything drivers embed in paths, sockets, or URL segments. A new `require_plain_name` helper enforces non-empty, ≤64 chars, `[A-Za-z0-9._-]`, and **rejects `.` and `..`** as traversal names. `VmId::new` and `VmSpec::validate` for **disk ids** now go through it (disk ids were only checked for emptiness before).
> 
> **Makes `restore_reattaches_disks` actually catch wrong disk paths.** The source VM boots from private copies of harness disks; after checkpoint, those copies are duplicated for restore and the originals are **deleted**, so a driver that reopens checkpoint-recorded paths instead of `RestoreSpec::disks` fails. Checkpoint-capable drivers skip early when checkpoint is unsupported to avoid large disk copies on hardware harnesses.
> 
> New tests: `vm_id_refuses_the_traversal_names`, `disk_ids_are_plain_names`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b22af79bd902e05a9dd0de23fd2d4dbe6b0d406. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->