### PR TITLE
refactor(vm): attach guest networks through the driver port's GuestNetwork (R2, part 3)

### DIFF
--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -567,6 +567,11 @@ impl SandboxService {
     }
 
     /// Validate one exact cleanup generation before host-side deletion.
+    ///
+    /// The address comes back as v4 because that is what the rules it
+    /// gates are written in: the System VM's DNAT and fwmark rules are
+    /// iptables, not ip6tables. A lease from another dataplane would be
+    /// one this cleanup path could not express.
     pub(crate) async fn prepare_cleanup(
         &self,
         ticket: &arcbox_connect::v1::SandboxCleanupTicket,
@@ -583,11 +588,18 @@ impl SandboxService {
                 .map_err(SandboxError::from)?;
             return Ok(std::net::Ipv4Addr::UNSPECIFIED);
         }
-        self.manager
+        let lease = self
+            .manager
             .validate_network_cleanup(&ticket.id, &ticket.token)
             .await
-            .map(|allocation| allocation.ip_address)
-            .map_err(SandboxError::from)
+            .map_err(SandboxError::from)?;
+        match lease.ip {
+            std::net::IpAddr::V4(ip) => Ok(ip),
+            std::net::IpAddr::V6(ip) => Err(SandboxError::Internal(format!(
+                "sandbox {} holds {ip}; host cleanup here is IPv4-only",
+                ticket.id
+            ))),
+        }
     }
 
     /// Revalidate and recycle one exact generation after guest DNAT cleanup.

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -154,6 +154,9 @@ impl GuestNetwork for TapNetwork {
     /// DNAT to the pool address, an iptables one takes the fixed guest
     /// address plus the pool IP's mark, which is what selects that TAP's
     /// policy-routing table (CORE-81/CORE-83).
+    ///
+    /// [`TryFrom<HostIngress> for ExposeTarget`](ExposeTarget::try_from) is
+    /// the inverse, for the System VM code that still names the local type.
     fn host_ingress(&self, lease: &NetworkLease) -> Result<HostIngress> {
         let allocation = self.allocation(lease)?;
         Ok(match self.expose_target(&allocation.tap_name) {
@@ -226,6 +229,32 @@ impl NetworkReconcile for TapNetwork {
 
     fn replay_complete(&self) {
         self.mark_reconciled();
+    }
+}
+
+/// The port's answer as this crate's own vocabulary, for the System VM
+/// code that still names [`ExposeTarget`] (R3 moves that call to the
+/// composition root and this impl goes with it).
+///
+/// Lossy in one direction only: a mark travels with
+/// [`HostIngress::GuestAddress`] and [`ExposeTarget`] has no room for it.
+/// That costs nothing over *this* network, whose `host_ingress` mints the
+/// mark as `invariant::fwmark(pool_ip)` — the value the System VM's
+/// port-forward code derives from the pool address it is handed anyway —
+/// so the round trip through here is lossless. It would cost an adapter
+/// whose mark is anything else, which is why this conversion belongs to
+/// the adapter that can make that promise rather than to the consumer.
+impl TryFrom<HostIngress> for ExposeTarget {
+    type Error = Error;
+
+    fn try_from(ingress: HostIngress) -> Result<Self> {
+        match ingress {
+            HostIngress::PoolAddress => Ok(Self::PoolIp),
+            HostIngress::GuestAddress { .. } => Ok(Self::GuestIpWithFwmark),
+            other => Err(Error::Network(format!(
+                "host ingress {other:?} has no expose target on a TAP network"
+            ))),
+        }
     }
 }
 
@@ -411,6 +440,32 @@ mod tests {
         let mut foreign = lease;
         foreign.ip = "fd00::2".parse().unwrap();
         assert!(network.host_ingress(&foreign).is_err());
+    }
+
+    /// The round trip over this network is lossless: the mark it mints is
+    /// the one the System VM's port-forward code derives for itself.
+    #[tokio::test]
+    async fn expose_target_round_trips_through_host_ingress() {
+        let network = network();
+        let lease = GuestNetwork::reserve(&network, &vm("box"), policy(NetworkMode::Nat))
+            .await
+            .unwrap();
+        let tap = network.allocation(&lease).unwrap().tap_name;
+        for (applied, expected) in [
+            (crate::AppliedDatapath::Ebpf, ExposeTarget::PoolIp),
+            (crate::AppliedDatapath::Untranslated, ExposeTarget::PoolIp),
+            (
+                crate::AppliedDatapath::Iptables,
+                ExposeTarget::GuestIpWithFwmark,
+            ),
+        ] {
+            network.applied.lock().unwrap().insert(tap.clone(), applied);
+            let ingress = network.host_ingress(&lease).unwrap();
+            assert_eq!(ExposeTarget::try_from(ingress).unwrap(), expected);
+            if let HostIngress::GuestAddress { fwmark } = ingress {
+                assert_eq!(fwmark, invariant::fwmark("172.20.0.2".parse().unwrap()));
+            }
+        }
     }
 
     #[test]

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -10,8 +10,10 @@
 //! | `quarantine(lease)` | `quarantine_checked(vm, alloc)` |
 //! | `release(lease)` | `release_checked(alloc)` |
 //! | `identity(lease, mode)` | the invariant identity, or the pool identity under `LegacySnapshot` |
+//! | `host_ingress(lease)` | `expose_target(tap)`, with the pool IP's fwmark |
 //! | `reconcile()` | `Some(self)` while a quarantine ledger is kept |
 //! | `NetworkReconcile::*` | the `*_quarantine` / `*_startup_cleanup` methods |
+//! | `replay_complete()` | `mark_reconciled()` |
 //!
 //! A [`NetworkLease`] carries what the port needs — VM, address, prefix,
 //! gateway, MAC, cleanup token — and the allocation is rebuilt from it:
@@ -24,13 +26,13 @@
 use std::net::IpAddr;
 
 use arcbox_vm_driver::net::{
-    AttachMode, GuestNetwork, NetworkIdentity, NetworkLease, NetworkMode, NetworkPolicy,
-    NetworkReconcile,
+    AttachMode, GuestNetwork, HostIngress, NetworkIdentity, NetworkLease, NetworkMode,
+    NetworkPolicy, NetworkReconcile,
 };
 use arcbox_vm_driver::{Error, NicAttachment, NicSpec, Result, VmId};
 use async_trait::async_trait;
 
-use crate::{NetworkAllocation, TapNetwork, invariant, tap_name_from_ip};
+use crate::{ExposeTarget, NetworkAllocation, TapNetwork, invariant, tap_name_from_ip};
 
 /// The device name every guest sees its one NIC under.
 pub const NIC_ID: &str = "eth0";
@@ -148,6 +150,20 @@ impl GuestNetwork for TapNetwork {
         Self::identity_for(lease, mode)
     }
 
+    /// What the lease's TAP actually carries: an eBPF or legacy TAP takes
+    /// DNAT to the pool address, an iptables one takes the fixed guest
+    /// address plus the pool IP's mark, which is what selects that TAP's
+    /// policy-routing table (CORE-81/CORE-83).
+    fn host_ingress(&self, lease: &NetworkLease) -> Result<HostIngress> {
+        let allocation = self.allocation(lease)?;
+        Ok(match self.expose_target(&allocation.tap_name) {
+            ExposeTarget::PoolIp => HostIngress::PoolAddress,
+            ExposeTarget::GuestIpWithFwmark => HostIngress::GuestAddress {
+                fwmark: invariant::fwmark(allocation.ip_address),
+            },
+        })
+    }
+
     fn reconcile(&self) -> Option<&dyn NetworkReconcile> {
         self.quarantine_dir.is_some().then_some(self)
     }
@@ -180,9 +196,12 @@ impl NetworkReconcile for TapNetwork {
             .collect()
     }
 
-    async fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<()> {
-        self.validate_quarantine(vm.as_str(), token)?;
-        Ok(())
+    /// The ledger's own copy of the allocation, back as the lease it was.
+    /// After a restart it is the only record of the address that
+    /// generation held, which is what the host's cleanup matches on.
+    async fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<NetworkLease> {
+        let allocation = self.validate_quarantine(vm.as_str(), token)?;
+        Ok(Self::lease(vm, &allocation))
     }
 
     async fn finalize_cleanup(&self, vm: &VmId, token: &str) -> Result<()> {
@@ -203,6 +222,10 @@ impl NetworkReconcile for TapNetwork {
 
     async fn wait_startup_cleanup_complete(&self) {
         Self::wait_startup_cleanup_complete(self).await;
+    }
+
+    fn replay_complete(&self) {
+        self.mark_reconciled();
     }
 }
 
@@ -349,6 +372,47 @@ mod tests {
         assert_eq!(legacy.mac, lease.mac);
     }
 
+    /// Host ingress follows what the lease's TAP actually carries, which
+    /// is the inverse of what the guest is told under the invariant
+    /// identity: the guest holds the fixed address while the host must
+    /// target the pool one. No mapping from identity + lease could say
+    /// that, which is why the port asks the network.
+    #[tokio::test]
+    async fn host_ingress_follows_the_tap_and_inverts_the_guest_identity() {
+        let network = network();
+        let lease = GuestNetwork::reserve(&network, &vm("box"), policy(NetworkMode::Nat))
+            .await
+            .unwrap();
+        let tap = network.allocation(&lease).unwrap().tap_name;
+        let record = |applied| {
+            network.applied.lock().unwrap().insert(tap.clone(), applied);
+        };
+
+        record(crate::AppliedDatapath::Ebpf);
+        assert_eq!(
+            network.host_ingress(&lease).unwrap(),
+            HostIngress::PoolAddress
+        );
+        // The guest, meanwhile, is told the fixed invariant address.
+        assert_eq!(
+            network.identity(&lease, AttachMode::Invariant).ip,
+            v4("169.254.100.2")
+        );
+
+        record(crate::AppliedDatapath::Iptables);
+        assert_eq!(
+            network.host_ingress(&lease).unwrap(),
+            HostIngress::GuestAddress {
+                fwmark: invariant::fwmark("172.20.0.2".parse().unwrap()),
+            }
+        );
+
+        // A lease this network could never have handed out.
+        let mut foreign = lease;
+        foreign.ip = "fd00::2".parse().unwrap();
+        assert!(network.host_ingress(&foreign).is_err());
+    }
+
     #[test]
     fn reconcile_is_offered_only_with_a_ledger() {
         assert!(network().reconcile().is_none());
@@ -426,8 +490,16 @@ mod tests {
             Arc::new(IptablesLegacy::default()),
         )
         .unwrap();
-        network.mark_reconciled();
         let reconcile = network.reconcile().unwrap();
+        // Until the owner says it has replayed, no token finalizes the
+        // sweep — what it must cover is still being discovered.
+        assert!(
+            reconcile
+                .validate_startup_cleanup(&TapNetwork::startup_cleanup_token(&network).unwrap())
+                .await
+                .is_err()
+        );
+        reconcile.replay_complete();
         let startup = reconcile.startup_cleanup_token().await.unwrap();
         reconcile.finalize_startup_cleanup(&startup).await.unwrap();
         assert!(reconcile.startup_cleanup_token().await.is_none());
@@ -454,10 +526,15 @@ mod tests {
                 .await,
             Err(Error::PreconditionFailed(_))
         ));
-        reconcile
-            .validate_cleanup(&vm("box"), &lease.cleanup_token)
-            .await
-            .unwrap();
+        // The right token hands back the lease the ledger holds — after a
+        // restart, the only surviving record of that generation's address.
+        assert_eq!(
+            reconcile
+                .validate_cleanup(&vm("box"), &lease.cleanup_token)
+                .await
+                .unwrap(),
+            lease
+        );
         reconcile
             .finalize_cleanup(&vm("box"), &lease.cleanup_token)
             .await

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -547,14 +547,24 @@ mod tests {
         .unwrap();
         let reconcile = network.reconcile().unwrap();
         // Until the owner says it has replayed, no token finalizes the
-        // sweep — what it must cover is still being discovered.
-        assert!(
+        // sweep — what it must cover is still being discovered. The class
+        // is the point: come back later, holding the very token that was
+        // just refused, rather than "fetch a current one".
+        assert!(matches!(
             reconcile
                 .validate_startup_cleanup(&TapNetwork::startup_cleanup_token(&network).unwrap())
-                .await
-                .is_err()
-        );
+                .await,
+            Err(Error::Unavailable(_))
+        ));
         reconcile.replay_complete();
+        // Once it has, a token that names no pending sweep is the other
+        // answer entirely: a failed precondition no retry can satisfy.
+        assert!(matches!(
+            reconcile
+                .validate_startup_cleanup("another-generation")
+                .await,
+            Err(Error::PreconditionFailed(_))
+        ));
         let startup = reconcile.startup_cleanup_token().await.unwrap();
         reconcile.finalize_startup_cleanup(&startup).await.unwrap();
         assert!(reconcile.startup_cleanup_token().await.is_none());

--- a/virt/arcbox-tap-net/src/lib.rs
+++ b/virt/arcbox-tap-net/src/lib.rs
@@ -513,7 +513,7 @@ impl TapNetwork {
     /// suffices for both; everything else — iptables TAPs, and TAPs whose
     /// activation record died with a previous agent process — needs the
     /// CORE-81 guest-IP + fwmark form.
-    pub fn expose_target(&self, tap_name: &str) -> ExposeTarget {
+    pub(crate) fn expose_target(&self, tap_name: &str) -> ExposeTarget {
         match self.applied.lock().unwrap().get(tap_name) {
             Some(AppliedDatapath::Ebpf | AppliedDatapath::Untranslated) => ExposeTarget::PoolIp,
             Some(AppliedDatapath::Iptables) | None => ExposeTarget::GuestIpWithFwmark,

--- a/virt/arcbox-tap-net/src/lib.rs
+++ b/virt/arcbox-tap-net/src/lib.rs
@@ -11,11 +11,12 @@
 //! D-VM6, R2). Everything that touches the kernel is Linux-only; the pool,
 //! the encoders, and the ledger compile and are unit-tested everywhere.
 //!
-//! Two surfaces, one state: [`TapNetwork`]'s inherent methods are what the
-//! sandbox manager calls today, and its [`GuestNetwork`] / [`NetworkReconcile`]
-//! impls ([`guest_network`]) are the same operations spoken in the port's
-//! vocabulary — a [`NetworkLease`] instead of a [`NetworkAllocation`], a
-//! [`NicSpec`] out of activation. R2b moves the manager onto the port.
+//! Two surfaces, one state: the [`GuestNetwork`] / [`NetworkReconcile`]
+//! impls ([`guest_network`]) are what every consumer reaches — a
+//! [`NetworkLease`] instead of a [`NetworkAllocation`], a [`NicSpec`] out
+//! of activation — and [`TapNetwork`]'s inherent methods are what they are
+//! written in. Only the constructors are called from outside now; the
+//! System VM composes this network and then speaks to it through the port.
 //!
 //! [`GuestNetwork`]: arcbox_vm_driver::net::GuestNetwork
 //! [`NetworkReconcile`]: arcbox_vm_driver::net::NetworkReconcile
@@ -91,13 +92,8 @@ pub enum Datapath {
     Iptables,
 }
 
-/// The name the sandbox manager gives [`AttachMode`] — the host-side
-/// addressing scheme applied when a TAP is materialized (see
-/// [`TapNetwork::activate`]). Kept until R2b moves the manager onto the port.
-pub type TapMode = AttachMode;
-
-/// The name this type had inside `arcbox-vm`; the sandbox manager keeps
-/// using it until R2b moves it onto the port.
+/// The name this type had inside `arcbox-vm`, kept so the System VM's
+/// composition still reads as it did.
 pub type NetworkManager = TapNetwork;
 
 /// The translation mechanism actually applied to an active TAP.
@@ -150,10 +146,10 @@ pub enum ExposeTarget {
 /// The TAP network: an IPv4 pool plus, per VM, a point-to-point TAP with
 /// its translation, and the quarantine ledger.
 ///
-/// Reached two ways — through the inherent methods below (the sandbox
-/// manager, until R2b) and through the `GuestNetwork` port
-/// ([`guest_network`]). Both share this one state, so a lease the port
-/// activated is a TAP the inherent `release_checked` tears down.
+/// Reached through the `GuestNetwork` port ([`guest_network`]), which is
+/// written in the inherent methods below. Both share this one state, so a
+/// lease the port activated is a TAP the inherent `release_checked` tears
+/// down.
 pub struct TapNetwork {
     /// Base IP from which the pool starts (host-octet 2 onwards).
     base: Ipv4Addr,

--- a/virt/arcbox-tap-net/src/lib.rs
+++ b/virt/arcbox-tap-net/src/lib.rs
@@ -100,12 +100,15 @@ pub type TapMode = AttachMode;
 /// using it until R2b moves it onto the port.
 pub type NetworkManager = TapNetwork;
 
-/// The translation mechanism actually applied to an active invariant TAP.
+/// The translation mechanism actually applied to an active TAP.
 ///
 /// Distinct from the configured [`Datapath`]: a TAP configured for
 /// eBPF lands on `Iptables` when the object cannot be loaded or this TAP's
 /// attach fails. Teardown and expose targeting must follow what was applied,
-/// not what was asked for.
+/// not what was asked for — which is why a [`AttachMode::LegacySnapshot`]
+/// TAP records [`Self::Untranslated`] rather than nothing at all: absent and
+/// "deliberately untranslated" are opposite answers for expose targeting,
+/// and only the second one is knowable from the lease.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     not(target_os = "linux"),
@@ -119,9 +122,19 @@ enum AppliedDatapath {
     Ebpf,
     /// The CORE-81 iptables/fwmark rule set.
     Iptables,
+    /// None: the guest owns the pool address itself, so nothing is
+    /// rewritten per TAP ([`AttachMode::LegacySnapshot`]).
+    Untranslated,
 }
 
 /// How host-side expose/port-forward DNAT must target a sandbox.
+///
+/// This crate answers the question through the port, as
+/// [`GuestNetwork::host_ingress`]; the type stays public because the
+/// System VM's port-forward code still names it (R3 moves that call to
+/// the composition root).
+///
+/// [`GuestNetwork::host_ingress`]: arcbox_vm_driver::net::GuestNetwork::host_ingress
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExposeTarget {
     /// DNAT straight to the pool IP, delivered by the main-table TAP route.
@@ -376,14 +389,24 @@ impl TapNetwork {
                 AttachMode::LegacySnapshot => self.gateway,
             };
             tap::create(&allocation.tap_name, local, allocation.ip_address)?;
-            if mode == AttachMode::Invariant
-                && let Err(error) = self.install_translation(allocation)
-            {
-                // Unwind the partial translation and the TAP so a failed
-                // activation leaves no half-translated interface behind.
-                let _ = self.deactivate_translation(allocation);
-                tap::destroy(&allocation.tap_name);
-                return Err(error);
+            if mode == AttachMode::Invariant {
+                if let Err(error) = self.install_translation(allocation) {
+                    // Unwind the partial translation and the TAP so a failed
+                    // activation leaves no half-translated interface behind.
+                    let _ = self.deactivate_translation(allocation);
+                    tap::destroy(&allocation.tap_name);
+                    return Err(error);
+                }
+            } else {
+                // A legacy guest owns the pool address, so this TAP carries
+                // no translation — recorded, not left absent, because
+                // `expose_target` reads an absent record as "an invariant
+                // TAP this process did not activate" and answers the
+                // opposite way.
+                self.applied
+                    .lock()
+                    .unwrap()
+                    .insert(allocation.tap_name.clone(), AppliedDatapath::Untranslated);
             }
         }
         Ok(())
@@ -485,16 +508,14 @@ impl TapNetwork {
     /// How expose DNAT must target the sandbox behind `tap_name` (CORE-83).
     ///
     /// Follows the *applied* datapath, not the configured one: an eBPF TAP's
-    /// egress program translates pool-IP packets on the TAP itself, so the
-    /// plain pool-IP form suffices; everything else — iptables TAPs, legacy
-    /// guests, and TAPs whose activation record died with a previous agent
-    /// process — needs the CORE-81 guest-IP + fwmark form.
-    pub fn expose_target(&self, tap_name: &str, net_invariant: bool) -> ExposeTarget {
-        if !net_invariant {
-            return ExposeTarget::PoolIp;
-        }
+    /// egress program translates pool-IP packets on the TAP itself and a
+    /// legacy TAP never translated anything, so the plain pool-IP form
+    /// suffices for both; everything else — iptables TAPs, and TAPs whose
+    /// activation record died with a previous agent process — needs the
+    /// CORE-81 guest-IP + fwmark form.
+    pub fn expose_target(&self, tap_name: &str) -> ExposeTarget {
         match self.applied.lock().unwrap().get(tap_name) {
-            Some(AppliedDatapath::Ebpf) => ExposeTarget::PoolIp,
+            Some(AppliedDatapath::Ebpf | AppliedDatapath::Untranslated) => ExposeTarget::PoolIp,
             Some(AppliedDatapath::Iptables) | None => ExposeTarget::GuestIpWithFwmark,
         }
     }

--- a/virt/arcbox-tap-net/src/quarantine.rs
+++ b/virt/arcbox-tap-net/src/quarantine.rs
@@ -140,9 +140,20 @@ impl TapNetwork {
 
     /// Check that `token` names the pending startup cleanup of this process
     /// generation and that reconciliation has finished.
+    ///
+    /// The two refusals are different answers and must not be folded
+    /// together. Before [`Self::mark_reconciled`] the owner is still
+    /// replaying what a previous process left, so no token — not even the
+    /// current one — can finalize a sweep whose contents are still being
+    /// discovered: retry-later, and the same token will do. Everything else
+    /// is a token that does not name this generation, which no retry fixes.
     pub fn validate_startup_cleanup(&self, token: &str) -> Result<()> {
-        if !self.startup_reconciled.load(Ordering::Acquire)
-            || !self.startup_barrier.load(Ordering::Acquire)
+        if !self.startup_reconciled.load(Ordering::Acquire) {
+            return Err(TapNetError::Unavailable(
+                "sandbox startup cleanup is awaiting the owner's durable-state replay".into(),
+            ));
+        }
+        if !self.startup_barrier.load(Ordering::Acquire)
             || self.startup_host_cleaned.load(Ordering::Acquire)
             || token != self.startup_token
         {

--- a/virt/arcbox-tap-net/src/tests.rs
+++ b/virt/arcbox-tap-net/src/tests.rs
@@ -114,14 +114,9 @@ fn test_tap_name_encodes_last_two_octets() {
 #[test]
 fn expose_target_follows_the_applied_datapath() {
     let manager = TapNetwork::new("172.20.0.0/16", "172.20.0.1", vec![]).unwrap();
-    // Legacy guests own the pool IP outright.
+    // No activation record: an invariant TAP a previous process left.
     assert_eq!(
-        manager.expose_target("vmtap0-2", false),
-        ExposeTarget::PoolIp
-    );
-    // Invariant TAP without an activation record.
-    assert_eq!(
-        manager.expose_target("vmtap0-2", true),
+        manager.expose_target("vmtap0-2"),
         ExposeTarget::GuestIpWithFwmark
     );
     let record = |applied| {
@@ -132,15 +127,17 @@ fn expose_target_follows_the_applied_datapath() {
             .insert("vmtap0-2".to_owned(), applied)
     };
     record(AppliedDatapath::Ebpf);
-    assert_eq!(
-        manager.expose_target("vmtap0-2", true),
-        ExposeTarget::PoolIp
-    );
+    assert_eq!(manager.expose_target("vmtap0-2"), ExposeTarget::PoolIp);
     record(AppliedDatapath::Iptables);
     assert_eq!(
-        manager.expose_target("vmtap0-2", true),
+        manager.expose_target("vmtap0-2"),
         ExposeTarget::GuestIpWithFwmark
     );
+    // A legacy guest owns the pool IP outright. Recorded at activation
+    // rather than left absent, which is what keeps it distinguishable
+    // from the leftover TAP above.
+    record(AppliedDatapath::Untranslated);
+    assert_eq!(manager.expose_target("vmtap0-2"), ExposeTarget::PoolIp);
 }
 
 #[tokio::test]

--- a/virt/arcbox-vm-driver/src/net.rs
+++ b/virt/arcbox-vm-driver/src/net.rs
@@ -45,11 +45,42 @@ pub trait GuestNetwork: Send + Sync {
     /// [`GuestNetwork::activate`] was given.
     fn identity(&self, lease: &NetworkLease, mode: AttachMode) -> NetworkIdentity;
 
+    /// How host-side forwarding reaches this guest: the address DNAT must
+    /// target, and any packet mark the datapath needs to see.
+    ///
+    /// Decided by the datapath that actually applied to this lease, not by
+    /// the policy that was asked for — an adapter that falls back at
+    /// activation time reports the fallback's answer here. It is therefore
+    /// not derivable from [`GuestNetwork::identity`] plus the lease: a
+    /// network that gives every guest the same address translated per
+    /// interface has the host target the *lease's* address while the guest
+    /// holds the fixed one, which is the exact inverse of what those two
+    /// values say.
+    ///
+    /// A read, like [`GuestNetwork::identity`]: what applied to a lease is
+    /// state the network already holds by the time anyone can ask.
+    fn host_ingress(&self, lease: &NetworkLease) -> Result<HostIngress>;
+
     /// The cleanup-token protocol and startup sweep, when the network keeps
     /// a quarantine ledger.
     fn reconcile(&self) -> Option<&dyn NetworkReconcile> {
         None
     }
+}
+
+/// Where host-side forwarding sends packets destined for one guest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum HostIngress {
+    /// DNAT to the lease's own (pool) address; the datapath translates
+    /// onwards.
+    PoolAddress,
+    /// DNAT to the guest's address, marking packets with `fwmark` so the
+    /// datapath's policy routing picks them up.
+    GuestAddress {
+        /// The mark the forwarding rule must set.
+        fwmark: u32,
+    },
 }
 
 /// What kind of connectivity a VM gets.
@@ -146,8 +177,14 @@ pub trait NetworkReconcile: Send + Sync {
     /// list.
     async fn pending_cleanups(&self) -> Result<Vec<(VmId, String)>>;
 
-    /// Checks that `token` names `vm`'s pending cleanup generation.
-    async fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<()>;
+    /// Checks that `token` names `vm`'s pending cleanup generation, and
+    /// hands back the lease it names.
+    ///
+    /// The lease is the answer, not an acknowledgement: the host cleanup
+    /// this gates is keyed by the address that generation held, and after
+    /// a restart the only place that address survives is the ledger the
+    /// network is reading here.
+    async fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<NetworkLease>;
 
     /// Ends `vm`'s quarantine and returns its address to the pool.
     async fn finalize_cleanup(&self, vm: &VmId, token: &str) -> Result<()>;
@@ -164,6 +201,12 @@ pub trait NetworkReconcile: Send + Sync {
 
     /// Waits until no startup cleanup is pending.
     async fn wait_startup_cleanup_complete(&self);
+
+    /// The owner has finished replaying its durable state into this ledger.
+    /// Until it has, the startup sweep cannot be finalized: a host must not
+    /// declare a previous process's forwarding state gone while the owner is
+    /// still discovering what it left behind.
+    fn replay_complete(&self);
 }
 
 #[cfg(test)]

--- a/virt/arcbox-vm-driver/src/testkit/fake_network.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_network.rs
@@ -10,7 +10,8 @@ use tokio::sync::watch;
 use super::lock;
 use crate::error::{Error, Result};
 use crate::net::{
-    AttachMode, GuestNetwork, NetworkIdentity, NetworkLease, NetworkPolicy, NetworkReconcile,
+    AttachMode, GuestNetwork, HostIngress, NetworkIdentity, NetworkLease, NetworkPolicy,
+    NetworkReconcile,
 };
 use crate::spec::{MacAddr, NicAttachment, NicSpec, VmId};
 
@@ -21,7 +22,9 @@ use crate::spec::{MacAddr, NicAttachment, NicSpec, VmId};
 /// `NicSpec` on `tapN`; `quarantine` moves a lease into a ledger that
 /// [`NetworkReconcile`] drains through the token protocol.
 /// [`FakeNetwork::with_startup_cleanup`] starts with a pending startup
-/// cleanup so that half of the protocol can be exercised too.
+/// cleanup so that half of the protocol can be exercised too — including
+/// its ordering: until [`NetworkReconcile::replay_complete`] says the
+/// owner has finished replaying, no token names a finalizable sweep.
 ///
 /// It answers that protocol in the same error *classes* a real adapter
 /// does — [`Error::Unavailable`] for come-back-later (a pending startup
@@ -50,6 +53,9 @@ struct Ledger {
 struct StartupCleanup {
     token: String,
     host_cleaned: bool,
+    /// `true` once the owner said it had replayed its durable state into
+    /// this ledger; until then no token names a finalizable sweep.
+    replayed: bool,
 }
 
 const PREFIX_LEN: u8 = 16;
@@ -70,6 +76,7 @@ impl FakeNetwork {
         Self::build(Some(StartupCleanup {
             token: token.into(),
             host_cleaned: false,
+            replayed: false,
         }))
     }
 
@@ -277,6 +284,14 @@ impl GuestNetwork for FakeNetwork {
         }
     }
 
+    /// The lease's own address: the fake translates nothing per interface,
+    /// so there is no mark to set and nothing for the host to target but
+    /// the address the guest itself holds.
+    fn host_ingress(&self, lease: &NetworkLease) -> Result<HostIngress> {
+        host_number(lease.ip)?;
+        Ok(HostIngress::PoolAddress)
+    }
+
     fn reconcile(&self) -> Option<&dyn NetworkReconcile> {
         Some(self)
     }
@@ -294,8 +309,8 @@ impl NetworkReconcile for FakeNetwork {
             .collect())
     }
 
-    async fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<()> {
-        lock(&self.ledger).validate_cleanup(vm, token)
+    async fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<NetworkLease> {
+        lock(&self.ledger).validate_cleanup(vm, token).cloned()
     }
 
     async fn finalize_cleanup(&self, vm: &VmId, token: &str) -> Result<()> {
@@ -340,13 +355,19 @@ impl NetworkReconcile for FakeNetwork {
         // A closed channel cannot happen: the sender lives in `self`.
         let _ = pending.wait_for(|pending| !pending).await;
     }
+
+    fn replay_complete(&self) {
+        if let Some(startup) = lock(&self.ledger).startup.as_mut() {
+            startup.replayed = true;
+        }
+    }
 }
 
 impl Ledger {
     /// A token that does not name a pending generation — of this VM or of
     /// none at all — is a failed precondition: no retry of that token can
     /// succeed, the caller needs a current one.
-    fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<()> {
+    fn validate_cleanup(&self, vm: &VmId, token: &str) -> Result<&NetworkLease> {
         let lease = self
             .quarantined
             .get(vm)
@@ -356,11 +377,16 @@ impl Ledger {
                 "vm {vm} cleanup token does not name the pending generation"
             )));
         }
-        Ok(())
+        Ok(lease)
     }
 
     fn validate_startup_cleanup(&self, token: &str) -> Result<()> {
         match &self.startup {
+            // The owner is still discovering what the previous process
+            // left: come back, rather than "that token is wrong".
+            Some(startup) if !startup.replayed => Err(Error::Unavailable(
+                "the network's owner has not finished replaying its durable state".into(),
+            )),
             Some(startup) if !startup.host_cleaned && startup.token == token => Ok(()),
             Some(startup) if !startup.host_cleaned => Err(Error::PreconditionFailed(
                 "startup cleanup token mismatch".into(),
@@ -421,8 +447,14 @@ mod tests {
         assert_eq!(invariant.mac, lease.mac);
         assert_eq!(invariant.dns, vec![lease.gateway]);
         // Nothing is translated per interface here, so the mode changes
-        // nothing about what the guest is told.
+        // nothing about what the guest is told — and the host reaches the
+        // guest at that same address, with no mark to set.
         assert_eq!(net.identity(&lease, AttachMode::LegacySnapshot), invariant);
+        assert_eq!(net.host_ingress(&lease).unwrap(), HostIngress::PoolAddress);
+        // A lease from another network is not one this fake can answer for.
+        let mut foreign = lease;
+        foreign.ip = "192.0.2.7".parse().unwrap();
+        assert!(net.host_ingress(&foreign).is_err());
     }
 
     #[tokio::test]
@@ -451,6 +483,16 @@ mod tests {
             reconcile.validate_cleanup(&id("a"), "wrong").await,
             Err(Error::PreconditionFailed(_))
         ));
+        // The right token hands the lease back: the address is what the
+        // host's cleanup of that generation is keyed by, and after a
+        // restart the ledger is the only place it survives.
+        assert_eq!(
+            reconcile
+                .validate_cleanup(&id("a"), &a.cleanup_token)
+                .await
+                .unwrap(),
+            a
+        );
         assert!(matches!(
             net.reserve(&id("a"), policy()).await,
             Err(Error::Unavailable(_))
@@ -533,6 +575,14 @@ mod tests {
             reconcile.startup_cleanup_token().await.as_deref(),
             Some("boot-1")
         );
+        // Nothing can be finalized while the owner is still replaying its
+        // durable state: even its own token is a come-back-later, because
+        // what the sweep must cover is not yet known.
+        assert!(matches!(
+            reconcile.validate_startup_cleanup("boot-1").await,
+            Err(Error::Unavailable(_))
+        ));
+        reconcile.replay_complete();
         // Another generation's token can never name this sweep.
         assert!(matches!(
             reconcile.validate_startup_cleanup("boot-2").await,

--- a/virt/arcbox-vm/examples/sandbox-smoke.rs
+++ b/virt/arcbox-vm/examples/sandbox-smoke.rs
@@ -113,19 +113,21 @@ async fn main() -> anyhow::Result<()> {
         .network
         .as_ref()
         .context("no network allocation on smoke-1")?;
+    let tap = tap_name_for(&net.ip_address)
+        .with_context(|| format!("IP {} is not a pool address", net.ip_address))?;
     println!(
-        "  [net.1]  tap={} ip={} gw={}",
-        net.tap_name, net.ip_address, net.gateway
+        "  [net.1]  tap={tap} ip={} gw={}",
+        net.ip_address, net.gateway
     );
     check_ip_in_cidr(&net.ip_address, &net_cidr)
         .with_context(|| format!("IP {} not in subnet {}", net.ip_address, net_cidr))?;
     println!("  [net.1]  {} is within {net_cidr} ✓", net.ip_address);
 
     // N.2 — TAP interface visible on host.
-    if tap_exists(&net.tap_name) {
-        println!("  [net.2]  TAP {} visible on host ✓", net.tap_name);
+    if tap_exists(&tap) {
+        println!("  [net.2]  TAP {tap} visible on host ✓");
     } else {
-        bail!("TAP {} not found on host after create", net.tap_name);
+        bail!("TAP {tap} not found on host after create");
     }
 
     // N.3 — Second sandbox must receive a distinct IP.
@@ -154,7 +156,7 @@ async fn main() -> anyhow::Result<()> {
             .inspect_sandbox(&id2)
             .ok()
             .and_then(|i| i.network)
-            .map(|n| n.tap_name);
+            .and_then(|n| tap_name_for(&n.ip_address));
 
         manager
             .stop_sandbox(&id2, 10)
@@ -433,6 +435,16 @@ fn check_ip_in_cidr(ip: &str, cidr: &str) -> anyhow::Result<()> {
     } else {
         bail!("{ip} is not in {cidr}")
     }
+}
+
+/// The TAP name the sandbox network gives a pool address.
+///
+/// Derived rather than reported: the host interface is a host detail the
+/// sandbox API deliberately does not expose (CORE-54), and this smoke test
+/// runs on the host that owns it.
+fn tap_name_for(ip: &str) -> Option<String> {
+    let octets = ip.parse::<std::net::Ipv4Addr>().ok()?.octets();
+    Some(format!("vmtap{}-{}", octets[2], octets[3]))
 }
 
 /// Return `true` if the named TAP interface exists on the host.

--- a/virt/arcbox-vm/src/environment.rs
+++ b/virt/arcbox-vm/src/environment.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 
 use arcbox_snapshot::snapshot_cow::{BlockTools, BusyboxBlockTools};
 use arcbox_vm_driver::VmDriver;
+use arcbox_vm_driver::net::GuestNetwork;
 
 use crate::network::{IptablesLegacy, PacketFilter};
 
@@ -27,6 +28,17 @@ pub struct SandboxEnvironment {
     /// the VMM ahead of the guest, and a driver without it is refused at
     /// construction rather than at the first boot.
     pub driver: Option<Arc<dyn VmDriver>>,
+    /// What the sandboxes' NICs attach to, behind the guest-network port
+    /// (`arcbox_vm_driver::net::GuestNetwork`). `None` — the reference —
+    /// is the Linux TAP network built from the config's `[network]`
+    /// section, its datapath, and the packet filter below, inside
+    /// `SandboxManager::with_environment`; a composer on another
+    /// dataplane supplies its own here. Whatever is supplied must offer
+    /// the `NetworkReconcile` capability: the quarantine ledger is how a
+    /// host learns which addresses a previous process still holds, and a
+    /// network without it is refused at construction rather than at the
+    /// first cleanup ticket.
+    pub network: Option<Arc<dyn GuestNetwork>>,
     /// Loop-device and block-size operations for the copy-on-write rootfs
     /// (`arcbox_snapshot::snapshot_cow::BlockTools`).
     pub block_tools: Arc<dyn BlockTools>,
@@ -38,11 +50,13 @@ pub struct SandboxEnvironment {
 
 impl Default for SandboxEnvironment {
     /// The System VM's userland: the Firecracker driver from the config,
-    /// busybox applets at [`BusyboxBlockTools::DEFAULT_PATH`],
-    /// iptables-legacy at [`IptablesLegacy::DEFAULT_PATH`].
+    /// the TAP network from the config, busybox applets at
+    /// [`BusyboxBlockTools::DEFAULT_PATH`], iptables-legacy at
+    /// [`IptablesLegacy::DEFAULT_PATH`].
     fn default() -> Self {
         Self {
             driver: None,
+            network: None,
             block_tools: Arc::new(BusyboxBlockTools::default()),
             packet_filter: Arc::new(IptablesLegacy::default()),
         }

--- a/virt/arcbox-vm/src/lib.rs
+++ b/virt/arcbox-vm/src/lib.rs
@@ -30,12 +30,17 @@
 //!
 //! - [`SandboxManager`] — top-level sandbox orchestrator
 //! - [`SandboxEnvironment`] — the environment-specific components a
-//!   composer supplies: the VM driver, block tooling, the packet filter
+//!   composer supplies: the VM driver, the guest network, block tooling,
+//!   the packet filter
 //! - [`RootfsBuilder`] — OCI/overlay2 → ext4 with `/sbin/vm-agent` injected,
 //!   and the default busybox image; the composer supplies [`RootfsPaths`]
 //! - [`SandboxInstance`] / [`SandboxState`] — per-sandbox runtime state
-//! - [`NetworkManager`] — TAP lifecycle & IP allocation (`arcbox-tap-net`'s
-//!   `TapNetwork`, re-exported through [`network`])
+//! - [`network`] — `arcbox-tap-net`, re-exported: the Linux TAP adapter
+//!   this crate builds when a composer supplies no guest network, and the
+//!   `invariant` addressing the System VM's own port-forward and init code
+//!   still names. Sandboxes reach it only through the driver port's
+//!   `GuestNetwork`; [`NetworkManager`] is that adapter's type, not a
+//!   surface the manager speaks.
 //! - [`VmmConfig`] / [`SandboxSpec`] — configuration types
 //!
 //! Snapshot lineage — the checkpoint catalog, the copy-on-write rootfs

--- a/virt/arcbox-vm/src/lib.rs
+++ b/virt/arcbox-vm/src/lib.rs
@@ -61,8 +61,11 @@ pub mod vsock;
 pub use arcbox_vm_proto::boot as boot_proto;
 
 /// The sandbox TAP network lives in `arcbox-tap-net` (vm-stack-redesign
-/// R2); this path stays so the manager and `arcbox-agent` keep resolving
-/// `crate::network::*` until R2b moves them onto the driver port.
+/// R2). Sandboxes reach it through the driver port; this path stays for
+/// the two things that are not sandbox lifecycle — building the default
+/// adapter when a composer supplies none, and the System VM's own
+/// port-forward and init code, which still name `invariant` and
+/// `ExposeTarget` until R3 moves those calls to the composition root.
 pub use arcbox_tap_net as network;
 
 // The snapshot lineage moved to the engine layer (arcbox-snapshot); these

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -397,9 +397,7 @@ impl SandboxManager {
         Ok(SandboxNetworkIdentity {
             ip: allocation.ip_address,
             cleanup_token: allocation.cleanup_token.clone(),
-            expose: self
-                .network
-                .expose_target(&allocation.tap_name, instance.net_invariant),
+            expose: self.network.expose_target(&allocation.tap_name),
         })
     }
 }

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -20,7 +20,7 @@ use arcbox_fc_driver::jail::{
 };
 use arcbox_fc_driver::{FcDriver, FcDriverConfig};
 use arcbox_vm_driver::net::{
-    GuestNetwork, HostIngress, NetworkLease, NetworkMode, NetworkPolicy, NetworkReconcile,
+    GuestNetwork, NetworkIdentity, NetworkLease, NetworkMode, NetworkPolicy, NetworkReconcile,
 };
 use arcbox_vm_driver::{
     CheckpointFormat, CheckpointImage, CheckpointKind, IsolationSpec, NicSpec, Prepare, PreparedVm,
@@ -435,7 +435,7 @@ impl SandboxManager {
         Ok(SandboxNetworkIdentity {
             ip: lease.ipv4()?,
             cleanup_token: lease.cleanup_token.clone(),
-            expose: expose_target(self.network.host_ingress(lease)?)?,
+            expose: crate::network::ExposeTarget::try_from(self.network.host_ingress(lease)?)?,
         })
     }
 }
@@ -453,54 +453,36 @@ pub(super) trait LeaseExt {
     fn ipv4(&self) -> Result<std::net::Ipv4Addr>;
     /// The gateway the guest routes through.
     fn gateway_ipv4(&self) -> Result<std::net::Ipv4Addr>;
-    /// The subnet mask `prefix_len` describes, clamped at /32 so an
-    /// out-of-range prefix cannot overflow the shift.
-    fn netmask(&self) -> std::net::Ipv4Addr;
 }
 
 impl LeaseExt for NetworkLease {
     fn ipv4(&self) -> Result<std::net::Ipv4Addr> {
-        ipv4(self.ip, self)
+        ipv4(self.ip)
     }
 
     fn gateway_ipv4(&self) -> Result<std::net::Ipv4Addr> {
-        ipv4(self.gateway, self)
-    }
-
-    fn netmask(&self) -> std::net::Ipv4Addr {
-        let prefix = self.prefix_len.min(32);
-        if prefix == 0 {
-            std::net::Ipv4Addr::UNSPECIFIED
-        } else {
-            std::net::Ipv4Addr::from(!0u32 << (32 - prefix))
-        }
+        ipv4(self.gateway)
     }
 }
 
-fn ipv4(address: std::net::IpAddr, lease: &NetworkLease) -> Result<std::net::Ipv4Addr> {
+/// One address of a lease or identity, narrowed. See [`LeaseExt`].
+pub(super) fn ipv4(address: std::net::IpAddr) -> Result<std::net::Ipv4Addr> {
     match address {
         std::net::IpAddr::V4(v4) => Ok(v4),
         std::net::IpAddr::V6(v6) => Err(VmmError::Network(format!(
-            "sandbox {} holds {v6}; this manager's sandboxes are IPv4-only",
-            lease.vm
+            "the guest network offered {v6}; this manager's sandboxes are IPv4-only"
         ))),
     }
 }
 
-/// How host-side forwarding must target a sandbox, as the guest agent's
-/// port-forward code still names it.
-///
-/// The mark travels with [`HostIngress::GuestAddress`] but is dropped
-/// here: the agent derives the same value from the pool address it is
-/// already given (`arcbox_tap_net::invariant::fwmark`). R3 moves that call
-/// to the composition root and this mapping goes with it.
-fn expose_target(ingress: HostIngress) -> Result<crate::network::ExposeTarget> {
-    match ingress {
-        HostIngress::PoolAddress => Ok(crate::network::ExposeTarget::PoolIp),
-        HostIngress::GuestAddress { .. } => Ok(crate::network::ExposeTarget::GuestIpWithFwmark),
-        other => Err(VmmError::Network(format!(
-            "guest network reports host ingress {other:?}, which has no expose target here"
-        ))),
+/// The subnet mask `prefix_len` describes, clamped at /32 so an
+/// out-of-range prefix cannot overflow the shift.
+pub(super) fn netmask(prefix_len: u8) -> std::net::Ipv4Addr {
+    let prefix = prefix_len.min(32);
+    if prefix == 0 {
+        std::net::Ipv4Addr::UNSPECIFIED
+    } else {
+        std::net::Ipv4Addr::from(!0u32 << (32 - prefix))
     }
 }
 

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -20,7 +20,8 @@ use arcbox_fc_driver::jail::{
 };
 use arcbox_fc_driver::{FcDriver, FcDriverConfig};
 use arcbox_vm_driver::net::{
-    GuestNetwork, NetworkIdentity, NetworkLease, NetworkMode, NetworkPolicy, NetworkReconcile,
+    AttachMode, GuestNetwork, NetworkIdentity, NetworkLease, NetworkMode, NetworkPolicy,
+    NetworkReconcile,
 };
 use arcbox_vm_driver::{
     CheckpointFormat, CheckpointImage, CheckpointKind, IsolationSpec, NicSpec, Prepare, PreparedVm,

--- a/virt/arcbox-vm/src/sandbox.rs
+++ b/virt/arcbox-vm/src/sandbox.rs
@@ -19,8 +19,11 @@ use arcbox_fc_driver::jail::{
     stage_snapshot_files,
 };
 use arcbox_fc_driver::{FcDriver, FcDriverConfig};
+use arcbox_vm_driver::net::{
+    GuestNetwork, HostIngress, NetworkLease, NetworkMode, NetworkPolicy, NetworkReconcile,
+};
 use arcbox_vm_driver::{
-    CheckpointFormat, CheckpointImage, CheckpointKind, IsolationSpec, Prepare, PreparedVm,
+    CheckpointFormat, CheckpointImage, CheckpointKind, IsolationSpec, NicSpec, Prepare, PreparedVm,
     VmDriver, VmHandle, VmId,
 };
 use chrono::{DateTime, Utc};
@@ -31,7 +34,7 @@ use uuid::Uuid;
 use crate::config::VmmConfig;
 use crate::environment::SandboxEnvironment;
 use crate::error::{Result, VmmError};
-use crate::network::{NetworkAllocation, NetworkManager};
+use crate::network::NetworkManager;
 use crate::snapshot::{SnapshotCatalog, SnapshotDraft};
 use crate::snapshot_cow::{CowHandle, CowManager, CowOptions};
 use crate::template_catalog::TemplateCatalog;
@@ -61,6 +64,7 @@ pub use execution::{
     ExecutionChannel, ExecutionOutput, ExecutionSnapshot, ExecutionSpec, StdinState,
 };
 pub use pause::reason as pause_reason;
+pub(crate) use types::NetworkAttachment;
 pub use types::{
     CheckpointInfo, CheckpointSummary, IdleAction, LifecycleUpdate, RestoreSandboxSpec,
     SandboxEvent, SandboxId, SandboxInfo, SandboxInstance, SandboxMountSpec, SandboxNetworkInfo,
@@ -81,7 +85,10 @@ pub struct SandboxManager {
     /// `Prepare` capability is required at construction: the boot and pool
     /// flows spawn the VMM ahead of the guest.
     driver: Arc<dyn VmDriver>,
-    network: Arc<NetworkManager>,
+    /// What every sandbox NIC attaches to, behind the guest-network port.
+    /// Its `NetworkReconcile` capability is required at construction: the
+    /// cleanup-token protocol and the startup sweep are not optional here.
+    network: Arc<dyn GuestNetwork>,
     snapshots: Arc<SnapshotCatalog>,
     /// Template catalog (CORE-107); see `templates.rs` for the manager surface.
     templates: Arc<TemplateCatalog>,
@@ -117,8 +124,11 @@ impl SandboxManager {
     /// Fails with [`VmmError::Config`] when the environment's driver lacks a
     /// capability every sandbox needs — `Prepare` (the flows spawn the VMM
     /// ahead of the guest), `Vsock` (the guest agent is reached over it) or
-    /// `VsockListen` (the readiness gate is the guest's dial-out) — so a
-    /// driver without one is refused here instead of at the first boot.
+    /// `VsockListen` (the readiness gate is the guest's dial-out) — or when
+    /// its guest network offers no `NetworkReconcile` (the cleanup-token
+    /// protocol is how a host releases the addresses a previous process
+    /// held), so an environment missing one is refused here instead of at
+    /// the first boot or the first cleanup ticket.
     pub fn with_environment(config: VmmConfig, environment: SandboxEnvironment) -> Result<Self> {
         let driver = environment.driver.unwrap_or_else(|| {
             Arc::new(FcDriver::new(FcDriverConfig::from(&config.firecracker))) as Arc<dyn VmDriver>
@@ -152,14 +162,24 @@ impl SandboxManager {
             &config.firecracker.data_dir,
         ))?);
         drop(records.load_all()?);
-        let network = Arc::new(NetworkManager::with_quarantine_dir(
-            &config.network.cidr,
-            &config.network.gateway,
-            config.network.dns.clone(),
-            Path::new(&config.firecracker.data_dir).join("sandbox-network-quarantine"),
-            config.firecracker.sandbox_datapath,
-            environment.packet_filter,
-        )?);
+        let network: Arc<dyn GuestNetwork> = match environment.network {
+            Some(network) => network,
+            None => Arc::new(NetworkManager::with_quarantine_dir(
+                &config.network.cidr,
+                &config.network.gateway,
+                config.network.dns.clone(),
+                Path::new(&config.firecracker.data_dir).join("sandbox-network-quarantine"),
+                config.firecracker.sandbox_datapath,
+                environment.packet_filter,
+            )?),
+        };
+        if network.reconcile().is_none() {
+            return Err(VmmError::Config(
+                "guest network has no reconcile capability; the quarantine ledger is how a host \
+                 releases the addresses a previous process held"
+                    .into(),
+            ));
+        }
         let snapshots = Arc::new(SnapshotCatalog::new(&config.firecracker.data_dir));
         let templates = Arc::new(TemplateCatalog::new(&config.firecracker.data_dir));
         let (events_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
@@ -200,7 +220,7 @@ impl SandboxManager {
                     let swept = reconcile::sweep_orphans(
                         &config,
                         driver.as_ref(),
-                        &network,
+                        &*network,
                         &cow_manager,
                         &snapshots,
                         &records,
@@ -212,7 +232,7 @@ impl SandboxManager {
                         Some(&swept.ids),
                     )?;
                     reconcile::finalize_sweep(swept).await?;
-                    network.mark_reconciled();
+                    reconcile_capability(&*network).replay_complete();
                     Ok::<_, VmmError>(inactive)
                 }
                 .await
@@ -237,7 +257,7 @@ impl SandboxManager {
                 Path::new(&config.firecracker.data_dir),
                 None,
             )?;
-            network.mark_reconciled();
+            reconcile_capability(&*network).replay_complete();
             instances.write().unwrap().extend(
                 inactive
                     .into_iter()
@@ -322,71 +342,89 @@ impl SandboxManager {
     /// forwarding cleanup.
     pub async fn pending_network_cleanups(&self) -> Result<Vec<(String, String)>> {
         self.await_reconcile().await?;
-        Ok(self.network.pending_quarantines())
+        Ok(self
+            .reconcile_network()
+            .pending_cleanups()
+            .await
+            .map_err(VmmError::from)?
+            .into_iter()
+            .map(|(vm, token)| (vm.as_str().to_owned(), token))
+            .collect())
     }
 
     /// Validate one exact pending host-cleanup ticket.
-    pub async fn validate_network_cleanup(
-        &self,
-        id: &str,
-        token: &str,
-    ) -> Result<NetworkAllocation> {
+    ///
+    /// Returns the lease that generation held: the host's forwarding rules
+    /// for it are keyed by its address, and after an agent restart the
+    /// quarantine ledger is the only place that address survives.
+    pub async fn validate_network_cleanup(&self, id: &str, token: &str) -> Result<NetworkLease> {
         self.await_reconcile().await?;
-        self.network
-            .validate_quarantine(id, token)
-            .map_err(VmmError::from)
+        Ok(self
+            .reconcile_network()
+            .validate_cleanup(&VmId::new(id)?, token)
+            .await?)
     }
 
     /// Recycle one exact inactive sandbox generation after forwarding cleanup.
     pub async fn finalize_network_cleanup(&self, id: &str, token: &str) -> Result<()> {
         self.await_reconcile().await?;
-        self.network
-            .finalize_quarantine(id, token)
-            .map_err(VmmError::from)
-    }
-
-    /// Reject allocation/exposure until startup cleanup replay is finalized.
-    pub fn ensure_startup_cleanup_complete(&self) -> Result<()> {
-        self.network
-            .ensure_startup_cleanup_complete()
-            .map_err(VmmError::from)
+        Ok(self
+            .reconcile_network()
+            .finalize_cleanup(&VmId::new(id)?, token)
+            .await?)
     }
 
     /// Wait until the current agent generation's startup cleanup is complete.
     pub async fn wait_startup_cleanup_complete(&self) {
-        self.network.wait_startup_cleanup_complete().await;
+        self.reconcile_network()
+            .wait_startup_cleanup_complete()
+            .await;
     }
 
     /// Opaque ticket for the host cleanup pass required after agent startup.
     pub async fn startup_cleanup_token(&self) -> Result<Option<String>> {
         self.await_reconcile().await?;
-        Ok(self.network.startup_cleanup_token())
+        Ok(self.reconcile_network().startup_cleanup_token().await)
     }
 
     /// Validate the current process-generation startup cleanup ticket.
     pub async fn validate_startup_cleanup(&self, token: &str) -> Result<()> {
         self.await_reconcile().await?;
-        self.network
+        Ok(self
+            .reconcile_network()
             .validate_startup_cleanup(token)
-            .map_err(VmmError::from)
+            .await?)
     }
 
     /// Release the startup gate once host listeners and legacy DNAT are gone.
     pub async fn finalize_startup_cleanup(&self, token: &str) -> Result<()> {
         self.await_reconcile().await?;
-        self.network
+        Ok(self
+            .reconcile_network()
             .finalize_startup_cleanup(token)
-            .map_err(VmmError::from)
+            .await?)
+    }
+
+    /// The guest network's cleanup protocol.
+    pub(super) fn reconcile_network(&self) -> &dyn NetworkReconcile {
+        reconcile_capability(&*self.network)
     }
 
     /// Return the active generation's network identity: the external pool IP
     /// (what DNS, expose, and the API report), its opaque cleanup token, and
     /// how expose DNAT must target the sandbox (CORE-81/CORE-83).
+    ///
+    /// No startup-cleanup gate here, unlike every method above. An identity
+    /// needs a live lease; a lease comes only from `reserve`, which the
+    /// guest network refuses while the same startup barrier is closed; and
+    /// both callers in the guest agent await `wait_startup_cleanup_complete`
+    /// before asking. The gate this used to take could therefore only ever
+    /// have fired for a sandbox that has no lease to report anyway, and it
+    /// has no non-blocking form on the port.
     pub fn sandbox_network_identity(&self, id: &str) -> Result<SandboxNetworkIdentity> {
-        self.ensure_startup_cleanup_complete()?;
         let instance = self.get_instance(&id.to_owned())?;
         let instance = instance.lock().unwrap();
-        let allocation = instance
+        let lease = instance
             .network
             .as_ref()
             .ok_or_else(|| VmmError::WrongState {
@@ -395,10 +433,82 @@ impl SandboxManager {
                 actual: instance.state.to_string(),
             })?;
         Ok(SandboxNetworkIdentity {
-            ip: allocation.ip_address,
-            cleanup_token: allocation.cleanup_token.clone(),
-            expose: self.network.expose_target(&allocation.tap_name),
+            ip: lease.ipv4()?,
+            cleanup_token: lease.cleanup_token.clone(),
+            expose: expose_target(self.network.host_ingress(lease)?)?,
         })
+    }
+}
+
+/// What the sandbox stack needs from a [`NetworkLease`] beyond its fields.
+///
+/// The port's lease carries an [`IpAddr`](std::net::IpAddr) because a guest
+/// network need not be IPv4 (the platform's node dataplane is IPv6-only),
+/// while everything downstream of *this* manager — the pool address it
+/// reports, the netmask a legacy guest is reconfigured with, the crash
+/// journal's on-disk shape — is v4. The narrowing happens here, once, and
+/// says so when a lease cannot answer.
+pub(super) trait LeaseExt {
+    /// The lease's address.
+    fn ipv4(&self) -> Result<std::net::Ipv4Addr>;
+    /// The gateway the guest routes through.
+    fn gateway_ipv4(&self) -> Result<std::net::Ipv4Addr>;
+    /// The subnet mask `prefix_len` describes, clamped at /32 so an
+    /// out-of-range prefix cannot overflow the shift.
+    fn netmask(&self) -> std::net::Ipv4Addr;
+}
+
+impl LeaseExt for NetworkLease {
+    fn ipv4(&self) -> Result<std::net::Ipv4Addr> {
+        ipv4(self.ip, self)
+    }
+
+    fn gateway_ipv4(&self) -> Result<std::net::Ipv4Addr> {
+        ipv4(self.gateway, self)
+    }
+
+    fn netmask(&self) -> std::net::Ipv4Addr {
+        let prefix = self.prefix_len.min(32);
+        if prefix == 0 {
+            std::net::Ipv4Addr::UNSPECIFIED
+        } else {
+            std::net::Ipv4Addr::from(!0u32 << (32 - prefix))
+        }
+    }
+}
+
+fn ipv4(address: std::net::IpAddr, lease: &NetworkLease) -> Result<std::net::Ipv4Addr> {
+    match address {
+        std::net::IpAddr::V4(v4) => Ok(v4),
+        std::net::IpAddr::V6(v6) => Err(VmmError::Network(format!(
+            "sandbox {} holds {v6}; this manager's sandboxes are IPv4-only",
+            lease.vm
+        ))),
+    }
+}
+
+/// How host-side forwarding must target a sandbox, as the guest agent's
+/// port-forward code still names it.
+///
+/// The mark travels with [`HostIngress::GuestAddress`] but is dropped
+/// here: the agent derives the same value from the pool address it is
+/// already given (`arcbox_tap_net::invariant::fwmark`). R3 moves that call
+/// to the composition root and this mapping goes with it.
+fn expose_target(ingress: HostIngress) -> Result<crate::network::ExposeTarget> {
+    match ingress {
+        HostIngress::PoolAddress => Ok(crate::network::ExposeTarget::PoolIp),
+        HostIngress::GuestAddress { .. } => Ok(crate::network::ExposeTarget::GuestIpWithFwmark),
+        other => Err(VmmError::Network(format!(
+            "guest network reports host ingress {other:?}, which has no expose target here"
+        ))),
+    }
+}
+
+/// The connectivity every sandbox gets: egress through the host's address,
+/// which is what the System VM's netfilter provides for the pool.
+pub(super) const fn sandbox_network_policy() -> NetworkPolicy {
+    NetworkPolicy {
+        mode: NetworkMode::Nat,
     }
 }
 
@@ -412,6 +522,16 @@ pub struct SandboxNetworkIdentity {
     /// How expose DNAT must target this sandbox, decided by the datapath
     /// actually applied to its TAP (CORE-81/CORE-83).
     pub expose: crate::network::ExposeTarget,
+}
+
+/// The guest network's cleanup protocol, which
+/// [`SandboxManager::with_environment`] requires — the quarantine ledger
+/// gates every address the pool hands out, and the startup sweep gates the
+/// pool itself.
+pub(super) fn reconcile_capability(network: &dyn GuestNetwork) -> &dyn NetworkReconcile {
+    network.reconcile().expect(
+        "SandboxManager::with_environment requires the guest network's reconcile capability",
+    )
 }
 
 /// The driver's `Prepare` capability, which [`SandboxManager::with_environment`]

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -1,5 +1,5 @@
 use super::record::{SandboxRecordStore, SandboxTransition};
-use super::spec::build_vm_spec;
+use super::spec::{build_vm_spec, nic_spec};
 use super::types::action;
 use super::*;
 use arcbox_snapshot::SnapshotError;
@@ -1082,8 +1082,9 @@ async fn do_boot(
     }
     .map_err(|error| failed(error.into()))?;
 
+    let nic = net_alloc.map(nic_spec).transpose().map_err(failed)?;
     let vm_spec =
-        build_vm_spec(id, spec, net_alloc, kernel_path, rootfs_path, isolation).map_err(failed)?;
+        build_vm_spec(id, spec, nic, kernel_path, rootfs_path, isolation).map_err(failed)?;
     let handle = prepared
         .boot(vm_spec)
         .await

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -1,8 +1,9 @@
 use super::record::{SandboxRecordStore, SandboxTransition};
-use super::spec::{build_vm_spec, nic_spec};
+use super::spec::build_vm_spec;
 use super::types::action;
 use super::*;
 use arcbox_snapshot::SnapshotError;
+use arcbox_vm_driver::net::GuestNetwork;
 use arcbox_vm_driver::{VmHandle, VsockListener};
 
 type BootOutput = (Arc<dyn VmHandle>, Box<dyn VsockListener>);
@@ -30,10 +31,10 @@ struct BootFailure {
 pub(super) async fn boot_sandbox(
     id: SandboxId,
     spec: SandboxSpec,
-    net_alloc: Option<NetworkAllocation>,
+    net: Option<NetworkAttachment>,
     vm_dir: PathBuf,
     instances: Arc<RwLock<HashMap<SandboxId, Arc<Mutex<SandboxInstance>>>>>,
-    network: Arc<NetworkManager>,
+    network: Arc<dyn GuestNetwork>,
     driver: Arc<dyn VmDriver>,
     config: Arc<VmmConfig>,
     events_tx: broadcast::Sender<SandboxEvent>,
@@ -46,7 +47,7 @@ pub(super) async fn boot_sandbox(
     match do_boot(
         &id,
         &spec,
-        net_alloc.as_ref(),
+        net.as_ref(),
         &vm_dir,
         driver.as_ref(),
         &config,
@@ -458,7 +459,7 @@ pub(super) async fn fail_live_sandbox(
     message: &str,
     vm_dir: &Path,
     instances: &super::InstanceMap,
-    network: &Arc<NetworkManager>,
+    network: &Arc<dyn GuestNetwork>,
     config: &Arc<VmmConfig>,
     cow_manager: &Arc<CowManager>,
     records: &SandboxRecordStore,
@@ -496,7 +497,7 @@ pub(super) async fn fail_live_sandbox_locked(
     message: &str,
     vm_dir: &Path,
     instance: &Arc<Mutex<SandboxInstance>>,
-    network: &Arc<NetworkManager>,
+    network: &Arc<dyn GuestNetwork>,
     config: &Arc<VmmConfig>,
     cow_manager: &Arc<CowManager>,
     records: &SandboxRecordStore,
@@ -811,7 +812,7 @@ async fn tear_down_orphaned_boot(
 async fn do_boot(
     id: &str,
     spec: &SandboxSpec,
-    net_alloc: Option<&NetworkAllocation>,
+    net: Option<&NetworkAttachment>,
     vm_dir: &Path,
     driver: &dyn VmDriver,
     config: &VmmConfig,
@@ -848,15 +849,16 @@ async fn do_boot(
     };
 
     let process_pid = super::journaled_pid(&*prepared);
-    let spawned_record = super::reconcile::SandboxStateRecord::new(
+    let journal_error = super::reconcile::SandboxStateRecord::new(
         id,
         process_pid,
-        net_alloc,
+        net.map(|net| &net.lease),
         None,
-        fc_cfg.jailer.is_some(),
+        config,
         None,
-    );
-    let journal_error = super::reconcile::write_state_record(vm_dir, &spawned_record).err();
+    )
+    .and_then(|record| super::reconcile::write_state_record(vm_dir, &record))
+    .err();
 
     // Once the VMM is up, make it immediately owned by the instance. Cleanup
     // still waits for the paths/CoW phase before it may abort boot.
@@ -929,11 +931,11 @@ async fn do_boot(
                     let record = super::reconcile::SandboxStateRecord::new(
                         id,
                         process_pid,
-                        net_alloc,
+                        net.map(|net| &net.lease),
                         cow_handle.as_ref(),
-                        true,
+                        config,
                         None,
-                    );
+                    )?;
                     super::reconcile::write_state_record(vm_dir, &record)?;
                     match stage_rootfs_device_for_jailer(
                         &cr,
@@ -957,11 +959,11 @@ async fn do_boot(
                             let record = super::reconcile::SandboxStateRecord::new(
                                 id,
                                 process_pid,
-                                net_alloc,
+                                net.map(|net| &net.lease),
                                 None,
-                                true,
+                                config,
                                 None,
-                            );
+                            )?;
                             super::reconcile::write_state_record(vm_dir, &record)?;
                             stage_rootfs_copy_for_jailer(&cr, &spec.rootfs, jc.uid, jc.gid).await?
                         }
@@ -994,11 +996,11 @@ async fn do_boot(
                     let record = super::reconcile::SandboxStateRecord::new(
                         id,
                         process_pid,
-                        net_alloc,
+                        net.map(|net| &net.lease),
                         cow_handle.as_ref(),
-                        false,
+                        config,
                         None,
-                    );
+                    )?;
                     super::reconcile::write_state_record(vm_dir, &record)?;
                     create_rootfs_symlink(vm_dir, &cow_handle.as_ref().unwrap().dm_device)?
                 }
@@ -1082,9 +1084,15 @@ async fn do_boot(
     }
     .map_err(|error| failed(error.into()))?;
 
-    let nic = net_alloc.map(nic_spec).transpose().map_err(failed)?;
-    let vm_spec =
-        build_vm_spec(id, spec, nic, kernel_path, rootfs_path, isolation).map_err(failed)?;
+    let vm_spec = build_vm_spec(
+        id,
+        spec,
+        net.map(|net| net.nic.clone()),
+        kernel_path,
+        rootfs_path,
+        isolation,
+    )
+    .map_err(failed)?;
     let handle = prepared
         .boot(vm_spec)
         .await

--- a/virt/arcbox-vm/src/sandbox/boot.rs
+++ b/virt/arcbox-vm/src/sandbox/boot.rs
@@ -1084,15 +1084,8 @@ async fn do_boot(
     }
     .map_err(|error| failed(error.into()))?;
 
-    let vm_spec = build_vm_spec(
-        id,
-        spec,
-        net.map(|net| net.nic.clone()),
-        kernel_path,
-        rootfs_path,
-        isolation,
-    )
-    .map_err(failed)?;
+    let vm_spec =
+        build_vm_spec(id, spec, net, kernel_path, rootfs_path, isolation).map_err(failed)?;
     let handle = prepared
         .boot(vm_spec)
         .await

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -923,10 +923,15 @@ impl SandboxManager {
             if snap_meta.net_invariant {
                 return Ok(());
             }
+            // What to tell the guest is the network's answer for the mode
+            // its interface was activated in, not the lease read raw.
+            let identity = self
+                .network
+                .identity(lease, crate::network::TapMode::LegacySnapshot);
             let cmd = crate::boot_proto::NetReconfigCommand {
-                ip: lease.ipv4()?,
-                netmask: lease.netmask(),
-                gateway: lease.gateway_ipv4()?,
+                ip: super::ipv4(identity.ip)?,
+                netmask: super::netmask(identity.prefix_len),
+                gateway: super::ipv4(identity.gateway)?,
             };
             tokio::time::timeout(
                 std::time::Duration::from_secs(10),

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -830,7 +830,7 @@ impl SandboxManager {
             let restore = super::spec::restore_spec(
                 &resource_owner,
                 &chroot,
-                net_alloc.as_ref(),
+                net_alloc.as_ref().map(super::spec::nic_spec).transpose()?,
                 IsolationSpec::try_from(jailer)?,
             )?;
             Ok(Arc::from(

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -600,9 +600,9 @@ impl SandboxManager {
                 // NAT, no guest work); legacy snapshots keep the legacy TAP
                 // shape and are re-addressed over the reconfig RPC below.
                 let mode = if snap_meta.net_invariant {
-                    crate::network::TapMode::Invariant
+                    AttachMode::Invariant
                 } else {
-                    crate::network::TapMode::LegacySnapshot
+                    AttachMode::LegacySnapshot
                 };
                 nic = Some(self.network.activate(lease, mode).await?);
             }
@@ -925,9 +925,7 @@ impl SandboxManager {
             }
             // What to tell the guest is the network's answer for the mode
             // its interface was activated in, not the lease read raw.
-            let identity = self
-                .network
-                .identity(lease, crate::network::TapMode::LegacySnapshot);
+            let identity = self.network.identity(lease, AttachMode::LegacySnapshot);
             let cmd = crate::boot_proto::NetReconfigCommand {
                 ip: super::ipv4(identity.ip)?,
                 netmask: super::netmask(identity.prefix_len),

--- a/virt/arcbox-vm/src/sandbox/checkpoint.rs
+++ b/virt/arcbox-vm/src/sandbox/checkpoint.rs
@@ -352,7 +352,7 @@ impl SandboxManager {
         reservation: IdReservation,
         error: VmmError,
         prepared: Option<Arc<dyn PreparedVm>>,
-        network: Option<NetworkAllocation>,
+        network: Option<NetworkLease>,
         cow_handle: Option<CowHandle>,
     ) -> VmmError {
         let arc = reservation.instance();
@@ -360,16 +360,17 @@ impl SandboxManager {
             let inst = arc.lock().unwrap();
             (inst.vm_dir.clone(), inst.pool_slot_id.clone())
         };
-        let state_record = super::reconcile::SandboxStateRecord::new(
+        let journal_error = super::reconcile::SandboxStateRecord::new(
             id,
             prepared.as_deref().and_then(super::journaled_pid),
             network.as_ref(),
             cow_handle.as_ref(),
-            self.config.firecracker.jailer.is_some(),
+            &self.config,
             None,
         )
-        .with_pool_slot(pool_slot_id.as_deref());
-        let journal_error = super::reconcile::write_state_record(&vm_dir, &state_record).err();
+        .map(|record| record.with_pool_slot(pool_slot_id.as_deref()))
+        .and_then(|record| super::reconcile::write_state_record(&vm_dir, &record))
+        .err();
         {
             let mut inst = arc.lock().unwrap();
             inst.state = SandboxState::Failed;
@@ -551,9 +552,16 @@ impl SandboxManager {
 
         // Reserve network metadata, journal it, then materialize the TAP. This
         // mirrors Create so an agent crash never leaves an unowned interface.
-        let net_alloc = if request.network_override {
-            match self.network.reserve(&new_id) {
-                Ok(allocation) => Some(allocation),
+        let lease = if request.network_override {
+            match self
+                .network
+                .reserve(
+                    &VmId::new(new_id.as_str())?,
+                    super::sandbox_network_policy(),
+                )
+                .await
+            {
+                Ok(lease) => Some(lease),
                 Err(error) => {
                     let abort = self.records.abort_provision(&new_id, generation)?;
                     if let Some(durability_error) = abort.durability_error {
@@ -567,22 +575,26 @@ impl SandboxManager {
         } else {
             None
         };
-        let ip_address = net_alloc
+        let ip_address = lease
             .as_ref()
-            .map(|n| n.ip_address.to_string())
+            .map(|lease| lease.ip.to_string())
             .unwrap_or_default();
-        let setup = (|| -> Result<()> {
+        // The NIC is tracked apart from the lease: the lease is owed back
+        // to the pool from `reserve` on, so the rollback below must see one
+        // whose TAP a failed journal write meant was never built.
+        let mut nic: Option<NicSpec> = None;
+        let setup = async {
             super::reconcile::create_runtime_dir(&vm_dir)?;
             let cleanup_record = super::reconcile::SandboxStateRecord::new(
                 &new_id,
                 None,
-                net_alloc.as_ref(),
+                lease.as_ref(),
                 None,
-                self.config.firecracker.jailer.is_some(),
+                &self.config,
                 None,
-            );
+            )?;
             super::reconcile::write_state_record(&vm_dir, &cleanup_record)?;
-            if let Some(network) = &net_alloc {
+            if let Some(lease) = &lease {
                 // The restored guest keeps the addressing its snapshot baked:
                 // invariant snapshots pair with an invariant TAP (host-side
                 // NAT, no guest work); legacy snapshots keep the legacy TAP
@@ -592,13 +604,14 @@ impl SandboxManager {
                 } else {
                     crate::network::TapMode::LegacySnapshot
                 };
-                self.network.activate(network, mode)?;
+                nic = Some(self.network.activate(lease, mode).await?);
             }
-            Ok(())
-        })();
+            Ok::<_, VmmError>(())
+        }
+        .await;
         if let Err(error) = setup {
             return Err(self
-                .rollback_restore(&new_id, reservation, error, None, net_alloc, None)
+                .rollback_restore(&new_id, reservation, error, None, lease, None)
                 .await);
         }
         let fc_cfg = &self.config.firecracker;
@@ -627,16 +640,16 @@ impl SandboxManager {
                 // and crash reconciliation key the chroot and dm/CoW teardown
                 // on it (see release_runtime_resources / sweep_orphans).
                 reservation.instance().lock().unwrap().pool_slot_id = Some(slot.slot_id.clone());
-                let adopted_record = super::reconcile::SandboxStateRecord::new(
+                let handover = super::reconcile::SandboxStateRecord::new(
                     &new_id,
                     super::journaled_pid(&*slot.prepared),
-                    net_alloc.as_ref(),
+                    lease.as_ref(),
                     slot.cow_handle.as_ref(),
-                    true,
+                    &self.config,
                     None,
                 )
-                .with_pool_slot(Some(&slot.slot_id));
-                let handover = super::reconcile::write_state_record(&vm_dir, &adopted_record);
+                .map(|record| record.with_pool_slot(Some(&slot.slot_id)))
+                .and_then(|record| super::reconcile::write_state_record(&vm_dir, &record));
                 let PreparedSlot {
                     slot_id,
                     prepared: slot_prepared,
@@ -683,7 +696,7 @@ impl SandboxManager {
                                 reservation,
                                 error,
                                 Some(slot_prepared),
-                                net_alloc,
+                                lease.clone(),
                                 pending_cow,
                             )
                             .await);
@@ -713,24 +726,29 @@ impl SandboxManager {
                     Ok(spawned) => spawned,
                     Err(error) => {
                         return Err(self
-                            .rollback_restore(&new_id, reservation, error, None, net_alloc, None)
+                            .rollback_restore(
+                                &new_id,
+                                reservation,
+                                error,
+                                None,
+                                lease.clone(),
+                                None,
+                            )
                             .await);
                     }
                 };
 
                 let pid = super::journaled_pid(&*spawned_prepared);
                 let journal = |cow: Option<&CowHandle>| {
-                    super::reconcile::write_state_record(
-                        &vm_dir,
-                        &super::reconcile::SandboxStateRecord::new(
-                            &new_id,
-                            pid,
-                            net_alloc.as_ref(),
-                            cow,
-                            true,
-                            None,
-                        ),
+                    super::reconcile::SandboxStateRecord::new(
+                        &new_id,
+                        pid,
+                        lease.as_ref(),
+                        cow,
+                        &self.config,
+                        None,
                     )
+                    .and_then(|record| super::reconcile::write_state_record(&vm_dir, &record))
                 };
                 if let Err(error) = journal(None) {
                     return Err(self
@@ -739,7 +757,7 @@ impl SandboxManager {
                             reservation,
                             error,
                             Some(Arc::clone(&spawned_prepared)),
-                            net_alloc,
+                            lease.clone(),
                             None,
                         )
                         .await);
@@ -808,7 +826,7 @@ impl SandboxManager {
                                 reservation,
                                 error,
                                 Some(Arc::clone(&spawned_prepared)),
-                                net_alloc,
+                                lease.clone(),
                                 pending_cow,
                             )
                             .await);
@@ -830,7 +848,7 @@ impl SandboxManager {
             let restore = super::spec::restore_spec(
                 &resource_owner,
                 &chroot,
-                net_alloc.as_ref().map(super::spec::nic_spec).transpose()?,
+                nic.clone(),
                 IsolationSpec::try_from(jailer)?,
             )?;
             Ok(Arc::from(
@@ -847,7 +865,7 @@ impl SandboxManager {
                         reservation,
                         error,
                         Some(prepared),
-                        net_alloc,
+                        lease.clone(),
                         pending_cow,
                     )
                     .await);
@@ -894,7 +912,7 @@ impl SandboxManager {
         // silent breakage `network_override` exists to prevent — fail the
         // restore rather than hand back a half-networked sandbox.
         let net_reconfig = async {
-            let Some(ref net) = net_alloc else {
+            let Some(lease) = &lease else {
                 return Ok(());
             };
             // Invariant-addressed snapshot: the guest already holds the fixed
@@ -906,9 +924,9 @@ impl SandboxManager {
                 return Ok(());
             }
             let cmd = crate::boot_proto::NetReconfigCommand {
-                ip: net.ip_address,
-                netmask: net.netmask(),
-                gateway: net.gateway,
+                ip: lease.ipv4()?,
+                netmask: lease.netmask(),
+                gateway: lease.gateway_ipv4()?,
             };
             tokio::time::timeout(
                 std::time::Duration::from_secs(10),
@@ -929,7 +947,7 @@ impl SandboxManager {
                     reservation,
                     error,
                     Some(Arc::clone(&prepared)),
-                    net_alloc,
+                    lease.clone(),
                     pending_cow,
                 )
                 .await);
@@ -940,23 +958,24 @@ impl SandboxManager {
         // Persist cleanup metadata before handing runtime resources to the
         // instance. A failed durable write aborts and unwinds every resource.
         let adopted_slot = reservation.instance().lock().unwrap().pool_slot_id.clone();
-        let state_record = super::reconcile::SandboxStateRecord::new(
+        let journaled = super::reconcile::SandboxStateRecord::new(
             &new_id,
             super::journaled_pid(&*prepared),
-            net_alloc.as_ref(),
+            lease.as_ref(),
             pending_cow.as_ref(),
-            true,
+            &self.config,
             None,
         )
-        .with_pool_slot(adopted_slot.as_deref());
-        if let Err(error) = super::reconcile::write_state_record(&vm_dir, &state_record) {
+        .map(|record| record.with_pool_slot(adopted_slot.as_deref()))
+        .and_then(|record| super::reconcile::write_state_record(&vm_dir, &record));
+        if let Err(error) = journaled {
             return Err(self
                 .rollback_restore(
                     &new_id,
                     reservation,
                     error,
                     Some(Arc::clone(&prepared)),
-                    net_alloc,
+                    lease.clone(),
                     pending_cow,
                 )
                 .await);
@@ -978,7 +997,7 @@ impl SandboxManager {
                         reservation,
                         error,
                         Some(Arc::clone(&prepared)),
-                        net_alloc,
+                        lease.clone(),
                         pending_cow,
                     )
                     .await);
@@ -994,7 +1013,7 @@ impl SandboxManager {
         let arc = reservation.instance();
         {
             let mut inst = arc.lock().unwrap();
-            inst.network.clone_from(&net_alloc);
+            inst.network.clone_from(&lease);
             inst.prepared = Some(prepared);
             inst.handle = Some(handle);
             inst.cow_handle = pending_cow.take();
@@ -1189,8 +1208,8 @@ impl SandboxManager {
 #[cfg(test)]
 mod tests {
     use super::super::testing::{
-        FrozenOnCheckpoint, RELEASES_NETWORK, assert_failed_and_released, expect_err, fake_manager,
-        live_sandbox, live_sandbox_with,
+        FrozenOnCheckpoint, assert_failed_and_released, expect_err, fake_manager, live_sandbox,
+        live_sandbox_with,
     };
     use super::super::types::action;
     use super::*;
@@ -1216,7 +1235,10 @@ mod tests {
         assert_eq!(inst.state, SandboxState::Ready);
         assert!(inst.prepared.is_some() && inst.handle.is_some());
         assert!(inst.cow_handle.is_some());
-        assert_eq!(inst.network.is_some(), RELEASES_NETWORK);
+        assert!(
+            inst.network.is_some(),
+            "the lease survives a failed capture"
+        );
         assert_eq!(handle.state(), arcbox_vm_driver::VmState::Running);
         assert_eq!(probe.teardown_count(), 0);
     }
@@ -1244,7 +1266,7 @@ mod tests {
             "the driver's error is the reported one: {error}"
         );
 
-        assert_failed_and_released(&manager, &instance, &probe, "frozen");
+        assert_failed_and_released(&manager, &instance, &probe, "frozen").await;
         assert!(
             matches!(handle.state(), arcbox_vm_driver::VmState::Exited(_)),
             "the frozen guest is killed: {}",

--- a/virt/arcbox-vm/src/sandbox/cleanup.rs
+++ b/virt/arcbox-vm/src/sandbox/cleanup.rs
@@ -1,6 +1,7 @@
 use super::record::{SandboxRecordStore, SandboxTransition};
 use super::types::{SandboxBootTask, action};
 use super::*;
+use arcbox_vm_driver::net::GuestNetwork;
 
 #[cfg(not(test))]
 const BOOT_RESOURCE_HANDOFF_TIMEOUT: Duration = Duration::from_secs(10);
@@ -25,7 +26,7 @@ pub(super) async fn remove_sandbox_impl(
     force: bool,
     expected: &Arc<Mutex<SandboxInstance>>,
     instances: &Arc<RwLock<HashMap<SandboxId, Arc<Mutex<SandboxInstance>>>>>,
-    network: &Arc<NetworkManager>,
+    network: &Arc<dyn GuestNetwork>,
     events_tx: &broadcast::Sender<SandboxEvent>,
     config: &Arc<VmmConfig>,
     cow_manager: &Arc<CowManager>,
@@ -209,7 +210,7 @@ pub(super) async fn expire_sandbox(
     generation: Option<Uuid>,
     armed_for: &std::sync::Weak<Mutex<SandboxInstance>>,
     instances: &Arc<RwLock<HashMap<SandboxId, Arc<Mutex<SandboxInstance>>>>>,
-    network: &Arc<NetworkManager>,
+    network: &Arc<dyn GuestNetwork>,
     events_tx: &broadcast::Sender<SandboxEvent>,
     config: &Arc<VmmConfig>,
     cow_manager: &Arc<CowManager>,
@@ -273,7 +274,7 @@ pub(super) async fn expire_sandbox(
 pub(super) async fn release_runtime_resources(
     id: &str,
     arc: &Arc<Mutex<SandboxInstance>>,
-    network: &Arc<NetworkManager>,
+    network: &Arc<dyn GuestNetwork>,
     config: &Arc<VmmConfig>,
     cow_manager: &Arc<CowManager>,
 ) -> Result<()> {
@@ -294,13 +295,12 @@ pub(super) async fn release_runtime_resources(
 
     // Release network resources (destroys TAP via ioctl).
     {
-        let mut inst = arc.lock().unwrap();
-        if let Some(net) = inst.network.take() {
-            drop(inst);
-            if let Err(error) = network.quarantine_checked(id, &net) {
-                arc.lock().unwrap().network = Some(net);
-                return Err(error.into());
-            }
+        let lease = arc.lock().unwrap().network.take();
+        if let Some(lease) = lease
+            && let Err(error) = network.quarantine(lease.clone()).await
+        {
+            arc.lock().unwrap().network = Some(lease);
+            return Err(error.into());
         }
     }
 
@@ -383,10 +383,9 @@ pub(super) fn inst_to_info(inst: &SandboxInstance) -> SandboxInfo {
         labels: inst.labels.clone(),
         vcpus: inst.spec.vcpus,
         memory_mib: inst.spec.memory_mib,
-        network: inst.network.as_ref().map(|n| SandboxNetworkInfo {
-            ip_address: n.ip_address.to_string(),
-            gateway: n.gateway.to_string(),
-            tap_name: n.tap_name.clone(),
+        network: inst.network.as_ref().map(|lease| SandboxNetworkInfo {
+            ip_address: lease.ip.to_string(),
+            gateway: lease.gateway.to_string(),
         }),
         created_at: inst.created_at,
         ready_at: inst.ready_at,
@@ -407,6 +406,7 @@ mod tests {
     use super::*;
     use crate::sandbox::record::{PersistPhase, ProvisionIntent, SandboxProvisionOutcome};
     use crate::snapshot_cow::{CowOptions, CowTestProbe};
+    use arcbox_vm_driver::testkit::FakeNetwork;
     use std::os::unix::fs::PermissionsExt;
 
     fn instance(id: &str) -> Arc<Mutex<SandboxInstance>> {
@@ -489,14 +489,7 @@ mod tests {
             let mut config = VmmConfig::default();
             config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
             let config = Arc::new(config);
-            let network = Arc::new(
-                NetworkManager::new(
-                    &config.network.cidr,
-                    &config.network.gateway,
-                    config.network.dns.clone(),
-                )
-                .unwrap(),
-            );
+            let network: Arc<dyn GuestNetwork> = Arc::new(FakeNetwork::new());
             let cow_manager =
                 Arc::new(CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap());
             let snapshots = Arc::new(crate::snapshot::SnapshotCatalog::new(
@@ -627,14 +620,7 @@ mod tests {
         let mut config = VmmConfig::default();
         config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
         let config = Arc::new(config);
-        let network = Arc::new(
-            NetworkManager::new(
-                &config.network.cidr,
-                &config.network.gateway,
-                config.network.dns.clone(),
-            )
-            .unwrap(),
-        );
+        let network: Arc<dyn GuestNetwork> = Arc::new(FakeNetwork::new());
         let cow_manager =
             Arc::new(CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap());
         let snapshots = Arc::new(crate::snapshot::SnapshotCatalog::new(
@@ -824,14 +810,7 @@ mod tests {
         let arc = instance("job");
         arc.lock().unwrap().pool_slot_id = Some("pool-slot".into());
         let config = Arc::new(config);
-        let network = Arc::new(
-            NetworkManager::new(
-                &config.network.cidr,
-                &config.network.gateway,
-                config.network.dns.clone(),
-            )
-            .unwrap(),
-        );
+        let network: Arc<dyn GuestNetwork> = Arc::new(FakeNetwork::new());
         let cow_manager =
             Arc::new(CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap());
 
@@ -873,14 +852,7 @@ mod tests {
         let mut config = VmmConfig::default();
         config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
         let config = Arc::new(config);
-        let network = Arc::new(
-            NetworkManager::new(
-                &config.network.cidr,
-                &config.network.gateway,
-                config.network.dns.clone(),
-            )
-            .unwrap(),
-        );
+        let network: Arc<dyn GuestNetwork> = Arc::new(FakeNetwork::new());
         let cow_manager =
             Arc::new(CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap());
         let records = Arc::new(SandboxRecordStore::new(data_dir.path()).unwrap());

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -435,9 +435,18 @@ impl SandboxManager {
         // Populate the reserved instance.
         let mut creating_instance = arc.lock().unwrap();
         creating_instance.network.clone_from(&lease);
-        let attachment = lease
-            .zip(nic)
-            .map(|(lease, nic)| NetworkAttachment { lease, nic });
+        // What the guest is told over its NIC is the network's answer for
+        // the mode it was activated in, not a constant of any one adapter.
+        let attachment = lease.zip(nic).map(|(lease, nic)| {
+            let identity = self
+                .network
+                .identity(&lease, crate::network::TapMode::Invariant);
+            NetworkAttachment {
+                lease,
+                nic,
+                identity,
+            }
+        });
         // The boot bakes the invariant `ip=` identity unless the caller
         // supplied an explicit ip= (see do_boot); record which one this guest
         // runs so checkpoints carry the right restore contract.

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -353,11 +353,7 @@ impl SandboxManager {
             )?;
             super::reconcile::write_state_record(&vm_dir, &cleanup_record)?;
             if let Some(lease) = &lease {
-                nic = Some(
-                    self.network
-                        .activate(lease, crate::network::TapMode::Invariant)
-                        .await?,
-                );
+                nic = Some(self.network.activate(lease, AttachMode::Invariant).await?);
             }
 
             let outcome = SandboxProvisionOutcome {
@@ -438,9 +434,7 @@ impl SandboxManager {
         // What the guest is told over its NIC is the network's answer for
         // the mode it was activated in, not a constant of any one adapter.
         let attachment = lease.zip(nic).map(|(lease, nic)| {
-            let identity = self
-                .network
-                .identity(&lease, crate::network::TapMode::Invariant);
+            let identity = self.network.identity(&lease, AttachMode::Invariant);
             NetworkAttachment {
                 lease,
                 nic,

--- a/virt/arcbox-vm/src/sandbox/lifecycle.rs
+++ b/virt/arcbox-vm/src/sandbox/lifecycle.rs
@@ -52,7 +52,18 @@ impl SandboxManager {
     /// proceeds anyway and `reserve` surfaces the honest UNAVAILABLE.
     async fn await_network_release(&self, id: &SandboxId) {
         let deadline = std::time::Instant::now() + Duration::from_secs(10);
-        while self.network.quarantine_pending(id) {
+        loop {
+            match self.reconcile_network().pending_cleanups().await {
+                Ok(pending) if !pending.iter().any(|(vm, _)| vm.as_str() == id) => return,
+                Ok(_) => {}
+                Err(error) => {
+                    // The ledger is what the wait is about, so an unreadable
+                    // one is not something to spin on: fall through and let
+                    // `reserve` report it.
+                    warn!(sandbox_id = %id, %error, "network cleanup ledger is unreadable");
+                    return;
+                }
+            }
             if std::time::Instant::now() > deadline {
                 warn!(
                     sandbox_id = %id,
@@ -293,40 +304,60 @@ impl SandboxManager {
         let ttl_deadline = record.ttl_deadline;
         let spec = record.effective_spec;
         let arc = reservation.instance();
-        let mut creating_instance = arc.lock().unwrap();
-        creating_instance.record_generation = Some(generation);
-        creating_instance.labels.clone_from(&spec.labels);
-        creating_instance.spec.clone_from(&spec);
-        // Computed by the durable record so a same-key create retry keeps
-        // the original cap instead of re-deriving it from a later "now".
-        creating_instance.ttl_deadline = ttl_deadline;
+        let cleanup_lock = {
+            let mut creating_instance = arc.lock().unwrap();
+            creating_instance.record_generation = Some(generation);
+            creating_instance.labels.clone_from(&spec.labels);
+            creating_instance.spec.clone_from(&spec);
+            // Computed by the durable record so a same-key create retry keeps
+            // the original cap instead of re-deriving it from a later "now".
+            creating_instance.ttl_deadline = ttl_deadline;
+            creating_instance.cleanup_lock.clone()
+        };
+        // Reserving and activating the network are awaits, and the std
+        // `MutexGuard` on the instance cannot be held across one. The
+        // instance's cleanup lock is what closes the window instead: every
+        // teardown path for this generation takes it, so nothing can tear
+        // down what this create is still building while the guard is down.
+        let _creating = cleanup_lock.lock().await;
 
         // Reserve the IP without touching the host, durably journal it, then
         // materialize the TAP. No external resource exists before its cleanup
         // metadata does.
-        let mut net_alloc = None;
-        let setup = (|| -> Result<(String, Option<String>)> {
+        // Tracked apart from the NIC on purpose: the lease exists from
+        // `reserve` on, and the rollback below must hand back one whose TAP
+        // was never built — a journal write between the two can fail.
+        let mut lease: Option<NetworkLease> = None;
+        let mut nic: Option<NicSpec> = None;
+        let setup = async {
             if spec.network.mode != "none" {
-                net_alloc = Some(self.network.reserve(&id)?);
+                lease = Some(
+                    self.network
+                        .reserve(&VmId::new(&id)?, super::sandbox_network_policy())
+                        .await?,
+                );
             }
-            let ip_address = net_alloc
+            let ip_address = lease
                 .as_ref()
-                .map(|net| net.ip_address.to_string())
+                .map(|lease| lease.ip.to_string())
                 .unwrap_or_default();
 
             super::reconcile::create_runtime_dir(&vm_dir)?;
             let cleanup_record = super::reconcile::SandboxStateRecord::new(
                 &id,
                 None,
-                net_alloc.as_ref(),
+                lease.as_ref(),
                 None,
-                self.config.firecracker.jailer.is_some(),
+                &self.config,
                 None,
-            );
+            )?;
             super::reconcile::write_state_record(&vm_dir, &cleanup_record)?;
-            if let Some(net) = &net_alloc {
-                self.network
-                    .activate(net, crate::network::TapMode::Invariant)?;
+            if let Some(lease) = &lease {
+                nic = Some(
+                    self.network
+                        .activate(lease, crate::network::TapMode::Invariant)
+                        .await?,
+                );
             }
 
             let outcome = SandboxProvisionOutcome {
@@ -335,8 +366,9 @@ impl SandboxManager {
             let commit =
                 self.records
                     .transition(&id, generation, SandboxTransition::Starting(outcome))?;
-            Ok((ip_address, commit.durability_error))
-        })();
+            Ok::<_, VmmError>((ip_address, commit.durability_error))
+        }
+        .await;
 
         let (ip_address, starting_durability_error) = match setup {
             Ok(result) => result,
@@ -348,8 +380,8 @@ impl SandboxManager {
                 warn!(sandbox_id = %id, error = %error, "sandbox create setup failed; rolling back");
                 let mut rollback_errors = Vec::new();
                 let mut network_cleanup_failed = false;
-                if let Some(net) = &net_alloc
-                    && let Err(release_error) = self.network.release_checked(net)
+                if let Some(reserved) = lease.clone()
+                    && let Err(release_error) = self.network.release(reserved).await
                 {
                     network_cleanup_failed = true;
                     rollback_errors.push(format!("network: {release_error}"));
@@ -361,7 +393,8 @@ impl SandboxManager {
                     rollback_errors.push(format!("directory {}: {remove_error}", vm_dir.display()));
                 }
                 if !rollback_errors.is_empty() {
-                    creating_instance.network.clone_from(&net_alloc);
+                    let mut creating_instance = arc.lock().unwrap();
+                    creating_instance.network = lease;
                     creating_instance.state = SandboxState::Failed;
                     creating_instance.error = Some(error.to_string());
                     let record_error = self
@@ -400,7 +433,11 @@ impl SandboxManager {
         };
 
         // Populate the reserved instance.
-        creating_instance.network.clone_from(&net_alloc);
+        let mut creating_instance = arc.lock().unwrap();
+        creating_instance.network.clone_from(&lease);
+        let attachment = lease
+            .zip(nic)
+            .map(|(lease, nic)| NetworkAttachment { lease, nic });
         // The boot bakes the invariant `ip=` identity unless the caller
         // supplied an explicit ip= (see do_boot); record which one this guest
         // runs so checkpoints carry the right restore contract.
@@ -418,13 +455,12 @@ impl SandboxManager {
             let cow_manager = Arc::clone(&self.cow_manager);
             let records = Arc::clone(&self.records);
             let id_clone = id.clone();
-            let net_alloc_clone = net_alloc;
             let (resource_handoff_tx, resource_handoff) = tokio::sync::oneshot::channel();
             let handle = tokio::spawn(async move {
                 boot_sandbox(
                     id_clone,
                     spec,
-                    net_alloc_clone,
+                    attachment,
                     vm_dir,
                     instances,
                     network,
@@ -731,7 +767,7 @@ impl SandboxManager {
                     ip_address: inst
                         .network
                         .as_ref()
-                        .map(|n| n.ip_address.to_string())
+                        .map(|lease| lease.ip.to_string())
                         .unwrap_or_default(),
                     created_at: inst.created_at,
                     paused_at: inst.paused_at,
@@ -848,4 +884,52 @@ fn snapshot_files(info: &crate::snapshot::SnapshotInfo) -> Vec<PathBuf> {
     std::iter::once(info.vmstate_path.clone())
         .chain(info.mem_path.clone())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::testing::fake_manager_direct;
+    use super::*;
+
+    /// A create that fails between reserving an address and building its
+    /// TAP must hand the address back.
+    ///
+    /// That window is real — the durable journal is written inside it, on
+    /// purpose, so no host resource exists before its cleanup metadata —
+    /// and a rollback that only knew about *activated* leases would strand
+    /// the address in the pool for the life of the process. Driven here by
+    /// planting a directory where the journal's file goes.
+    #[tokio::test]
+    async fn a_create_that_fails_before_activation_hands_the_address_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let (manager, _driver, _probe) = fake_manager_direct(dir.path()).await;
+        let vm_dir = dir.path().join("sandboxes").join("doomed");
+        std::fs::create_dir_all(vm_dir.join("state.json")).unwrap();
+
+        let spec = SandboxSpec {
+            id: Some("doomed".into()),
+            ..SandboxSpec::default()
+        };
+        super::super::testing::expect_err(manager.create_sandbox(spec).await, "the create");
+
+        // Nothing is quarantined — the lease never reached a TAP — and the
+        // address is back in the pool for the next sandbox.
+        assert!(
+            manager
+                .reconcile_network()
+                .pending_cleanups()
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        let reused = manager
+            .network
+            .reserve(
+                &VmId::new("next").unwrap(),
+                super::super::sandbox_network_policy(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(reused.ip, "10.200.0.2".parse::<std::net::IpAddr>().unwrap());
+    }
 }

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -78,7 +78,7 @@ pub(super) fn delete_pause_snapshots(
 struct ResumedRuntime {
     prepared: Arc<dyn PreparedVm>,
     handle: Arc<dyn VmHandle>,
-    network: Option<NetworkAllocation>,
+    network: Option<NetworkLease>,
     cow_handle: Option<CowHandle>,
     ip_address: String,
 }
@@ -308,7 +308,7 @@ impl SandboxManager {
                     return Ok(inst
                         .network
                         .as_ref()
-                        .map(|n| n.ip_address.to_string())
+                        .map(|lease| lease.ip.to_string())
                         .unwrap_or_default());
                 }
                 SandboxState::Paused => {}
@@ -545,13 +545,12 @@ impl SandboxManager {
         }
 
         {
-            let mut inst = arc.lock().unwrap();
-            if let Some(net) = inst.network.take() {
-                drop(inst);
-                if let Err(error) = self.network.quarantine_checked(id, &net) {
-                    arc.lock().unwrap().network = Some(net);
-                    return Err(error.into());
-                }
+            let lease = arc.lock().unwrap().network.take();
+            if let Some(lease) = lease
+                && let Err(error) = self.network.quarantine(lease.clone()).await
+            {
+                arc.lock().unwrap().network = Some(lease);
+                return Err(error.into());
             }
         }
 
@@ -581,8 +580,12 @@ impl SandboxManager {
         let uid = jailer.uid;
         let gid = jailer.gid;
 
-        // Incrementally-owned resources for the unwind.
-        let mut net_alloc: Option<NetworkAllocation> = None;
+        // Incrementally-owned resources for the unwind. The lease is held
+        // apart from the NIC because it is owed to the pool from `reserve`
+        // on, and the journal write between the two can fail — an unwind
+        // that only knew about activated leases would strand that address.
+        let mut lease: Option<NetworkLease> = None;
+        let mut nic: Option<NicSpec> = None;
         let mut prepared: Option<Arc<dyn PreparedVm>> = None;
         let mut cow_handle: Option<CowHandle> = None;
 
@@ -591,20 +594,22 @@ impl SandboxManager {
             // TAP — the same order boot and restore use, so a crash never
             // leaves an unowned interface.
             if networked {
-                net_alloc = Some(self.network.reserve(id)?);
+                lease = Some(
+                    self.network
+                        .reserve(&VmId::new(id.as_str())?, super::sandbox_network_policy())
+                        .await?,
+                );
             }
-            let ip_address = net_alloc
+            let ip_address = lease
                 .as_ref()
-                .map(|n| n.ip_address.to_string())
+                .map(|lease| lease.ip.to_string())
                 .unwrap_or_default();
-            let journal =
-                |pid: Option<i32>, cow: Option<&CowHandle>, net: Option<&NetworkAllocation>| {
-                    let record =
-                        super::reconcile::SandboxStateRecord::new(id, pid, net, cow, true, None);
-                    super::reconcile::write_state_record(vm_dir, &record)
-                };
-            journal(None, None, net_alloc.as_ref())?;
-            if let Some(net) = &net_alloc {
+            let journal = |pid: Option<i32>, cow: Option<&CowHandle>, net: Option<&NetworkLease>| {
+                super::reconcile::SandboxStateRecord::new(id, pid, net, cow, &self.config, None)
+                    .and_then(|record| super::reconcile::write_state_record(vm_dir, &record))
+            };
+            journal(None, None, lease.as_ref())?;
+            if let Some(lease) = &lease {
                 // The resumed guest keeps the addressing its pause checkpoint
                 // baked, exactly as Restore does: an invariant guest pairs
                 // with an invariant TAP (host-side NAT, no guest work), a
@@ -615,7 +620,7 @@ impl SandboxManager {
                 } else {
                     crate::network::TapMode::LegacySnapshot
                 };
-                self.network.activate(net, mode)?;
+                nic = Some(self.network.activate(lease, mode).await?);
             }
 
             // Fresh chroot + VMM process, prepared through the driver.
@@ -626,7 +631,7 @@ impl SandboxManager {
             );
             let pid = super::journaled_pid(&*spawned);
             prepared = Some(spawned);
-            journal(pid, None, net_alloc.as_ref())?;
+            journal(pid, None, lease.as_ref())?;
 
             // Stage kernel + the retained disk + snapshot files.
             if let Some(kernel) = snap_meta.kernel_path.as_deref() {
@@ -640,7 +645,7 @@ impl SandboxManager {
                     ))
                 })?;
                 let handle = self.cow_manager.reattach(id, rootfs).await?;
-                journal(pid, Some(&handle), net_alloc.as_ref())?;
+                journal(pid, Some(&handle), lease.as_ref())?;
                 stage_rootfs_device_for_jailer(&cr, &handle.dm_device, uid, gid).await?;
                 cow_handle = Some(handle);
             } else {
@@ -687,7 +692,7 @@ impl SandboxManager {
             let restore = restore_spec(
                 id,
                 &cr,
-                net_alloc.as_ref().map(super::spec::nic_spec).transpose()?,
+                nic.clone(),
                 IsolationSpec::try_from(jailer)?,
             )?;
             let handle: Arc<dyn VmHandle> = Arc::from(
@@ -731,13 +736,13 @@ impl SandboxManager {
             // identity and its resolv.conf already points at the fixed
             // gateway; the fresh TAP carries the new pool IP host-side, so
             // resume awaits nothing here.
-            if let Some(ref net) = net_alloc
+            if let Some(lease) = &lease
                 && !snap_meta.net_invariant
             {
                 let cmd = crate::boot_proto::NetReconfigCommand {
-                    ip: net.ip_address,
-                    netmask: net.netmask(),
-                    gateway: net.gateway,
+                    ip: lease.ipv4()?,
+                    netmask: lease.netmask(),
+                    gateway: lease.gateway_ipv4()?,
                 };
                 tokio::time::timeout(
                     std::time::Duration::from_secs(10),
@@ -748,11 +753,11 @@ impl SandboxManager {
                 .and_then(|r| r)?;
             }
 
-            journal(pid, cow_handle.as_ref(), net_alloc.as_ref())?;
+            journal(pid, cow_handle.as_ref(), lease.as_ref())?;
             Ok(ResumedRuntime {
                 prepared: prepared.take().expect("prepared set above"),
                 handle,
-                network: net_alloc.take(),
+                network: lease.take(),
                 cow_handle: cow_handle.take(),
                 ip_address,
             })
@@ -763,7 +768,7 @@ impl SandboxManager {
             Ok(resumed) => Ok(resumed),
             Err(error) => {
                 let unwound = self
-                    .unwind_resume(id, vm_dir, jailer, prepared, cow_handle, net_alloc)
+                    .unwind_resume(id, vm_dir, jailer, prepared, cow_handle, lease)
                     .await;
                 Err(ResumeFailure { error, unwound })
             }
@@ -781,7 +786,7 @@ impl SandboxManager {
         jailer: &crate::config::JailerConfig,
         prepared: Option<Arc<dyn PreparedVm>>,
         cow_handle: Option<CowHandle>,
-        net_alloc: Option<NetworkAllocation>,
+        net_lease: Option<NetworkLease>,
     ) -> bool {
         let mut clean = true;
 
@@ -812,8 +817,8 @@ impl SandboxManager {
             }
         }
 
-        if let Some(net) = net_alloc
-            && let Err(error) = self.network.quarantine_checked(id, &net)
+        if let Some(lease) = net_lease
+            && let Err(error) = self.network.quarantine(lease).await
         {
             warn!(sandbox_id = %id, error = %error, "resume unwind: network quarantine failed");
             clean = false;
@@ -990,7 +995,8 @@ mod tests {
             "the commit failure is the reported error: {error}"
         );
 
-        super::super::testing::assert_failed_and_released(&manager, &instance, &probe, "frozen");
+        super::super::testing::assert_failed_and_released(&manager, &instance, &probe, "frozen")
+            .await;
         assert_eq!(
             handle.state(),
             arcbox_vm_driver::VmState::Exited(arcbox_vm_driver::ExitStatus::signaled(9)),

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -739,10 +739,13 @@ impl SandboxManager {
             if let Some(lease) = &lease
                 && !snap_meta.net_invariant
             {
+                let identity = self
+                    .network
+                    .identity(lease, crate::network::TapMode::LegacySnapshot);
                 let cmd = crate::boot_proto::NetReconfigCommand {
-                    ip: lease.ipv4()?,
-                    netmask: lease.netmask(),
-                    gateway: lease.gateway_ipv4()?,
+                    ip: super::ipv4(identity.ip)?,
+                    netmask: super::netmask(identity.prefix_len),
+                    gateway: super::ipv4(identity.gateway)?,
                 };
                 tokio::time::timeout(
                     std::time::Duration::from_secs(10),

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -616,9 +616,9 @@ impl SandboxManager {
                 // legacy one with the legacy TAP shape plus the reconfig RPC
                 // below (CORE-81).
                 let mode = if snap_meta.net_invariant {
-                    crate::network::TapMode::Invariant
+                    AttachMode::Invariant
                 } else {
-                    crate::network::TapMode::LegacySnapshot
+                    AttachMode::LegacySnapshot
                 };
                 nic = Some(self.network.activate(lease, mode).await?);
             }
@@ -741,7 +741,7 @@ impl SandboxManager {
             {
                 let identity = self
                     .network
-                    .identity(lease, crate::network::TapMode::LegacySnapshot);
+                    .identity(lease, AttachMode::LegacySnapshot);
                 let cmd = crate::boot_proto::NetReconfigCommand {
                     ip: super::ipv4(identity.ip)?,
                     netmask: super::netmask(identity.prefix_len),

--- a/virt/arcbox-vm/src/sandbox/pause.rs
+++ b/virt/arcbox-vm/src/sandbox/pause.rs
@@ -687,7 +687,7 @@ impl SandboxManager {
             let restore = restore_spec(
                 id,
                 &cr,
-                net_alloc.as_ref(),
+                net_alloc.as_ref().map(super::spec::nic_spec).transpose()?,
                 IsolationSpec::try_from(jailer)?,
             )?;
             let handle: Arc<dyn VmHandle> = Arc::from(

--- a/virt/arcbox-vm/src/sandbox/pool.rs
+++ b/virt/arcbox-vm/src/sandbox/pool.rs
@@ -77,10 +77,10 @@ pub(super) async fn prepare_slot(
     reconcile::create_runtime_dir(&vm_dir)?;
     reconcile::write_state_record(
         &vm_dir,
-        &SandboxStateRecord::new(&slot_id, None, None, None, true, None),
+        &SandboxStateRecord::new(&slot_id, None, None, None, config, None)?,
     )?;
 
-    match stage_slot(driver, fc_cfg, jc, cow_manager, snapshot, &slot_id, &vm_dir).await {
+    match stage_slot(driver, config, jc, cow_manager, snapshot, &slot_id, &vm_dir).await {
         Ok((prepared, cow_handle, image)) => Ok(PreparedSlot {
             slot_id,
             prepared,
@@ -148,13 +148,14 @@ type StagedSlot = (Arc<dyn PreparedVm>, Option<CowHandle>, CheckpointImage);
 
 async fn stage_slot(
     driver: &dyn VmDriver,
-    fc_cfg: &crate::config::FirecrackerConfig,
+    config: &VmmConfig,
     jc: &JailerConfig,
     cow_manager: &CowManager,
     snapshot: &SnapshotMeta,
     slot_id: &str,
     vm_dir: &Path,
 ) -> std::result::Result<StagedSlot, SlotFailure> {
+    let fc_cfg = &config.firecracker;
     let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
     let cr = chroot_root(&fc_cfg.binary, base, slot_id);
 
@@ -172,7 +173,7 @@ async fn stage_slot(
     let journal = |cow: Option<&CowHandle>| {
         reconcile::write_state_record(
             vm_dir,
-            &SandboxStateRecord::new(slot_id, pid, None, cow, true, None),
+            &SandboxStateRecord::new(slot_id, pid, None, cow, config, None)?,
         )
     };
     let carry = |error: VmmError, prepared, cow_handle| SlotFailure {

--- a/virt/arcbox-vm/src/sandbox/reconcile.rs
+++ b/virt/arcbox-vm/src/sandbox/reconcile.rs
@@ -16,16 +16,17 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use arcbox_vm_driver::net::{GuestNetwork, NetworkLease};
 use arcbox_vm_driver::{ProcessRecord, ShutdownMode, VmDriver, VmId, VmRecord};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use super::policy::recovery::{self, JournalEvidence, RecoveryAction, SweepAction};
 use super::record::{SandboxRecord, SandboxRecordStore, SandboxTransition};
-use super::{SandboxInstance, SandboxState};
+use super::{LeaseExt, SandboxInstance, SandboxState};
 use crate::config::VmmConfig;
 use crate::error::{Result, VmmError};
-use crate::network::{NetworkAllocation, NetworkManager};
+use crate::network::NetworkAllocation;
 use crate::snapshot_cow::{CowHandle, CowManager};
 
 /// How long the sweep gives the driver to find and reconnect to one
@@ -102,7 +103,20 @@ pub(super) struct SandboxStateRecord {
     /// The VMM's PID at boot time.
     #[serde(default)]
     pub pid: Option<i32>,
-    /// Network allocation to release (TAP + IP).
+    /// The lease to hand back, in the shape `arcbox-tap-net`'s
+    /// [`NetworkAllocation`] has written since before the guest-network
+    /// port existed.
+    ///
+    /// The lease is what the sweep actually needs, but the on-disk shape
+    /// is a contract in both directions (see the type doc above), and
+    /// `NetworkAllocation`'s `tap_name` and `dns_servers` are not
+    /// `#[serde(default)]`: dropping either would turn one skipped
+    /// sandbox into a sweep that fails to parse and leaks every journaled
+    /// resource on an agent that predates the port. Both are therefore
+    /// reconstructed on write — the TAP name by [`tap_name_for`], the
+    /// same rule [`validate_state_record`] enforces, and the resolvers
+    /// from the network config the pool was built with — and neither is
+    /// read back: [`SandboxStateRecord::lease`] is what the sweep uses.
     #[serde(default)]
     pub network: Option<NetworkAllocation>,
     /// dm-snapshot CoW resources to tear down.
@@ -120,25 +134,56 @@ pub(super) struct SandboxStateRecord {
     pub pool_slot_id: Option<String>,
 }
 
+/// The TAP name an allocation for `ip` carries.
+///
+/// One definition, shared by the journal writer and
+/// [`validate_state_record`], so a record this agent writes is exactly one
+/// it accepts.
+fn tap_name_for(ip: std::net::Ipv4Addr) -> String {
+    let octets = ip.octets();
+    format!("vmtap{}-{}", octets[2], octets[3])
+}
+
 impl SandboxStateRecord {
     /// Assemble a record from boot/restore results.
     pub fn new(
         id: &str,
         pid: Option<i32>,
-        network: Option<&NetworkAllocation>,
+        network: Option<&NetworkLease>,
         cow: Option<&CowHandle>,
-        jailer: bool,
+        config: &VmmConfig,
         restore_origin_dir: Option<&Path>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        let network = network
+            .map(|lease| legacy_allocation(lease, &config.network.dns))
+            .transpose()?;
+        Ok(Self {
             id: id.to_owned(),
             pid,
-            network: network.cloned(),
+            network,
             cow: cow.map(CowRecord::from_handle),
-            jailer,
+            jailer: config.firecracker.jailer.is_some(),
             restore_origin_dir: restore_origin_dir.map(Path::to_path_buf),
             pool_slot_id: None,
-        }
+        })
+    }
+
+    /// The lease this record's network field stands for, for a sweep that
+    /// must hand the address back.
+    pub fn lease(&self) -> Result<Option<NetworkLease>> {
+        self.network
+            .as_ref()
+            .map(|allocation| {
+                Ok(NetworkLease {
+                    vm: VmId::new(self.id.as_str())?,
+                    ip: allocation.ip_address.into(),
+                    prefix_len: allocation.prefix_len,
+                    gateway: allocation.gateway.into(),
+                    mac: allocation.mac_address.parse().map_err(VmmError::from)?,
+                    cleanup_token: allocation.cleanup_token.clone(),
+                })
+            })
+            .transpose()
     }
 
     /// Key the record's chroot and dm/CoW resources by an adopted pool
@@ -154,6 +199,23 @@ impl SandboxStateRecord {
     pub fn resource_owner(&self) -> &str {
         self.pool_slot_id.as_deref().unwrap_or(&self.id)
     }
+}
+
+/// `lease` in the journal's legacy allocation shape.
+///
+/// `tap_name` and `dns_servers` are the two fields a lease does not carry;
+/// see [`SandboxStateRecord::network`] for why they are written anyway.
+fn legacy_allocation(lease: &NetworkLease, dns: &[String]) -> Result<NetworkAllocation> {
+    let ip = lease.ipv4()?;
+    Ok(NetworkAllocation {
+        tap_name: tap_name_for(ip),
+        ip_address: ip,
+        prefix_len: lease.prefix_len,
+        gateway: lease.gateway_ipv4()?,
+        mac_address: lease.mac.to_string(),
+        dns_servers: dns.to_vec(),
+        cleanup_token: lease.cleanup_token.clone(),
+    })
 }
 
 /// Atomically persist crash-recovery metadata before resources are exposed.
@@ -211,7 +273,7 @@ pub(super) struct OrphanSweep {
 pub(super) async fn sweep_orphans(
     config: &VmmConfig,
     driver: &dyn VmDriver,
-    network: &NetworkManager,
+    network: &dyn GuestNetwork,
     cow_manager: &CowManager,
     snapshots: &crate::snapshot::SnapshotCatalog,
     store: &SandboxRecordStore,
@@ -276,8 +338,8 @@ pub(super) async fn sweep_orphans(
             cow_manager.teardown_checked(&cow.into_handle()).await?;
         }
 
-        if let Some(alloc) = &record.network {
-            network.quarantine_checked(&record.id, alloc)?;
+        if let Some(lease) = record.lease()? {
+            network.quarantine(lease).await.map_err(VmmError::from)?;
         }
 
         if record.jailer
@@ -459,8 +521,7 @@ fn validate_state_record(
         )));
     }
     if let Some(network) = &record.network {
-        let octets = network.ip_address.octets();
-        let expected = format!("vmtap{}-{}", octets[2], octets[3]);
+        let expected = tap_name_for(network.ip_address);
         if network.tap_name != expected {
             return Err(crate::error::VmmError::Config(format!(
                 "sandbox {} cleanup record has unexpected TAP {}",
@@ -514,6 +575,68 @@ mod tests {
     use super::super::SandboxSpec;
     use super::super::record::{PersistPhase, ProvisionIntent, SandboxProvisionOutcome};
     use super::*;
+
+    /// `state.json` written before the guest-network port existed, verbatim.
+    /// The sweep replays leases out of records like this one, so the shape
+    /// is a contract in both directions: this agent must read it, and an
+    /// agent that predates the port must read what this one writes (its
+    /// `NetworkAllocation` has no `#[serde(default)]` on `tap_name` or
+    /// `dns_servers`, and a record missing either fails its whole sweep).
+    const LEGACY_RECORD: &str = r#"{
+      "id": "box",
+      "pid": 4242,
+      "network": {
+        "tap_name": "vmtap0-7",
+        "ip_address": "172.20.0.7",
+        "prefix_len": 16,
+        "gateway": "172.20.0.1",
+        "mac_address": "02:fc:00:00:00:07",
+        "dns_servers": ["1.1.1.1"],
+        "cleanup_token": "gen-1"
+      },
+      "cow": null,
+      "jailer": true,
+      "restore_origin_dir": null,
+      "pool_slot_id": null
+    }"#;
+
+    #[test]
+    fn a_pre_port_journal_loads_and_is_written_back_unchanged() {
+        let record: SandboxStateRecord = serde_json::from_str(LEGACY_RECORD).unwrap();
+        let lease = record.lease().unwrap().expect("the record holds a lease");
+        assert_eq!(lease.vm.as_str(), "box");
+        assert_eq!(lease.ip, "172.20.0.7".parse::<std::net::IpAddr>().unwrap());
+        assert_eq!(lease.prefix_len, 16);
+        assert_eq!(
+            lease.gateway,
+            "172.20.0.1".parse::<std::net::IpAddr>().unwrap()
+        );
+        assert_eq!(lease.mac.to_string(), "02:fc:00:00:00:07");
+        assert_eq!(lease.cleanup_token, "gen-1");
+
+        // ...and the record this agent writes from that lease is the same
+        // JSON, field for field — including the two the lease does not
+        // carry, which are reconstructed rather than dropped.
+        let mut config = VmmConfig::default();
+        config.network.dns = vec!["1.1.1.1".into()];
+        config.firecracker.jailer = Some(crate::config::JailerConfig {
+            binary: "/usr/bin/jailer".into(),
+            uid: 0,
+            gid: 0,
+            chroot_base_dir: None,
+            netns: None,
+            new_pid_ns: false,
+            cgroup_version: None,
+            parent_cgroup: None,
+            resource_limits: vec![],
+        });
+        let written =
+            SandboxStateRecord::new("box", Some(4242), Some(&lease), None, &config, None).unwrap();
+        assert_eq!(
+            serde_json::to_value(&written).unwrap(),
+            serde_json::from_str::<serde_json::Value>(LEGACY_RECORD).unwrap()
+        );
+    }
 
     fn record_in_phase(store: &SandboxRecordStore, id: &str, phase: PersistPhase) -> SandboxRecord {
         let spec = SandboxSpec {
@@ -867,6 +990,8 @@ mod tests {
             .unwrap();
         vm.detach().unwrap().detach().await.unwrap();
         let pid = vm.record().process.map(|process| process.pid).unwrap();
+        let mut config = VmmConfig::default();
+        config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
         write_state_record(
             &vm_dir,
             &SandboxStateRecord::new(
@@ -874,14 +999,12 @@ mod tests {
                 Some(i32::try_from(pid).unwrap()),
                 None,
                 None,
-                false,
+                &config,
                 None,
-            ),
+            )
+            .unwrap(),
         )
         .unwrap();
-
-        let mut config = VmmConfig::default();
-        config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
         let manager = super::super::SandboxManager::with_environment(
             config,
             crate::SandboxEnvironment {

--- a/virt/arcbox-vm/src/sandbox/spec.rs
+++ b/virt/arcbox-vm/src/sandbox/spec.rs
@@ -14,7 +14,6 @@ use arcbox_vm_driver::{
 
 use crate::boot_proto::KernelIpParam;
 use crate::error::{Result, VmmError};
-use crate::network::NetworkAllocation;
 use crate::sandbox::SandboxSpec;
 
 /// The boot recipe as the driver port sees it.
@@ -27,15 +26,19 @@ use crate::sandbox::SandboxSpec;
 /// network-agnostic and restore with zero guest-side work. The guest-side
 /// vm-agent parses the `ip=` parameter back via `KernelIpParam::from_str`
 /// to derive the DNS nameserver.
+///
+/// `nic` is what the guest network handed back when it activated this
+/// sandbox's lease — the one NIC a sandbox ever has, or none when the
+/// sandbox is networkless.
 pub(super) fn build_vm_spec(
     id: &str,
     spec: &SandboxSpec,
-    net_alloc: Option<&NetworkAllocation>,
+    nic: Option<NicSpec>,
     kernel: PathBuf,
     rootfs: PathBuf,
     isolation: IsolationSpec,
 ) -> Result<VmSpec> {
-    let cmdline = if net_alloc.is_some() && !spec.boot_args.contains("ip=") {
+    let cmdline = if nic.is_some() && !spec.boot_args.contains("ip=") {
         let ip_param = KernelIpParam {
             client: crate::network::invariant::GUEST_IP,
             gateway: crate::network::invariant::GUEST_GATEWAY,
@@ -60,7 +63,7 @@ pub(super) fn build_vm_spec(
             initrd: None,
         },
         disks: vec![rootfs_disk(rootfs)],
-        nics: net_alloc.map(nic_spec).transpose()?.into_iter().collect(),
+        nics: nic.into_iter().collect(),
         // CID 3 is the conventional guest CID; each VMM is isolated so the
         // same CID is safe across concurrent sandboxes.
         vsock: Some(VsockSpec { guest_cid: 3 }),
@@ -87,7 +90,7 @@ pub(super) fn rootfs_disk(path: PathBuf) -> DiskSpec {
 }
 
 /// The guest's one NIC, `eth0`, on the allocation's TAP with its MAC.
-pub(super) fn nic_spec(net: &NetworkAllocation) -> Result<NicSpec> {
+pub(super) fn nic_spec(net: &crate::network::NetworkAllocation) -> Result<NicSpec> {
     Ok(NicSpec {
         id: "eth0".into(),
         mac: net.mac_address.parse().map_err(VmmError::from)?,
@@ -98,17 +101,18 @@ pub(super) fn nic_spec(net: &NetworkAllocation) -> Result<NicSpec> {
 }
 
 /// What a restore may change about the checkpointed VM: its identity
-/// (`owner`, the id the jail is keyed by), the fresh TAP, and the disk it
-/// runs on — the rootfs staged into the owner's jail.
+/// (`owner`, the id the jail is keyed by), the fresh NIC the guest network
+/// activated, and the disk it runs on — the rootfs staged into the owner's
+/// jail.
 pub(super) fn restore_spec(
     owner: &str,
     chroot: &Path,
-    net_alloc: Option<&NetworkAllocation>,
+    nic: Option<NicSpec>,
     isolation: IsolationSpec,
 ) -> Result<RestoreSpec> {
     Ok(RestoreSpec {
         id: VmId::new(owner)?,
-        nics: net_alloc.map(nic_spec).transpose()?.into_iter().collect(),
+        nics: nic.into_iter().collect(),
         disks: vec![rootfs_disk(chroot.join("rootfs.ext4"))],
         isolation,
     })
@@ -118,15 +122,14 @@ pub(super) fn restore_spec(
 mod tests {
     use super::*;
 
-    fn allocation() -> NetworkAllocation {
-        NetworkAllocation {
-            tap_name: "vmtap0-7".into(),
-            ip_address: "172.20.0.7".parse().unwrap(),
-            prefix_len: 16,
-            gateway: "172.20.0.1".parse().unwrap(),
-            mac_address: "02:fc:00:00:00:07".into(),
-            dns_servers: vec![],
-            cleanup_token: String::new(),
+    /// The NIC a guest network hands back from activating a lease.
+    fn nic() -> NicSpec {
+        NicSpec {
+            id: "eth0".into(),
+            mac: "02:fc:00:00:00:07".parse().unwrap(),
+            attachment: NicAttachment::Tap {
+                name: "vmtap0-7".into(),
+            },
         }
     }
 
@@ -145,7 +148,7 @@ mod tests {
         let vm = build_vm_spec(
             "box",
             &spec,
-            Some(&allocation()),
+            Some(nic()),
             PathBuf::from("/jail/vmlinux"),
             PathBuf::from("/jail/rootfs.ext4"),
             IsolationSpec::None,
@@ -188,7 +191,7 @@ mod tests {
         let vm = build_vm_spec(
             "box",
             &pinned,
-            Some(&allocation()),
+            Some(nic()),
             "/k".into(),
             "/r".into(),
             IsolationSpec::None,

--- a/virt/arcbox-vm/src/sandbox/spec.rs
+++ b/virt/arcbox-vm/src/sandbox/spec.rs
@@ -8,8 +8,8 @@
 use std::path::{Path, PathBuf};
 
 use arcbox_vm_driver::{
-    BootSpec, CacheMode, ConsoleSpec, DiskSpec, IsolationSpec, NicAttachment, NicSpec, RestoreSpec,
-    VmId, VmSpec, VsockSpec,
+    BootSpec, CacheMode, ConsoleSpec, DiskSpec, IsolationSpec, NicSpec, RestoreSpec, VmId, VmSpec,
+    VsockSpec,
 };
 
 use crate::boot_proto::KernelIpParam;
@@ -89,17 +89,6 @@ pub(super) fn rootfs_disk(path: PathBuf) -> DiskSpec {
     }
 }
 
-/// The guest's one NIC, `eth0`, on the allocation's TAP with its MAC.
-pub(super) fn nic_spec(net: &crate::network::NetworkAllocation) -> Result<NicSpec> {
-    Ok(NicSpec {
-        id: "eth0".into(),
-        mac: net.mac_address.parse().map_err(VmmError::from)?,
-        attachment: NicAttachment::Tap {
-            name: net.tap_name.clone(),
-        },
-    })
-}
-
 /// What a restore may change about the checkpointed VM: its identity
 /// (`owner`, the id the jail is keyed by), the fresh NIC the guest network
 /// activated, and the disk it runs on — the rootfs staged into the owner's
@@ -120,6 +109,8 @@ pub(super) fn restore_spec(
 
 #[cfg(test)]
 mod tests {
+    use arcbox_vm_driver::NicAttachment;
+
     use super::*;
 
     /// The NIC a guest network hands back from activating a lease.

--- a/virt/arcbox-vm/src/sandbox/spec.rs
+++ b/virt/arcbox-vm/src/sandbox/spec.rs
@@ -14,39 +14,43 @@ use arcbox_vm_driver::{
 
 use crate::boot_proto::KernelIpParam;
 use crate::error::{Result, VmmError};
-use crate::sandbox::SandboxSpec;
+use crate::sandbox::{NetworkAttachment, SandboxSpec, ipv4, netmask};
 
 /// The boot recipe as the driver port sees it.
 ///
 /// `kernel` and `rootfs` are the paths the VMM must open — in jailer mode
 /// already staged inside the jail, so the driver finds them there and
-/// stages nothing itself. Every sandbox boots the identical fixed identity
-/// (CORE-81) unless the caller pinned its own `ip=`: the pool IP stays a
-/// host-side property of the TAP, so snapshots taken from this guest are
-/// network-agnostic and restore with zero guest-side work. The guest-side
-/// vm-agent parses the `ip=` parameter back via `KernelIpParam::from_str`
-/// to derive the DNS nameserver.
+/// stages nothing itself.
 ///
-/// `nic` is what the guest network handed back when it activated this
-/// sandbox's lease — the one NIC a sandbox ever has, or none when the
-/// sandbox is networkless.
+/// `net` is what the guest network handed back when it activated this
+/// sandbox's lease — the one NIC a sandbox ever has plus the addressing a
+/// guest on it sees — or none when the sandbox is networkless. The `ip=`
+/// parameter is that identity, not a constant: under the TAP network's
+/// invariant identity (CORE-81) every sandbox boots the same fixed
+/// address, the pool address stays a host-side property of the interface,
+/// and snapshots are network-agnostic — but that is one adapter's answer,
+/// and a guest booted with another adapter's NIC must be told that
+/// adapter's addressing. A caller who pinned its own `ip=` keeps it. The
+/// guest-side vm-agent parses the parameter back via
+/// `KernelIpParam::from_str` to derive the DNS nameserver.
 pub(super) fn build_vm_spec(
     id: &str,
     spec: &SandboxSpec,
-    nic: Option<NicSpec>,
+    net: Option<&NetworkAttachment>,
     kernel: PathBuf,
     rootfs: PathBuf,
     isolation: IsolationSpec,
 ) -> Result<VmSpec> {
-    let cmdline = if nic.is_some() && !spec.boot_args.contains("ip=") {
-        let ip_param = KernelIpParam {
-            client: crate::network::invariant::GUEST_IP,
-            gateway: crate::network::invariant::GUEST_GATEWAY,
-            netmask: crate::network::invariant::GUEST_NETMASK,
-        };
-        format!("{} {ip_param}", spec.boot_args)
-    } else {
-        spec.boot_args.clone()
+    let cmdline = match net {
+        Some(net) if !spec.boot_args.contains("ip=") => {
+            let ip_param = KernelIpParam {
+                client: ipv4(net.identity.ip)?,
+                gateway: ipv4(net.identity.gateway)?,
+                netmask: netmask(net.identity.prefix_len),
+            };
+            format!("{} {ip_param}", spec.boot_args)
+        }
+        _ => spec.boot_args.clone(),
     };
     Ok(VmSpec {
         id: VmId::new(id)?,
@@ -63,7 +67,7 @@ pub(super) fn build_vm_spec(
             initrd: None,
         },
         disks: vec![rootfs_disk(rootfs)],
-        nics: nic.into_iter().collect(),
+        nics: net.map(|net| net.nic.clone()).into_iter().collect(),
         // CID 3 is the conventional guest CID; each VMM is isolated so the
         // same CID is safe across concurrent sandboxes.
         vsock: Some(VsockSpec { guest_cid: 3 }),
@@ -110,16 +114,36 @@ pub(super) fn restore_spec(
 #[cfg(test)]
 mod tests {
     use arcbox_vm_driver::NicAttachment;
+    use arcbox_vm_driver::net::{NetworkIdentity, NetworkLease};
 
     use super::*;
 
-    /// The NIC a guest network hands back from activating a lease.
-    fn nic() -> NicSpec {
-        NicSpec {
-            id: "eth0".into(),
-            mac: "02:fc:00:00:00:07".parse().unwrap(),
-            attachment: NicAttachment::Tap {
-                name: "vmtap0-7".into(),
+    /// What a guest network hands back from activating a lease: the NIC,
+    /// and the fixed invariant addressing a guest on the System VM's TAP
+    /// network is told to use over it.
+    fn attachment() -> NetworkAttachment {
+        NetworkAttachment {
+            lease: NetworkLease {
+                vm: VmId::new("box").unwrap(),
+                ip: "172.20.0.7".parse().unwrap(),
+                prefix_len: 16,
+                gateway: "172.20.0.1".parse().unwrap(),
+                mac: "02:fc:00:00:00:07".parse().unwrap(),
+                cleanup_token: "gen-1".into(),
+            },
+            nic: NicSpec {
+                id: "eth0".into(),
+                mac: "02:fc:00:00:00:07".parse().unwrap(),
+                attachment: NicAttachment::Tap {
+                    name: "vmtap0-7".into(),
+                },
+            },
+            identity: NetworkIdentity {
+                ip: crate::network::invariant::GUEST_IP.into(),
+                prefix_len: crate::network::invariant::GUEST_PREFIX_LEN,
+                gateway: crate::network::invariant::GUEST_GATEWAY.into(),
+                dns: vec![crate::network::invariant::GUEST_GATEWAY.into()],
+                mac: "02:fc:00:00:00:07".parse().unwrap(),
             },
         }
     }
@@ -139,7 +163,7 @@ mod tests {
         let vm = build_vm_spec(
             "box",
             &spec,
-            Some(nic()),
+            Some(&attachment()),
             PathBuf::from("/jail/vmlinux"),
             PathBuf::from("/jail/rootfs.ext4"),
             IsolationSpec::None,
@@ -152,9 +176,20 @@ mod tests {
         };
         assert_eq!(image, Path::new("/jail/vmlinux"));
         assert!(cmdline.starts_with("console=ttyS0 ip="), "{cmdline}");
+        // The whole `ip=` comes from the network's identity, netmask
+        // included: the TAP network's /30 renders as the fixed netmask its
+        // guests have always booted with.
         assert!(
             cmdline.contains(&crate::network::invariant::GUEST_IP.to_string()),
             "{cmdline}"
+        );
+        assert!(
+            cmdline.contains(&crate::network::invariant::GUEST_NETMASK.to_string()),
+            "{cmdline}"
+        );
+        assert_eq!(
+            netmask(crate::network::invariant::GUEST_PREFIX_LEN),
+            crate::network::invariant::GUEST_NETMASK
         );
         assert_eq!(vm.disks.len(), 1);
         assert!(vm.disks[0].root && !vm.disks[0].read_only);
@@ -182,7 +217,7 @@ mod tests {
         let vm = build_vm_spec(
             "box",
             &pinned,
-            Some(nic()),
+            Some(&attachment()),
             "/k".into(),
             "/r".into(),
             IsolationSpec::None,

--- a/virt/arcbox-vm/src/sandbox/testing.rs
+++ b/virt/arcbox-vm/src/sandbox/testing.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use arcbox_vm_driver::testkit::FakeDriver;
+use arcbox_vm_driver::testkit::{FakeDriver, FakeNetwork};
 use arcbox_vm_driver::{
     BootSpec, Checkpoint, CheckpointImage, CheckpointOptions, ConsoleSpec, Error, ExitStatus,
     IsolationSpec, PreparedVm, ShutdownMode, VmDriver as _, VmEvent, VmHandle, VmId, VmRecord,
@@ -22,37 +22,60 @@ use crate::config::{JailerConfig, VmmConfig};
 use crate::snapshot_cow::{CowManager, CowOptions, CowTestProbe};
 use crate::{SandboxEnvironment, VmmError};
 
-/// Whether the live sandbox carries a network allocation. Releasing one on
-/// Linux talks to netlink and iptables (root, and the System VM's binaries),
-/// which an unprivileged unit test cannot — the tap-net crate skips those
-/// paths without root for the same reason; the macOS build's no-op branch
-/// is what lets these tests drive the release end to end.
-pub(super) const RELEASES_NETWORK: bool = cfg!(not(target_os = "linux"));
-
-/// A manager over [`FakeDriver`] with a probed CoW manager and jailer mode
-/// configured (checkpoints, pause and restore require it), its startup
-/// cleanup finalized so networks can be reserved.
+/// A manager over [`FakeDriver`] and [`FakeNetwork`] with a probed CoW
+/// manager and jailer mode configured (checkpoints, pause and restore
+/// require it), its startup cleanup finalized so leases can be reserved.
+///
+/// Both fakes are what make these tests platform-free: the TAP network
+/// reserves and releases through netlink and iptables, which an
+/// unprivileged unit test cannot drive on Linux, so the release paths used
+/// to be exercised on macOS only.
 pub(super) async fn fake_manager(
     data_dir: &Path,
 ) -> (SandboxManager, FakeDriver, Arc<CowTestProbe>) {
+    build_fake_manager(
+        data_dir,
+        Some(JailerConfig {
+            binary: "/usr/bin/jailer".into(),
+            uid: 0,
+            gid: 0,
+            chroot_base_dir: Some(data_dir.join("jailer").to_string_lossy().into_owned()),
+            netns: None,
+            new_pid_ns: false,
+            cgroup_version: None,
+            parent_cgroup: None,
+            resource_limits: vec![],
+        }),
+    )
+    .await
+}
+
+/// [`fake_manager`] in direct mode, for the flows that do not need a
+/// jailer.
+///
+/// A jailer chroot under a temp dir spends the whole AF_UNIX socket-path
+/// budget, leaving `max_sandbox_id_len` at zero — so any test that calls
+/// `create_sandbox` for real is refused at id validation before it reaches
+/// anything it meant to exercise.
+pub(super) async fn fake_manager_direct(
+    data_dir: &Path,
+) -> (SandboxManager, FakeDriver, Arc<CowTestProbe>) {
+    build_fake_manager(data_dir, None).await
+}
+
+async fn build_fake_manager(
+    data_dir: &Path,
+    jailer: Option<JailerConfig>,
+) -> (SandboxManager, FakeDriver, Arc<CowTestProbe>) {
     let mut config = VmmConfig::default();
     config.firecracker.data_dir = data_dir.to_string_lossy().into_owned();
-    config.firecracker.jailer = Some(JailerConfig {
-        binary: "/usr/bin/jailer".into(),
-        uid: 0,
-        gid: 0,
-        chroot_base_dir: Some(data_dir.join("jailer").to_string_lossy().into_owned()),
-        netns: None,
-        new_pid_ns: false,
-        cgroup_version: None,
-        parent_cgroup: None,
-        resource_limits: vec![],
-    });
+    config.firecracker.jailer = jailer;
     let driver = FakeDriver::new();
     let mut manager = SandboxManager::with_environment(
         config,
         SandboxEnvironment {
             driver: Some(Arc::new(driver.clone())),
+            network: Some(Arc::new(FakeNetwork::with_startup_cleanup("test-boot"))),
             ..SandboxEnvironment::default()
         },
     )
@@ -191,7 +214,11 @@ pub(super) async fn live_sandbox_with(
     );
     let handle = wrap(Arc::from(prepared.boot(vm_spec(&vm_id)).await.unwrap()));
     let cow_handle = manager.cow_manager.setup(id, "/rootfs.ext4").await.unwrap();
-    let network = RELEASES_NETWORK.then(|| manager.network.reserve(id).unwrap());
+    let lease = manager
+        .network
+        .reserve(&vm_id, super::sandbox_network_policy())
+        .await
+        .unwrap();
 
     let spec = SandboxSpec {
         id: Some(id.to_owned()),
@@ -212,10 +239,7 @@ pub(super) async fn live_sandbox_with(
             id,
             generation,
             SandboxTransition::Starting(SandboxProvisionOutcome {
-                ip_address: network
-                    .as_ref()
-                    .map(|network| network.ip_address.to_string())
-                    .unwrap_or_default(),
+                ip_address: lease.ip.to_string(),
             }),
         )
         .unwrap();
@@ -228,16 +252,17 @@ pub(super) async fn live_sandbox_with(
         &SandboxStateRecord::new(
             id,
             super::journaled_pid(&*prepared),
-            network.as_ref(),
+            Some(&lease),
             Some(&cow_handle),
-            true,
+            &manager.config,
             None,
-        ),
+        )
+        .unwrap(),
     )
     .unwrap();
 
     let mut instance =
-        SandboxInstance::new_with_generation(id.to_owned(), spec, network, vm_dir, generation);
+        SandboxInstance::new_with_generation(id.to_owned(), spec, Some(lease), vm_dir, generation);
     instance.state = SandboxState::Ready;
     instance.prepared = Some(prepared);
     instance.handle = Some(Arc::clone(&handle));
@@ -253,42 +278,44 @@ pub(super) async fn live_sandbox_with(
 
 /// Every mark of a sandbox that failed the way a failed boot does: `Failed`
 /// in memory and on the durable record, no VMM (the prepared process
-/// discarded, the handle dropped), CoW overlay and network (where the test
-/// carries one, [`RELEASES_NETWORK`]) released, crash journal cleared.
-/// Panics on the first mark that is missing.
-pub(super) fn assert_failed_and_released(
+/// discarded, the handle dropped), CoW overlay and network lease released,
+/// crash journal cleared. Panics on the first mark that is missing.
+pub(super) async fn assert_failed_and_released(
     manager: &SandboxManager,
     instance: &Arc<Mutex<SandboxInstance>>,
     probe: &CowTestProbe,
     id: &str,
 ) {
-    let inst = instance.lock().unwrap();
-    assert_eq!(inst.state, SandboxState::Failed);
+    {
+        let inst = instance.lock().unwrap();
+        assert_eq!(inst.state, SandboxState::Failed);
+        assert!(
+            inst.error.is_some(),
+            "the failure is recorded on the instance"
+        );
+        assert!(inst.prepared.is_none(), "the VMM process is discarded");
+        assert!(inst.handle.is_none(), "the dead VM's handle is dropped");
+        assert!(inst.cow_handle.is_none(), "the CoW overlay is released");
+        assert!(inst.network.is_none(), "the network lease is released");
+        assert_eq!(probe.teardown_count(), 1, "the CoW teardown ran once");
+        assert_eq!(
+            manager.records.load(id).unwrap().unwrap().phase,
+            super::record::PersistPhase::Failed
+        );
+        assert!(
+            !inst.vm_dir.join("state.json").exists(),
+            "the crash journal is cleared once every resource is released"
+        );
+    }
     assert!(
-        inst.error.is_some(),
-        "the failure is recorded on the instance"
-    );
-    assert!(inst.prepared.is_none(), "the VMM process is discarded");
-    assert!(inst.handle.is_none(), "the dead VM's handle is dropped");
-    assert!(inst.cow_handle.is_none(), "the CoW overlay is released");
-    assert!(inst.network.is_none(), "the network allocation is released");
-    assert_eq!(probe.teardown_count(), 1, "the CoW teardown ran once");
-    assert_eq!(
         manager
-            .network
-            .pending_quarantines()
+            .reconcile_network()
+            .pending_cleanups()
+            .await
+            .unwrap()
             .iter()
-            .any(|(quarantined, _)| quarantined == id),
-        RELEASES_NETWORK,
-        "the TAP + IP are quarantined for host cleanup"
-    );
-    assert_eq!(
-        manager.records.load(id).unwrap().unwrap().phase,
-        super::record::PersistPhase::Failed
-    );
-    assert!(
-        !inst.vm_dir.join("state.json").exists(),
-        "the crash journal is cleared once every resource is released"
+            .any(|(quarantined, _)| quarantined.as_str() == id),
+        "the address is quarantined for host cleanup"
     );
 }
 

--- a/virt/arcbox-vm/src/sandbox/types.rs
+++ b/virt/arcbox-vm/src/sandbox/types.rs
@@ -3,20 +3,25 @@ use serde::{Deserialize, Serialize};
 
 pub type SandboxId = String;
 
-/// A sandbox's network as the boot and restore flows carry it: the lease
-/// the guest network reserved, and the NIC it returned when it activated
-/// that lease.
+/// A sandbox's network as the boot flow carries it: the lease the guest
+/// network reserved, the NIC it returned when it activated that lease, and
+/// the addressing the guest is told to use over it.
 ///
-/// The two travel together because both halves are needed at once and
-/// neither derives the other — the crash journal records the lease, the
-/// VM spec boots the NIC, and only the network knows which interface it
-/// built for which address.
+/// The three travel together because all of them are needed at once and
+/// none derives the others — the crash journal records the lease, the VM
+/// spec boots the NIC, the kernel command line carries the identity, and
+/// only the network knows which interface it built for which address or
+/// what a guest on it sees.
 #[derive(Clone)]
 pub struct NetworkAttachment {
     /// The reserved address, and the cleanup token its generation ends on.
     pub lease: NetworkLease,
     /// The interface the driver attaches the guest's `eth0` to.
     pub nic: NicSpec,
+    /// What the guest is told over that interface, from
+    /// [`GuestNetwork::identity`](arcbox_vm_driver::net::GuestNetwork::identity)
+    /// under the mode it was activated in.
+    pub identity: NetworkIdentity,
 }
 
 pub(super) struct SandboxBootTask {

--- a/virt/arcbox-vm/src/sandbox/types.rs
+++ b/virt/arcbox-vm/src/sandbox/types.rs
@@ -3,6 +3,22 @@ use serde::{Deserialize, Serialize};
 
 pub type SandboxId = String;
 
+/// A sandbox's network as the boot and restore flows carry it: the lease
+/// the guest network reserved, and the NIC it returned when it activated
+/// that lease.
+///
+/// The two travel together because both halves are needed at once and
+/// neither derives the other — the crash journal records the lease, the
+/// VM spec boots the NIC, and only the network knows which interface it
+/// built for which address.
+#[derive(Clone)]
+pub struct NetworkAttachment {
+    /// The reserved address, and the cleanup token its generation ends on.
+    pub lease: NetworkLease,
+    /// The interface the driver attaches the guest's `eth0` to.
+    pub nic: NicSpec,
+}
+
 pub(super) struct SandboxBootTask {
     pub(super) resource_handoff: Option<tokio::sync::oneshot::Receiver<()>>,
     pub(super) handle: tokio::task::JoinHandle<()>,
@@ -205,8 +221,11 @@ pub struct SandboxInstance {
     /// present once a boot or restore succeeded; shared with the tasks that
     /// checkpoint or shut it down.
     pub handle: Option<Arc<dyn VmHandle>>,
-    /// Allocated network resources.
-    pub network: Option<NetworkAllocation>,
+    /// The address the guest network reserved for this sandbox, absent
+    /// when the sandbox is networkless or its lease has been handed back.
+    /// The NIC that activating it produced is not kept: the VM was booted
+    /// with it and nothing here reads it again.
+    pub network: Option<NetworkLease>,
     /// Directory holding the VM's runtime files (socket, logs, metrics).
     pub vm_dir: PathBuf,
     /// When the sandbox record was created.
@@ -249,7 +268,7 @@ impl SandboxInstance {
     pub(super) fn new(
         id: SandboxId,
         spec: SandboxSpec,
-        network: Option<NetworkAllocation>,
+        network: Option<NetworkLease>,
         vm_dir: PathBuf,
     ) -> Self {
         Self::new_inner(id, spec, network, vm_dir, None)
@@ -258,7 +277,7 @@ impl SandboxInstance {
     pub(super) fn new_with_generation(
         id: SandboxId,
         spec: SandboxSpec,
-        network: Option<NetworkAllocation>,
+        network: Option<NetworkLease>,
         vm_dir: PathBuf,
         generation: Uuid,
     ) -> Self {
@@ -268,7 +287,7 @@ impl SandboxInstance {
     fn new_inner(
         id: SandboxId,
         spec: SandboxSpec,
-        network: Option<NetworkAllocation>,
+        network: Option<NetworkLease>,
         vm_dir: PathBuf,
         record_generation: Option<Uuid>,
     ) -> Self {
@@ -344,7 +363,6 @@ pub struct SandboxInfo {
 pub struct SandboxNetworkInfo {
     pub ip_address: String,
     pub gateway: String,
-    pub tap_name: String,
 }
 
 // Events

--- a/virt/arcbox-vm/tests/e2e.rs
+++ b/virt/arcbox-vm/tests/e2e.rs
@@ -274,12 +274,20 @@ async fn e2e_sandbox_with_tap_network() {
     let tap_name = {
         let info = mgr.inspect_sandbox(&id).unwrap();
         let net = info.network.expect("tap mode should populate network info");
+        // The host interface is deliberately not part of the sandbox API
+        // (CORE-54); this test owns the host, so it derives the name the
+        // TAP network gives a pool address.
+        let octets = net
+            .ip_address
+            .parse::<std::net::Ipv4Addr>()
+            .expect("a pool address")
+            .octets();
+        let tap_name = format!("vmtap{}-{}", octets[2], octets[3]);
         assert!(
-            common::iface_exists(&net.tap_name),
-            "TAP {} should exist while sandbox is running",
-            net.tap_name
+            common::iface_exists(&tap_name),
+            "TAP {tap_name} should exist while sandbox is running"
         );
-        net.tap_name
+        tap_name
     };
 
     mgr.remove_sandbox(&id, true).await.unwrap();


### PR DESCRIPTION
Third and last PR of R2: `SandboxManager` stops naming the Linux TAP network and reaches its guest networks through the driver port. Design: company repo `engineering/arcbox/architecture/vm-stack-redesign.md` (D-VM6, R2).

Writing the conversion surfaced three shapes the port did not have; each is here with why it is not derivable from what was already exposed.

## The three port shapes

**`host_ingress(lease) -> HostIngress`** — where host-side forwarding must send packets for one guest: the lease's own address, or the guest's plus the mark that selects its policy-routing table. Not derivable from `identity` + lease: under the identity-invariant datapath the guest holds the *fixed* address while the host must target the *pool* one, so any mapping from those two values inverts exactly that case and silently breaks port forwarding on the default datapath. And the answer follows the datapath that actually *applied* — a per-TAP eBPF→iptables fallback at activation time changes it — which only the network that activated the lease knows. A read, like `identity`.

**`validate_cleanup -> Result<NetworkLease>`** — the host cleanup that call gates is keyed by the address the finished generation held (`remove_orphan_rules_for(sandbox_ip, token)`), and after an agent restart the quarantine ledger is the only place that address survives: `provision_outcome` is write-once at create, so the durable record cannot stand in. The TAP adapter already computed the lease and discarded it.

**`replay_complete()`** — the owner telling the ledger it has finished replaying its durable state. Without it the manager could not allocate an address at all: `TapNetwork` starts with `startup_barrier = true, startup_reconciled = false`, `validate_startup_cleanup` refuses until the owner has settled, `finalize_startup_cleanup` is the only thing that clears the barrier, and `reserve` refuses while it is up. Verified by deleting the call: four manager tests fail at `finalize_startup_cleanup` with `expected: current sandbox startup cleanup generation`. The fake now models that gate for real rather than not at all, which is what makes the ordering testable off Linux.

## The manager over the port

`SandboxEnvironment` gains `network: Option<Arc<dyn GuestNetwork>>` (`None` builds the TAP network from the config exactly as before); a network offering no `NetworkReconcile` is a `VmmError::Config` at construction, the same shape as the existing `Prepare`/`Vsock` checks. `SandboxInstance.network` is a `NetworkLease`. The NIC the VM boots with is whatever `activate` returned rather than a second derivation from a TAP name and a MAC string; `NetworkAttachment` carries the pair into the boot task, which needs both.

**The `MutexGuard` split.** `create_sandbox` held a `std::sync::MutexGuard` on the instance across reserve/journal/activate, which the port's `async` methods make impossible. It now takes the instance's `cleanup_lock` — which every teardown path already takes, so nothing can tear down what the create is still building — and drops the std guard across each await, re-acquiring to mutate. No tokio `Mutex` on the instance: R3 replaces the whole lock structure with an actor.

**`state.json` keeps its shape.** The journal's field stays a `NetworkAllocation`; the lease is mapped to and from it inside `reconcile.rs`. `tap_name` comes from the address by the one formula `validate_state_record` also enforces (one function, shared by writer and validator, so they cannot drift) and `dns_servers` from the network config the pool was built with. Neither is read back — the sweep uses `SandboxStateRecord::lease` — but both are written, because an agent predating the port has no `#[serde(default)]` on either and a record missing one fails its *whole* sweep rather than skipping one sandbox. `a_pre_port_journal_loads_and_is_written_back_unchanged` pins both directions against a literal pre-port record and asserts the JSON is identical field for field.

## Removed guard, recorded

`sandbox_network_identity` no longer calls `ensure_startup_cleanup_complete`. It has no non-blocking form on the port, and the guard was unreachable: an identity needs a live lease, a lease comes only from `reserve`, which refuses while the same startup barrier is closed, and both guest-agent callers await `wait_startup_cleanup_complete` before asking. The reasoning sits in the code where the guard was.

## Defect found and fixed while converting

The create and resume rollbacks released only *activated* leases. The durable journal write sits between `reserve` and `activate` on purpose — no host resource exists before its cleanup metadata does — so a failure in that window left the address reserved with nothing owning it, stranded in the pool for the life of the process. Both paths now track the lease from `reserve` on and the NIC separately. `a_create_that_fails_before_activation_hands_the_address_back` fails without the fix (the next reserve gets `.3` instead of the released `.2`).

## Behaviour

Identical, with one narrow exception. The cleanup-token protocol keeps its wire codes: `Error::Unavailable → VmmError::Unavailable → 503`, `Error::PreconditionFailed → VmmError::FailedPrecondition → SandboxError::WrongState → 412`. The port-forward target is unchanged under both datapaths — `expose_target`'s `net_invariant` argument is replaced by `AppliedDatapath::Untranslated`, recorded when a legacy attach applies no translation, because an *absent* record means "an invariant TAP some previous process activated" and takes the opposite answer.

The exception: a create that pins its own `ip=` in `boot_args` on an iptables-datapath TAP now reports `GuestIpWithFwmark` where it used to report `PoolIp` — that sandbox's inbound path is already dead either way, since the TAP translates to `169.254.100.2`, which such a guest does not hold.

Two small surface changes fall out. `SandboxNetworkInfo` loses `tap_name`: the field is `reserved` in `arcbox.sandbox.v1` and deliberately not exposed (CORE-54), so it had no consumer; the smoke example and the Linux e2e derive the name themselves, being the host that owns it. And `validate_network_cleanup` returns the lease, which the guest agent narrows to v4 at its own iptables call site — one line there, where the v4-ness belongs, since the port's lease is an `IpAddr` because a guest network need not be v4.

## Acceptance

`RELEASES_NETWORK` is gone from `sandbox/testing.rs`. The manager's tests run over `FakeNetwork`, which releases on every platform, so the failure paths are no longer exercised on macOS alone.

## Validation

`cargo fmt --all --check`; `cargo clippy -p arcbox-vm-driver -p arcbox-tap-net -p arcbox-vm --all-targets --all-features -- -D warnings`; `cargo test -p arcbox-vm-driver --all-features -p arcbox-tap-net -p arcbox-vm` (148 + 45 + 37 + 28 + 3 + 1, 0 failed); `cargo test -p arcbox-fc-driver` (53); `cargo check --target aarch64-unknown-linux-musl` for the three crates, all targets; `cargo run -p xtask -- check-layers`; `cargo clippy -p arcbox-agent --target aarch64-unknown-linux-musl --all-targets` — warning set identical to master's backlog.

Not run: the sandbox e2e ladder, which needs a Linux host with KVM and root.

## Review round

Two findings fixed in `04b1da1f`, one answered.

The kernel `ip=` was rendered from `arcbox_tap_net::invariant`'s constants — one adapter's answer to a question `GuestNetwork::identity` is defined to answer, so a guest booted on another adapter's NIC would have been told the TAP network's addressing. `NetworkAttachment` now carries the identity the network returned for the mode it activated in, and the legacy re-address RPC asks the same way. Unchanged on the System VM: `identity(_, Invariant)` *is* those constants and `netmask(30) == GUEST_NETMASK`, which the boot-spec test now asserts rather than assumes.

`HostIngress -> ExposeTarget` was a hand-written mapping in the manager. It could not have been a `TryFrom` there — both types are foreign to `arcbox-vm` — so it moved to `arcbox-tap-net` as `impl TryFrom<HostIngress> for ExposeTarget`, beside the code that renders the forward direction.

A fourth, on the second pass, caught a divergence this branch introduced and fixed the adapter rather than the fake (`d3f38619`): `TapNetwork::validate_startup_cleanup` folded four unrelated conditions into one `WrongState`, which the port carries as `PreconditionFailed` — a 412 telling the host to fetch a current token when, before `replay_complete`, the refused token is the only one there will ever be. `arcbox-tap-net`'s own error docs already called that state `Unavailable` (503, retry later), and `FakeNetwork` was written to it here, so the two adapters disagreed. The condition is split out; the contract test asserts the class rather than `is_err()`, which is what let it through, and pins the other refusal beside it. Unreachable through `SandboxManager` — every startup-method caller awaits its own reconciliation, which cannot complete before `replay_complete` — so no wire code changes.

The remaining finding, that a non-TAP adapter's `fwmark` is dropped on the way to `mark_rule_args`, is accurate about a future adapter and deliberately left to R3-PR-G, which moves that call to the composition root; closing it now would mean editing the agent's rule construction, which this PR must keep byte-identical. It is unreachable today and provably so: the only implementation that returns `GuestAddress` is `TapNetwork`, whose mark is `invariant::fwmark(pool_ip)` — the value `mark_rule_args` computes for itself. The `TryFrom` above states that precondition in the crate that can guarantee it.

## Residue retired

`TapMode` was `arcbox-tap-net`'s alias for the port's `AttachMode`, kept for the manager while it still spoke the TAP network's vocabulary; the manager says `AttachMode` now and the alias goes with its only consumer. The "until R2b" notes across both crates described this PR as pending — what actually remains is narrower and now says so: the System VM's port-forward and init code still name `invariant` and `ExposeTarget`, and its composition still builds the TAP network by name. Sandbox lifecycle touches neither.

## Rebase

Rebased onto #668 (R3 part 1), which landed while this was in flight. The spec builders moved to `sandbox/spec.rs` and `persistence`/`policy` split out; the conflicts were mechanical — `build_vm_spec`/`restore_spec` take the NIC in their new home, `SandboxPhase` is `record::PersistPhase`, and the journal test lands beside the recovery helpers. Every commit compiles on its own.
