### PR TITLE
feat(vm-driver): a guest network can adopt a lease whose guest still runs

### DIFF
--- a/virt/arcbox-tap-net/README.md
+++ b/virt/arcbox-tap-net/README.md
@@ -38,6 +38,7 @@ for the guest agent's port-forward and init code.
 |------|-----------------|
 | `reserve(vm, policy)` | `reserve(vm)` — `Isolated` and `Nat` are the same TAP shape (egress policy is the composer's netfilter business); `Bridged` is refused |
 | `activate(lease, mode)` | `activate(alloc, mode)` — returns `NicSpec { id: "eth0", mac, Tap { name } }` |
+| `adopt(lease, mode)` | `adopt(vm, alloc, mode)` — the guest is still running: the TAP is left alone, the address goes back out of the pool, and the translation the previous process's exit took with it is re-established (its eBPF TCX links died with that process) |
 | `quarantine(lease)` | `quarantine_checked(vm, alloc)` |
 | `release(lease)` | `release_checked(alloc)` |
 | `identity(lease, mode)` | the invariant link under `Invariant` (every fresh boot and invariant restore), the pool address under `LegacySnapshot` — the resolver is the gateway either way |

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -391,6 +391,7 @@ mod tests {
         // Two records claiming one address: adopting either is a guess.
         let mut twin = lease.clone();
         twin.vm = vm("twin");
+        twin.mac = crate::mac_from_vm_id("twin");
         let error = GuestNetwork::adopt(&restarted, &twin, AttachMode::Invariant)
             .await
             .unwrap_err();

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -7,6 +7,7 @@
 //! |------|----------|
 //! | `reserve(vm, policy)` | `reserve(vm)`; the [`NetworkAllocation`] becomes a [`NetworkLease`] |
 //! | `activate(lease, mode)` | `activate(alloc, mode)`; returns the TAP as a [`NicSpec`] named `eth0` |
+//! | `adopt(lease, mode)` | `adopt(vm, alloc, mode)`; the guest is already running |
 //! | `quarantine(lease)` | `quarantine_checked(vm, alloc)` |
 //! | `release(lease)` | `release_checked(alloc)` |
 //! | `identity(lease, mode)` | the invariant identity, or the pool identity under `LegacySnapshot` |
@@ -134,6 +135,13 @@ impl GuestNetwork for TapNetwork {
         let allocation = self.allocation(lease)?;
         Self::activate(self, &allocation, mode)?;
         Ok(Self::nic_spec(lease, &allocation))
+    }
+
+    /// The TAP is the running guest's NIC: adoption re-establishes the
+    /// host state around it and leaves the device alone.
+    async fn adopt(&self, lease: &NetworkLease, mode: AttachMode) -> Result<()> {
+        let allocation = self.allocation(lease)?;
+        Ok(Self::adopt(self, lease.vm.as_str(), &allocation, mode)?)
     }
 
     async fn quarantine(&self, lease: NetworkLease) -> Result<()> {
@@ -352,6 +360,82 @@ mod tests {
             NicAttachment::Tap {
                 name: "vmtap0-2".into()
             }
+        );
+    }
+
+    /// The pool must stop offering an adopted address, or the next
+    /// `reserve` puts a second sandbox on a live guest's TAP — and a
+    /// refused adoption must leave it exactly as it was, since the owner's
+    /// fallback is to tear that sandbox down. Off Linux, where adoption's
+    /// host half has no live device to find.
+    #[cfg(not(target_os = "linux"))]
+    #[tokio::test]
+    async fn an_adopted_address_leaves_the_pool_and_a_refusal_changes_nothing() {
+        // What a previous process journaled, its guest still running.
+        let previous = network();
+        let lease = GuestNetwork::reserve(&previous, &vm("box"), policy(NetworkMode::Nat))
+            .await
+            .unwrap();
+        assert_eq!(lease.ip, v4("172.20.0.2"));
+        drop(previous);
+
+        let restarted = network();
+        GuestNetwork::adopt(&restarted, &lease, AttachMode::Invariant)
+            .await
+            .unwrap();
+        let fresh = GuestNetwork::reserve(&restarted, &vm("other"), policy(NetworkMode::Nat))
+            .await
+            .unwrap();
+        assert_eq!(fresh.ip, v4("172.20.0.3"), "the adopted address is held");
+
+        // Two records claiming one address: adopting either is a guess.
+        let mut twin = lease.clone();
+        twin.vm = vm("twin");
+        let error = GuestNetwork::adopt(&restarted, &twin, AttachMode::Invariant)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&error, Error::Network(m) if m.contains("172.20.0.2")),
+            "{error}"
+        );
+        // The refusal handed nothing back: were it to free the live
+        // guest's address, the pool would offer it here.
+        let next = GuestNetwork::reserve(&restarted, &vm("third"), policy(NetworkMode::Nat))
+            .await
+            .unwrap();
+        assert_eq!(next.ip, v4("172.20.0.4"));
+    }
+
+    /// Live or awaiting cleanup finalization, never both: a quarantined
+    /// id is refused before any host work, in the class no retry fixes.
+    #[tokio::test]
+    async fn a_quarantined_lease_is_not_adoptable() {
+        let root = tempfile::tempdir().unwrap();
+        let ledgered = TapNetwork::with_quarantine_dir(
+            "172.20.0.0/16",
+            "172.20.0.1",
+            vec![],
+            root.path().join("q"),
+            Datapath::default(),
+            Arc::new(IptablesLegacy::default()),
+        )
+        .unwrap();
+        // The allocation a previous process journaled and this one found
+        // in its ledger, awaiting the host's cleanup finalization.
+        let allocation = TapNetwork::reserve(&network(), "box").unwrap();
+        ledgered
+            .quarantined
+            .lock()
+            .unwrap()
+            .insert("box".to_owned(), allocation.clone());
+
+        let lease = TapNetwork::lease(&vm("box"), &allocation);
+        let error = GuestNetwork::adopt(&ledgered, &lease, AttachMode::Invariant)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&error, Error::PreconditionFailed(m) if m.contains("box")),
+            "{error}"
         );
     }
 

