### PR TITLE
feat(vm-driver): close the three GuestNetwork gaps the manager conversion needs (R2, part 2)

### DIFF
--- a/virt/arcbox-tap-net/README.md
+++ b/virt/arcbox-tap-net/README.md
@@ -49,8 +49,8 @@ token; the allocation is rebuilt from it (TAP name from the address,
 resolvers from the network), so there is no side table to keep. Errors:
 `TapNetError` maps variant for variant into `arcbox_vm::VmmError`
 (`WrongState` / `Unavailable` keep their 412 / 503 meaning) and into the
-port's `Error` (`Io` kept, the rest `Network` with the classification in
-the text).
+port's `Error` (`Unavailable` and `PreconditionFailed` carry the same two
+answers; `Io` keeps its shape, the faults land on `Network`).
 
 ## Usage
 

--- a/virt/arcbox-tap-net/README.md
+++ b/virt/arcbox-tap-net/README.md
@@ -42,7 +42,7 @@ agent's port-forward and init code.
 | `release(lease)` | `release_checked(alloc)` |
 | `identity(lease, mode)` | the invariant link under `Invariant` (every fresh boot and invariant restore), the pool address under `LegacySnapshot` — the resolver is the gateway either way |
 | `reconcile()` | `Some(self)` while a quarantine ledger is kept |
