### PR TITLE
fix(snapshot): attach loop devices the way busybox losetup actually works

### DIFF
--- a/.github/workflows/test-vm-linux.yml
+++ b/.github/workflows/test-vm-linux.yml
@@ -113,10 +113,20 @@ jobs:
           key: linux-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: linux-cargo-
 
+      # BusyBox's losetup has no long options; the loop-attach code drives
+      # it as `losetup -f` then `losetup LOOPDEV FILE`, and the only honest
+      # check is a real busybox. Ubuntu's 1.30 has the same option surface
+      # as the System VM's, so it exercises the same path
+      # (busybox_block_tools_attach_report_and_detach).
+      - name: Install busybox
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y busybox-static
+
       - name: Build test binary
         run: cargo test --test integration -p arcbox-vm -p arcbox-tap-net --no-run
 
-      - name: Run integration tests (as root for TAP creation)
+      - name: Run integration tests (as root for TAP creation and loop devices)
         run: sudo env PATH="$PATH" HOME="$HOME" cargo test --test integration -p arcbox-vm -p arcbox-tap-net
 
   # ---------------------------------------------------------------------------

--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -65,7 +65,11 @@ The restructure plan and its locked decisions live in the company repo:
     one; the System VM's `/arcbox/bin/dmsetup` comes from the guest
     agent's `VmmConfig` (`firecracker.dmsetup_candidates`), not from here.
     Adding a new host operation means adding a trait method, never a
-    hard-coded binary path.
+    hard-coded binary path. BusyBox's `losetup` has no `--show` (no long
+    options at all), so `BusyboxBlockTools` attaches as `losetup -f` then
+    `losetup LOOPDEV FILE` with a bounded retry when the queried device is
+    claimed in between — tested against a real busybox in
+    `test-vm-linux`'s `integration` job.
   - `CowManager`'s test seam (`CowTestProbe`, `new_with_test_probe`) is
     behind the **`test-probe` feature**, not `#[cfg(test)]`: a
     `cfg(test)` item does not exist for another crate's tests, and its