--- a/virt/arcbox-tap-net/src/lib.rs
+++ b/virt/arcbox-tap-net/src/lib.rs
@@ -408,6 +408,107 @@ impl TapNetwork {
         Ok(())
     }
 
+    /// Take `alloc` back as a live network for `vm_id`, whose guest
+    /// outlived the process that activated it, re-establishing the host
+    /// state that died with that process.
+    ///
+    /// Not a second [`Self::activate`]: the TAP is the running guest's
+    /// NIC, so it is never created or re-addressed here, and its absence
+    /// is an error — the link the guest boots on is gone, and the owner's
+    /// answer to that is to tear the sandbox down. A failure therefore
+    /// leaves the pool exactly as it found it. Deliberately not gated on
+    /// [`Self::ensure_startup_cleanup_complete`], unlike [`Self::reserve`]:
+    /// adoption is what the startup sweep does, before that gate opens.
+    pub fn adopt(&self, vm_id: &str, alloc: &NetworkAllocation, mode: AttachMode) -> Result<()> {
+        quarantine::validate_id(vm_id)?;
+        // Live or awaiting cleanup finalization, never both.
+        if self.quarantined.lock().unwrap().contains_key(vm_id) {
+            return Err(TapNetError::WrongState {
+                id: vm_id.to_owned(),
+                expected: "no pending cleanup".into(),
+                actual: "cleanup awaiting host finalization".into(),
+            });
+        }
+        // Two records claiming one address is an inconsistent journal:
+        // adopting either is a guess, and handing it out again would put a
+        // second sandbox on a live TAP.
+        if !self
+            .allocated
+            .lock()
+            .unwrap()
+            .insert(u32::from(alloc.ip_address))
+        {
+            return Err(TapNetError::Network(format!(
+                "sandbox {vm_id} cannot adopt {}: the address is already allocated",
+                alloc.ip_address
+            )));
+        }
+        let adopted = self.readopt_host_state(alloc, mode);
+        if adopted.is_err() {
+            // The owner's fallback is to tear the sandbox down, so a
+            // refused adoption must not keep the address on its way out.
+            self.allocated
+                .lock()
+                .unwrap()
+                .remove(&u32::from(alloc.ip_address));
+        }
+        adopted
+    }
+
+    /// The half of [`Self::adopt`] that runs with the address already
+    /// taken: the pool's naming rule, the guest's device, the translation.
+    fn readopt_host_state(&self, alloc: &NetworkAllocation, mode: AttachMode) -> Result<()> {
+        info!(
+            tap = %alloc.tap_name,
+            ip = %alloc.ip_address,
+            ?mode,
+            "adopting a live sandbox network"
+        );
+        // The rule `reserve` writes by: any other TAP name for this
+        // address is not a record this pool could have produced.
+        if alloc.tap_name != tap_name_from_ip(alloc.ip_address) {
+            return Err(TapNetError::Network(format!(
+                "adopted TAP {} is not the name this pool gives {}",
+                alloc.tap_name, alloc.ip_address
+            )));
+        }
+        #[cfg(target_os = "linux")]
+        {
+            // Existence only — never `tap::create`: the interface is live
+            // and carrying the guest's traffic.
+            invariant::tap_ifindex(&alloc.tap_name)?;
+            if mode == AttachMode::Invariant {
+                // eBPF TCX links are file descriptors that died with the
+                // process that opened them (see the `ebpf` module docs), so
+                // an adopted invariant TAP has its onlink route and no
+                // programs: the guest is alive and unreachable until they
+                // are re-attached. Iptables rules survive instead and their
+                // install appends rather than replaces, so remove first —
+                // through the tolerant removal (no `applied` record yet is
+                // exactly its "activated by a previous agent process"
+                // case), whose failure on rules that never existed must not
+                // block the adoption.
+                if let Err(error) = self.deactivate_translation(alloc) {
+                    debug!(
+                        tap = %alloc.tap_name,
+                        %error,
+                        "pre-adoption translation removal incomplete"
+                    );
+                }
+                self.install_translation(alloc)?;
+            } else {
+                // Same reason as in `activate`: `expose_target` reads an
+                // absent record as an invariant TAP this process did not
+                // activate, and answers the opposite way.
+                self.applied
+                    .lock()
+                    .unwrap()
+                    .insert(alloc.tap_name.clone(), AppliedDatapath::Untranslated);
+            }
+        }
+        Ok(())
+    }
+
     /// Apply the invariant pool-IP translation to an existing TAP, honoring
     /// the configured [`Datapath`] and falling back to iptables when
     /// the eBPF path is unavailable, then record what was applied.

