### PR TITLE
feat(snapshot): a live sandbox's CoW survives the startup sweep

### DIFF
--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -322,7 +322,10 @@ pub(super) async fn sweep_orphans(
             .iter()
             .map(|record| (record.id.as_str(), record.phase)),
     );
-    cow_manager.reconcile_stale(&retained)?;
+    // No sandbox is kept alive across this sweep yet, so no dm device is in
+    // use by a running VM — every one of them is an orphan to reap (CORE-135
+    // part 2b decides adopt-or-kill and fills this in).
+    cow_manager.reconcile_stale(&retained, &HashSet::new())?;
 
     let mut swept = HashSet::new();
     let mut runtime_dirs = Vec::new();

--- a/engine/arcbox-snapshot/src/snapshot_cow.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow.rs
@@ -1144,6 +1144,38 @@ mod tests {
         );
     }
 
+    /// The kernel answers with the path it resolved, so rediscovering a loop
+    /// by the spelling the caller configured only works when that spelling
+    /// is already canonical. A data directory reached through a symlink is
+    /// not an exotic deployment, and there it would cost a live sandbox its
+    /// adoption and hide this manager's own loops from teardown.
+    #[test]
+    fn a_template_reached_through_a_symlink_is_matched_by_its_resolved_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let templates = tmp.path().join("templates");
+        std::fs::create_dir(&templates).unwrap();
+        std::fs::write(templates.join("rootfs.ext4"), b"rootfs").unwrap();
+        let linked = tmp.path().join("data");
+        std::os::unix::fs::symlink(&templates, &linked).unwrap();
+        let configured = linked.join("rootfs.ext4");
+
+        let spellings = persistence::backing_spellings(&configured);
+
+        let resolved = std::fs::canonicalize(&configured).unwrap();
+        assert_ne!(
+            configured, resolved,
+            "the symlinked spelling has to differ, or this asserts nothing"
+        );
+        assert!(
+            spellings.contains(&configured.to_string_lossy().into_owned()),
+            "{spellings:?}"
+        );
+        assert!(
+            spellings.contains(&resolved.to_string_lossy().into_owned()),
+            "{spellings:?}"
+        );
+    }
+
     /// What makes the eventual teardown balance: the first adopted sandbox
     /// registers the template it found, and every later one holding the same
     /// template adds a reference rather than a second registration.

