### PR TITLE
fix(xtask): a crate's dev-dependency on itself is not a layer edge

### DIFF
--- a/xtask/src/commands/check_layers/graph.rs
+++ b/xtask/src/commands/check_layers/graph.rs
@@ -158,9 +158,14 @@ impl TryFrom<&Metadata> for Graph {
             }
             let layer = layer_of_manifest(&metadata.workspace_root, &package.manifest_path)
                 .with_context(|| format!("placing workspace member {} in a layer", package.name))?;
+            // A crate's dev-dependency on itself (the way a crate turns on
+            // its own optional feature for its tests, e.g. `testkit`) is
+            // not an edge between layers; the graph drops it here so no
+            // rule has to special-case it.
             let mut deps: Vec<String> = package
                 .dependencies
                 .iter()
+                .filter(|dependency| dependency.name != package.name.as_str())
                 .map(|dependency| dependency.name.clone())
                 .collect();
             deps.sort();
@@ -229,6 +234,41 @@ mod tests {
         .to_string();
         assert!(error.contains("`platform`"), "{error}");
         assert!(error.contains("common, virt"), "{error}");
+    }
+
+    #[test]
+    fn a_self_dependency_is_not_an_edge() {
+        let metadata: Metadata = serde_json::from_value(serde_json::json!({
+            "packages": [{
+                "name": "arcbox-vm-driver",
+                "version": "0.1.0",
+                "id": "path+file:///ws/virt/arcbox-vm-driver#0.1.0",
+                "manifest_path": "/ws/virt/arcbox-vm-driver/Cargo.toml",
+                "dependencies": [
+                    {"name": "arcbox-vm-driver", "req": "*", "kind": "dev", "optional": false,
+                     "uses_default_features": true, "features": ["testkit"], "target": null},
+                    {"name": "serde", "req": "^1", "kind": null, "optional": false,
+                     "uses_default_features": true, "features": [], "target": null}
+                ],
+                "targets": [], "features": {}, "source": null, "license": null,
+                "license_file": null, "description": null, "edition": "2024",
+                "authors": [], "categories": [], "keywords": [], "readme": null,
+                "repository": null, "homepage": null, "documentation": null,
+                "links": null, "publish": null, "default_run": null, "rust_version": null,
+                "metadata": null
+            }],
+            "workspace_members": ["path+file:///ws/virt/arcbox-vm-driver#0.1.0"],
+            "workspace_default_members": ["path+file:///ws/virt/arcbox-vm-driver#0.1.0"],
+            "resolve": null,
+            "target_directory": "/ws/target",
+            "version": 1,
+            "workspace_root": "/ws",
+            "metadata": null
+        }))
+        .unwrap();
+        let graph = Graph::try_from(&metadata).unwrap();
+        assert_eq!(graph.members.len(), 1);
+        assert_eq!(graph.members[0].deps, ["serde"]);
     }
 
     #[test]