--- a/virt/arcbox-tap-net/src/lib.rs
+++ b/virt/arcbox-tap-net/src/lib.rs
@@ -494,7 +494,14 @@ impl TapNetwork {
                 // duplicates every surviving rule, so refuse instead and
                 // let the owner fall back.
                 self.deactivate_translation(alloc)?;
-                self.install_translation(alloc)?;
+                if let Err(error) = self.install_translation(alloc) {
+                    // As in `activate`, minus the TAP destroy: the device
+                    // is the live guest's. This leaves the TAP with no
+                    // translation rather than half of one, which is where
+                    // the failed removal above would have left it anyway.
+                    let _ = self.deactivate_translation(alloc);
+                    return Err(error);
+                }
             } else {
                 // Same reason as in `activate`: `expose_target` reads an
                 // absent record as an invariant TAP this process did not

--- a/virt/arcbox-tap-net/src/lib.rs
+++ b/virt/arcbox-tap-net/src/lib.rs
@@ -421,6 +421,12 @@ impl TapNetwork {
     /// adoption is what the startup sweep does, before that gate opens.
     pub fn adopt(&self, vm_id: &str, alloc: &NetworkAllocation, mode: AttachMode) -> Result<()> {
         quarantine::validate_id(vm_id)?;
+        // A journaled record is not this process's memory: hold it to the
+        // rules `reserve` writes by, as the ledger's loader holds its
+        // markers. An address outside this pool is the case that bites —
+        // `next_ip` would never see it as taken, while its TAP name (the
+        // last two octets) can be one this pool hands out.
+        quarantine::validate_allocation(vm_id, alloc, self.base, self.prefix_len, self.gateway)?;
         // Live or awaiting cleanup finalization, never both.
         if self.quarantined.lock().unwrap().contains_key(vm_id) {
             return Err(TapNetError::WrongState {
@@ -456,7 +462,11 @@ impl TapNetwork {
     }
 
     /// The half of [`Self::adopt`] that runs with the address already
-    /// taken: the pool's naming rule, the guest's device, the translation.
+    /// taken: the guest's device, and the translation its exit took away.
+    #[allow(
+        clippy::unnecessary_wraps,
+        reason = "Linux adoption is fallible; macOS test builds compile the no-op branch"
+    )]
     fn readopt_host_state(&self, alloc: &NetworkAllocation, mode: AttachMode) -> Result<()> {
         info!(
             tap = %alloc.tap_name,
@@ -464,14 +474,6 @@ impl TapNetwork {
             ?mode,
             "adopting a live sandbox network"
         );
-        // The rule `reserve` writes by: any other TAP name for this
-        // address is not a record this pool could have produced.
-        if alloc.tap_name != tap_name_from_ip(alloc.ip_address) {
-            return Err(TapNetError::Network(format!(
-                "adopted TAP {} is not the name this pool gives {}",
-                alloc.tap_name, alloc.ip_address
-            )));
-        }
         #[cfg(target_os = "linux")]
         {
             // Existence only — never `tap::create`: the interface is live
@@ -486,15 +488,12 @@ impl TapNetwork {
                 // install appends rather than replaces, so remove first —
                 // through the tolerant removal (no `applied` record yet is
                 // exactly its "activated by a previous agent process"
-                // case), whose failure on rules that never existed must not
-                // block the adoption.
-                if let Err(error) = self.deactivate_translation(alloc) {
-                    debug!(
-                        tap = %alloc.tap_name,
-                        %error,
-                        "pre-adoption translation removal incomplete"
-                    );
-                }
+                // case). Its absent-rule case is already an `Ok`, so an
+                // error here means the removal itself failed and what the
+                // TAP still carries is unknown; installing on top of that
+                // duplicates every surviving rule, so refuse instead and
+                // let the owner fall back.
+                self.deactivate_translation(alloc)?;
                 self.install_translation(alloc)?;
             } else {
                 // Same reason as in `activate`: `expose_target` reads an

--- a/virt/arcbox-tap-net/src/quarantine.rs
+++ b/virt/arcbox-tap-net/src/quarantine.rs
@@ -262,7 +262,7 @@ pub fn load_quarantines(
                 marker.id
             )));
         }
-        validate_quarantine_allocation(&marker.id, &marker.allocation, base, prefix_len, gateway)?;
+        validate_allocation(&marker.id, &marker.allocation, base, prefix_len, gateway)?;
         if !tokens.insert(marker.allocation.cleanup_token.clone()) {
             return Err(TapNetError::Network(format!(
                 "duplicate sandbox network quarantine token for {}",
@@ -289,7 +289,12 @@ pub fn load_quarantines(
     Ok(quarantined)
 }
 
-fn validate_quarantine_allocation(
+/// Whether `allocation` is one this network could have written for `id`:
+/// an allocatable address of this pool, with the prefix, gateway, TAP name
+/// and MAC that `reserve` derives. Applied to every record read back from
+/// durable state — the ledger's markers at load, and a journaled lease at
+/// [`TapNetwork::adopt`] — since neither is this process's own memory.
+pub fn validate_allocation(
     id: &str,
     allocation: &NetworkAllocation,
     base: Ipv4Addr,
@@ -303,7 +308,7 @@ fn validate_quarantine_allocation(
     let broadcast = network | !mask;
     if ip & mask != network || ip <= network + 1 || ip == u32::from(gateway) || ip == broadcast {
         return Err(TapNetError::Network(format!(
-            "sandbox network quarantine {id} has non-allocatable IP {}",
+            "sandbox network record {id} has non-allocatable IP {}",
             allocation.ip_address
         )));
     }
@@ -313,7 +318,7 @@ fn validate_quarantine_allocation(
         || allocation.mac_address != mac_from_vm_id(id).to_string()
     {
         return Err(TapNetError::Network(format!(
-            "sandbox network quarantine {id} metadata does not match the current network"
+            "sandbox network record {id} metadata does not match the current network"
         )));
     }
     Ok(())

--- a/virt/arcbox-tap-net/src/tests.rs
+++ b/virt/arcbox-tap-net/src/tests.rs
@@ -140,36 +140,46 @@ fn expose_target_follows_the_applied_datapath() {
     assert_eq!(manager.expose_target("vmtap0-2"), ExposeTarget::PoolIp);
 }
 
-/// A record naming any other TAP for its address is not one this pool
-/// could have written, so adoption refuses it — and hands the address
-/// back, since the owner answers a refusal by tearing the sandbox down.
+/// A journaled record is held to the rules `reserve` writes by. The
+/// address matters most: one from another pool is invisible to `next_ip`,
+/// while its TAP name — the last two octets — can be one this pool hands
+/// out, so a later sandbox would create its TAP over a live guest's.
 #[test]
-fn adopt_refuses_a_tap_name_this_pool_would_not_give() {
+fn adopt_refuses_a_record_this_pool_would_not_have_written() {
     let pool = || TapNetwork::new("10.0.99.0/24", "10.0.99.1", vec![]).unwrap();
-    // What a previous process journaled, with the TAP name rewritten.
-    let mut allocation = pool().reserve("box").unwrap();
-    allocation.tap_name = "vmtap-elsewhere".into();
-
+    let journaled = pool().reserve("box").unwrap();
     let manager = pool();
-    let error = manager
-        .adopt("box", &allocation, AttachMode::Invariant)
-        .unwrap_err();
-    assert!(error.to_string().contains("vmtap-elsewhere"), "{error}");
-    assert!(
-        !manager
-            .allocated
-            .lock()
-            .unwrap()
-            .contains(&u32::from(allocation.ip_address)),
-        "a refused adoption keeps no address"
-    );
 
-    // An id the port could never name (`..`) is refused before that.
-    allocation.tap_name = tap_name_from_ip(allocation.ip_address);
+    let mut foreign = journaled.clone();
+    foreign.ip_address = "172.20.99.2".parse().unwrap(); // also named vmtap99-2
+    let error = manager
+        .adopt("box", &foreign, AttachMode::Invariant)
+        .unwrap_err();
+    assert!(error.to_string().contains("non-allocatable"), "{error}");
+
+    let mut renamed = journaled.clone();
+    renamed.tap_name = "vmtap-elsewhere".into();
     assert!(
         manager
-            .adopt("..", &allocation, AttachMode::Invariant)
+            .adopt("box", &renamed, AttachMode::Invariant)
             .is_err()
+    );
+    // Another VM's record: the MAC follows the id that reserved it.
+    assert!(
+        manager
+            .adopt("other", &journaled, AttachMode::Invariant)
+            .is_err()
+    );
+    // An id the port could never name (`..`) is refused before all of that.
+    assert!(
+        manager
+            .adopt("..", &journaled, AttachMode::Invariant)
+            .is_err()
+    );
+
+    assert!(
+        manager.allocated.lock().unwrap().is_empty(),
+        "a refused adoption keeps no address"
     );
 }
 

--- a/virt/arcbox-tap-net/src/tests.rs
+++ b/virt/arcbox-tap-net/src/tests.rs
@@ -140,6 +140,62 @@ fn expose_target_follows_the_applied_datapath() {
     assert_eq!(manager.expose_target("vmtap0-2"), ExposeTarget::PoolIp);
 }
 
+/// A record naming any other TAP for its address is not one this pool
+/// could have written, so adoption refuses it — and hands the address
+/// back, since the owner answers a refusal by tearing the sandbox down.
+#[test]
+fn adopt_refuses_a_tap_name_this_pool_would_not_give() {
+    let pool = || TapNetwork::new("10.0.99.0/24", "10.0.99.1", vec![]).unwrap();
+    // What a previous process journaled, with the TAP name rewritten.
+    let mut allocation = pool().reserve("box").unwrap();
+    allocation.tap_name = "vmtap-elsewhere".into();
+
+    let manager = pool();
+    let error = manager
+        .adopt("box", &allocation, AttachMode::Invariant)
+        .unwrap_err();
+    assert!(error.to_string().contains("vmtap-elsewhere"), "{error}");
+    assert!(
+        !manager
+            .allocated
+            .lock()
+            .unwrap()
+            .contains(&u32::from(allocation.ip_address)),
+        "a refused adoption keeps no address"
+    );
+
+    // An id the port could never name (`..`) is refused before that.
+    allocation.tap_name = tap_name_from_ip(allocation.ip_address);
+    assert!(
+        manager
+            .adopt("..", &allocation, AttachMode::Invariant)
+            .is_err()
+    );
+}
+
+/// The TAP is the running guest's NIC: its absence means the guest's link
+/// is gone, so adoption fails rather than creating one, and the address it
+/// took goes back to the pool.
+#[test]
+#[cfg(target_os = "linux")]
+fn adopt_refuses_a_missing_tap_and_frees_the_address() {
+    let pool = || TapNetwork::new("10.0.98.0/24", "10.0.98.1", vec![]).unwrap();
+    let allocation = pool().reserve("box").unwrap();
+    let manager = pool();
+    let error = manager
+        .adopt("box", &allocation, AttachMode::Invariant)
+        .unwrap_err();
+    assert!(error.to_string().contains(&allocation.tap_name), "{error}");
+    assert!(
+        !manager
+            .allocated
+            .lock()
+            .unwrap()
+            .contains(&u32::from(allocation.ip_address)),
+        "a refused adoption keeps no address"
+    );
+}
+
 #[tokio::test]
 async fn startup_waiter_unblocks_after_host_finalization() {
     let root = tempfile::tempdir().unwrap();

--- a/virt/arcbox-vm-driver/README.md
+++ b/virt/arcbox-vm-driver/README.md
@@ -40,8 +40,10 @@ that the flags and the accessors agree.
 | `DebugSnapshot` | `handle.debug()` | driver-specific JSON for post-mortems |
 
 `net::GuestNetwork` is the second port: reserve a lease, activate it into
-a `NicSpec`, ask what the guest sees under the mode it was activated in,
-quarantine/release, and the `NetworkReconcile` cleanup-token protocol.
+a `NicSpec`, adopt one whose guest outlived the process that activated it
+(re-establishing the host state that died with that process), ask what
+the guest sees under the mode it was activated in, quarantine/release,
+and the `NetworkReconcile` cleanup-token protocol.
 That protocol answers with `Error::Unavailable` (come back later) and
 `Error::PreconditionFailed` (that token names no pending generation);
 those two classes are the contract callers turn into their wire codes, so

--- a/virt/arcbox-vm-driver/src/net.rs
+++ b/virt/arcbox-vm-driver/src/net.rs
@@ -27,6 +27,27 @@ pub trait GuestNetwork: Send + Sync {
     /// the driver boots with.
     async fn activate(&self, lease: &NetworkLease, mode: AttachMode) -> Result<NicSpec>;
 
+    /// Re-registers a lease whose guest is still running, and re-establishes
+    /// whatever host state died with the previous process.
+    ///
+    /// The third way a lease becomes live: a host that restarts while its
+    /// guests keep running replays its durable leases through this, then
+    /// declares the replay done ([`NetworkReconcile::replay_complete`]).
+    /// Unlike [`GuestNetwork::activate`] it must not create or re-address
+    /// the guest's interface — the link is live and carrying traffic.
+    ///
+    /// `mode` is what the lease was activated as, which the caller knows
+    /// and the network does not: it decides whether the guest holds the
+    /// pool address itself or the fixed invariant one.
+    ///
+    /// Fallible on purpose, and the failure is not fatal to the caller: an
+    /// adapter that cannot re-establish says so, and the owner falls back
+    /// to tearing the VM down — the behavior it had before adoption
+    /// existed. Hence no default body: an adapter that silently claimed
+    /// adoption worked would leave a live guest unreachable, which is
+    /// strictly worse than that fallback.
+    async fn adopt(&self, lease: &NetworkLease, mode: AttachMode) -> Result<()>;
+
     /// Tears the host side down but keeps the address reserved until the
     /// cleanup protocol confirms host forwarding state is gone. Idempotent.
     async fn quarantine(&self, lease: NetworkLease) -> Result<()>;

--- a/virt/arcbox-vm-driver/src/net.rs
+++ b/virt/arcbox-vm-driver/src/net.rs
@@ -40,6 +40,11 @@ pub trait GuestNetwork: Send + Sync {
     /// and the network does not: it decides whether the guest holds the
     /// pool address itself or the fixed invariant one.
     ///
+    /// Not idempotent, unlike [`GuestNetwork::quarantine`]: a lease that is
+    /// already live, or whose address another live lease holds, is an
+    /// error. Two records claiming one address is an inconsistent replay,
+    /// and adopting either of them is a guess.
+    ///
     /// Fallible on purpose, and the failure is not fatal to the caller: an
     /// adapter that cannot re-establish says so, and the owner falls back
     /// to tearing the VM down — the behavior it had before adoption

--- a/virt/arcbox-vm-driver/src/testkit/fake_network.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_network.rs
@@ -242,8 +242,11 @@ impl GuestNetwork for FakeNetwork {
     /// ([`FakeNetwork::adopted_mode`]). Its refusals are a real adapter's,
     /// each saying the durable record cannot be true — a lease of another
     /// network, one awaiting cleanup finalization (live or quarantined,
-    /// never both), an address already held. Unlike `reserve` it is not
-    /// gated on the startup sweep: adoption is what that sweep does.
+    /// never both), an address already held (re-adoption included: this is
+    /// not idempotent) — plus a VM that already holds a live lease, which
+    /// is this fake being stricter than an address pool can be, as its
+    /// `reserve` already is. Unlike `reserve` it is not gated on the
+    /// startup sweep: adoption is what that sweep does.
     async fn adopt(&self, lease: &NetworkLease, mode: AttachMode) -> Result<()> {
         if self.fail_adopt.swap(false, Ordering::AcqRel) {
             return Err(Error::Network(format!(
@@ -259,16 +262,22 @@ impl GuestNetwork for FakeNetwork {
                 lease.vm
             )));
         }
-        if ledger.active.contains_key(&lease.vm) {
-            return Err(Error::PreconditionFailed(format!(
-                "vm {} already holds a live lease",
-                lease.vm
-            )));
-        }
+        // Address before VM, as the TAP network answers it: its live state
+        // is the address pool, so re-adopting a live lease is the
+        // duplicate-address refusal there too. The VM check below is this
+        // fake being stricter than an address pool can be — the same
+        // strictness its `reserve` already has.
         if !ledger.used.insert(host) {
             return Err(Error::Network(format!(
                 "vm {} cannot adopt {}: the address is already held",
                 lease.vm, lease.ip
+            )));
+        }
+        if ledger.active.contains_key(&lease.vm) {
+            ledger.used.remove(&host);
+            return Err(Error::PreconditionFailed(format!(
+                "vm {} already holds a live lease",
+                lease.vm
             )));
         }
         ledger.active.insert(lease.vm.clone(), lease.clone());
@@ -543,6 +552,12 @@ mod tests {
         let live = replayed("a", 2);
         net.adopt(&live, AttachMode::Invariant).await.unwrap();
         assert_eq!(net.adopted_mode(&id("a")), Some(AttachMode::Invariant));
+        // Re-adopting a live lease is the address collision, the answer the
+        // TAP network gives it too — `adopt` is not a no-op the second time.
+        assert!(matches!(
+            net.adopt(&live, AttachMode::Invariant).await,
+            Err(Error::Network(_))
+        ));
         // The pool has stopped offering that address...
         let next = net.reserve(&id("b"), policy()).await.unwrap();
         assert_ne!(next.ip, live.ip);

--- a/virt/arcbox-vm-driver/src/testkit/fake_network.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_network.rs
@@ -3,6 +3,7 @@
 use std::collections::{BTreeSet, HashMap};
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
 use tokio::sync::watch;
@@ -25,6 +26,8 @@ use crate::spec::{MacAddr, NicAttachment, NicSpec, VmId};
 /// cleanup so that half of the protocol can be exercised too — including
 /// its ordering: until [`NetworkReconcile::replay_complete`] says the
 /// owner has finished replaying, no token names a finalizable sweep.
+/// `adopt` is the third way a lease becomes live;
+/// [`FakeNetwork::fail_adopt_once`] scripts the refusal to fall back from.
 ///
 /// It answers that protocol in the same error *classes* a real adapter
 /// does — [`Error::Unavailable`] for come-back-later (a pending startup
@@ -38,6 +41,8 @@ pub struct FakeNetwork {
     ledger: Mutex<Ledger>,
     /// `true` while a startup cleanup is pending.
     startup_pending: watch::Sender<bool>,
+    /// Scripted failure, armed once and consumed by the next `adopt`.
+    fail_adopt: AtomicBool,
 }
 
 #[derive(Default)]
@@ -45,6 +50,8 @@ struct Ledger {
     /// Host numbers in use, active or quarantined.
     used: BTreeSet<u16>,
     active: HashMap<VmId, NetworkLease>,
+    /// The mode each adopted lease was originally activated in.
+    adopted: HashMap<VmId, AttachMode>,
     quarantined: HashMap<VmId, NetworkLease>,
     startup: Option<StartupCleanup>,
     minted: u64,
@@ -88,7 +95,21 @@ impl FakeNetwork {
                 ..Ledger::default()
             }),
             startup_pending: watch::Sender::new(pending),
+            fail_adopt: AtomicBool::new(false),
         }
+    }
+
+    /// Arms a scripted failure: the next [`GuestNetwork::adopt`] fails
+    /// and changes nothing — an adapter that cannot re-establish the host
+    /// state its guest needs, which the owner must answer by tearing the
+    /// VM down rather than keeping a live but unreachable one.
+    pub fn fail_adopt_once(&self) {
+        self.fail_adopt.store(true, Ordering::Release);
+    }
+
+    /// The mode `vm`'s lease was adopted in, if it was adopted.
+    pub fn adopted_mode(&self, vm: &VmId) -> Option<AttachMode> {
+        lock(&self.ledger).adopted.get(vm).copied()
     }
 
     fn set_startup_pending(&self, ledger: &Ledger) {
@@ -215,6 +236,46 @@ impl GuestNetwork for FakeNetwork {
         })
     }
 
+    /// Re-registers `lease` as live. Nothing here dies with a process, so
+    /// adoption is bookkeeping only: the address leaves the pool as
+    /// `reserve` takes it, and the mode is recorded
+    /// ([`FakeNetwork::adopted_mode`]). Its refusals are a real adapter's,
+    /// each saying the durable record cannot be true — a lease of another
+    /// network, one awaiting cleanup finalization (live or quarantined,
+    /// never both), an address already held. Unlike `reserve` it is not
+    /// gated on the startup sweep: adoption is what that sweep does.
+    async fn adopt(&self, lease: &NetworkLease, mode: AttachMode) -> Result<()> {
+        if self.fail_adopt.swap(false, Ordering::AcqRel) {
+            return Err(Error::Network(format!(
+                "scripted adopt failure for vm {}",
+                lease.vm
+            )));
+        }
+        let host = host_number(lease.ip)?;
+        let mut ledger = lock(&self.ledger);
+        if ledger.quarantined.contains_key(&lease.vm) {
+            return Err(Error::PreconditionFailed(format!(
+                "vm {} lease is quarantined; it cannot also be live",
+                lease.vm
+            )));
+        }
+        if ledger.active.contains_key(&lease.vm) {
+            return Err(Error::PreconditionFailed(format!(
+                "vm {} already holds a live lease",
+                lease.vm
+            )));
+        }
+        if !ledger.used.insert(host) {
+            return Err(Error::Network(format!(
+                "vm {} cannot adopt {}: the address is already held",
+                lease.vm, lease.ip
+            )));
+        }
+        ledger.active.insert(lease.vm.clone(), lease.clone());
+        ledger.adopted.insert(lease.vm.clone(), mode);
+        Ok(())
+    }
+
     async fn quarantine(&self, lease: NetworkLease) -> Result<()> {
         let mut ledger = lock(&self.ledger);
         let host = host_number(lease.ip)?;
@@ -232,6 +293,7 @@ impl GuestNetwork for FakeNetwork {
         match ledger.active.get(&lease.vm) {
             Some(current) if *current == lease => {
                 ledger.active.remove(&lease.vm);
+                ledger.adopted.remove(&lease.vm);
             }
             Some(_) => return Err(ledger.stale(&lease)),
             // A lease replayed from a durable record after a crash is
@@ -259,6 +321,7 @@ impl GuestNetwork for FakeNetwork {
         match current {
             Some(current) if *current == lease => {
                 ledger.active.remove(&lease.vm);
+                ledger.adopted.remove(&lease.vm);
                 ledger.quarantined.remove(&lease.vm);
                 ledger.used.remove(&host);
                 Ok(())
@@ -455,6 +518,76 @@ mod tests {
         let mut foreign = lease;
         foreign.ip = "192.0.2.7".parse().unwrap();
         assert!(net.host_ingress(&foreign).is_err());
+    }
+
+    /// A lease as a previous process's durable record hands it back: this
+    /// network never minted it.
+    fn replayed(vm: &str, host: u16) -> NetworkLease {
+        let [hi, lo] = host.to_be_bytes();
+        NetworkLease {
+            vm: id(vm),
+            ip: IpAddr::V4(Ipv4Addr::new(10, 200, hi, lo)),
+            prefix_len: PREFIX_LEN,
+            gateway: IpAddr::V4(GATEWAY),
+            mac: MacAddr::new([0x02, 0xfa, 0xce, 0x00, hi, lo]),
+            cleanup_token: format!("boot-1-{vm}"),
+        }
+    }
+
+    /// Adoption is the third way a lease becomes live, so the pool must
+    /// stop offering its address and every live-path read must answer
+    /// about it.
+    #[tokio::test]
+    async fn an_adopted_lease_holds_its_address_and_answers_the_live_reads() {
+        let net = FakeNetwork::new();
+        let live = replayed("a", 2);
+        net.adopt(&live, AttachMode::Invariant).await.unwrap();
+        assert_eq!(net.adopted_mode(&id("a")), Some(AttachMode::Invariant));
+        // The pool has stopped offering that address...
+        let next = net.reserve(&id("b"), policy()).await.unwrap();
+        assert_ne!(next.ip, live.ip);
+        // ...and the reads a live lease answers do answer about it.
+        assert_eq!(net.identity(&live, AttachMode::Invariant).ip, live.ip);
+        assert_eq!(net.host_ingress(&live).unwrap(), HostIngress::PoolAddress);
+
+        // Two records claiming one address: adopting either is a guess.
+        let mut twin = live.clone();
+        twin.vm = id("twin");
+        assert!(matches!(
+            net.adopt(&twin, AttachMode::Invariant).await,
+            Err(Error::Network(_))
+        ));
+        // The refusal changed nothing: the pool hands out what it would
+        // have handed out anyway.
+        let after = net.reserve(&id("c"), policy()).await.unwrap();
+        assert_eq!(after.ip, "10.200.0.4".parse::<IpAddr>().unwrap());
+        // Not a lease of this network at all.
+        let mut foreign = live.clone();
+        foreign.ip = "192.0.2.7".parse().unwrap();
+        assert!(net.adopt(&foreign, AttachMode::Invariant).await.is_err());
+
+        // Live and awaiting cleanup are exclusive, in both directions.
+        net.quarantine(live.clone()).await.unwrap();
+        assert_eq!(net.adopted_mode(&id("a")), None);
+        assert!(matches!(
+            net.adopt(&live, AttachMode::Invariant).await,
+            Err(Error::PreconditionFailed(_))
+        ));
+    }
+
+    /// The scripted refusal an owner falls back from leaves the pool
+    /// untouched, so tearing the VM down is all that happened.
+    #[tokio::test]
+    async fn a_scripted_adopt_failure_takes_nothing_and_is_armed_once() {
+        let net = FakeNetwork::new();
+        let live = replayed("a", 2);
+        net.fail_adopt_once();
+        assert!(net.adopt(&live, AttachMode::Invariant).await.is_err());
+        assert_eq!(net.adopted_mode(&id("a")), None);
+        // Nothing was taken: the same adopt goes through once the knob is
+        // spent, where a half-applied one would refuse a duplicate.
+        net.adopt(&live, AttachMode::LegacySnapshot).await.unwrap();
+        assert_eq!(net.adopted_mode(&id("a")), Some(AttachMode::LegacySnapshot));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Part 1 of [CORE-135](https://linear.app/arcbox/issue/CORE-135) ("Startup
reconcile destroys live sandboxes instead of re-adopting them", blocks
PLAT-194): the `GuestNetwork` port and the Linux TAP adapter learn to
**adopt** a lease whose guest is still running.

Adoption needs several things to become true at once; most of them live in
the sandbox manager (`virt/arcbox-vm`) and wait on the R3 crate move. The
two here are the ones that decide whether adoption is possible at all, so
they go first — the same shape as #667.

## Why `adopt` is a required method and not a defaulted no-op

`virt/arcbox-tap-net/src/ebpf.rs:20-23`:

> TCX links are plain file descriptors: they detach when dropped and die
> with the process, so a crashed agent leaves no kernel state behind beyond
> the TAP itself (which the reconcile sweep already removes). The route dies
> with the TAP. Nothing is pinned.

So on the default (eBPF) datapath a still-running guest whose composing
process restarted has: its TAP (persistent), its onlink route (dies with the
TAP, so alive), and **no translation programs**. An `adopt` that did nothing
to the network would hand back a VM that is alive and unreachable — strictly
worse than today's honest kill, and invisible until something tries to talk
to the sandbox. Hence no default body, and hence the TAP adapter
removes-then-installs the translation on every adopt: the iptables install
is `-A` per rule and those rules *do* survive a restart, so installing over
a survivor would duplicate all seven.

## The second finding: the pool did not know about live addresses

`TapNetwork::new_inner` seeds the in-memory `allocated` set only from
quarantined entries, and `next_ip` consults only that set — never the
kernel. An address held by a still-running guest was therefore free as far
as the pool was concerned, and the next `reserve` would have handed it to a
new sandbox on top of a live TAP. `adopt` takes it back out of the pool, and
a refused adopt returns it, because the owner's fallback is to tear that
sandbox down and quarantine the lease.

## What is here

- `async fn adopt(&self, lease: &NetworkLease, mode: AttachMode) -> Result<()>`
  on `GuestNetwork`, placed after `activate`: the third way a lease becomes
  live, after which every live-path read (`identity`, `host_ingress`) must
  answer about it. `mode` is the caller's, exactly as on `activate` and
  `identity`.
- `TapNetwork::adopt` — holds the journaled record to the rules `reserve`
  writes by (the quarantine loader's own `validate_allocation`, now shared:
  in-pool and allocatable, with the prefix, gateway, TAP name and MAC this
  pool would have written), refuses a quarantined lease (live and awaiting
  cleanup finalization are exclusive) and a duplicate address, never creates
  or re-addresses the TAP (a missing one is an error: the link the guest
  boots on is gone), and re-establishes the translation — removed first, and
  a removal that *fails* (as against finding nothing, which is already an
  `Ok` inside it) refuses the adoption rather than duplicating every rule
  that survived. It is deliberately *not* gated on the startup barrier —
  adoption is what the startup sweep does, before that gate opens. Recording
  `applied` again is a bonus fix: without a record `expose_target` answers
  `GuestIpWithFwmark` for an eBPF TAP, which is the wrong DNAT target.
- `FakeNetwork::adopt` with the same refusals, plus `fail_adopt_once` — the
  scripted failure part 2 needs to test the fall-back-to-kill path on macOS.

No file under `virt/arcbox-vm/` changes: it compiles against the new port
untouched (`cargo check -p arcbox-vm --all-targets`), which keeps this clear
of the in-flight `arcbox-vm` → `computer/arcbox-computer-runtime` move.

## Checks

`cargo fmt --all`; `cargo clippy -p arcbox-vm-driver -p arcbox-tap-net
--all-targets --all-features -- -D warnings` on macOS **and** on
`aarch64-unknown-linux-musl`; `cargo test -p arcbox-vm-driver
--all-features`; `cargo test -p arcbox-tap-net`; `cargo check --workspace
--all-targets`; `cargo run -p xtask -- check-layers`.

Tests assert observable state, not that `adopt` calls anything: the pool
stops offering an adopted address and a refusal leaves it exactly as it was;
a quarantined lease is not adoptable; a TAP name this pool would not give is
refused; and (Linux-only) a missing TAP is refused and frees the address.
The fake covers the adopt/reserve interaction, the live reads, and the knob.
Proving the eBPF re-attach itself needs a real TAP and root — that is the
Linux e2e in part 2.

## Not in this PR

Part 2, after the crate move: `state.json`'s `net_invariant`, the sweep's
adopt-vs-kill decision, `policy/recovery.rs`'s `Adopted` evidence,
`kill_sandbox_process` for an adopted instance, and
`arcbox-snapshot::reconcile_stale` learning a live set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes guest network lifecycle and host translation state on agent restart; pool accounting and iptables/eBPF re-attach must be correct to avoid double allocation or unreachable live guests, but scope is bounded to the TAP adapter and port contract with extensive tests.
> 
> **Overview**
> Adds **`GuestNetwork::adopt`** as the third path to a live lease (after `reserve` and `activate`), for guests that keep running when the composing process exits. The port method is **required** with no default: a silent no-op would leave eBPF-translated guests alive but unreachable after restart.
> 
> **`TapNetwork::adopt`** puts the journaled address back in the in-memory pool, validates the record with shared **`validate_allocation`** (renamed from quarantine-only validation), refuses quarantined or duplicate-address cases, does **not** create or re-address the TAP, and on Linux re-attaches eBPF TCX / refreshes iptables translation (remove-then-install so surviving rules are not duplicated). It is intentionally **not** gated on the startup cleanup barrier—that sweep uses adoption before the gate opens. Failed adoption rolls the address out of the pool again.
> 
> **`FakeNetwork`** mirrors the same refusals and adds **`fail_adopt_once`** for tests of the owner’s tear-down fallback. Docs and tests cover pool holding, quarantine exclusion, invalid journaled records, and missing TAP on Linux.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fcfc439d7424608e0b40b4c66ece6837b5bd1f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->