### PR TITLE
fix(fc-driver): adopt yields a kill-able handle even when the orphan's API is dead

### DIFF
--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -28,8 +28,9 @@ catalog, no engine, no orchestrator.
 | `api` | pause, resume, snapshot, ctrl-alt-del, describe, vm-config over the raw client |
 | `listener` | the port's `VsockListener` over a `{uds}_{port}` socket |
 | `discover` | finding a Firecracker that outlived its booter: the recorded pid and any `/proc` candidate, held to the same `--id` / `--api-sock` / jail-root test |
+| `adopt` | rebuilding a handle over what `discover` found: a bounded API reconnect for the full `FcHandle`, else `FcProcessHandle` over the process alone |
 | `prepared` | `FcPrepared: PreparedVm` — a spawned VMM waiting for a spec |
-| `handle` | `FcHandle: VmHandle + Vsock + VsockListen + Checkpoint + Detach` |
+| `handle` | `FcHandle: VmHandle + Vsock + VsockListen + Checkpoint + Detach`; `FcProcessHandle: VmHandle + Detach`, over a VMM whose API is unreachable |
 | `driver` | `FcDriver: VmDriver + Prepare + Adopt` |
 
 ## Usage
@@ -68,6 +69,25 @@ the name a checkpoint of this driver records, and a disk that already sits
 in the jail under another name is given that name too for the load (a hard
 link, or a device node or copy) and loses it once the drive points at the
 disk itself.
+
+**Adopt never fails on the API.** `Adopt::adopt` finds the VMM by its
+process — the recorded pid when it is still a Firecracker the record
+names, else a `/proc` scan by `--id`, `--api-sock`, or jail root
+(`discover`) — and `Ok(None)` means nothing survived. A found process is
+always adopted: the exit prober goes over the verified pid first, then the
+API is reconnected best-effort with a short bound (`adopt::API_TIMEOUT`,
+2 s for `GET /` and `GET /vm/config`). A VMM that answers yields the full
+`FcHandle` — vsock at the path Firecracker reports, checkpoint under a
+jail, `Quiesced` if it was paused. One whose socket is missing, wedged, or
+closes yields an `FcProcessHandle`: `id`/`record`/`state`/`events`,
+`shutdown` (`Kill` is SIGKILL plus the bounded reap; `Graceful` degrades to
+it, since the ctrl-alt-del that would ask the guest is an API call), and
+`detach`; every API-backed accessor is `None`. The record either handle
+reports names the process that was verified, not the one the caller
+recorded. This is what lets the sandbox manager's restart sweep
+`shutdown(Kill)` an orphan whose control socket died with its booter — the
+blind SIGKILL by pid it replaced had no API dependency, and neither does
+this.
 
 ## Path rules
 