--- a/engine/arcbox-snapshot/src/snapshot_cow.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow.rs
@@ -190,8 +190,10 @@ pub struct CowManager {
     /// Serializes the cache-miss attach+insert window so two concurrent
     /// first-time setups for the same template converge on a single
     /// `TemplateEntry` instead of each attaching its own loop device and
-    /// leaking the loser.  (TOCTOU on `losetup -f` itself is handled by
-    /// the kernel via `losetup --show`.)
+    /// leaking the loser.  (The other race — a free loop device claimed by
+    /// another process between query and attach — is [`BlockTools`]'s to
+    /// handle; `BusyboxBlockTools` re-queries and retries, since busybox
+    /// has no atomic `losetup -f --show`.)
     losetup_lock: AsyncMutex<()>,
     cow_dir: PathBuf,
     tools: Arc<dyn BlockTools>,

--- a/engine/arcbox-snapshot/src/snapshot_cow.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow.rs
@@ -742,10 +742,20 @@ async fn dmsetup_create(bin: &Path, name: &str, table: &str) -> Result<()> {
     Ok(())
 }
 
-/// Remove a dm device via `dmsetup remove`.
+/// Remove a dm device via `dmsetup remove --retry`.
+///
+/// The caller has already reaped the VM process, so its opener is gone, but
+/// on a host with udev that very close is what wakes the next one: the dm
+/// udev rules put an inotify `watch` on every dm node, a close-after-write
+/// re-triggers the blkid probe, and the probe holds the device open for a
+/// moment — right when the remove ioctl runs. `--retry` repeats the remove
+/// on `EBUSY` for a few seconds instead of failing on the first, which is
+/// libdevmapper's own answer to that race; a device that is genuinely still
+/// in use fails as before, only later. (Reconciliation at startup uses the
+/// same flag: `persistence.rs`.)
 async fn dmsetup_remove(bin: &Path, name: &str) -> Result<()> {
     let mut cmd = Command::new(bin);
-    cmd.args(["remove", name]);
+    cmd.args(["remove", "--retry", name]);
 
     let output = run_cmd(cmd).await?;
 

--- a/engine/arcbox-snapshot/src/snapshot_cow/block_tools.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow/block_tools.rs
@@ -9,12 +9,15 @@
 //! implementation. [`BusyboxBlockTools`] is the reference: the System VM's
 //! behaviour, unchanged.
 //!
-//! Device-node helpers that only need syscalls (`stat`, `mknod`) are plain
-//! functions here rather than trait methods: there is nothing environment
-//! specific about them once they stop shelling out.
+//! Device-node helpers that only need syscalls (`stat`, `mknod`) or a
+//! sysfs read are plain functions here rather than trait methods: there is
+//! nothing environment specific about them once they stop shelling out.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
+
+use tracing::debug;
 
 use crate::error::{Result, SnapshotError};
 
@@ -26,8 +29,11 @@ use crate::error::{Result, SnapshotError};
 /// `Send + Sync`.
 pub trait BlockTools: Send + Sync {
     /// Attach `backing` as a loop device and return the device path
-    /// (`/dev/loopN`). Allocation and attach must be one atomic step against
-    /// concurrent callers (`losetup -f --show`, or `LOOP_CONFIGURE`).
+    /// (`/dev/loopN`). Must hold up against concurrent callers in other
+    /// processes: either allocate and attach in one atomic step
+    /// (`LOOP_CONFIGURE`, util-linux `losetup -f --show`) or, when the tool
+    /// cannot, query a free device, attach to it, and retry when another
+    /// process claimed it in between (what [`BusyboxBlockTools`] does).
     fn attach_loop(&self, backing: &Path, read_only: bool) -> Result<String>;
 
     /// Detach a loop device.
@@ -37,10 +43,27 @@ pub trait BlockTools: Send + Sync {
     fn device_sectors(&self, device: &str) -> Result<u64>;
 }
 
+/// How many free-device queries [`BusyboxBlockTools::attach_loop`] makes
+/// before giving up on a device that keeps being claimed underneath it.
+const ATTACH_ATTEMPTS: u32 = 8;
+
+/// Pause between those attempts — long enough for the competing attach to
+/// finish, short enough to be invisible next to the subprocess spawns.
+const ATTACH_RETRY_DELAY: Duration = Duration::from_millis(5);
+
 /// [`BlockTools`] over busybox applets — the System VM's userland.
 ///
 /// Every operation runs `<busybox> <applet> …`; the applets are `losetup`
-/// (busybox ≥ 1.21 for `-f --show`) and `blockdev`.
+/// and `blockdev`. BusyBox's `losetup` has no long options at all
+/// (`util-linux/losetup.c`: `[-rP] [-o OFS] {-f|LOOPDEV} FILE`), so
+/// util-linux's atomic allocate-and-report form `-f --show` is an
+/// unrecognized-option error there, and `-f FILE` attaches without printing
+/// which device it used. Attaching is therefore two applet runs: `losetup
+/// -f` prints the first free device, then `losetup [-r] /dev/loopN FILE`
+/// attaches to exactly that device. Another process can claim the queried
+/// device in between (`mount -o loop`, a concurrent template build), in
+/// which case the attach fails and [`attach_loop`](BlockTools::attach_loop)
+/// re-queries and retries, up to [`ATTACH_ATTEMPTS`] times.
 #[derive(Debug, Clone)]
 pub struct BusyboxBlockTools {
     busybox: PathBuf,
@@ -69,6 +92,43 @@ impl BusyboxBlockTools {
                 ))
             })
     }