--- a/xtask/src/commands/check_layers/graph.rs
+++ b/xtask/src/commands/check_layers/graph.rs
@@ -161,11 +161,18 @@ impl TryFrom<&Metadata> for Graph {
             // A crate's dev-dependency on itself (the way a crate turns on
             // its own optional feature for its tests, e.g. `testkit`) is
             // not an edge between layers; the graph drops it here so no
-            // rule has to special-case it.
+            // rule has to special-case it. Identity is the manifest
+            // directory, not the name: a dependency on a *different*
+            // package that happens to share the name (a registry version,
+            // a renamed path dep) is a real edge and stays.
+            let own_dir = package.manifest_path.parent();
             let mut deps: Vec<String> = package
                 .dependencies
                 .iter()
-                .filter(|dependency| dependency.name != package.name.as_str())
+                .filter(|dependency| {
+                    !(dependency.name == package.name.as_str()
+                        && dependency.path.as_deref() == own_dir)
+                })
                 .map(|dependency| dependency.name.clone())
                 .collect();
             deps.sort();
@@ -246,7 +253,12 @@ mod tests {
                 "manifest_path": "/ws/virt/arcbox-vm-driver/Cargo.toml",
                 "dependencies": [
                     {"name": "arcbox-vm-driver", "req": "*", "kind": "dev", "optional": false,
-                     "uses_default_features": true, "features": ["testkit"], "target": null},
+                     "uses_default_features": true, "features": ["testkit"], "target": null,
+                     "path": "/ws/virt/arcbox-vm-driver"},
+                    {"name": "arcbox-vm-driver", "req": "^0.1", "kind": null, "optional": false,
+                     "uses_default_features": true, "features": [], "target": null,
+                     "source": "registry+https://github.com/rust-lang/crates.io-index",
+                     "rename": "published-driver"},
                     {"name": "serde", "req": "^1", "kind": null, "optional": false,
                      "uses_default_features": true, "features": [], "target": null}
                 ],
@@ -268,7 +280,9 @@ mod tests {
         .unwrap();
         let graph = Graph::try_from(&metadata).unwrap();
         assert_eq!(graph.members.len(), 1);
-        assert_eq!(graph.members[0].deps, ["serde"]);
+        // The path dep on its own directory is dropped; the same-named
+        // registry package is a real edge and stays.
+        assert_eq!(graph.members[0].deps, ["arcbox-vm-driver", "serde"]);
     }
 
     #[test]

--- a/xtask/src/commands/check_layers/graph.rs
+++ b/xtask/src/commands/check_layers/graph.rs
@@ -158,21 +158,18 @@ impl TryFrom<&Metadata> for Graph {
             }
             let layer = layer_of_manifest(&metadata.workspace_root, &package.manifest_path)
                 .with_context(|| format!("placing workspace member {} in a layer", package.name))?;
-            // A crate's dev-dependency on itself (the way a crate turns on
-            // its own optional feature for its tests, e.g. `testkit`) is
-            // not an edge between layers; the graph drops it here so no
-            // rule has to special-case it. Identity is the manifest
-            // directory, not the name: a dependency on a *different*
-            // package that happens to share the name (a registry version,
-            // a renamed path dep) is a real edge and stays.
-            let own_dir = package.manifest_path.parent();
+            // A dependency that carries the crate's own name is never an
+            // edge to another workspace member: member names are unique, so
+            // it is either the crate itself (the dev-dependency a crate uses
+            // to turn on its own optional feature for its tests, e.g.
+            // `testkit`) or a foreign package that happens to share the name
+            // (a registry version). The graph keys targets by name and would
+            // resolve either to the member — a false self edge — so both are
+            // dropped here; neither is something a layer rule is about.
             let mut deps: Vec<String> = package
                 .dependencies
                 .iter()
-                .filter(|dependency| {
-                    !(dependency.name == package.name.as_str()
-                        && dependency.path.as_deref() == own_dir)
-                })
+                .filter(|dependency| dependency.name != package.name.as_str())
                 .map(|dependency| dependency.name.clone())
                 .collect();
             deps.sort();
@@ -280,9 +277,10 @@ mod tests {
         .unwrap();
         let graph = Graph::try_from(&metadata).unwrap();
         assert_eq!(graph.members.len(), 1);
-        // The path dep on its own directory is dropped; the same-named
-        // registry package is a real edge and stays.
-        assert_eq!(graph.members[0].deps, ["arcbox-vm-driver", "serde"]);
+        // Neither the dev-dep on itself nor the same-named registry package
+        // is an edge: by name both would resolve to the member itself, and
+        // neither is a dependency between two workspace members.
+        assert_eq!(graph.members[0].deps, ["serde"]);
     }
 
     #[test]


### PR DESCRIPTION
Master's `linux-engine` job fails since #655 + #656 landed together: `arcbox-vm-driver` enables its own `testkit` feature for its tests through a dev-dependency on itself, and `check-layers` reported that as the port depending on a workspace member (rule D-VM1). The graph now drops self-edges at construction (a unit test pins it on a synthetic `cargo metadata`), so no rule has to special-case the idiom. `cargo xtask check-layers` on this branch: `63 members, 156 edges checked, 2 grandfathered`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to xtask graph construction for layer checking; no runtime or security impact.
> 
> **Overview**
> **Fixes `check-layers` false violations** when a workspace crate lists a dependency whose package name matches its own (common for dev-dependencies that enable optional features like `testkit`, or a renamed registry crate with the same name).
> 
> When building the dependency graph from `cargo metadata`, dependencies whose **name equals the member’s package name** are now **filtered out** before edges are recorded. Name-based resolution would otherwise treat those as edges to the same member, which layer rules were never meant to evaluate.
> 
> A unit test on synthetic metadata ensures both a self dev-dependency and a same-named registry dependency are dropped while real deps (e.g. `serde`) remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e61d420f189ce5e4a8e12e83df3a5495379336eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->