--- a/virt/arcbox-fc-driver/src/adopt.rs
+++ b/virt/arcbox-fc-driver/src/adopt.rs
@@ -1,0 +1,226 @@
+//! Rebuilding a handle over the Firecracker [`discover`](crate::discover)
+//! found.
+//!
+//! The process is the VM's identity and all a kill needs; the API is what
+//! everything else needs. So the guard goes over the verified pid first,
+//! and the API is reconnected best-effort within a short bound: a VMM
+//! that answers `GET /` and `GET /vm/config` gets the full [`FcHandle`] —
+//! its devices and paused state read back — and one whose socket is
+//! missing, wedged, or closes gets an [`FcProcessHandle`], kill-able and
+//! observable and nothing more. An adopt never fails on the API: the
+//! sandbox manager's restart sweep adopts in order to `shutdown(Kill)`,
+//! and an orphan whose control socket died with its booter would otherwise
+//! be unkillable through the port — the blind SIGKILL by pid this replaced
+//! had no such dependency.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use arcbox_vm_driver::{ProcessRecord, Result, VmHandle, VmRecord};
+use fc_sdk::Client;
+use fc_sdk::types::{FullVmConfiguration, InstanceInfo, InstanceInfoState};
+
+use crate::api;
+use crate::config::FcDriverConfig;
+use crate::discover::Found;
+use crate::handle::{FcHandle, FcProcessHandle};
+use crate::listener::VsockEndpoint;
+use crate::process::FcProcess;
+use crate::render::VmLayout;
+
+/// How long an adopt gives the API to describe the VM before settling for
+/// the process alone.
+///
+/// Two round-trips on a local socket take microseconds; a socket that has
+/// not answered in this long is not going to. Well inside the sandbox
+/// manager's per-orphan adopt budget (10 s), which this must stay under.
+pub const API_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// A handle over `found`, the VMM `record` names, giving its API
+/// `api_timeout` to answer.
+///
+/// The record the handle reports carries the process that was verified:
+/// the recorded pid may have been recycled and the VM found by the `/proc`
+/// scan instead, and the API socket may have come off its command line.
+pub(crate) async fn rebuild(
+    config: &FcDriverConfig,
+    found: Found,
+    record: &VmRecord,
+    api_timeout: Duration,
+) -> Result<Box<dyn VmHandle>> {
+    let layout = VmLayout::new(&record.id, &found.isolation, config, &record.runtime_dir)?;
+    let process = Arc::new(FcProcess::adopt(found.pid, found.api_socket.clone()));
+    let record = VmRecord {
+        process: Some(ProcessRecord {
+            pid: found.pid,
+            api_socket: Some(found.api_socket.clone()),
+        }),
+        ..record.clone()
+    };
+    let client = fc_sdk::connection::connect(&found.api_socket);
+    let (info, devices) = match tokio::time::timeout(api_timeout, describe(&client)).await {
+        Ok(Ok(answered)) => answered,
+        Ok(Err(error)) => return Ok(process_only(process, record, &error.to_string())),
+        Err(_) => {
+            return Ok(process_only(
+                process,
+                record,
+                &format!("no answer within {api_timeout:?}"),
+            ));
+        }
+    };
+    let vsock = devices
+        .vsock
+        .map(|vsock| VsockEndpoint::new(layout.host_view(&vsock.uds_path)));
+    let quiesced = matches!(info.state, InstanceInfoState::Paused);
+    Ok(Box::new(FcHandle::new(
+        process, client, layout, record, vsock, quiesced,
+    )))
+}
+
+/// The instance's state and its devices — what a full handle is built from.
+async fn describe(client: &Client) -> crate::error::Result<(InstanceInfo, FullVmConfiguration)> {
+    let info = api::describe(client).await?;
+    let devices = api::vm_config(client).await?;
+    Ok((info, devices))
+}
+
+/// The fallback, and the warning that says why: the VM stays a process
+/// this driver can kill, and nothing more.
+fn process_only(process: Arc<FcProcess>, record: VmRecord, why: &str) -> Box<dyn VmHandle> {
+    tracing::warn!(vm = %record.id, pid = process.pid(), socket = %process.api_socket().display(),
+        "the adopted vmm's api did not answer ({why}); adopting the process alone: kill-able, nothing else");
+    Box::new(FcProcessHandle::new(process, record))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use arcbox_vm_driver::{IsolationSpec, ShutdownMode, VmId, VmState};
+
+    use super::*;
+    use crate::NAME;
+    use crate::api::fake_fc::FakeFc;
+    use crate::process::UNKNOWN_EXIT;
+
+    /// A `sleep` child standing in for the orphan, its `Found`, and the
+    /// record the sweep would hand over — a stale pid, no socket.
+    fn orphan(api_socket: PathBuf, runtime_dir: &Path) -> (tokio::process::Child, Found, VmRecord) {
+        let child = tokio::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn test child");
+        let found = Found {
+            pid: child.id().unwrap(),
+            api_socket,
+            isolation: IsolationSpec::None,
+        };
+        let record = VmRecord {
+            id: VmId::new("box").unwrap(),
+            driver: NAME.to_owned(),
+            runtime_dir: runtime_dir.to_path_buf(),
+            process: Some(ProcessRecord {
+                pid: u32::try_from(i32::MAX - 1).unwrap(),
+                api_socket: None,
+            }),
+        };
+        (child, found, record)
+    }
+
+    fn config() -> FcDriverConfig {
+        FcDriverConfig::new("/opt/fc/firecracker")
+    }
+
+    /// Kills through the handle and proves the child was reaped by it.
+    async fn kill_through(vm: &dyn VmHandle, mut child: tokio::process::Child) {
+        let reaper = tokio::spawn(async move { child.wait().await.unwrap() });
+        assert_eq!(vm.shutdown(ShutdownMode::Kill).await.unwrap(), UNKNOWN_EXIT);
+        assert_eq!(vm.state(), VmState::Exited(UNKNOWN_EXIT));
+        use std::os::unix::process::ExitStatusExt as _;
+        assert_eq!(reaper.await.unwrap().signal(), Some(9));
+    }
+
+    #[tokio::test]
+    async fn an_orphan_whose_api_socket_is_missing_is_adopted_by_its_process() {
+        let dir = tempfile::tempdir().unwrap();
+        let (child, found, record) = orphan(dir.path().join("absent.sock"), dir.path());
+        let pid = found.pid;
+        let vm = rebuild(&config(), found, &record, API_TIMEOUT)
+            .await
+            .expect("a verified process is adopted whatever its api does");
+        assert_eq!(vm.state(), VmState::Running);
+        // The record names the process that was verified, not the stale one.
+        let process = vm.record().process.unwrap();
+        assert_eq!(process.pid, pid);
+        assert_eq!(process.api_socket, Some(dir.path().join("absent.sock")));
+        assert!(vm.vsock().is_none() && vm.vsock_listener().is_none());
+        assert!(vm.checkpoint().is_none());
+        assert!(vm.detach().is_some());
+        kill_through(&*vm, child).await;
+    }
+
+    #[tokio::test]
+    async fn an_orphan_whose_api_hangs_is_adopted_within_the_bound() {
+        let dir = tempfile::tempdir().unwrap();
+        // A socket that accepts and never answers: the VMM's API thread is
+        // wedged, or something else squats on the path.
+        let socket = dir.path().join("wedged.sock");
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+        let sink = tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                // Held open and never answered, for as long as the runtime.
+                tokio::spawn(async move {
+                    let _held = stream;
+                    std::future::pending::<()>().await;
+                });
+            }
+        });
+        let (child, found, record) = orphan(socket, dir.path());
+        let bound = Duration::from_millis(300);
+        let started = tokio::time::Instant::now();
+        let vm = rebuild(&config(), found, &record, bound)
+            .await
+            .expect("a wedged api does not fail the adopt");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "settled for the process within the bound, not the hang"
+        );
+        assert!(vm.vsock().is_none() && vm.checkpoint().is_none());
+        kill_through(&*vm, child).await;
+        sink.abort();
+    }
+
+    #[tokio::test]
+    async fn a_vmm_that_answers_is_adopted_with_its_devices_and_state() {
+        let dir = tempfile::tempdir().unwrap();
+        // The vsock is where Firecracker says it bound it — after a restore
+        // the checkpoint's recorded path, not this runtime dir's.
+        let recorded = dir.path().join("source").join("firecracker.vsock");
+        std::fs::create_dir_all(recorded.parent().unwrap()).unwrap();
+        let devices = format!(
+            r#"{{"vsock":{{"guest_cid":3,"uds_path":"{}"}}}}"#,
+            recorded.display()
+        );
+        let fc = FakeFc::start(dir.path(), move |route, _| match route {
+            "GET /" => (
+                200,
+                r#"{"app_name":"fake","id":"box","state":"Paused","vmm_version":"1.10.1"}"#.into(),
+            ),
+            "GET /vm/config" => (200, devices.clone()),
+            other => panic!("the driver called {other} unexpectedly"),
+        });
+        let (child, found, record) = orphan(fc.socket().to_path_buf(), dir.path());
+        let vm = rebuild(&config(), found, &record, API_TIMEOUT)
+            .await
+            .expect("adopt");
+        assert_eq!(fc.calls(), ["GET /", "GET /vm/config"]);
+        // The full handle: the paused state and the vsock device read back.
+        assert_eq!(vm.state(), VmState::Quiesced);
+        assert!(vm.vsock().is_some() && vm.detach().is_some());
+        let listener = vm.vsock_listener().unwrap().listen(51).await.unwrap();
+        assert!(dir.path().join("source/firecracker.vsock_51").exists());
+        drop(listener);
+        kill_through(&*vm, child).await;
+    }
+}