+
+    /// `losetup -f`: the first free loop device, as `/dev/loopN`.
+    fn next_free_loop(&self) -> Result<String> {
+        let output = self.run("losetup", &["-f"])?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(SnapshotError::DeviceMapper(format!("losetup -f: {stderr}")));
+        }
+        parse_free_loop(&output.stdout)
+    }
+
+    /// Confirm the kernel agrees that `device` now backs `backing`.
+    ///
+    /// `/sys/block/loopN/loop/backing_file` is the kernel's own view of the
+    /// attachment (the resolved path of the file it holds open); busybox's
+    /// exit status only says its ioctls returned zero. No sysfs node — no
+    /// `/sys` mounted, an unusual kernel — leaves nothing to check and is
+    /// not a failure. A device that answers with a different file is
+    /// detached again so a failed attach leaks nothing.
+    fn verify_attached(&self, device: &str, backing: &Path) -> Result<()> {
+        let Some(actual) = loop_backing_file(device)? else {
+            return Ok(());
+        };
+        let matches = actual == backing.to_string_lossy()
+            || std::fs::canonicalize(backing).is_ok_and(|path| path.to_string_lossy() == actual);
+        if matches {
+            return Ok(());
+        }
+        let detach_note = match self.detach_loop(device) {
+            Ok(()) => String::new(),
+            Err(detach) => format!("; and detaching it again failed: {detach}"),
+        };
+        Err(SnapshotError::DeviceMapper(format!(
+            "{device} backs {actual}, not {}{detach_note}",
+            backing.display()
+        )))
+    }
 }
 
 impl Default for BusyboxBlockTools {
@@ -78,33 +138,52 @@ impl Default for BusyboxBlockTools {
 }
 
 impl BlockTools for BusyboxBlockTools {
-    /// Uses the atomic `losetup -f --show` form so the kernel allocates and
-    /// attaches in a single `LOOP_CTL_GET_FREE`+`LOOP_SET_FD` call, avoiding
-    /// the TOCTOU window of separate `-f` then `attach` invocations against
-    /// other processes that might claim the same slot.
+    /// `losetup -f`, then `losetup [-r] /dev/loopN FILE`, retried when the
+    /// queried device is claimed by someone else before the attach lands.
+    /// A lost race shows up either as the kernel's `EBUSY` from
+    /// `LOOP_CONFIGURE`/`LOOP_SET_FD` — busybox prints "Device or resource
+    /// busy" — or, when busybox notices the device is taken before it
+    /// issues the ioctl, as a failure with whatever stale errno text it had
+    /// on hand, so the classifier also asks sysfs whether the device gained
+    /// a backing file. Any other failure is reported with busybox's stderr.
     fn attach_loop(&self, backing: &Path, read_only: bool) -> Result<String> {
         let backing_str = backing
             .to_str()
             .ok_or_else(|| SnapshotError::DeviceMapper("non-UTF-8 path".into()))?;
-        let output = if read_only {
-            self.run("losetup", &["-r", "-f", "--show", backing_str])?
-        } else {
-            self.run("losetup", &["-f", "--show", backing_str])?
-        };
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(SnapshotError::DeviceMapper(format!(
-                "losetup attach {}: {stderr}",
-                backing.display()
-            )));
+        let mut last_loss = String::new();
+        for attempt in 1..=ATTACH_ATTEMPTS {
+            let device = self.next_free_loop()?;
+            let mut args = Vec::with_capacity(3);
+            if read_only {
+                args.push("-r");
+            }
+            args.extend([device.as_str(), backing_str]);
+            let output = self.run("losetup", &args)?;
+            if output.status.success() {
+                self.verify_attached(&device, backing)?;
+                return Ok(device);
+            }
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+            if !(is_busy_message(&stderr) || loop_backing_file(&device)?.is_some()) {
+                return Err(SnapshotError::DeviceMapper(format!(
+                    "losetup {device} {}: {stderr}",
+                    backing.display()
+                )));
+            }
+            debug!(
+                %device,
+                attempt,
+                %stderr,
+                "free loop device was claimed by another process; re-querying"
+            );
+            last_loss = format!("{device}: {stderr}");
+            std::thread::sleep(ATTACH_RETRY_DELAY);
         }
-        let dev = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        if dev.is_empty() {
-            return Err(SnapshotError::DeviceMapper(
-                "losetup --show returned empty device path".into(),
-            ));
-        }
-        Ok(dev)
+        Err(SnapshotError::DeviceMapper(format!(
+            "losetup attach {}: another process claimed the free loop device on all \
+             {ATTACH_ATTEMPTS} attempts (last: {last_loss})",
+            backing.display()
+        )))
     }
 
     fn detach_loop(&self, device: &str) -> Result<()> {
@@ -130,6 +209,46 @@ impl BlockTools for BusyboxBlockTools {
             .trim()
             .parse::<u64>()
             .map_err(|e| SnapshotError::DeviceMapper(format!("blockdev parse: {e}")))
+    }
+}
+
+/// The device `losetup -f` printed: `/dev/loopN` plus a trailing newline,
+/// nothing else accepted — the name is reused verbatim as the attach target
+/// and as the sysfs node to verify against.
+fn parse_free_loop(stdout: &[u8]) -> Result<String> {
+    let text = String::from_utf8_lossy(stdout);
+    let device = text.trim();
+    match device.strip_prefix("/dev/loop") {
+        Some(index) if !index.is_empty() && index.bytes().all(|byte| byte.is_ascii_digit()) => {
+            Ok(device.to_owned())
+        }
+        _ => Err(SnapshotError::DeviceMapper(format!(
+            "losetup -f printed {device:?}, not a /dev/loopN device"
+        ))),
+    }
+}
+
+/// Whether a failed attach's stderr names the lost-race error: the kernel's
+/// `EBUSY` ("Device or resource busy") from a device that was free a moment
+/// ago, however the tool spells it.
+fn is_busy_message(stderr: &str) -> bool {
+    stderr.to_ascii_lowercase().contains("busy")
+}
+
+/// The file the kernel reports as backing loop device `device`
+/// (`/dev/loopN`), read from `/sys/block/loopN/loop/backing_file`: the
+/// resolved path of the file the device holds open.
+///
+/// `None` when the device is unattached or the sysfs node is absent — a
+/// host without sysfs, or a name that is not a loop device at all.
+pub(super) fn loop_backing_file(device: &str) -> Result<Option<String>> {
+    let Some(name) = Path::new(device).file_name().and_then(|name| name.to_str()) else {
+        return Ok(None);
+    };
+    match std::fs::read_to_string(format!("/sys/block/{name}/loop/backing_file")) {
+        Ok(path) => Ok(Some(path.trim().to_owned())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
     }
 }
 
@@ -234,5 +353,127 @@ mod tests {
         let tools = BusyboxBlockTools::new("/nonexistent/arcbox-busybox");
         let err = tools.detach_loop("/dev/loop0").unwrap_err();
         assert!(err.to_string().contains("spawn"), "{err}");
+    }
+
+    #[test]
+    fn free_loop_output_is_a_loop_device_with_the_newline_stripped() {
+        assert_eq!(parse_free_loop(b"/dev/loop3\n").unwrap(), "/dev/loop3");
+        assert_eq!(parse_free_loop(b"/dev/loop12").unwrap(), "/dev/loop12");
+        for garbage in [
+            &b""[..],
+            b"\n",
+            b"/dev/loop",
+            b"/dev/loopX",
+            b"loop3\n",
+            b"/dev/sda1\n",
+        ] {
+            let err = parse_free_loop(garbage).unwrap_err();
+            assert!(
+                err.to_string().contains("not a /dev/loopN"),
+                "{garbage:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn busy_classifier_matches_the_kernel_message_however_spelled() {
+        assert!(is_busy_message(
+            "losetup: /tmp/x.img: Device or resource busy"
+        ));
+        assert!(is_busy_message("losetup: /dev/loop3: EBUSY"));
+        assert!(is_busy_message("device BUSY"));
+        assert!(!is_busy_message(
+            "losetup: /tmp/x.img: No such file or directory"
+        ));
+        assert!(!is_busy_message(""));
+    }
+
+    /// A busybox stand-in: a shell script that logs every invocation's
+    /// arguments to `calls` and runs `body` (a `case "$*"` over them). It
+    /// hands out `/dev/loop9999`, a device no host has, so the sysfs
+    /// verification finds nothing to compare and the script stays the only
+    /// authority on what happened.
+    fn fake_busybox(dir: &Path, body: &str) -> (BusyboxBlockTools, PathBuf) {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let calls = dir.join("calls");
+        let script = dir.join("busybox");
+        std::fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> {}\ncase \"$*\" in\n{body}\nesac\n",
+                calls.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        (BusyboxBlockTools::new(script), calls)
+    }
+
+    fn attach_calls(calls: &Path) -> Vec<String> {
+        std::fs::read_to_string(calls)
+            .unwrap_or_default()
+            .lines()
+            .filter(|line| line.starts_with("losetup /dev/loop") || line.starts_with("losetup -r"))
+            .map(str::to_owned)
+            .collect()
+    }
+
+    #[test]
+    fn attach_queries_a_free_device_then_attaches_to_exactly_that_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tools, calls) = fake_busybox(
+            dir.path(),
+            "\"losetup -f\") echo /dev/loop9999 ;;\n\
+             \"losetup -r /dev/loop9999 \"*) exit 0 ;;\n\
+             *) echo \"unexpected: $*\" >&2; exit 2 ;;",
+        );
+        let backing = dir.path().join("template.ext4");
+        std::fs::write(&backing, b"").unwrap();
+
+        let device = tools.attach_loop(&backing, true).unwrap();
+
+        assert_eq!(device, "/dev/loop9999");
+        assert_eq!(
+            attach_calls(&calls),
+            [format!("losetup -r /dev/loop9999 {}", backing.display())]
+        );
+    }
+
+    #[test]
+    fn attach_retries_a_claimed_device_a_bounded_number_of_times() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tools, calls) = fake_busybox(
+            dir.path(),
+            "\"losetup -f\") echo /dev/loop9999 ;;\n\
+             *) echo \"losetup: $3: Device or resource busy\" >&2; exit 1 ;;",
+        );
+
+        let err = tools
+            .attach_loop(Path::new("/tmp/cow.img"), false)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("8 attempts"), "{err}");
+        assert_eq!(attach_calls(&calls).len(), 8);
+    }
+
+    #[test]
+    fn attach_reports_any_other_failure_at_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tools, calls) = fake_busybox(
+            dir.path(),
+            "\"losetup -f\") echo /dev/loop9999 ;;\n\
+             *) echo \"losetup: /tmp/cow.img: No such file or directory\" >&2; exit 1 ;;",
+        );
+
+        let err = tools
+            .attach_loop(Path::new("/tmp/cow.img"), false)
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("No such file or directory"),
+            "{err}"
+        );
+        assert_eq!(attach_calls(&calls).len(), 1);
     }
 }