-| `NetworkReconcile::*` | `pending_quarantines`, `validate_quarantine` / `finalize_quarantine`, and the `*_startup_cleanup` set |
+| `NetworkReconcile::*` | `pending_quarantines` (an id the port cannot name is an error, not a dropped entry), `validate_quarantine` / `finalize_quarantine`, and the `*_startup_cleanup` set |
 
 The `NetworkLease` carries VM, address, prefix, gateway, MAC and cleanup
 token; the allocation is rebuilt from it (TAP name from the address,

--- a/virt/arcbox-tap-net/README.md
+++ b/virt/arcbox-tap-net/README.md
@@ -40,7 +40,7 @@ agent's port-forward and init code.
 | `activate(lease, mode)` | `activate(alloc, mode)` — returns `NicSpec { id: "eth0", mac, Tap { name } }` |
 | `quarantine(lease)` | `quarantine_checked(vm, alloc)` |
 | `release(lease)` | `release_checked(alloc)` |
-| `identity(lease)` | the invariant link for every fresh boot and invariant restore; the pool address once the TAP was activated as `LegacySnapshot` — the resolver is the gateway either way |
+| `identity(lease, mode)` | the invariant link under `Invariant` (every fresh boot and invariant restore), the pool address under `LegacySnapshot` — the resolver is the gateway either way |
 | `reconcile()` | `Some(self)` while a quarantine ledger is kept |
 | `NetworkReconcile::*` | `pending_quarantines`, `validate_quarantine` / `finalize_quarantine`, and the `*_startup_cleanup` set |
 

--- a/virt/arcbox-tap-net/src/error.rs
+++ b/virt/arcbox-tap-net/src/error.rs
@@ -3,9 +3,11 @@
 //! The variants mirror the shapes the sandbox manager already classifies
 //! for its wire codes — a token mismatch is `WrongState` (412 upstream), a
 //! closed startup gate or a pending same-id cleanup is `Unavailable` (503,
-//! retry later) — so `arcbox-vm`'s `From` impl maps them variant for
-//! variant. Everything the TAP, netlink, netfilter, and eBPF plumbing can
-//! fail with is `Network` with the failing step in the message.
+//! retry later) — so both `From` impls below carry them across without a
+//! reclassification: whether the manager reaches this network directly or
+//! through the driver port, the answer keeps its code. Everything the TAP,
+//! netlink, netfilter, and eBPF plumbing can fail with is `Network` with
+//! the failing step in the message.
 
 use thiserror::Error;
 
@@ -46,19 +48,21 @@ pub enum TapNetError {
 /// `Result` specialised to this crate's [`TapNetError`].
 pub type Result<T> = std::result::Result<T, TapNetError>;
 
-/// Into the port's error. `Io` keeps its shape and a `Network` message is
-/// already the whole story; a closed gate, a token mismatch, or a ledger
-/// decode failure keeps its classification in the text, because the port
-/// has no retry-later or token-mismatch variant to carry it (its
-/// `WrongState` is about VM lifecycle state).
+/// Into the port's error, variant for variant where a shape exists: a
+/// closed gate stays retry-later and a token mismatch stays a failed
+/// precondition, so the 503 / 412 a caller answers with survives the port
+/// boundary. The port's `WrongState` is about VM lifecycle state and
+/// cannot carry the token mismatch, so [`TapNetError::WrongState`]'s three
+/// fields collapse into the precondition message. `Io` keeps its shape,
+/// and a ledger decode failure is a fault like any other `Network` one.
 impl From<TapNetError> for arcbox_vm_driver::Error {
     fn from(err: TapNetError) -> Self {
         match err {
             TapNetError::Io(io) => Self::Io(io),
             TapNetError::Network(msg) => Self::Network(msg),
-            other @ (TapNetError::Json(_)
-            | TapNetError::WrongState { .. }
-            | TapNetError::Unavailable(_)) => Self::Network(other.to_string()),
+            TapNetError::Unavailable(msg) => Self::Unavailable(msg),
+            wrong @ TapNetError::WrongState { .. } => Self::PreconditionFailed(wrong.to_string()),
+            json @ TapNetError::Json(_) => Self::Network(json.to_string()),
         }
     }
 }
@@ -70,7 +74,7 @@ mod tests {
     use super::TapNetError as T;
 
     #[test]
-    fn errors_keep_io_and_flatten_the_rest_into_network() {
+    fn errors_keep_io_and_the_faults_land_on_network() {
         let io = Error::from(T::Io(std::io::Error::other("disk")));
         assert!(matches!(io, Error::Io(_)), "{io}");
         // A network failure's message is already the whole story.
@@ -79,23 +83,38 @@ mod tests {
             matches!(&network, Error::Network(m) if m == "TUNSETIFF vmtap0-2: EPERM"),
             "{network}"
         );
-        // Everything else keeps its classification in the text, since the
-        // port has no retry-later or token-mismatch shape to carry it.
-        for error in [
-            T::Unavailable("gate".into()),
-            T::WrongState {
-                id: "box".into(),
-                expected: "token a".into(),
-                actual: "token b".into(),
-            },
-            T::Json(serde_json::from_str::<u8>("x").unwrap_err()),
-        ] {
-            let text = error.to_string();
-            let mapped = Error::from(error);
-            assert!(
-                matches!(&mapped, Error::Network(m) if *m == text),
-                "{mapped}"
-            );
-        }
+        // A ledger that will not decode is a fault, not a protocol answer.
+        let json = T::Json(serde_json::from_str::<u8>("x").unwrap_err());
+        let text = json.to_string();
+        let mapped = Error::from(json);
+        assert!(
+            matches!(&mapped, Error::Network(m) if *m == text),
+            "{mapped}"
+        );
+    }
+
+    /// The cleanup protocol's two answers keep their classification across
+    /// the port: "come back later" and "that is not the token", which the
+    /// callers above turn into 503 and 412.
+    #[test]
+    fn the_cleanup_protocols_answers_survive_the_port() {
+        let gate = Error::from(T::Unavailable("startup cleanup pending".into()));
+        assert!(
+            matches!(&gate, Error::Unavailable(m) if m == "startup cleanup pending"),
+            "{gate}"
+        );
+        let mismatch = Error::from(T::WrongState {
+            id: "box".into(),
+            expected: "cleanup token a".into(),
+            actual: "b".into(),
+        });
+        let Error::PreconditionFailed(message) = &mismatch else {
+            panic!("a token mismatch is a failed precondition, got {mismatch}");
+        };
+        // The three fields the port cannot carry stay readable in the text.
+        assert!(
+            message.contains("box") && message.contains("cleanup token a") && message.contains('b'),
+            "{message}"
+        );
     }
 }

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -156,16 +156,22 @@ impl GuestNetwork for TapNetwork {
 #[async_trait]
 impl NetworkReconcile for TapNetwork {
     /// Every quarantined VM with its token.
-    async fn pending_cleanups(&self) -> Vec<(VmId, String)> {
+    ///
+    /// Every id the network reserves, writes, or loads passes the `VmId`
+    /// rules (`quarantine::validate_id`), so a ledger entry that fails
+    /// here cannot come from this crate — but the ledger is on disk, and
+    /// an entry the port cannot name would pin its address out of the pool
+    /// with no way to finalize it. It is reported, not skipped.
+    async fn pending_cleanups(&self) -> Result<Vec<(VmId, String)>> {
         self.pending_quarantines()
             .into_iter()
             .map(|(id, token)| {
-                // Every id the network reserves, writes, or loads passes the
-                // `VmId` rules (`quarantine::validate_id`), so an entry that
-                // fails here cannot exist.
-                let vm = VmId::new(id.as_str())
-                    .expect("quarantine ledger ids are validated as VmIds at write and load");
-                (vm, token)
+                let vm = VmId::new(id.as_str()).map_err(|error| {
+                    Error::Network(format!(
+                        "quarantine ledger holds an id this port cannot name: {error}"
+                    ))
+                })?;
+                Ok((vm, token))
             })
             .collect()
     }
@@ -355,6 +361,50 @@ mod tests {
         assert!(ledgered.reconcile().is_some());
     }
 
+    /// The loader refuses a ledger file whose id the port cannot name (see
+    /// below), so this can only be reached by planting one — but the list
+    /// is read from durable state, and an entry it cannot name pins an
+    /// address out of the pool. Reporting it is what makes that visible;
+    /// dropping it would hide the leak, and panicking would take the
+    /// caller down.
+    #[tokio::test]
+    async fn a_ledger_id_the_port_cannot_name_is_reported() {
+        let root = tempfile::tempdir().unwrap();
+        let network = TapNetwork::with_quarantine_dir(
+            "172.20.0.0/16",
+            "172.20.0.1",
+            vec![],
+            root.path().join("q"),
+            Datapath::default(),
+            Arc::new(IptablesLegacy::default()),
+        )
+        .unwrap();
+        let long_id = "x".repeat(VmId::MAX_LEN + 1);
+        network.quarantined.lock().unwrap().insert(
+            long_id.clone(),
+            NetworkAllocation {
+                tap_name: "vmtap0-3".into(),
+                ip_address: "172.20.0.3".parse().unwrap(),
+                prefix_len: 16,
+                gateway: "172.20.0.1".parse().unwrap(),
+                mac_address: crate::mac_from_vm_id(&long_id).to_string(),
+                dns_servers: vec![],
+                cleanup_token: uuid::Uuid::new_v4().to_string(),
+            },
+        );
+
+        let error = network
+            .reconcile()
+            .unwrap()
+            .pending_cleanups()
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&error, Error::Network(m) if m.contains("cannot name")),
+            "{error}"
+        );
+    }
+
     /// The token protocol through the port: quarantine, then the pending
     /// list names the lease's token, a wrong token is refused, and
     /// finalizing returns the address to the pool. Off Linux only, where
@@ -383,7 +433,7 @@ mod tests {
             .unwrap();
         network.quarantine(lease.clone()).await.unwrap();
         assert_eq!(
-            reconcile.pending_cleanups().await,
+            reconcile.pending_cleanups().await.unwrap(),
             vec![(vm("box"), lease.cleanup_token.clone())]
         );
         // The address stays out of the pool, and the id is refused until
@@ -408,7 +458,7 @@ mod tests {
             .finalize_cleanup(&vm("box"), &lease.cleanup_token)
             .await
             .unwrap();
-        assert!(reconcile.pending_cleanups().await.is_empty());
+        assert!(reconcile.pending_cleanups().await.unwrap().is_empty());
         let reused = GuestNetwork::reserve(&network, &vm("box"), policy(NetworkMode::Nat))
             .await
             .unwrap();

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -9,7 +9,7 @@
 //! | `activate(lease, mode)` | `activate(alloc, mode)`; returns the TAP as a [`NicSpec`] named `eth0` |
 //! | `quarantine(lease)` | `quarantine_checked(vm, alloc)` |
 //! | `release(lease)` | `release_checked(alloc)` |
-//! | `identity(lease)` | the invariant identity, or the pool identity for a TAP activated as `LegacySnapshot` |
+//! | `identity(lease, mode)` | the invariant identity, or the pool identity under `LegacySnapshot` |
 //! | `reconcile()` | `Some(self)` while a quarantine ledger is kept |
 //! | `NetworkReconcile::*` | the `*_quarantine` / `*_startup_cleanup` methods |
 //!
@@ -36,11 +36,6 @@ use crate::{NetworkAllocation, TapNetwork, invariant, tap_name_from_ip};
 pub const NIC_ID: &str = "eth0";
 
 impl TapNetwork {
-    /// The mode `tap_name` was activated in by this process, if it is up.
-    fn attach_mode(&self, tap_name: &str) -> Option<AttachMode> {
-        self.attached.lock().unwrap().get(tap_name).copied()
-    }
-
     /// The [`NetworkLease`] for `vm` over `allocation`.
     fn lease(vm: &VmId, allocation: &NetworkAllocation) -> NetworkLease {
         NetworkLease {
@@ -149,14 +144,7 @@ impl GuestNetwork for TapNetwork {
         Ok(self.release_checked(&allocation)?)
     }
 
-    fn identity(&self, lease: &NetworkLease) -> NetworkIdentity {
-        let mode = match lease.ip {
-            IpAddr::V4(ip) => self
-                .attach_mode(&tap_name_from_ip(ip))
-                .unwrap_or(AttachMode::Invariant),
-            // Not a lease of this network; there is no TAP to look up.
-            IpAddr::V6(_) => AttachMode::Invariant,
-        };
+    fn identity(&self, lease: &NetworkLease, mode: AttachMode) -> NetworkIdentity {
         Self::identity_for(lease, mode)
     }
 
@@ -323,16 +311,19 @@ mod tests {
         );
         // Identity still answers — the invariant shape, which needs nothing
         // from the address.
-        assert_eq!(network.identity(&lease).ip, v4("169.254.100.2"));
+        assert_eq!(
+            network.identity(&lease, AttachMode::Invariant).ip,
+            v4("169.254.100.2")
+        );
     }
 
     #[test]
-    fn identity_follows_the_recorded_attach_mode() {
+    fn identity_follows_the_attach_mode_it_is_given() {
         let network = network();
         let lease = TapNetwork::lease(&vm("box"), &TapNetwork::reserve(&network, "box").unwrap());
 
-        // Not activated yet: what a fresh boot gets on its command line.
-        let fresh = network.identity(&lease);
+        // What a fresh boot — and every invariant restore — is told.
+        let fresh = network.identity(&lease, AttachMode::Invariant);
         assert_eq!(fresh.ip, v4("169.254.100.2"));
         assert_eq!(fresh.prefix_len, 30);
         assert_eq!(fresh.gateway, v4("169.254.100.1"));
@@ -340,24 +331,12 @@ mod tests {
         assert_eq!(fresh.mac, lease.mac);
 
         // A legacy-snapshot restore re-addresses the guest to the pool.
-        network
-            .attached
-            .lock()
-            .unwrap()
-            .insert("vmtap0-2".into(), AttachMode::LegacySnapshot);
-        let legacy = network.identity(&lease);
+        let legacy = network.identity(&lease, AttachMode::LegacySnapshot);
         assert_eq!(legacy.ip, v4("172.20.0.2"));
         assert_eq!(legacy.prefix_len, 16);
         assert_eq!(legacy.gateway, v4("172.20.0.1"));
         assert_eq!(legacy.dns, vec![v4("172.20.0.1")]);
         assert_eq!(legacy.mac, lease.mac);
-
-        network
-            .attached
-            .lock()
-            .unwrap()
-            .insert("vmtap0-2".into(), AttachMode::Invariant);
-        assert_eq!(network.identity(&lease), fresh);
     }
 
     #[test]

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -386,17 +386,20 @@ mod tests {
             reconcile.pending_cleanups().await,
             vec![(vm("box"), lease.cleanup_token.clone())]
         );
-        // The address stays out of the pool, and the id stays refused.
+        // The address stays out of the pool, and the id is refused until
+        // the host finalizes — a retry-later answer, not a fault.
         assert!(matches!(
             GuestNetwork::reserve(&network, &vm("box"), policy(NetworkMode::Nat)).await,
-            Err(Error::Network(_))
+            Err(Error::Unavailable(_))
         ));
-        assert!(
+        // A token from another generation is a failed precondition: no
+        // retry of it can ever succeed.
+        assert!(matches!(
             reconcile
                 .validate_cleanup(&vm("box"), "wrong-generation")
-                .await
-                .is_err()
-        );
+                .await,
+            Err(Error::PreconditionFailed(_))
+        ));
         reconcile
             .validate_cleanup(&vm("box"), &lease.cleanup_token)
             .await

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -157,11 +157,15 @@ impl GuestNetwork for TapNetwork {
 impl NetworkReconcile for TapNetwork {
     /// Every quarantined VM with its token.
     ///
-    /// Every id the network reserves, writes, or loads passes the `VmId`
-    /// rules (`quarantine::validate_id`), so a ledger entry that fails
-    /// here cannot come from this crate — but the ledger is on disk, and
-    /// an entry the port cannot name would pin its address out of the pool
-    /// with no way to finalize it. It is reported, not skipped.
+    /// The error is a broken invariant rather than an expected on-disk
+    /// case: every id this crate reserves, writes, or loads passes the
+    /// `VmId` rules (`quarantine::validate_id`), and a marker file
+    /// carrying anything else fails construction outright. Should one
+    /// reach here, the whole list fails rather than losing that one entry
+    /// from it — nothing can name the entry, so nothing can finalize it,
+    /// so `finalize_startup_cleanup` refuses while it sits in the ledger
+    /// and the startup gate never opens. Dropping it would trade one loud
+    /// failure for that permanent, unexplained stall.
     async fn pending_cleanups(&self) -> Result<Vec<(VmId, String)>> {
         self.pending_quarantines()
             .into_iter()

--- a/virt/arcbox-tap-net/src/lib.rs
+++ b/virt/arcbox-tap-net/src/lib.rs
@@ -185,12 +185,6 @@ pub struct TapNetwork {
     /// with that process) or is legacy — both tear down via the tolerant
     /// iptables removal and expose via the fwmark form.
     applied: Mutex<HashMap<String, AppliedDatapath>>,
-    /// The [`AttachMode`] each active TAP was materialized in, keyed by TAP
-    /// name and living exactly as long as the TAP. What the guest sees
-    /// (`GuestNetwork::identity`) follows it; a TAP absent here — activated
-    /// by a previous process, or not yet activated — reads as `Invariant`,
-    /// the mode of every fresh boot.
-    attached: Mutex<HashMap<String, AttachMode>>,
     /// How the iptables-datapath translation (and the eBPF fallback) is
     /// expressed on this host; see [`packet_filter`].
     #[cfg_attr(
@@ -296,7 +290,6 @@ impl TapNetwork {
             startup_reconciled: AtomicBool::new(!startup_barrier),
             datapath,
             applied: Mutex::new(HashMap::new()),
-            attached: Mutex::new(HashMap::new()),
             packet_filter,
             #[cfg(target_os = "linux")]
             ebpf: Mutex::new(ebpf::Engine::Unloaded),
@@ -393,10 +386,6 @@ impl TapNetwork {
                 return Err(error);
             }
         }
-        self.attached
-            .lock()
-            .unwrap()
-            .insert(allocation.tap_name.clone(), mode);
         Ok(())
     }
 
@@ -542,7 +531,6 @@ impl TapNetwork {
 
         let ip_int = u32::from(alloc.ip_address);
         self.allocated.lock().unwrap().remove(&ip_int);
-        self.attached.lock().unwrap().remove(&alloc.tap_name);
 
         debug!(tap = %alloc.tap_name, ip = %alloc.ip_address, "releasing network");
         #[cfg(target_os = "linux")]

--- a/virt/arcbox-tap-net/src/quarantine.rs
+++ b/virt/arcbox-tap-net/src/quarantine.rs
@@ -48,7 +48,6 @@ impl TapNetwork {
         self.deactivate_translation(alloc)?;
         #[cfg(target_os = "linux")]
         tap::destroy_checked(&alloc.tap_name)?;
-        self.attached.lock().unwrap().remove(&alloc.tap_name);
         debug!(
             sandbox_id,
             tap = %alloc.tap_name,

--- a/virt/arcbox-vm-driver/README.md
+++ b/virt/arcbox-vm-driver/README.md
@@ -40,8 +40,12 @@ that the flags and the accessors agree.
 | `DebugSnapshot` | `handle.debug()` | driver-specific JSON for post-mortems |
 
 `net::GuestNetwork` is the second port: reserve a lease, activate it into
-a `NicSpec`, quarantine/release, and the `NetworkReconcile` cleanup-token
-protocol.
+a `NicSpec`, ask what the guest sees under the mode it was activated in,
+quarantine/release, and the `NetworkReconcile` cleanup-token protocol.
+That protocol answers with `Error::Unavailable` (come back later) and
+`Error::PreconditionFailed` (that token names no pending generation);
+those two classes are the contract callers turn into their wire codes, so
+an adapter must not flatten them into `Error::Network`.
 
 ## Usage
 

--- a/virt/arcbox-vm-driver/src/error.rs
+++ b/virt/arcbox-vm-driver/src/error.rs
@@ -58,6 +58,21 @@ pub enum Error {
     /// The guest-network port refused or failed an operation.
     #[error("network: {0}")]
     Network(String),
+
+    /// The operation cannot proceed yet, and retrying later is the remedy:
+    /// a startup-cleanup gate still closed, a same-id cleanup the host has
+    /// not finalized. Separate from [`Self::Network`] because a caller
+    /// surfaces it as "unavailable, come back" rather than as a fault.
+    #[error("unavailable: {0}")]
+    Unavailable(String),
+
+    /// A precondition the caller presented does not hold — a cleanup token
+    /// naming another generation, or naming one that no longer exists.
+    /// Retrying the same call never helps; the caller needs a current
+    /// token. Separate from [`Self::WrongState`], which is about where a
+    /// VM sits in its lifecycle.
+    #[error("failed precondition: {0}")]
+    PreconditionFailed(String),
 }
 
 /// `Result` specialised to this crate's [`Error`].

--- a/virt/arcbox-vm-driver/src/net.rs
+++ b/virt/arcbox-vm-driver/src/net.rs
@@ -34,9 +34,16 @@ pub trait GuestNetwork: Send + Sync {
     /// Returns the address to the pool outright, skipping quarantine.
     async fn release(&self, lease: NetworkLease) -> Result<()>;
 
-    /// The network as the guest sees it: what goes on the kernel command
-    /// line or into a net-reconfigure command.
-    fn identity(&self, lease: &NetworkLease) -> NetworkIdentity;
+    /// The network as the guest sees it under `mode`: what goes on the
+    /// kernel command line or into a net-reconfigure command.
+    ///
+    /// The mode is the caller's, not the lease's: a lease is reserved
+    /// before anyone knows how it will be attached, and the same lease
+    /// reads differently once activated as [`AttachMode::LegacySnapshot`]
+    /// (the guest owns the pool address) than as [`AttachMode::Invariant`]
+    /// (the address is the host's, translated per interface). Pass what
+    /// [`GuestNetwork::activate`] was given.
+    fn identity(&self, lease: &NetworkLease, mode: AttachMode) -> NetworkIdentity;
 
     /// The cleanup-token protocol and startup sweep, when the network keeps
     /// a quarantine ledger.

--- a/virt/arcbox-vm-driver/src/net.rs
+++ b/virt/arcbox-vm-driver/src/net.rs
@@ -87,6 +87,12 @@ pub enum AttachMode {
 ///
 /// Serialized into the VM's durable record so cleanup can be replayed after
 /// a crash; `cleanup_token` is what the two-step cleanup protocol checks.
+///
+/// Deliberately plain — no `#[non_exhaustive]`, because a runtime builds
+/// one from a record it read back and needs every field. What that costs
+/// is that the field *names* are an on-disk contract: a field added here
+/// must carry `#[serde(default)]` so a record written before it still
+/// loads, and nothing may key on the order they are declared in.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NetworkLease {
     /// The VM this lease belongs to.

--- a/virt/arcbox-vm-driver/src/net.rs
+++ b/virt/arcbox-vm-driver/src/net.rs
@@ -132,7 +132,13 @@ pub struct NetworkIdentity {
 pub trait NetworkReconcile: Send + Sync {
     /// VMs whose leases are quarantined, with the token each finalization
     /// must present.
-    async fn pending_cleanups(&self) -> Vec<(VmId, String)>;
+    ///
+    /// Fallible because a durable ledger is read back from disk: an entry
+    /// whose id is not a [`VmId`] is one this protocol could never name,
+    /// list, or finalize, and its address would stay out of the pool
+    /// forever. The caller sees that as an error rather than as a shorter
+    /// list.
+    async fn pending_cleanups(&self) -> Result<Vec<(VmId, String)>>;
 
     /// Checks that `token` names `vm`'s pending cleanup generation.
     async fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<()>;

--- a/virt/arcbox-vm-driver/src/testkit/fake_network.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_network.rs
@@ -22,6 +22,14 @@ use crate::spec::{MacAddr, NicAttachment, NicSpec, VmId};
 /// [`NetworkReconcile`] drains through the token protocol.
 /// [`FakeNetwork::with_startup_cleanup`] starts with a pending startup
 /// cleanup so that half of the protocol can be exercised too.
+///
+/// It answers that protocol in the same error *classes* a real adapter
+/// does — [`Error::Unavailable`] for come-back-later (a quarantined id, a
+/// gate still held by pending generations) and
+/// [`Error::PreconditionFailed`] for a token naming no pending generation.
+/// A caller's retry and precondition handling is therefore testable over
+/// this fake; flattening either into [`Error::Network`] would make a
+/// broken path look fine here and fail against the TAP network.
 pub struct FakeNetwork {
     ledger: Mutex<Ledger>,
     /// `true` while a startup cleanup is pending.
@@ -130,7 +138,14 @@ fn host_number(ip: IpAddr) -> Result<u16> {
 impl GuestNetwork for FakeNetwork {
     async fn reserve(&self, vm: &VmId, _policy: NetworkPolicy) -> Result<NetworkLease> {
         let mut ledger = lock(&self.ledger);
-        if ledger.active.contains_key(vm) || ledger.quarantined.contains_key(vm) {
+        // A quarantined id is the protocol's retry-later case: the address
+        // comes back once the host finalizes that generation.
+        if ledger.quarantined.contains_key(vm) {
+            return Err(Error::Unavailable(format!(
+                "vm {vm} cleanup is awaiting host finalization"
+            )));
+        }
+        if ledger.active.contains_key(vm) {
             return Err(Error::Network(format!("vm {vm} already holds a lease")));
         }
         let host = ledger
@@ -186,7 +201,9 @@ impl GuestNetwork for FakeNetwork {
             if existing.cleanup_token == lease.cleanup_token {
                 return Ok(());
             }
-            return Err(Error::Network(format!(
+            // Another generation of this id is mid-cleanup: retry-later,
+            // like the reserve above.
+            return Err(Error::Unavailable(format!(
                 "vm {} already has a different quarantined lease",
                 lease.vm
             )));
@@ -292,7 +309,8 @@ impl NetworkReconcile for FakeNetwork {
         let mut ledger = lock(&self.ledger);
         ledger.validate_startup_cleanup(token)?;
         if !ledger.quarantined.is_empty() {
-            return Err(Error::Network(
+            // Retry-later: the gate opens once those generations drain.
+            return Err(Error::Unavailable(
                 "cleanup generations remain pending; finalize them first".into(),
             ));
         }
@@ -311,13 +329,16 @@ impl NetworkReconcile for FakeNetwork {
 }
 
 impl Ledger {
+    /// A token that does not name a pending generation — of this VM or of
+    /// none at all — is a failed precondition: no retry of that token can
+    /// succeed, the caller needs a current one.
     fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<()> {
         let lease = self
             .quarantined
             .get(vm)
-            .ok_or_else(|| Error::Network(format!("vm {vm} has no pending cleanup")))?;
+            .ok_or_else(|| Error::PreconditionFailed(format!("vm {vm} has no pending cleanup")))?;
         if lease.cleanup_token != token {
-            return Err(Error::Network(format!(
+            return Err(Error::PreconditionFailed(format!(
                 "vm {vm} cleanup token does not name the pending generation"
             )));
         }
@@ -327,10 +348,12 @@ impl Ledger {
     fn validate_startup_cleanup(&self, token: &str) -> Result<()> {
         match &self.startup {
             Some(startup) if !startup.host_cleaned && startup.token == token => Ok(()),
-            Some(startup) if !startup.host_cleaned => {
-                Err(Error::Network("startup cleanup token mismatch".into()))
-            }
-            _ => Err(Error::Network("no startup cleanup is pending".into())),
+            Some(startup) if !startup.host_cleaned => Err(Error::PreconditionFailed(
+                "startup cleanup token mismatch".into(),
+            )),
+            _ => Err(Error::PreconditionFailed(
+                "no startup cleanup is pending".into(),
+            )),
         }
     }
 }
@@ -396,7 +419,10 @@ mod tests {
         net.quarantine(a.clone()).await.unwrap(); // idempotent
         let mut other = a.clone();
         other.cleanup_token = "other".into();
-        assert!(net.quarantine(other).await.is_err());
+        assert!(matches!(
+            net.quarantine(other).await,
+            Err(Error::Unavailable(_))
+        ));
         assert!(net.activate(&a, AttachMode::Invariant).await.is_err());
 
         let reconcile = net.reconcile().unwrap();
@@ -404,7 +430,17 @@ mod tests {
             reconcile.pending_cleanups().await.unwrap(),
             vec![(id("a"), a.cleanup_token.clone())]
         );
-        assert!(reconcile.validate_cleanup(&id("a"), "wrong").await.is_err());
+        // A token that names no pending generation is a failed
+        // precondition; the id itself is refused until the host finalizes,
+        // which is a retry-later. Callers turn those into 412 and 503.
+        assert!(matches!(
+            reconcile.validate_cleanup(&id("a"), "wrong").await,
+            Err(Error::PreconditionFailed(_))
+        ));
+        assert!(matches!(
+            net.reserve(&id("a"), policy()).await,
+            Err(Error::Unavailable(_))
+        ));
         // Still held: the next lease does not get a's address.
         let b = net.reserve(&id("b"), policy()).await.unwrap();
         assert_ne!(b.ip, a.ip);
@@ -483,12 +519,20 @@ mod tests {
             reconcile.startup_cleanup_token().await.as_deref(),
             Some("boot-1")
         );
-        assert!(reconcile.validate_startup_cleanup("boot-2").await.is_err());
+        // Another generation's token can never name this sweep.
+        assert!(matches!(
+            reconcile.validate_startup_cleanup("boot-2").await,
+            Err(Error::PreconditionFailed(_))
+        ));
 
         let a = net.reserve(&id("a"), policy()).await.unwrap();
         net.quarantine(a.clone()).await.unwrap();
-        // A quarantined lease keeps the startup cleanup from finalizing.
-        assert!(reconcile.finalize_startup_cleanup("boot-1").await.is_err());
+        // A quarantined lease keeps the startup cleanup from finalizing —
+        // retry-later, since finalizing that generation opens the gate.
+        assert!(matches!(
+            reconcile.finalize_startup_cleanup("boot-1").await,
+            Err(Error::Unavailable(_))
+        ));
 
         let waiter = tokio::spawn({
             let net = std::sync::Arc::clone(&net);

--- a/virt/arcbox-vm-driver/src/testkit/fake_network.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_network.rs
@@ -24,9 +24,10 @@ use crate::spec::{MacAddr, NicAttachment, NicSpec, VmId};
 /// cleanup so that half of the protocol can be exercised too.
 ///
 /// It answers that protocol in the same error *classes* a real adapter
-/// does — [`Error::Unavailable`] for come-back-later (a quarantined id, a
-/// gate still held by pending generations) and
-/// [`Error::PreconditionFailed`] for a token naming no pending generation.
+/// does — [`Error::Unavailable`] for come-back-later (a pending startup
+/// sweep, which closes the whole pool; a quarantined id; a gate still held
+/// by pending generations) and [`Error::PreconditionFailed`] for a token
+/// naming no pending generation.
 /// A caller's retry and precondition handling is therefore testable over
 /// this fake; flattening either into [`Error::Network`] would make a
 /// broken path look fine here and fail against the TAP network.
@@ -84,8 +85,7 @@ impl FakeNetwork {
     }
 
     fn set_startup_pending(&self, ledger: &Ledger) {
-        let pending = ledger.startup.as_ref().is_some_and(|s| !s.host_cleaned);
-        self.startup_pending.send_replace(pending);
+        self.startup_pending.send_replace(ledger.startup_pending());
     }
 }
 
@@ -96,6 +96,12 @@ impl Default for FakeNetwork {
 }
 
 impl Ledger {
+    /// `true` while the startup sweep's host-side cleanup is pending —
+    /// the gate that closes the whole pool.
+    fn startup_pending(&self) -> bool {
+        self.startup.as_ref().is_some_and(|s| !s.host_cleaned)
+    }
+
     fn lowest_free_host(&self) -> Option<u16> {
         (FIRST_HOST..u16::MAX).find(|n| !self.used.contains(n))
     }
@@ -138,8 +144,16 @@ fn host_number(ip: IpAddr) -> Result<u16> {
 impl GuestNetwork for FakeNetwork {
     async fn reserve(&self, vm: &VmId, _policy: NetworkPolicy) -> Result<NetworkLease> {
         let mut ledger = lock(&self.ledger);
-        // A quarantined id is the protocol's retry-later case: the address
-        // comes back once the host finalizes that generation.
+        // While the startup sweep is pending the *whole* pool is closed,
+        // not just the ids in it: the host has yet to confirm that the
+        // forwarding state of a previous process is gone.
+        if ledger.startup_pending() {
+            return Err(Error::Unavailable(
+                "startup cleanup is awaiting host finalization".into(),
+            ));
+        }
+        // A quarantined id is the protocol's retry-later case too: the
+        // address comes back once the host finalizes that generation.
         if ledger.quarantined.contains_key(vm) {
             return Err(Error::Unavailable(format!(
                 "vm {vm} cleanup is awaiting host finalization"
@@ -525,7 +539,24 @@ mod tests {
             Err(Error::PreconditionFailed(_))
         ));
 
-        let a = net.reserve(&id("a"), policy()).await.unwrap();
+        // The pool is closed while the sweep is pending — every id, not
+        // just the ones in the ledger.
+        assert!(matches!(
+            net.reserve(&id("a"), policy()).await,
+            Err(Error::Unavailable(_))
+        ));
+
+        // A quarantine can still arrive alongside a pending sweep, because
+        // that is where both come from: a previous process's leases,
+        // replayed from its durable records.
+        let a = NetworkLease {
+            vm: id("a"),
+            ip: IpAddr::V4(Ipv4Addr::new(10, 200, 0, 2)),
+            prefix_len: PREFIX_LEN,
+            gateway: IpAddr::V4(GATEWAY),
+            mac: MacAddr::new([0x02, 0xfa, 0xce, 0x00, 0x00, 0x02]),
+            cleanup_token: "boot-1-a".into(),
+        };
         net.quarantine(a.clone()).await.unwrap();
         // A quarantined lease keeps the startup cleanup from finalizing —
         // retry-later, since finalizing that generation opens the gate.
@@ -547,6 +578,8 @@ mod tests {
             .unwrap();
         reconcile.finalize_startup_cleanup("boot-1").await.unwrap();
         assert_eq!(reconcile.startup_cleanup_token().await, None);
+        // The pool opens with it, and the replayed address is back in it.
+        assert_eq!(net.reserve(&id("a"), policy()).await.unwrap().ip, a.ip);
         tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
             .await
             .expect("waiter released")

--- a/virt/arcbox-vm-driver/src/testkit/fake_network.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_network.rs
@@ -233,7 +233,10 @@ impl GuestNetwork for FakeNetwork {
         }
     }
 
-    fn identity(&self, lease: &NetworkLease) -> NetworkIdentity {
+    /// The lease's own address, whichever mode it was attached in: the
+    /// fake translates nothing per interface, so the guest sees exactly
+    /// what was reserved for it.
+    fn identity(&self, lease: &NetworkLease, _mode: AttachMode) -> NetworkIdentity {
         NetworkIdentity {
             ip: lease.ip,
             prefix_len: lease.prefix_len,
@@ -367,6 +370,20 @@ mod tests {
         net.release(a.clone()).await.unwrap();
         let c = net.reserve(&id("c"), policy()).await.unwrap();
         assert_eq!(c.ip, a.ip);
+    }
+
+    #[tokio::test]
+    async fn the_guest_sees_its_lease_in_either_attach_mode() {
+        let net = FakeNetwork::new();
+        let lease = net.reserve(&id("a"), policy()).await.unwrap();
+        let invariant = net.identity(&lease, AttachMode::Invariant);
+        assert_eq!(invariant.ip, lease.ip);
+        assert_eq!(invariant.gateway, lease.gateway);
+        assert_eq!(invariant.mac, lease.mac);
+        assert_eq!(invariant.dns, vec![lease.gateway]);
+        // Nothing is translated per interface here, so the mode changes
+        // nothing about what the guest is told.
+        assert_eq!(net.identity(&lease, AttachMode::LegacySnapshot), invariant);
     }
 
     #[tokio::test]

--- a/virt/arcbox-vm-driver/src/testkit/fake_network.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_network.rs
@@ -253,12 +253,14 @@ impl GuestNetwork for FakeNetwork {
 
 #[async_trait]
 impl NetworkReconcile for FakeNetwork {
-    async fn pending_cleanups(&self) -> Vec<(VmId, String)> {
-        lock(&self.ledger)
+    /// Always `Ok`: this ledger is a map keyed by [`VmId`], so it cannot
+    /// hold an id the protocol could not name.
+    async fn pending_cleanups(&self) -> Result<Vec<(VmId, String)>> {
+        Ok(lock(&self.ledger)
             .quarantined
             .iter()
             .map(|(vm, lease)| (vm.clone(), lease.cleanup_token.clone()))
-            .collect()
+            .collect())
     }
 
     async fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<()> {
@@ -399,7 +401,7 @@ mod tests {
 
         let reconcile = net.reconcile().unwrap();
         assert_eq!(
-            reconcile.pending_cleanups().await,
+            reconcile.pending_cleanups().await.unwrap(),
             vec![(id("a"), a.cleanup_token.clone())]
         );
         assert!(reconcile.validate_cleanup(&id("a"), "wrong").await.is_err());
@@ -411,7 +413,7 @@ mod tests {
             .finalize_cleanup(&id("a"), &a.cleanup_token)
             .await
             .unwrap();
-        assert!(reconcile.pending_cleanups().await.is_empty());
+        assert!(reconcile.pending_cleanups().await.unwrap().is_empty());
         let c = net.reserve(&id("c"), policy()).await.unwrap();
         assert_eq!(c.ip, a.ip);
     }
@@ -444,7 +446,14 @@ mod tests {
         forged.cleanup_token = "forged".into();
         assert!(net.release(forged).await.is_err());
         net.release(a2.clone()).await.unwrap();
-        assert!(net.reconcile().unwrap().pending_cleanups().await.is_empty());
+        assert!(
+            net.reconcile()
+                .unwrap()
+                .pending_cleanups()
+                .await
+                .unwrap()
+                .is_empty()
+        );
         let reused = net.reserve(&id("d"), policy()).await.unwrap();
         assert_eq!(reused.ip, a2.ip);
 

--- a/virt/arcbox-vm/src/error.rs
+++ b/virt/arcbox-vm/src/error.rs
@@ -169,8 +169,10 @@ impl From<arcbox_snapshot::SnapshotError> for VmmError {
 /// Variant-for-variant where a native shape exists, so a driver-reported
 /// `NotFound` or `WrongState` keeps the wire code the equivalent native
 /// error already has (the guest agent classifies `VmmError` by variant;
-/// anything it does not know becomes a 500). What has no native shape —
-/// an adapter fault, a checkpoint another driver wrote — stays
+/// anything it does not know becomes a 500), and so do the guest
+/// network's two protocol answers — retry-later and failed precondition,
+/// the 503 and 412 of the cleanup-token protocol. What has no native
+/// shape — an adapter fault, a checkpoint another driver wrote — stays
 /// [`VmmError::Driver`] with the port error intact for its `source` chain.
 impl From<arcbox_vm_driver::Error> for VmmError {
     fn from(err: arcbox_vm_driver::Error) -> Self {
@@ -189,6 +191,12 @@ impl From<arcbox_vm_driver::Error> for VmmError {
             D::Io(io) => Self::Io(io),
             D::Network(msg) => Self::Network(msg),
             D::InvalidSpec(msg) => Self::Config(msg),
+            // The cleanup-token protocol's two answers: come back later
+            // (503) and this token is not the one (412). They arrive here
+            // from the guest network and are what the agent's classifier
+            // turns back into those codes.
+            D::Unavailable(msg) => Self::Unavailable(msg),
+            D::PreconditionFailed(msg) => Self::FailedPrecondition(msg),
             other @ (D::Driver { .. } | D::ForeignCheckpoint(_)) => Self::Driver(other),
         }
     }
@@ -280,5 +288,25 @@ mod tests {
     fn test_network_error_display() {
         let e = VmmError::Network("TAP creation failed".into());
         assert_eq!(e.to_string(), "network error: TAP creation failed");
+    }
+
+    /// The guest network answers the cleanup-token protocol with "come
+    /// back later" and "that is not the token"; both cross the driver port
+    /// and must land on the variants the agent classifies as 503 and 412.
+    /// Folding either into `Network` would make it a 500.
+    #[test]
+    fn the_ports_cleanup_answers_keep_their_classification() {
+        use arcbox_vm_driver::Error as D;
+
+        let retry = VmmError::from(D::Unavailable("startup cleanup pending".into()));
+        assert!(
+            matches!(&retry, VmmError::Unavailable(m) if m == "startup cleanup pending"),
+            "{retry}"
+        );
+        let mismatch = VmmError::from(D::PreconditionFailed("token b is not token a".into()));
+        assert!(
+            matches!(&mismatch, VmmError::FailedPrecondition(m) if m == "token b is not token a"),
+            "{mismatch}"
+        );
     }
 }


### PR DESCRIPTION
Part 1 of R2b (vm-stack-redesign "`GuestNetwork` and `arcbox-tap-net`", R2,
D-VM6): the three additive port shapes the sandbox manager needs before it
can hold `NetworkLease`s. **The manager conversion itself is not in this
PR** — closing the three gaps surfaced two more, and both are port-design
calls rather than mechanical ones (bottom of this description).

## The three shapes

**`identity(lease, mode)`.** A lease is reserved before anyone knows how it
will be attached, so the network cannot answer "what does the guest see"
from the lease alone: the same lease reads as the invariant link when
activated `Invariant` and as the pool address under `LegacySnapshot`. The
caller always knows which mode it passed to `activate`, so `identity` takes
it too. That deletes the TAP network's only reason to remember, per
interface, how it was activated — the `attached` map goes with the lookup
it fed.

**`Error::Unavailable` / `Error::PreconditionFailed`.** The cleanup-token
protocol has two answers that are not faults: come back later (the startup
gate is closed, a same-id cleanup is pending) and that token is not the
current one. The guest agent turns the first into 503 and the second into
412, and it classifies by variant — so with only `Network` to land on, both
would have become 500s the moment the manager reached the network through
the port. Both `From` chains now map variant for variant: `TapNetError`'s
`Unavailable`/`WrongState` into the port, the port's pair into `VmmError`'s
`Unavailable`/`FailedPrecondition`. The port's own `WrongState` is
untouched — it is about where a VM sits in its lifecycle, and cannot carry
a token mismatch.

The testkit's `FakeNetwork` answers the cleanup protocol in those same two
classes, so a caller's retry and precondition handling is testable over it
— flattening them there would let a broken retry path pass against the fake
and fail against the TAP network.

**`pending_cleanups() -> Result<Vec<(VmId, String)>>`.** The quarantine list
is read back from durable state, so an entry whose id is not a `VmId` is
possible in a way an in-memory map's is not — and it is the worst kind to
drop: its address stays out of the pool with nothing able to name,
validate, or finalize it. The TAP adapter drops the `expect` that stood on
the loader's validation and reports instead.

## On-disk compatibility

Nothing on disk changes. No record, journal, or ledger format is touched:
`SandboxRecordStore`'s `RECORD_VERSION`, the per-sandbox `state.json`
(`SandboxStateRecord`, still carrying a `NetworkAllocation`), and the
quarantine ledger markers are all byte-identical to master. The two new
`Error` variants are in-process only — no error shape is serialized
anywhere. An agent from either side of this change reads the other's files.

## Validation

`cargo fmt --all`; `cargo clippy -p arcbox-vm-driver -p arcbox-tap-net
-p arcbox-vm --all-targets --all-features -- -D warnings` (clean);
`cargo test -p arcbox-vm-driver --all-features -p arcbox-tap-net -p arcbox-vm`
(259 green); `cargo test -p arcbox-fc-driver` (unchanged, green);
`cargo check --target aarch64-unknown-linux-musl -p arcbox-vm-driver
-p arcbox-tap-net -p arcbox-vm --all-targets --all-features`;
`cargo clippy -p arcbox-agent --target aarch64-unknown-linux-musl
--all-targets` (30 warnings, all pre-existing and all inside
`guest/arcbox-agent` + `common/arcbox-pty`, none on the changed surface —
the agent compiles unmodified); `cargo run -p xtask -- check-layers`
(65 members, 162 edges).

## What blocks the manager conversion

Two facts the manager's public surface must keep answering have no shape in
the port. Both are additive one-liners for the adapters, but they are
design calls on what the port models, so they are not in this PR:

1. **A validated cleanup does not report its address.**
   `NetworkReconcile::validate_cleanup` returns `()`
   (`virt/arcbox-vm-driver/src/net.rs:144`), but
   `SandboxManager::validate_network_cleanup` returns the allocation
   (`virt/arcbox-vm/src/sandbox.rs:328`) because the agent needs the pool
   IP: `prepare_cleanup` maps it out
   (`guest/arcbox-agent/src/sandbox.rs:589`) and hands it to
   `remove_orphan_rules_for(sandbox_ip, token)`
   (`guest/arcbox-agent/src/agent/linux/sandbox.rs:407`). After a restart
   that address lives only in the network's ledger: the manager's own
   instance map is rebuilt without a network, and the durable record cannot
   stand in — `provision_outcome` is write-once at create
   (`persistence.rs:153-165`), so a sandbox that took a fresh lease on
   resume records an address that is no longer the live one. Proposed:
   `validate_cleanup(vm, token) -> Result<NetworkLease>`. It costs the TAP
   adapter nothing — `validate_quarantine` already returns the allocation
   and today's impl discards it (`guest_network.rs:179`).

2. **The port carries no host-forwarding view (`ExposeTarget`).**
   `sandbox_network_identity` reports how expose DNAT must target a sandbox
   (`virt/arcbox-vm/src/sandbox.rs:401`), and that is decided by the
   datapath *actually applied* to the TAP — eBPF TAPs take DNAT to the pool
   IP, everything else needs the invariant IP plus its fwmark companion
   (`virt/arcbox-tap-net/src/lib.rs:492`, keyed on `applied`, which records
   the per-TAP eBPF→iptables fallback). It is not derivable from
   `NetworkIdentity` + the lease: on the eBPF datapath the guest holds the
   invariant address while DNAT must target the pool one, so any mapping
   from those two values gets that case backwards and breaks port
   forwarding on the default datapath. Either the port grows a
   host-forwarding view (`forwarding(lease, mode) -> {target, mark}`), or
   the decision moves into the guest agent with the rest of the System-VM
   port-forward specifics, which is where the design doc puts it (R5) but
   which changes agent sources this PR keeps untouched.

Not a blocker, for the record: `TapNetwork::mark_reconciled` is also off the
port, but it needs no port shape — every manager path that consults it
(`startup_cleanup_token`, `validate_startup_cleanup`,
`finalize_startup_cleanup`) already gates on `await_reconcile()` first, so
the flag is the manager's own gate mirrored in the network and can retire
with the conversion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes guest-network error classification and trait signatures across TAP and fake adapters; wrong mapping would mis-wire HTTP status codes for cleanup, but behavior is heavily tested and does not alter persisted formats.
> 
> **Overview**
> Adds three **GuestNetwork** port shapes the sandbox manager needs before it can hold `NetworkLease`s through the driver port (manager conversion is **not** in this PR).
> 
> **`identity(lease, mode)`** — Callers pass the same `AttachMode` used at `activate`, because invariant vs legacy snapshot changes what the guest is told. The TAP network drops its per-TAP `attached` map that previously inferred mode from internal state.
> 
> **`Error::Unavailable` and `Error::PreconditionFailed`** on `arcbox-vm-driver::Error` — Cleanup-token protocol answers (retry later vs wrong token) map variant-for-variant through `TapNetError` → driver → `VmmError` so agents can keep **503** and **412** instead of flattening to `Network` (**500**). `FakeNetwork` uses the same classes so tests match real adapters.
> 
> **`pending_cleanups() -> Result<Vec<...>>`** — Unnameable ledger ids fail the whole list as `Network` instead of panicking or silently dropping entries that would pin addresses forever.
> 
> Docs and tests are updated across `arcbox-tap-net`, `arcbox-vm-driver`, and `arcbox-vm`; on-disk record formats are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1584995d152347aa2ebfeb3749290d4246e54477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->