--- a/virt/arcbox-fc-driver/src/api.rs
+++ b/virt/arcbox-fc-driver/src/api.rs
@@ -12,6 +12,9 @@ use fc_sdk::types::{
 
 use crate::error::{FcError, Result};
 
+#[cfg(test)]
+pub(crate) mod fake_fc;
+
 /// `PATCH /vm {"state": "Paused"}`.
 pub async fn pause(client: &Client) -> Result<()> {
     client

--- a/virt/arcbox-fc-driver/src/api/fake_fc.rs
+++ b/virt/arcbox-fc-driver/src/api/fake_fc.rs
@@ -44,6 +44,11 @@ impl FakeFc {
         }
     }
 
+    /// The socket this answers on.
+    pub fn socket(&self) -> &Path {
+        &self.socket
+    }
+
     /// A client that talks to this socket.
     pub fn client(&self) -> fc_sdk::Client {
         fc_sdk::connection::connect(&self.socket)

--- a/virt/arcbox-fc-driver/src/api/fake_fc.rs
+++ b/virt/arcbox-fc-driver/src/api/fake_fc.rs
@@ -1,11 +1,11 @@
 //! A Firecracker API socket the tests can script.
 //!
-//! The interesting checkpoint paths are the ones where a call fails —
-//! a capture that fails and a resume that fails on top of it, a guest the
-//! handle believes is frozen and is not. None of them are reachable against
-//! a real Firecracker, so this answers its API instead: one closure decides
-//! every reply from the request's method, path and body, and every request
-//! is recorded in order.
+//! The interesting paths are the ones a real Firecracker cannot be made to
+//! take — a capture that fails and a resume that fails on top of it, a
+//! guest the handle believes is frozen and is not, an adopt that finds the
+//! VMM answering. This answers the API instead: one closure decides every
+//! reply from the request's method, path and body, and every request is
+//! recorded in order.
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};

--- a/virt/arcbox-fc-driver/src/driver.rs
+++ b/virt/arcbox-fc-driver/src/driver.rs
@@ -11,12 +11,9 @@ use arcbox_vm_driver::{
 use async_trait::async_trait;
 
 use crate::config::FcDriverConfig;
-use crate::handle::FcHandle;
-use crate::listener::VsockEndpoint;
 use crate::prepared::FcPrepared;
-use crate::process::FcProcess;
-use crate::render::{self, VmLayout};
-use crate::{CHECKPOINT_FORMAT, NAME, api, discover};
+use crate::render;
+use crate::{CHECKPOINT_FORMAT, NAME, adopt, discover};
 
 /// The Firecracker adapter.
 ///
@@ -127,34 +124,20 @@ impl Adopt for FcDriver {
     /// Finds the VMM `record` names — the recorded pid when it is still a
     /// Firecracker, else a `/proc` scan by `--id`, `--api-sock`, or a
     /// jail root ending in `{firecracker binary name}/{id}/root` — and
-    /// rebuilds a handle over it: the API is reconnected, the VM's devices
-    /// and paused state are read back, and its exit is tracked by probing.
+    /// rebuilds a handle over it, its exit tracked by probing. The API is
+    /// reconnected best-effort within [`adopt::API_TIMEOUT`]: a VMM that
+    /// answers yields the full [`FcHandle`](crate::FcHandle) with its
+    /// devices and paused state read back; one whose socket is missing,
+    /// wedged, or closes yields an [`FcProcessHandle`](crate::FcProcessHandle)
+    /// that can be killed, observed, and detached, and nothing else. A
+    /// verified process is never left unadoptable by its API.
     async fn adopt(&self, record: &VmRecord) -> Result<Option<Box<dyn VmHandle>>> {
-        let Some(found) = discover::find(&self.config, record) else {
-            return Ok(None);
-        };
-        let client = fc_sdk::connection::connect(&found.api_socket);
-        let info = api::describe(&client).await?;
-        let devices = api::vm_config(&client).await?;
-        let layout = VmLayout::new(
-            &record.id,
-            &found.isolation,
-            &self.config,
-            &record.runtime_dir,
-        )?;
-        let vsock = devices
-            .vsock
-            .map(|vsock| VsockEndpoint::new(layout.host_view(&vsock.uds_path)));
-        let process = Arc::new(FcProcess::adopt(found.pid, found.api_socket));
-        let quiesced = matches!(info.state, fc_sdk::types::InstanceInfoState::Paused);
-        Ok(Some(Box::new(FcHandle::new(
-            process,
-            client,
-            layout,
-            record.clone(),
-            vsock,
-            quiesced,
-        ))))
+        match discover::find(&self.config, record) {
+            Some(found) => Ok(Some(
+                adopt::rebuild(&self.config, found, record, adopt::API_TIMEOUT).await?,
+            )),
+            None => Ok(None),
+        }
     }
 }
 

--- a/virt/arcbox-fc-driver/src/handle.rs
+++ b/virt/arcbox-fc-driver/src/handle.rs
@@ -1,5 +1,8 @@
 //! [`FcHandle`]: a running Firecracker VM behind the port's [`VmHandle`],
 //! with the vsock, listen, checkpoint, and detach capabilities.
+//!
+//! [`FcProcessHandle`] is the same port over a VMM process whose API is out
+//! of reach: kill, observe, detach, and nothing the API would serve.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -22,8 +25,11 @@ use crate::process::FcProcess;
 use crate::render::VmLayout;
 use crate::{CHECKPOINT_FORMAT, NAME, api, jail, listener, vsock};
 
+pub mod process_only;
 #[cfg(test)]
 mod tests;
+
+pub use process_only::FcProcessHandle;
 
 /// How long a graceful shutdown gives the `SendCtrlAltDel` API call itself.
 const CTRL_ALT_DEL_TIMEOUT: Duration = Duration::from_secs(5);

--- a/virt/arcbox-fc-driver/src/handle/process_only.rs
+++ b/virt/arcbox-fc-driver/src/handle/process_only.rs
@@ -1,0 +1,195 @@
+//! [`FcProcessHandle`]: the port's [`VmHandle`] over a Firecracker process
+//! whose API cannot be reached.
+//!
+//! An adopt verifies a VMM by its process — the pid, its `/proc` identity —
+//! and only then reconnects the API. When the socket is missing, wedged, or
+//! closes, the process is still a VM this driver owns and must be able to
+//! stop: the sandbox manager's restart sweep adopts exactly in order to
+//! `shutdown(Kill)`. This handle is that and no more: identify, observe,
+//! kill, and detach, all served by the process guard. Nothing that needs
+//! the API is offered — no vsock, no listener, no checkpoint — and a
+//! `Graceful` shutdown, whose ctrl-alt-del is an API call, kills at once.
+
+use std::sync::Arc;
+
+use arcbox_vm_driver::{
+    Detach, ExitStatus, Result, ShutdownMode, VmEvent, VmHandle, VmId, VmRecord, VmState,
+};
+use async_trait::async_trait;
+use tokio::sync::broadcast;
+
+use crate::process::FcProcess;
+
+/// A VMM process this driver verified but cannot talk to.
+///
+/// Dropping the handle kills the process unless [`Detach`] released it,
+/// as with [`FcHandle`](crate::FcHandle).
+pub struct FcProcessHandle {
+    process: Arc<FcProcess>,
+    record: VmRecord,
+}
+
+impl FcProcessHandle {
+    /// A handle over `process`, reporting `record`.
+    pub fn new(process: Arc<FcProcess>, record: VmRecord) -> Self {
+        Self { process, record }
+    }
+}
+
+impl Drop for FcProcessHandle {
+    fn drop(&mut self) {
+        if !self.process.is_detached() {
+            self.process.kill_now();
+        }
+    }
+}
+
+#[async_trait]
+impl VmHandle for FcProcessHandle {
+    fn id(&self) -> &VmId {
+        &self.record.id
+    }
+
+    fn record(&self) -> VmRecord {
+        self.record.clone()
+    }
+
+    /// `Running` until the process is seen gone: a guest Firecracker holds
+    /// paused is indistinguishable from a running one without the API.
+    fn state(&self) -> VmState {
+        match self.process.exit_status() {
+            Some(status) => VmState::Exited(status),
+            None => VmState::Running,
+        }
+    }
+
+    fn events(&self) -> broadcast::Receiver<VmEvent> {
+        self.process.events()
+    }
+
+    /// `Kill` as for any VM. `Graceful` degrades to it — asking the guest
+    /// (`SendCtrlAltDel`) needs the API this handle does not have, and
+    /// waiting out the deadline without having asked would gain nothing.
+    async fn shutdown(&self, mode: ShutdownMode) -> Result<ExitStatus> {
+        if matches!(mode, ShutdownMode::Graceful { .. }) && self.process.alive() {
+            tracing::warn!(vm = %self.record.id, pid = self.process.pid(),
+                "the vmm's api is unreachable: a graceful shutdown cannot ask the guest and kills it");
+        }
+        Ok(self.process.kill().await?)
+    }
+
+    /// Present as on every handle of this driver: releasing the process
+    /// needs only the guard.
+    fn detach(&self) -> Option<&dyn Detach> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl Detach for FcProcessHandle {
+    async fn detach(&self) -> Result<VmRecord> {
+        self.process.detach();
+        Ok(self.record.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    use arcbox_vm_driver::ProcessRecord;
+
+    use super::*;
+    use crate::NAME;
+    use crate::process::UNKNOWN_EXIT;
+
+    /// A `sleep` child adopted as a VMM, and the child to reap it with.
+    fn adopted() -> (FcProcessHandle, tokio::process::Child) {
+        let child = tokio::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn test child");
+        let pid = child.id().unwrap();
+        let socket = PathBuf::from("/nonexistent/arcbox-fc-driver/api.sock");
+        let record = VmRecord {
+            id: VmId::new("box").unwrap(),
+            driver: NAME.to_owned(),
+            runtime_dir: "/nonexistent/arcbox-fc-driver".into(),
+            process: Some(ProcessRecord {
+                pid,
+                api_socket: Some(socket.clone()),
+            }),
+        };
+        let process = Arc::new(FcProcess::adopt(pid, socket));
+        (FcProcessHandle::new(process, record), child)
+    }
+
+    fn signal_of(status: std::process::ExitStatus) -> Option<i32> {
+        use std::os::unix::process::ExitStatusExt as _;
+        status.signal()
+    }
+
+    #[tokio::test]
+    async fn kill_reaps_the_process_and_the_state_follows() {
+        let (vm, mut child) = adopted();
+        assert_eq!(*vm.id(), VmId::new("box").unwrap());
+        assert_eq!(vm.record().process.unwrap().pid, child.id().unwrap());
+        assert_eq!(vm.state(), VmState::Running);
+        // Nothing the API would serve; detach needs only the guard.
+        assert!(vm.vsock().is_none() && vm.vsock_listener().is_none());
+        assert!(VmHandle::checkpoint(&vm).is_none());
+        assert!(vm.balloon().is_none() && vm.console().is_none() && vm.debug().is_none());
+        assert!(VmHandle::detach(&vm).is_some());
+        let mut events = vm.events();
+        // The real parent reaps once the signal lands.
+        let reaper = tokio::spawn(async move { child.wait().await.unwrap() });
+        let status = vm.shutdown(ShutdownMode::Kill).await.unwrap();
+        assert_eq!(status, UNKNOWN_EXIT);
+        assert_eq!(vm.state(), VmState::Exited(status));
+        assert_eq!(events.recv().await.unwrap(), VmEvent::Exited(status));
+        assert!(events.try_recv().is_err(), "Exited is delivered once");
+        assert_eq!(signal_of(reaper.await.unwrap()), Some(9));
+        // Idempotent: an exited process just reports its status.
+        assert_eq!(vm.shutdown(ShutdownMode::Kill).await.unwrap(), status);
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_kills_at_once_without_waiting_out_the_deadline() {
+        let (vm, mut child) = adopted();
+        let reaper = tokio::spawn(async move { child.wait().await.unwrap() });
+        let started = tokio::time::Instant::now();
+        let status = vm
+            .shutdown(ShutdownMode::Graceful {
+                timeout: Duration::from_secs(60),
+            })
+            .await
+            .unwrap();
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "killed without waiting for a guest nobody could ask"
+        );
+        assert_eq!(status, UNKNOWN_EXIT);
+        assert_eq!(vm.state(), VmState::Exited(status));
+        assert_eq!(signal_of(reaper.await.unwrap()), Some(9));
+    }
+
+    #[tokio::test]
+    async fn drop_kills_unless_detached() {
+        let (vm, mut child) = adopted();
+        drop(vm);
+        assert_eq!(signal_of(child.wait().await.unwrap()), Some(9));
+
+        let (vm, mut child) = adopted();
+        let record = VmHandle::detach(&vm).unwrap().detach().await.unwrap();
+        assert_eq!(record, vm.record());
+        drop(vm);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "a detached process keeps running"
+        );
+        child.kill().await.unwrap();
+        child.wait().await.unwrap();
+    }
+}

--- a/virt/arcbox-fc-driver/src/handle/tests.rs
+++ b/virt/arcbox-fc-driver/src/handle/tests.rs
@@ -3,12 +3,9 @@
 use arcbox_vm_driver::{IsolationSpec, ProcessRecord};
 
 use super::*;
+use crate::api::fake_fc::FakeFc;
 use crate::config::FcDriverConfig;
 use crate::process::testing::{pid_exists, spawn};
-
-mod fake_fc;
-
-use fake_fc::FakeFc;
 
 /// A handle over a `sleep` child and an API socket nobody answers on.
 fn handle(dir: &Path, isolation: IsolationSpec, vsock: bool) -> FcHandle {

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -40,6 +40,10 @@
 //! - [`discover`] — finding a Firecracker that outlived the process which
 //!   booted it: the recorded pid when it is a Firecracker the record names,
 //!   else a `/proc` scan for one, by `--id`, `--api-sock`, or jail root.
+//! - [`adopt`] — rebuilding a handle over what `discover` found: the API
+//!   reconnected best-effort within a short bound for the full `FcHandle`,
+//!   else `FcProcessHandle` over the verified process alone. An adopt never
+//!   fails on the API.
 //! - [`driver`] — [`FcDriver`], the port's `VmDriver` with `Prepare` and
 //!   `Adopt`; `boot`/`restore` are prepare-then-boot/restore.
 //!
@@ -61,6 +65,7 @@
 
 #![warn(missing_docs)]
 
+pub mod adopt;
 pub mod api;
 pub mod config;
 pub mod discover;

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -33,7 +33,8 @@
 //! - [`handle`] — [`FcHandle`], the port's `VmHandle` over a running VM:
 //!   state and events from the guard, `Kill` and `Graceful` shutdown, and
 //!   the vsock, listen, checkpoint (pause → snapshot → resume or hold),
-//!   and detach capabilities.
+//!   and detach capabilities; and [`FcProcessHandle`], the same port over
+//!   a VMM process whose API is unreachable — kill, observe, detach.
 //! - [`prepared`] — [`FcPrepared`], the port's `PreparedVm`: a spawned
 //!   VMM waiting for a spec, listeners bound before the guest starts.
 //! - [`discover`] — finding a Firecracker that outlived the process which
@@ -77,7 +78,7 @@ pub mod vsock;
 pub use config::FcDriverConfig;
 pub use driver::FcDriver;
 pub use error::FcError;
-pub use handle::FcHandle;
+pub use handle::{FcHandle, FcProcessHandle};
 pub use prepared::FcPrepared;
 
 /// The driver's name.


### PR DESCRIPTION
Follow-up to #658, closing the gap Codex (thread on `virt/arcbox-vm/src/sandbox/reconcile.rs:451`) and pullfrog (`reconcile.rs:458`) found on #664.

## The gap

`FcDriver`'s `Adopt::adopt` was *find + reconnect*: `describe` and `vm/config` had to answer before any handle existed. A Firecracker that outlived its booter but whose API socket was missing, wedged, or closed during adoption therefore made `adopt` fail (or hang) — and the sandbox manager's startup reconcile, which after #664 adopts precisely in order to `shutdown(Kill)`, aborted its whole sweep where the pid-verified SIGKILL it replaced had no API dependency at all.

## The fix (driver side, where the plan puts it)

`Adopt::adopt` is now:

1. **identity** — `discover::find` as before: the recorded pid when it is still a Firecracker the record names, else the `/proc` scan by `--id` / `--api-sock` / jail root; nothing → `Ok(None)`;
2. **the guard first** — `FcProcess::adopt` over the verified pid (exit prober, `alive()`, `Kill` = SIGKILL + the bounded reap, as today);
3. **best-effort API reconnect** within `adopt::API_TIMEOUT` (2 s for `GET /` + `GET /vm/config`): a VMM that answers yields the full `FcHandle` exactly as before (vsock at the reported path, checkpoint under a jail, `Quiesced` if paused); a socket that is missing, refuses, hangs, or closes yields the new **`FcProcessHandle`** — `id`/`record`/`state` (from the prober)/`events`, `shutdown` (`Kill` works; `Graceful` degrades to `Kill` and warns, since the ctrl-alt-del that would ask the guest is an API call), `detach`; every API-backed accessor (`vsock`, `vsock_listener`, `checkpoint`) is `None`. **An adopt never fails on the API.**

`DriverCapabilities` are unchanged — they describe the driver; a process-only handle simply exposes nothing the API would serve. `Detach` is kept on it because the port defines that accessor as `Some` iff `capabilities().adopt` and it needs only the guard (drop kills unless detached, as on `FcHandle`).

One deliberate refinement: the record either adopted handle reports now names the process that was **verified** (`ProcessRecord { pid: found.pid, api_socket: Some(found.api_socket) }`) rather than echoing the caller's — the recorded pid may have been recycled and the VM found by the scan.

Timing vs the manager: `API_TIMEOUT` (2 s) sits well inside #664's 10 s `ADOPT_TIMEOUT`, and the `Kill` path of the process-only handle touches no socket (SIGKILL + `REAP_TIMEOUT` 5 s).

## Commits

1. `feat(fc-driver): a process-only handle for a VMM whose API is unreachable` — `handle/process_only.rs`, `FcProcessHandle` + tests (kill reaps and the state/event follow, graceful kills at once, drop kills unless detached).
2. `refactor(fc-driver): move the scripted Firecracker API next to the calls it fakes` — `FakeFc` from `handle/tests/` to `api/fake_fc.rs` (crate-visible test scaffolding, the shape `process::testing` already has).
3. `fix(fc-driver): adopt yields a kill-able handle even when the orphan's API is dead` — `adopt.rs` (`rebuild`, `API_TIMEOUT`), `driver.rs` wiring, README Adopt paragraph + layout rows, lib docs.

## Tests

`adopt::tests` (plain `sleep` child stands in for the orphan, `Found` built directly so they run on macOS too — `discover` has its own tests):
- API socket path does not exist → handle within the call, `record().process` = the verified pid, accessors `None`, `shutdown(Kill)` reaps the child (parent sees signal 9);
- a Unix listener that accepts and never answers → handle back within the (test-injected 300 ms) bound, then killed;
- a `FakeFc` answering `GET /` (Paused) and `GET /vm/config` (a vsock at a recorded path) → the full handle: `Quiesced`, `vsock`/`vsock_listener` `Some`, listener bound next to the reported socket, exactly those two calls made.

## Checks

`cargo fmt --all --check` · `cargo clippy -p arcbox-fc-driver --all-targets --all-features -- -D warnings` · `cargo test -p arcbox-fc-driver` (53 passed) · `cargo check --target aarch64-unknown-linux-musl -p arcbox-fc-driver --all-targets` · `cargo doc -p arcbox-fc-driver --no-deps` · `cargo test -p arcbox-vm` (140 passed) · `cargo run -q -p xtask -- check-layers`.

Closes the Codex thread on #664 (and pullfrog's on the same lines); `virt/arcbox-vm-driver` (the port) is untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orphan adoption and kill paths used by sandbox manager reconcile; behavior is narrower (process-only fallback) but affects VM lifecycle cleanup when the API is dead. Well bounded by timeouts and covered by new adopt/process-only tests.
> 
> **Overview**
> **Adopt no longer depends on a live Firecracker API.** After `discover` finds a verified VMM process, `adopt::rebuild` attaches `FcProcess::adopt` first, then tries `GET /` and `GET /vm/config` within **`adopt::API_TIMEOUT` (2 s)**. Success still returns **`FcHandle`** with devices and paused state; missing, wedged, or erroring sockets return **`FcProcessHandle`** — `shutdown(Kill)` (and **`Graceful`** degraded to kill), state/events from the process guard, **`detach`**, and **`None`** for vsock, listener, and checkpoint.
> 
> The adopted **`VmRecord`** now reflects the **verified** pid and api socket from discovery, not stale caller data. **`FakeFc`** moved to **`api/fake_fc.rs`** for adopt and handle tests. README and module docs describe the adopt module and process-only handle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6289b82104407fe3799a7feff854a74cf5a4e617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->