--- a/engine/arcbox-snapshot/src/snapshot_cow/block_tools.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow/block_tools.rs
@@ -164,7 +164,7 @@ impl BlockTools for BusyboxBlockTools {
                 return Ok(device);
             }
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-            if !(is_busy_message(&stderr) || loop_backing_file(&device)?.is_some()) {
+            if !(is_busy_message(&stderr, backing_str) || loop_backing_file(&device)?.is_some()) {
                 return Err(SnapshotError::DeviceMapper(format!(
                     "losetup {device} {}: {stderr}",
                     backing.display()
@@ -229,10 +229,17 @@ fn parse_free_loop(stdout: &[u8]) -> Result<String> {
 }
 
 /// Whether a failed attach's stderr names the lost-race error: the kernel's
-/// `EBUSY` ("Device or resource busy") from a device that was free a moment
-/// ago, however the tool spells it.
-fn is_busy_message(stderr: &str) -> bool {
-    stderr.to_ascii_lowercase().contains("busy")
+/// `EBUSY` from a device that was free a moment ago — "Device or resource
+/// busy" under glibc, "Resource busy" under musl, however the tool spells
+/// it. `losetup` echoes the backing path (`losetup: FILE: <reason>`, or
+/// just `losetup: FILE` when it died with errno 0), so that path is scrubbed
+/// first: a `busybox-…` template must not turn a permanent failure into a
+/// phantom race.
+fn is_busy_message(stderr: &str, backing: &str) -> bool {
+    stderr
+        .replace(backing, "")
+        .to_ascii_lowercase()
+        .contains("busy")
 }
 
 /// The file the kernel reports as backing loop device `device`
@@ -376,16 +383,37 @@ mod tests {
     }
 
     #[test]
-    fn busy_classifier_matches_the_kernel_message_however_spelled() {
+    fn busy_classifier_reads_the_reason_not_the_echoed_path() {
+        let img = "/tmp/x.img";
         assert!(is_busy_message(
-            "losetup: /tmp/x.img: Device or resource busy"
+            "losetup: /tmp/x.img: Device or resource busy\n",
+            img
         ));
-        assert!(is_busy_message("losetup: /dev/loop3: EBUSY"));
-        assert!(is_busy_message("device BUSY"));
+        assert!(is_busy_message("losetup: /tmp/x.img: Resource busy", img));
+        assert!(is_busy_message("losetup: /dev/loop3: EBUSY", img));
+        assert!(is_busy_message(
+            "losetup: /tmp/x.img: failed to set up loop device: Device or resource busy",
+            img
+        ));
         assert!(!is_busy_message(
-            "losetup: /tmp/x.img: No such file or directory"
+            "losetup: /tmp/x.img: No such file or directory",
+            img
         ));
-        assert!(!is_busy_message(""));
+        assert!(!is_busy_message("", img));
+
+        let template = "/templates/busybox-1.36.ext4";
+        assert!(!is_busy_message(
+            "losetup: /templates/busybox-1.36.ext4: No such file or directory",
+            template
+        ));
+        assert!(!is_busy_message(
+            "losetup: /templates/busybox-1.36.ext4",
+            template
+        ));
+        assert!(is_busy_message(
+            "losetup: /templates/busybox-1.36.ext4: Resource busy",
+            template
+        ));
     }
 
     /// A busybox stand-in: a shell script that logs every invocation's

--- a/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 
 use tracing::{debug, warn};
 
+use super::block_tools::loop_backing_file;
 use super::{
     CowManager, DM_NAME_PREFIX, TEMPLATE_LOOP_DIR, TEMPLATE_MARKER_TEMP_PREFIX,
     TEMPLATE_PENDING_PREFIX, dmsetup_remove,
@@ -206,7 +207,7 @@ impl CowManager {
             // Verify the loop is still attached AND still backs the
             // expected template, so we never detach a /dev/loopN that
             // was reused by another process after our crash.
-            let actual_backing = loop_backing_path(loop_basename)?;
+            let actual_backing = loop_backing_file(&dev)?;
 
             if !expected_backing.is_empty()
                 && actual_backing.as_deref() == Some(expected_backing.as_str())
@@ -443,13 +444,7 @@ pub(super) fn remove_file_durable(path: &Path) -> Result<()> {
 }
 
 pub(super) fn loop_backs_path(loop_device: &str, backing: &Path) -> Result<bool> {
-    let Some(loop_name) = Path::new(loop_device)
-        .file_name()
-        .and_then(|name| name.to_str())
-    else {
-        return Ok(false);
-    };
-    Ok(loop_backing_path(loop_name)?.is_some_and(|actual| actual == backing.to_string_lossy()))
+    Ok(loop_backing_file(loop_device)?.is_some_and(|actual| actual == backing.to_string_lossy()))
 }
 
 pub(super) fn loop_devices_for_backing_sync(backing: &Path) -> Result<Vec<String>> {
@@ -466,20 +461,13 @@ pub(super) fn loop_devices_for_backing_sync(backing: &Path) -> Result<Vec<String
         if index.is_empty() || !index.bytes().all(|byte| byte.is_ascii_digit()) {
             continue;
         }
-        if loop_backing_path(&name)?.as_deref() == Some(expected.as_ref()) {
-            devices.push(format!("/dev/{name}"));
+        let device = format!("/dev/{name}");
+        if loop_backing_file(&device)?.as_deref() == Some(expected.as_ref()) {
+            devices.push(device);
         }
     }
     devices.sort();
     Ok(devices)
-}
-
-fn loop_backing_path(loop_name: &str) -> Result<Option<String>> {
-    match std::fs::read_to_string(format!("/sys/block/{loop_name}/loop/backing_file")) {
-        Ok(path) => Ok(Some(path.trim().to_owned())),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error.into()),
-    }
 }
 
 fn incomplete_cleanup(

--- a/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
@@ -58,7 +58,8 @@ impl CowManager {
                     && name.starts_with(DM_NAME_PREFIX)
                 {
                     debug!(dm = %name, "removing stale dm-snapshot");
-                    run_sync_checked(Command::new(dmsetup).args(["remove", name]))?;
+                    // `--retry` for the same udev probe race `dmsetup_remove` documents.
+                    run_sync_checked(Command::new(dmsetup).args(["remove", "--retry", name]))?;
                 }
             }
         }

--- a/virt/arcbox-vm/tests/integration.rs
+++ b/virt/arcbox-vm/tests/integration.rs
@@ -150,12 +150,17 @@ fn busybox_block_tools_attach_report_and_detach() {
 
     let device = tools.attach_loop(&backing, false).unwrap();
 
-    let result = (|| -> Result<(), String> {
+    let sysfs_backing_file = {
         let index = device
             .strip_prefix("/dev/loop")
-            .filter(|index| !index.is_empty() && index.bytes().all(|b| b.is_ascii_digit()))
+            .filter(|index| !index.is_empty() && index.bytes().all(|b| b.is_ascii_digit()));
+        index.map(|index| format!("/sys/block/loop{index}/loop/backing_file"))
+    };
+    let result = (|| -> Result<(), String> {
+        let sysfs_backing_file = sysfs_backing_file
+            .as_deref()
             .ok_or_else(|| format!("attach returned {device}, not /dev/loopN"))?;
-        let reported = std::fs::read_to_string(format!("/sys/block/loop{index}/loop/backing_file"))
+        let reported = std::fs::read_to_string(sysfs_backing_file)
             .map_err(|e| format!("sysfs backing_file for {device}: {e}"))?;
         let expected = std::fs::canonicalize(&backing).map_err(|e| e.to_string())?;
         if reported.trim() != expected.to_string_lossy() {
@@ -178,8 +183,26 @@ fn busybox_block_tools_attach_report_and_detach() {
     let detached = tools.detach_loop(&device);
     result.unwrap();
     detached.unwrap();
+
+    // `LOOP_CLR_FD` with another opener — udev's blkid probe of the freshly
+    // attached device, on a stock distro — only marks the device autoclear
+    // and lets the last close release it, so a detach that has "succeeded"
+    // can still show the backing file for a moment. Wait for the kernel to
+    // actually let go before asserting there is nothing left to detach.
+    let sysfs_backing_file = sysfs_backing_file.unwrap();
+    let released_by = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::path::Path::new(&sysfs_backing_file).exists() {
+        assert!(
+            std::time::Instant::now() < released_by,
+            "{device} still backs {} five seconds after detach",
+            std::fs::read_to_string(&sysfs_backing_file)
+                .unwrap_or_default()
+                .trim()
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
     assert!(
         tools.detach_loop(&device).is_err(),
-        "detaching {device} a second time should fail"
+        "detaching the released {device} again should fail"
     );
 }

--- a/virt/arcbox-vm/tests/integration.rs
+++ b/virt/arcbox-vm/tests/integration.rs
@@ -117,3 +117,69 @@ fn block_device_numbers_round_trip_through_mknod() {
         .status();
     result.unwrap();
 }
+
+/// `BusyboxBlockTools` against a real busybox: attach a sparse file, read
+/// the device's size, detach, and confirm the kernel saw each step. BusyBox's
+/// `losetup` has no long options, so the applet-driving code cannot be
+/// checked with util-linux — this is the one place the real thing runs.
+/// Skips without root or a busybox (`BUSYBOX`, else `/bin/busybox`); the
+/// `integration` job installs `busybox-static` for it.
+#[test]
+#[cfg(target_os = "linux")]
+fn busybox_block_tools_attach_report_and_detach() {
+    use arcbox_vm::snapshot_cow::{BlockTools as _, BusyboxBlockTools};
+
+    const IMAGE_BYTES: u64 = 4 * 1024 * 1024;
+
+    if !common::is_root() {
+        eprintln!("SKIP busybox_block_tools_attach_report_and_detach — requires root");
+        return;
+    }
+    let busybox = std::env::var("BUSYBOX").unwrap_or_else(|_| "/bin/busybox".into());
+    if !std::path::Path::new(&busybox).exists() {
+        eprintln!("SKIP busybox_block_tools_attach_report_and_detach — no busybox at {busybox}");
+        return;
+    }
+    let tools = BusyboxBlockTools::new(&busybox);
+    let dir = tempfile::tempdir().unwrap();
+    let backing = dir.path().join("backing.img");
+    std::fs::File::create(&backing)
+        .unwrap()
+        .set_len(IMAGE_BYTES)
+        .unwrap();
+
+    let device = tools.attach_loop(&backing, false).unwrap();
+
+    let result = (|| -> Result<(), String> {
+        let index = device
+            .strip_prefix("/dev/loop")
+            .filter(|index| !index.is_empty() && index.bytes().all(|b| b.is_ascii_digit()))
+            .ok_or_else(|| format!("attach returned {device}, not /dev/loopN"))?;
+        let reported = std::fs::read_to_string(format!("/sys/block/loop{index}/loop/backing_file"))
+            .map_err(|e| format!("sysfs backing_file for {device}: {e}"))?;
+        let expected = std::fs::canonicalize(&backing).map_err(|e| e.to_string())?;
+        if reported.trim() != expected.to_string_lossy() {
+            return Err(format!(
+                "{device} backs {:?}, expected {}",
+                reported.trim(),
+                expected.display()
+            ));
+        }
+        let sectors = tools.device_sectors(&device).map_err(|e| e.to_string())?;
+        if sectors != IMAGE_BYTES / 512 {
+            return Err(format!(
+                "{device} has {sectors} sectors, expected {}",
+                IMAGE_BYTES / 512
+            ));
+        }
+        Ok(())
+    })();
+
+    let detached = tools.detach_loop(&device);
+    result.unwrap();
+    detached.unwrap();
+    assert!(
+        tools.detach_loop(&device).is_err(),
+        "detaching {device} a second time should fail"
+    );
+}


### PR DESCRIPTION
## The bug

`BusyboxBlockTools::attach_loop` ran `busybox losetup -f --show FILE`. BusyBox's `losetup` applet has no long options at all — `util-linux/losetup.c` parses `cdPo:far` (1.30: `do:far`), usage `[-rP] [-o OFS] {-f|LOOPDEV} FILE` — so `--show` was never supported and every attach failed with `losetup: unrecognized option: show`.

Consequences:

- `CowManager` never got a template loop device: dm-snapshot CoW silently degraded to copy mode on every sandbox since the busybox tools were introduced.
- #650 / #652 moved the docker-template vm-agent injection onto `attach_loop`, which turned the silent degradation into a hard failure: `cargo xtask e2e --test sandbox` on macOS fails on master with that message. The smoke passes end to end with the attach corrected.

## The fix

Attach is now the form busybox actually has: `losetup -f` (prints the first free device) followed by `losetup [-r] /dev/loopN FILE`. The window between the two is real — another process can claim the queried device — so a lost race re-queries and retries, bounded at 8 attempts with a 5 ms pause. Lost-race detection is two-pronged because busybox does not always say "busy": the kernel's `EBUSY` from `LOOP_CONFIGURE`/`LOOP_SET_FD` prints "Device or resource busy", but when busybox notices the device is taken *before* the ioctl (`LOOP_GET_STATUS` succeeds) it dies with whatever stale errno text it had, so the classifier also asks `/sys/block/loopN/loop/backing_file` whether the device gained a backing file. Any other failure is reported with stderr. A successful attach is verified against that same sysfs node (the kernel's resolved path of the file it holds open) where sysfs exists, and detached again on a mismatch so nothing leaks.

The sysfs reader moves from `persistence.rs` to `block_tools.rs`, next to the other syscall-only device helpers; `detach_loop` (`losetup -d`) and `device_sectors` (`blockdev --getsz`, which busybox has) are unchanged. Every comment that described the atomic `--show` form now describes query-then-attach with retry and why.

## Tests

- Unit (no busybox): free-device parser (`/dev/loopN` with trailing newline; garbage rejected), the busy classifier, and the retry loop against a scripted busybox stand-in — query→attach argument shape incl. `-r`, bounded give-up after 8 claimed-device failures, immediate error on any other failure.
- Real busybox: `busybox_block_tools_attach_report_and_detach` in `virt/arcbox-vm/tests/integration.rs` (root-only Linux, skips otherwise): attach a sparse file, assert `/dev/loopN`, sysfs `backing_file` names the file, `device_sectors == size/512`, detach succeeds, a second detach fails. `test-vm-linux`'s `integration` job now installs `busybox-static` (Ubuntu's 1.30 has the same short-option-only losetup as the System VM's), so this runs for real in CI.

## Note

With this in, real dm-snapshot CoW engages in production for the first time — template loops are shared, per-sandbox writes land in sparse COW files, and the restart reconciliation in `persistence.rs` (template markers, orphan detection) gets its first real exercise. Watch the sandbox e2e numbers (cold/warm/restore) and disk usage on the next runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Restores real dm-snapshot CoW for production sandboxes and changes loop attach/teardown on critical block-device paths; behavior is heavily tested but first real exercise of shared template loops and reconciliation at scale.
> 
> **Overview**
> **Fixes broken dm-snapshot CoW on the System VM** by replacing `busybox losetup -f --show`, which BusyBox rejects (no long options), with the supported two-step flow: `losetup -f` then `losetup [-r] /dev/loopN FILE`.
> 
> `BusyboxBlockTools::attach_loop` now **retries up to 8 times** when another process claims the free loop slot between query and attach, classifying races via busy stderr (with the backing path scrubbed so template names don’t look like “busy”) and via sysfs `backing_file`. Successful attaches are **verified against sysfs** and mismatches trigger detach so loops don’t leak.
> 
> **`dmsetup remove` uses `--retry`** in normal teardown and startup reconciliation to tolerate udev/blkid briefly holding dm nodes after the VM exits. Loop backing detection is **centralized** in `loop_backing_file` in `block_tools.rs` for persistence and attach logic.
> 
> CI installs **`busybox-static`** in the Linux VM integration job and adds a **root integration test** that exercises real busybox attach, sectors, and detach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 512977de577550064cc0626d0145f33306129c27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->