--- a/engine/arcbox-snapshot/src/snapshot_cow.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow.rs
@@ -838,6 +838,30 @@ async fn create_sparse_file(
 mod tests {
     use super::*;
 
+    /// A manager over `cow_dir` with nothing attached and no `dmsetup`;
+    /// tests that need one adjust the field they are about.
+    fn manager(cow_dir: &Path) -> CowManager {
+        CowManager {
+            templates: Mutex::new(HashMap::new()),
+            setup_orphans: Mutex::new(HashMap::new()),
+            losetup_lock: AsyncMutex::new(()),
+            cow_dir: cow_dir.to_path_buf(),
+            tools: Arc::new(BusyboxBlockTools::default()),
+            dmsetup_bin: None,
+            test_probe: None,
+        }
+    }
+
+    fn handle_for(dm_device: &Path, template: &Path) -> CowHandle {
+        CowHandle {
+            dm_name: "arcbox-snap-box".into(),
+            dm_device: dm_device.to_string_lossy().into_owned(),
+            cow_loop: "/dev/loop9".into(),
+            cow_file: PathBuf::from("/nonexistent/arcbox-cow-box.img"),
+            template_path: template.to_path_buf(),
+        }
+    }
+
     #[test]
     fn test_dm_name_format() {
         let name = format!("{DM_NAME_PREFIX}test-sandbox-123");
@@ -881,15 +905,7 @@ mod tests {
     #[test]
     fn template_marker_round_trip() {
         let tmp = tempfile::tempdir().unwrap();
-        let mgr = CowManager {
-            templates: Mutex::new(HashMap::new()),
-            setup_orphans: Mutex::new(HashMap::new()),
-            losetup_lock: AsyncMutex::new(()),
-            cow_dir: tmp.path().to_path_buf(),
-            tools: Arc::new(BusyboxBlockTools::default()),
-            dmsetup_bin: None,
-            test_probe: None,
-        };
+        let mgr = manager(tmp.path());
 
         let template = PathBuf::from("/var/lib/arcbox/rootfs.ext4");
         mgr.write_template_marker("/dev/loop7", &template).unwrap();
@@ -912,15 +928,7 @@ mod tests {
         std::fs::create_dir_all(&marker_dir).unwrap();
         let temporary = marker_dir.join(format!("{TEMPLATE_MARKER_TEMP_PREFIX}loop7"));
         std::fs::write(&temporary, b"/partial").unwrap();
-        let mgr = CowManager {
-            templates: Mutex::new(HashMap::new()),
-            setup_orphans: Mutex::new(HashMap::new()),
-            losetup_lock: AsyncMutex::new(()),
-            cow_dir: tmp.path().to_path_buf(),
-            tools: Arc::new(BusyboxBlockTools::default()),
-            dmsetup_bin: None,
-            test_probe: None,
-        };
+        let mgr = manager(tmp.path());
 
         mgr.cleanup_stale_template_markers().unwrap();
 
@@ -943,15 +951,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let cow_file = tmp.path().join("existing.img");
         std::fs::write(&cow_file, b"owned by another setup").unwrap();
-        let mgr = CowManager {
-            templates: Mutex::new(HashMap::new()),
-            setup_orphans: Mutex::new(HashMap::new()),
-            losetup_lock: AsyncMutex::new(()),
-            cow_dir: tmp.path().to_path_buf(),
-            tools: Arc::new(BusyboxBlockTools::default()),
-            dmsetup_bin: None,
-            test_probe: None,
-        };
+        let mgr = manager(tmp.path());
 
         let _ = mgr
             .rollback_setup(
@@ -971,22 +971,16 @@ mod tests {
     async fn zero_ref_template_is_not_reused() {
         let tmp = tempfile::tempdir().unwrap();
         let template = PathBuf::from("/template");
-        let mgr = CowManager {
-            templates: Mutex::new(HashMap::from([(
-                template.clone(),
-                TemplateEntry {
-                    loop_device: "/dev/loop7".into(),
-                    sectors: 1024,
-                    refcount: 0,
-                },
-            )])),
-            setup_orphans: Mutex::new(HashMap::new()),
-            losetup_lock: AsyncMutex::new(()),
-            cow_dir: tmp.path().to_path_buf(),
-            tools: Arc::new(BusyboxBlockTools::default()),
-            dmsetup_bin: Some("/not-used".into()),
-            test_probe: None,
-        };
+        let mut mgr = manager(tmp.path());
+        mgr.dmsetup_bin = Some("/not-used".into());
+        mgr.templates.lock().unwrap().insert(
+            template.clone(),
+            TemplateEntry {
+                loop_device: "/dev/loop7".into(),
+                sectors: 1024,
+                refcount: 0,
+            },
+        );
 
         assert!(matches!(
             mgr.setup("box", template.to_str().unwrap()).await,
@@ -1003,17 +997,126 @@ mod tests {
         );
     }
 
+    /// Nothing to re-register, whatever the journal claims — and the caller
+    /// has to hear about it, because its fallback is to kill the sandbox.
+    #[test]
+    fn adopt_refuses_a_missing_dm_device() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = manager(tmp.path());
+        let handle = handle_for(
+            &tmp.path().join("arcbox-snap-box"),
+            &tmp.path().join("t.ext4"),
+        );
+
+        let error = mgr.adopt(&handle).unwrap_err();
+
+        assert!(
+            matches!(&error, SnapshotError::FailedPrecondition(m) if m.contains("arcbox-snap-box")),
+            "{error}"
+        );
+        assert!(mgr.templates.lock().unwrap().is_empty());
+    }
+
+    /// The loop is the kernel's, so only the kernel can say whether it still
+    /// backs the recorded template; nothing backing it means the origin of
+    /// that snapshot cannot be identified, let alone held. Linux-only: off
+    /// it there is no `/sys/block` to answer either way.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn adopt_refuses_a_template_no_loop_device_backs() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Stands in for the live device node: `adopt` asks only whether the
+        // guest's device is still there.
+        let dm_device = tmp.path().join("arcbox-snap-box");
+        std::fs::write(&dm_device, b"").unwrap();
+        let template = tmp.path().join("t.ext4");
+        std::fs::write(&template, b"rootfs").unwrap();
+        let mgr = manager(tmp.path());
+
+        let error = mgr.adopt(&handle_for(&dm_device, &template)).unwrap_err();
+
+        assert!(
+            matches!(&error, SnapshotError::FailedPrecondition(m) if m.contains("no loop device backs")),
+            "{error}"
+        );
+        assert!(
+            mgr.templates.lock().unwrap().is_empty(),
+            "a refused adoption took a template reference"
+        );
+    }
+
+    /// What makes the eventual teardown balance: the first adopted sandbox
+    /// registers the template it found, and every later one holding the same
+    /// template adds a reference rather than a second registration.
+    #[test]
+    fn adopting_a_shared_template_registers_then_references() {
+        let mgr = manager(Path::new("/tmp"));
+        let template = Path::new("/templates/rootfs.ext4");
+
+        mgr.take_template_ref(template, "/dev/loop7", 2048).unwrap();
+        mgr.take_template_ref(template, "/dev/loop7", 2048).unwrap();
+
+        let templates = mgr.templates.lock().unwrap();
+        let entry = templates.get(template).unwrap();
+        assert_eq!(entry.refcount, 2);
+        assert_eq!(entry.loop_device, "/dev/loop7");
+        assert_eq!(entry.sectors, 2048);
+    }
+
+    /// Two refusals with the same consequence — the caller kills the sandbox
+    /// rather than adopt onto a template this manager cannot account for: an
+    /// entry left at refcount zero is the incomplete-setup sentinel the
+    /// acquire path also refuses on, and an entry naming a different loop
+    /// means one of the two is a leak whichever way it is resolved.
+    #[test]
+    fn adopting_refuses_a_zero_ref_or_relocated_template() {
+        let mgr = manager(Path::new("/tmp"));
+        let template = Path::new("/templates/rootfs.ext4");
+        mgr.templates.lock().unwrap().insert(
+            template.to_path_buf(),
+            TemplateEntry {
+                loop_device: "/dev/loop7".into(),
+                sectors: 2048,
+                refcount: 0,
+            },
+        );
+
+        let incomplete = mgr
+            .take_template_ref(template, "/dev/loop7", 2048)
+            .unwrap_err();
+        assert!(
+            matches!(&incomplete, SnapshotError::Unavailable(m) if m.contains("incomplete CoW setup")),
+            "{incomplete}"
+        );
+
+        mgr.templates
+            .lock()
+            .unwrap()
+            .get_mut(template)
+            .unwrap()
+            .refcount = 1;
+        let relocated = mgr
+            .take_template_ref(template, "/dev/loop9", 2048)
+            .unwrap_err();
+        assert!(
+            matches!(&relocated, SnapshotError::FailedPrecondition(m) if m.contains("/dev/loop9")),
+            "{relocated}"
+        );
+        assert_eq!(
+            mgr.templates
+                .lock()
+                .unwrap()
+                .get(template)
+                .unwrap()
+                .refcount,
+            1,
+            "a refused adoption took a template reference"
+        );
+    }
+
     #[tokio::test]
     async fn test_release_template_refcount() {
-        let mgr = CowManager {
-            templates: Mutex::new(HashMap::new()),
-            setup_orphans: Mutex::new(HashMap::new()),
-            losetup_lock: AsyncMutex::new(()),
-            cow_dir: PathBuf::from("/tmp"),
-            tools: Arc::new(BusyboxBlockTools::default()),
-            dmsetup_bin: None,
-            test_probe: None,
-        };
+        let mgr = manager(Path::new("/tmp"));
 
         let path = PathBuf::from("/tmp/template.ext4");
         {

--- a/engine/arcbox-snapshot/src/snapshot_cow.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow.rs
@@ -836,6 +836,8 @@ async fn create_sparse_file(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
 
     /// A manager over `cow_dir` with nothing attached and no `dmsetup`;
@@ -850,6 +852,30 @@ mod tests {
             dmsetup_bin: None,
             test_probe: None,
         }
+    }
+
+    /// A `dmsetup` that lists `listed` as snapshot devices and appends every
+    /// other invocation to `{dir}/dmsetup.log`, so a test can assert which
+    /// devices the sweep decided to remove without a device-mapper.
+    fn fake_dmsetup(dir: &Path, listed: &[&str]) -> PathBuf {
+        let listing = listed
+            .iter()
+            .enumerate()
+            .map(|(minor, name)| format!("{name}\\t(253, {minor})"))
+            .collect::<Vec<_>>()
+            .join("\\n");
+        let binary = dir.join("dmsetup");
+        std::fs::write(
+            &binary,
+            format!(
+                "#!/bin/sh\n\
+                 if [ \"$1\" = ls ]; then printf '{listing}\\n'; else echo \"$@\" >> '{}'; fi\n",
+                dir.join("dmsetup.log").display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755)).unwrap();
+        binary
     }
 
     fn handle_for(dm_device: &Path, template: &Path) -> CowHandle {
@@ -995,6 +1021,79 @@ mod tests {
                 .refcount,
             0
         );
+    }
+
+    /// The sweep must leave an adopted sandbox's device alone: a live VM
+    /// holds it open, so removing it fails — and `reconcile_stale` reports
+    /// that failure for the whole sweep, taking every other sandbox's
+    /// reconciliation down with it.
+    #[test]
+    fn a_live_dm_device_is_not_removed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut mgr = manager(tmp.path());
+        mgr.dmsetup_bin = Some(fake_dmsetup(
+            tmp.path(),
+            &["arcbox-snap-live", "arcbox-snap-dead", "foreign-snapshot"],
+        ));
+
+        mgr.reconcile_stale(&HashSet::new(), &HashSet::from(["live".to_owned()]))
+            .unwrap();
+
+        let removed = std::fs::read_to_string(tmp.path().join("dmsetup.log")).unwrap();
+        assert_eq!(
+            removed.lines().collect::<Vec<_>>(),
+            ["remove --retry arcbox-snap-dead"],
+            "the sweep removed the wrong devices"
+        );
+    }
+
+    /// A live device's overlay is the disk it is running on, so the caller
+    /// naming it as live is enough — it does not also have to remember to
+    /// list it among the retained files.
+    #[test]
+    fn a_live_sandbox_cow_file_is_kept() {
+        let tmp = tempfile::tempdir().unwrap();
+        let overlay = tmp.path().join("arcbox-cow-live.img");
+        std::fs::write(&overlay, b"exceptions").unwrap();
+        let mgr = manager(tmp.path());
+
+        mgr.reconcile_stale(&HashSet::new(), &HashSet::from(["live".to_owned()]))
+            .unwrap();
+
+        assert!(overlay.exists(), "a live sandbox's overlay was deleted");
+    }
+
+    /// The template map is the authority on which loops are in use, so a
+    /// marker whose template is live survives — detaching that loop would
+    /// pull the rootfs out from under the guest running on it, and the
+    /// marker is the loop's own recovery record.
+    #[test]
+    fn a_live_template_loop_survives_the_sweep() {
+        let tmp = tempfile::tempdir().unwrap();
+        let marker_dir = tmp.path().join(TEMPLATE_LOOP_DIR);
+        std::fs::create_dir_all(&marker_dir).unwrap();
+        let live = tmp.path().join("live.ext4");
+        let stale = tmp.path().join("stale.ext4");
+        std::fs::write(marker_dir.join("loop7"), live.to_string_lossy().as_bytes()).unwrap();
+        std::fs::write(marker_dir.join("loop8"), stale.to_string_lossy().as_bytes()).unwrap();
+        let mgr = manager(tmp.path());
+        mgr.templates.lock().unwrap().insert(
+            live,
+            TemplateEntry {
+                loop_device: "/dev/loop7".into(),
+                sectors: 1024,
+                refcount: 1,
+            },
+        );
+
+        mgr.reconcile_stale(&HashSet::new(), &HashSet::new())
+            .unwrap();
+
+        assert!(
+            marker_dir.join("loop7").exists(),
+            "the live template's recovery marker was cleared"
+        );
+        assert!(!marker_dir.join("loop8").exists());
     }
 
     /// Nothing to re-register, whatever the journal claims — and the caller

--- a/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::collections::hash_map::Entry;
 use std::io::Write;
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
@@ -145,15 +146,34 @@ impl CowManager {
 
     /// Remove orphaned dm-snapshot devices, COW files, and template loop
     /// devices left over from a previous crash. Called after orphaned
-    /// Firecracker processes are dead; it is synchronous because every
+    /// Firecracker processes are dead — every one of them except the
+    /// sandboxes named by `live_devices`, whose VMs are still running and
+    /// were reclaimed by [`Self::adopt`]. It is synchronous because every
     /// command is short and startup is already gated on reconciliation.
     ///
-    /// `keep_cow_ids` names sandboxes whose COW file is *retained state*,
-    /// not an orphan: a paused sandbox keeps its (detached) overlay on disk
-    /// so Resume can re-assemble the dm-snapshot with every written block
+    /// Both sets are keyed by the *resource owner* — the id in
+    /// `arcbox-cow-{owner}.img` and `arcbox-snap-{owner}` — which for a
+    /// sandbox that adopted a pre-warmed pool slot is the slot's id, not the
+    /// sandbox's.
+    ///
+    /// `keep_cow_files` names owners whose COW file is *retained state*, not
+    /// an orphan: a paused sandbox keeps its (detached) overlay on disk so
+    /// Resume can re-assemble the dm-snapshot with every written block
     /// intact (CORE-21). Deleting those files here would silently destroy a
     /// paused sandbox's disk across an agent restart.
-    pub fn reconcile_stale(&self, keep_cow_ids: &std::collections::HashSet<String>) -> Result<()> {
+    ///
+    /// `live_devices` names owners whose dm-snapshot is in use by a running
+    /// VM. The two sets stay separate because they describe genuinely
+    /// different states: a paused sandbox's device was already torn down at
+    /// pause, so reading its retained file as a live device would leave the
+    /// device of a sandbox that crashed mid-pause unreaped. The other
+    /// direction does hold — a live device's overlay is its running disk —
+    /// so those files are kept whether or not the caller lists them twice.
+    pub fn reconcile_stale(
+        &self,
+        keep_cow_files: &HashSet<String>,
+        live_devices: &HashSet<String>,
+    ) -> Result<()> {
         let dmsetup = self.dmsetup_bin.as_deref();
 
         // 1. Remove stale dm devices first — they pin the loop devices
@@ -164,8 +184,15 @@ impl CowManager {
             let stdout = String::from_utf8_lossy(&output.stdout);
             for line in stdout.lines() {
                 if let Some(name) = line.split_whitespace().next()
-                    && name.starts_with(DM_NAME_PREFIX)
+                    && let Some(owner) = name.strip_prefix(DM_NAME_PREFIX)
                 {
+                    // A live VM holds its device open, so removing it would
+                    // fail — and fail the whole sweep, taking every other
+                    // sandbox's reconciliation with it.
+                    if live_devices.contains(owner) {
+                        debug!(dm = %name, "keeping live sandbox dm-snapshot");
+                        continue;
+                    }
                     debug!(dm = %name, "removing stale dm-snapshot");
                     // `--retry` for the same udev probe race `dmsetup_remove` documents.
                     run_sync_checked(Command::new(dmsetup).args(["remove", "--retry", name]))?;
@@ -183,8 +210,8 @@ impl CowManager {
             };
             if let Some(rest) = name.strip_prefix("arcbox-cow-") {
                 let id = rest.strip_suffix(".img").unwrap_or(rest);
-                if keep_cow_ids.contains(id) {
-                    debug!(file = %path.display(), "keeping paused sandbox cow file");
+                if keep_cow_files.contains(id) || live_devices.contains(id) {
+                    debug!(file = %path.display(), "keeping retained sandbox cow file");
                     continue;
                 }
                 for loop_device in loop_devices_for_backing_sync(&path)? {
@@ -198,10 +225,10 @@ impl CowManager {
         // 3. Detach orphaned template loop devices.
         //
         // Template attaches are tracked only in the in-memory `templates`
-        // HashMap, which is empty at startup — without this pass, every
-        // crash+restart cycle would permanently leak one read-only loop
-        // device per unique rootfs template, eventually exhausting the
-        // 256-entry loop namespace.
+        // HashMap, which holds nothing at startup but what [`Self::adopt`]
+        // put there — without this pass, every crash+restart cycle would
+        // permanently leak one read-only loop device per unique rootfs
+        // template, eventually exhausting the 256-entry loop namespace.
         //
         // We use marker files written at attach time (under
         // `{cow_dir}/.template-loops/`) rather than a system-wide "any
@@ -304,6 +331,30 @@ impl CowManager {
                     "empty template marker: {}",
                     marker_path.display()
                 )));
+            }
+            // The map is the authority on which template loops are in use:
+            // an entry means a live dm-snapshot has this template as its
+            // origin, either because this manager attached it or because
+            // [`Self::adopt`] re-registered a still-running guest's. The
+            // marker stays too — it is that loop's recovery record, and its
+            // owner clears it on teardown. Before the pending branch, not
+            // after: that branch detaches *everything* backing the template,
+            // which is precisely the live loop. A pending marker for a live
+            // template is instead cleared by a later sweep, once nothing
+            // holds it — by which time its own loop, if it ever got one, is
+            // the one the teardown detached.
+            if self
+                .templates
+                .lock()
+                .unwrap()
+                .contains_key(Path::new(&expected_backing))
+            {
+                debug!(
+                    marker = %marker_path.display(),
+                    template = %expected_backing,
+                    "keeping live template loop"
+                );
+                continue;
             }
             if loop_basename.starts_with(TEMPLATE_PENDING_PREFIX) {
                 for loop_device in loop_devices_for_backing_sync(Path::new(&expected_backing))? {

--- a/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
@@ -1,14 +1,15 @@
+use std::collections::hash_map::Entry;
 use std::io::Write;
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use super::block_tools::loop_backing_file;
 use super::{
-    CowManager, DM_NAME_PREFIX, TEMPLATE_LOOP_DIR, TEMPLATE_MARKER_TEMP_PREFIX,
-    TEMPLATE_PENDING_PREFIX, dmsetup_remove,
+    CowHandle, CowManager, DM_NAME_PREFIX, TEMPLATE_LOOP_DIR, TEMPLATE_MARKER_TEMP_PREFIX,
+    TEMPLATE_PENDING_PREFIX, TemplateEntry, dmsetup_remove,
 };
 use crate::error::{Result, SnapshotError};
 
@@ -34,6 +35,114 @@ impl SetupOrphan {
 }
 
 impl CowManager {
+    /// Re-register the CoW resources of a sandbox whose VM is still running.
+    ///
+    /// Verifies the dm device is present and that the template's loop device
+    /// is still attached and still backs `handle.template_path`, then takes
+    /// the template refcount the handle is documented to own — which is what
+    /// keeps [`Self::reconcile_stale`] from detaching a shared loop out from
+    /// under a live rootfs, and what makes the eventual teardown balance.
+    ///
+    /// Call before [`Self::reconcile_stale`], once per adopted sandbox. A
+    /// failed verification is an error rather than a silent skip: the
+    /// caller's fallback is to tear the sandbox down, and it has to know.
+    pub fn adopt(&self, handle: &CowHandle) -> Result<()> {
+        #[cfg(any(test, feature = "test-probe"))]
+        if self.test_probe.is_some() {
+            // The probe stands in for every device this method inspects.
+            return Ok(());
+        }
+        // The device the guest is running on. Without it there is no
+        // snapshot to re-register, whatever the journal claims.
+        if !Path::new(&handle.dm_device).exists() {
+            return Err(SnapshotError::FailedPrecondition(format!(
+                "sandbox device {} is gone",
+                handle.dm_device
+            )));
+        }
+        // That snapshot's origin. Rediscovered rather than journaled: the
+        // loop belongs to the kernel, and only the kernel can say whether it
+        // still backs the template this handle names.
+        let loop_device = match loop_devices_for_backing_sync(&handle.template_path)?.as_slice() {
+            [device] => device.clone(),
+            [] => {
+                return Err(SnapshotError::FailedPrecondition(format!(
+                    "no loop device backs template {}",
+                    handle.template_path.display()
+                )));
+            }
+            // Which of them the live snapshot's origin is cannot be told from
+            // the backing file alone, and holding the refcount on the wrong
+            // one leaks the other at teardown.
+            devices => {
+                return Err(SnapshotError::FailedPrecondition(format!(
+                    "template {} is attached through {}",
+                    handle.template_path.display(),
+                    devices.join(", ")
+                )));
+            }
+        };
+        // Read before the map is locked, and unconditionally: the template
+        // map must never be held across a block-tools subprocess, and one
+        // extra `blockdev` per adopted sandbox is invisible next to the rest
+        // of a startup sweep.
+        let sectors = self.tools.device_sectors(&loop_device)?;
+        self.take_template_ref(&handle.template_path, &loop_device, sectors)?;
+        info!(
+            dm = %handle.dm_name,
+            template = %handle.template_path.display(),
+            loop_device = %loop_device,
+            "adopted a live sandbox's dm-snapshot"
+        );
+        Ok(())
+    }
+
+    /// Register `template` as held through `loop_device`, or add a reference
+    /// to the registration another holder already made.
+    ///
+    /// The bookkeeping half of [`Self::adopt`], with the device checks
+    /// already done: the reference the adopted handle's teardown decrements.
+    pub(super) fn take_template_ref(
+        &self,
+        template: &Path,
+        loop_device: &str,
+        sectors: u64,
+    ) -> Result<()> {
+        match self.templates.lock().unwrap().entry(template.to_path_buf()) {
+            Entry::Occupied(mut occupied) => {
+                let entry = occupied.get_mut();
+                // The same "incomplete setup" sentinel the acquire path
+                // refuses on: a template whose detach failed with no owner
+                // left to retry it must not be resurrected by an adoption.
+                if entry.refcount == 0 {
+                    return Err(SnapshotError::Unavailable(format!(
+                        "template {} still owns resources from an incomplete CoW setup",
+                        template.display()
+                    )));
+                }
+                // One template, one loop: a second one is a view of the
+                // world this manager cannot reconcile, and picking either
+                // would leak the other.
+                if entry.loop_device != loop_device {
+                    return Err(SnapshotError::FailedPrecondition(format!(
+                        "template {} is held through {} but backs {loop_device}",
+                        template.display(),
+                        entry.loop_device
+                    )));
+                }
+                entry.refcount += 1;
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(TemplateEntry {
+                    loop_device: loop_device.to_owned(),
+                    sectors,
+                    refcount: 1,
+                });
+            }
+        }
+        Ok(())
+    }
+
     /// Remove orphaned dm-snapshot devices, COW files, and template loop
     /// devices left over from a previous crash. Called after orphaned
     /// Firecracker processes are dead; it is synchronous because every

--- a/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
@@ -367,11 +367,18 @@ impl CowManager {
             let dev = format!("/dev/{loop_basename}");
             // Verify the loop is still attached AND still backs the
             // expected template, so we never detach a /dev/loopN that
-            // was reused by another process after our crash.
+            // was reused by another process after our crash. Either
+            // spelling counts (see [`backing_spellings`]): the marker holds
+            // the path this manager was configured with, the kernel answers
+            // with the one it resolved, and reading a difference between
+            // them as "reused by someone else" clears the marker and strands
+            // the loop forever — the exact leak this pass exists to prevent.
+            let expected = backing_spellings(Path::new(&expected_backing));
             let actual_backing = loop_backing_file(&dev)?;
 
-            if !expected_backing.is_empty()
-                && actual_backing.as_deref() == Some(expected_backing.as_str())
+            if actual_backing
+                .as_ref()
+                .is_some_and(|actual| expected.contains(actual))
             {
                 debug!(dev = %dev, "detaching stale template loop");
                 self.tools.detach_loop(&dev)?;

--- a/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
@@ -604,12 +604,33 @@ pub(super) fn remove_file_durable(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// How the kernel may spell `backing` in a loop device's `backing_file`:
+/// the caller's own spelling, and the resolved path.
+///
+/// [`loop_backing_file`] reports the *resolved* path of the file the device
+/// holds open, which is not the caller's spelling whenever that path
+/// reaches the file through a symlink — a data directory pointed at another
+/// volume, say. The attach path already accepts either
+/// (`BusyboxBlockTools::verify_attached`), and rediscovery has to as well:
+/// comparing one spelling makes a loop this manager attached itself
+/// invisible to teardown, and makes [`CowManager::adopt`] refuse a live
+/// sandbox whose rootfs is right there.
+pub(super) fn backing_spellings(backing: &Path) -> Vec<String> {
+    let literal = backing.to_string_lossy().into_owned();
+    let resolved = std::fs::canonicalize(backing)
+        .map(|path| path.to_string_lossy().into_owned())
+        .ok()
+        .filter(|resolved| *resolved != literal);
+    std::iter::once(literal).chain(resolved).collect()
+}
+
 pub(super) fn loop_backs_path(loop_device: &str, backing: &Path) -> Result<bool> {
-    Ok(loop_backing_file(loop_device)?.is_some_and(|actual| actual == backing.to_string_lossy()))
+    let expected = backing_spellings(backing);
+    Ok(loop_backing_file(loop_device)?.is_some_and(|actual| expected.contains(&actual)))
 }
 
 pub(super) fn loop_devices_for_backing_sync(backing: &Path) -> Result<Vec<String>> {
-    let expected = backing.to_string_lossy();
+    let expected = backing_spellings(backing);
     let mut devices = Vec::new();
     for entry in std::fs::read_dir("/sys/block")? {
         let entry = entry?;
@@ -623,7 +644,7 @@ pub(super) fn loop_devices_for_backing_sync(backing: &Path) -> Result<Vec<String
             continue;
         }
         let device = format!("/dev/{name}");
-        if loop_backing_file(&device)?.as_deref() == Some(expected.as_ref()) {
+        if loop_backing_file(&device)?.is_some_and(|actual| expected.contains(&actual)) {
             devices.push(device);
         }
     }


### PR DESCRIPTION
The startup sweep destroys a sandbox whose VM outlived the process that
booted it. Part 1 (#670) gave the guest network its `adopt` verb; this is
the same move for the CoW manager — the owner side of the disk.

## What the sweep did to a live sandbox

Two independent paths in `CowManager::reconcile_stale`:

1. **Step 1 removed every `arcbox-snap-*` device unconditionally.** The keep
   set protected only step 2's overlay *files*. A live Firecracker holds its
   device open, so `dmsetup remove --retry` fails — and that failure is the
   whole sweep's, so one live sandbox took every *other* sandbox's
   reconciliation down with it.
2. **Step 3 detached template loop devices** on the grounds that the
   in-memory `templates` map is empty at startup. That loop is the origin of
   the live dm-snapshot hanging off it.

## What this adds

`CowManager::adopt(&CowHandle)` — verifies the dm device is present and that
exactly one loop device still backs the recorded template, then takes the
template reference the handle is documented to own. That reference is the
point: it is what stops the sweep from detaching a shared loop out from
under a live rootfs, and what makes the eventual teardown balance. The loop
is rediscovered rather than journaled (only the kernel can say what still
backs a file); two loops backing one template is a refusal rather than a
guess, since holding the reference on the wrong one leaks the other. Every
refusal is an error, not a silent skip — the caller's fallback is to tear
the sandbox down, and it has to know.

`reconcile_stale(keep_cow_files, live_devices)` — two sets rather than one
widened one, because they mean genuinely different things: a paused
sandbox's overlay *file* is retained state while its device was already torn
down at pause, so conflating them would newly *keep* a device for a sandbox
that crashed mid-pause — the one case where a retained-looking id still has
a device to reap. The other direction does hold (a live device's overlay is
its running disk), so those files are kept whether or not the caller lists
them twice.

Step 3 now consults the template map instead of assuming it empty. That is a
correctness fix independent of adoption: the map is the authority on which
loops are in use, and asking it costs nothing.

The one caller passes an empty live set, so nothing behaves differently yet.

## One fix adoption dragged in

The kernel reports the *resolved* path of the file a loop device holds
open, and both rediscovery helpers compared it to the caller's spelling
verbatim — so a template reached through a symlink matched nothing, while
the attach path (`verify_attached`) already accepted either spelling. Latent
until `adopt` gave it a caller that acts on the answer (it would refuse a
live sandbox whose rootfs is right there); quieter and worse for the
existing callers, where `teardown_checked` read "no loop backs this file" as
"already detached" and the stale-template sweep skipped the detach while
clearing the marker anyway — stranding the loop with nothing left on disk
naming it, once per crash cycle. All three comparison sites now share one
rule (`backing_spellings`); the two callers that only ask whether a device is
attached are unchanged. Found by Cursor Bugbot, both rounds.

## Tests

Every new test was mutation-checked: each of the three skips was disabled in
turn and the corresponding test fails.

- `a_live_dm_device_is_not_removed` — the sweep's `dmsetup` decisions,
  through a fake binary that lists devices and logs its invocations.
- `a_live_sandbox_cow_file_is_kept`, `a_live_template_loop_survives_the_sweep`.
- `adopt_refuses_a_missing_dm_device`; `adopt_refuses_a_template_no_loop_device_backs`
  (Linux-only — off Linux there is no `/sys/block` to answer either way, so
  the assertion would pass for the wrong reason).
- `adopting_a_shared_template_registers_then_references` and
  `adopting_refuses_a_zero_ref_or_relocated_template` cover the reference
  bookkeeping, which is the half that must balance.

**Coverage this PR cannot add:** `adopt`'s success path needs a real loop
device and a real dm device, so it is unreachable from unit tests on either
OS. The only place in CI with root, loop devices and `dmsetup` is
`test-vm-linux`'s `integration` job, which runs
`--test integration -p arcbox-computer-runtime -p arcbox-tap-net` — reaching
it means either a test in that crate's suite or a workflow change, both
outside this PR's scope. Part 2b lands the acceptance test there (boot, drop
the manager, rebuild it, assert the sandbox is still `Running`), which is
what will exercise this path against real device-mapper.

## Next

Part 2b: the journal's `net_invariant` field, adopt-or-kill in
`sweep_orphans`, the recovery-policy verdict, the handle-based kill in
`remove_sandbox`, and `detach_all` for the graceful-shutdown half.

CORE-135, part 2a.
