### PR TITLE
feat(computer): the startup sweep adopts a live sandbox instead of killing it

### DIFF
--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
@@ -7,37 +7,20 @@ use crate::lifecycle::effect::{
 };
 use crate::lifecycle::event::Event;
 use crate::lifecycle::machine::State;
+use crate::sandbox::policy::recovery::{JournalEvidence, RecoveryAction, plan};
 use crate::sandbox::record::PersistPhase;
 use crate::sandbox::{IdleAction, SandboxState};
 
-/// `sandbox::policy::recovery::plan`'s verdict per phase, mirrored.
+/// `sandbox::policy::recovery::plan`'s verdict for a phase whose journal the
+/// startup sweep tore down — the evidence a seeded machine corresponds to.
 ///
-/// Those items are `pub(in crate::sandbox)`, so this table cannot call the
-/// real one — it is checked by eye against `sandbox/policy/recovery.rs`, whose
-/// own exhaustive test pins `plan`. Widening `plan`, `RecoveryAction` and
-/// `JournalEvidence` to `pub(crate)` would make this an assertion instead of a
-/// mirror; PR-F should do it when the recovery applier moves here.
-#[derive(Debug, PartialEq, Eq)]
-enum Recovery {
-    LeaveResumable,
-    Fail,
-    Reinstate(SandboxState),
-    FinishRemove,
-}
-
-fn recovery_plan(phase: PersistPhase) -> Recovery {
-    match phase {
-        PersistPhase::Creating => Recovery::LeaveResumable,
-        PersistPhase::Starting
-        | PersistPhase::Ready
-        | PersistPhase::Stopping
-        | PersistPhase::Pausing
-        | PersistPhase::Resuming => Recovery::Fail,
-        PersistPhase::Stopped => Recovery::Reinstate(SandboxState::Stopped),
-        PersistPhase::Failed => Recovery::Reinstate(SandboxState::Failed),
-        PersistPhase::Paused => Recovery::Reinstate(SandboxState::Paused),
-        PersistPhase::Removing => Recovery::FinishRemove,
-    }
+/// The real function, not a table checked by eye: the two cannot drift.
+/// `Swept` is the one evidence a `Recovered` event can carry, since the
+/// machine is seeded from what the sweep already acted on; the refusals and
+/// the reclaimed-alive verdict never reach this path, and
+/// `sandbox/policy/recovery.rs`'s own exhaustive table covers them.
+fn recovery_plan(phase: PersistPhase) -> RecoveryAction {
+    plan(phase, JournalEvidence::Swept)
 }
 
 #[test]
@@ -48,21 +31,26 @@ fn recovery_seeds_the_state_its_own_verdict_leaves_behind() {
         match recovery_plan(phase) {
             // Nobody acknowledged the intent, so the same request key still
             // resumes it: the machine stays where a fresh one starts.
-            Recovery::LeaveResumable => {
+            RecoveryAction::LeaveResumable => {
                 assert_eq!(state.durable(), Some(PersistPhase::Creating), "{phase:?}");
                 assert_eq!(state.to_public(), SandboxState::Starting, "{phase:?}");
             }
             // Recovery already wrote `Failed`; the machine only adopts it.
-            Recovery::Fail => {
+            RecoveryAction::Fail => {
                 assert_eq!(state.durable(), Some(PersistPhase::Failed), "{phase:?}");
                 assert_eq!(state.to_public(), SandboxState::Failed, "{phase:?}");
             }
-            Recovery::Reinstate(public) => {
+            RecoveryAction::Reinstate(public) => {
                 assert_eq!(state.durable(), Some(phase), "{phase:?}");
                 assert_eq!(state.to_public(), public, "{phase:?}");
             }
-            Recovery::FinishRemove => {
+            RecoveryAction::FinishRemove => {
                 assert_eq!(state.durable(), Some(PersistPhase::Removing), "{phase:?}");
+            }
+            // Both refusals answer a sweep that found no journal or adopted
+            // a phase it must not: neither seeds a machine.
+            refused @ (RecoveryAction::RefuseUnjournaled | RecoveryAction::RefuseAdopted) => {
+                panic!("{phase:?} with a swept journal cannot yield {refused:?}")
             }
         }
         // A seeded machine must still be drivable to its end.

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -257,19 +257,21 @@ impl SandboxManager {
                     // while leaving its lease and template refcount held.
                     reconcile::release_unclaimed(&mut runtime, &*network, &cow_manager).await;
                     let inactive = inactive?;
-                    reconcile::finalize_sweep(swept).await?;
-                    reconcile_capability(&*network).replay_complete();
-                    Ok::<_, VmmError>(inactive)
-                }
-                .await
-                .map(|inactive| {
-                    let mut map = instances.write().unwrap();
-                    map.extend(
+                    // Publish before anything else can fail. The reclaimed
+                    // sandboxes' only handles live in these instances, so a
+                    // later error — a runtime directory that will not delete,
+                    // say — would otherwise un-reclaim every guest by
+                    // dropping them, over something none of them caused.
+                    instances.write().unwrap().extend(
                         inactive
                             .into_iter()
                             .map(|instance| (instance.id.clone(), Arc::new(Mutex::new(instance)))),
                     );
-                })
+                    reconcile::finalize_sweep(swept).await?;
+                    reconcile_capability(&*network).replay_complete();
+                    Ok::<_, VmmError>(())
+                }
+                .await
                 .map_err(|error| Arc::<str>::from(error.to_string()));
                 let _ = reconcile_tx.send(Some(result));
             });

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -245,11 +245,18 @@ impl SandboxManager {
                         &records,
                     )
                     .await?;
+                    let mut runtime = swept.take_runtime();
                     let inactive = reconcile::normalize_durable_records(
                         &records,
                         Path::new(&config.firecracker.data_dir),
-                        Some(swept.take_runtime()),
-                    )?;
+                        Some(&mut runtime),
+                    );
+                    // Whatever normalization did not take is still held here
+                    // — on the error path that is every sandbox the sweep
+                    // reclaimed, and dropping the map would kill each VM
+                    // while leaving its lease and template refcount held.
+                    reconcile::release_unclaimed(&mut runtime, &*network, &cow_manager).await;
+                    let inactive = inactive?;
                     reconcile::finalize_sweep(swept).await?;
                     reconcile_capability(&*network).replay_complete();
                     Ok::<_, VmmError>(inactive)

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -49,7 +49,7 @@ mod execution;
 mod files;
 mod lifecycle;
 mod pause;
-mod policy;
+pub(crate) mod policy;
 mod pool;
 mod reconcile;
 pub(crate) mod record;

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -236,7 +236,7 @@ impl SandboxManager {
             let instances = Arc::clone(&instances);
             tokio::spawn(async move {
                 let result = async {
-                    let swept = reconcile::sweep_orphans(
+                    let mut swept = reconcile::sweep_orphans(
                         &config,
                         driver.as_ref(),
                         &*network,
@@ -248,7 +248,7 @@ impl SandboxManager {
                     let inactive = reconcile::normalize_durable_records(
                         &records,
                         Path::new(&config.firecracker.data_dir),
-                        Some(&swept.ids),
+                        Some(swept.take_runtime()),
                     )?;
                     reconcile::finalize_sweep(swept).await?;
                     reconcile_capability(&*network).replay_complete();

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -246,17 +246,23 @@ impl SandboxManager {
                     )
                     .await?;
                     let mut runtime = swept.take_runtime();
-                    let inactive = reconcile::normalize_durable_records(
+                    let mut inactive = Vec::new();
+                    let normalized = reconcile::normalize_durable_records(
                         &records,
                         Path::new(&config.firecracker.data_dir),
                         Some(&mut runtime),
+                        &mut inactive,
                     );
-                    // Whatever normalization did not take is still held here
-                    // — on the error path that is every sandbox the sweep
-                    // reclaimed, and dropping the map would kill each VM
-                    // while leaving its lease and template refcount held.
+                    // A reclaimed sandbox is in exactly one of these two by
+                    // now — never claimed, or built into an instance — and
+                    // dropping either would kill its guest while leaving its
+                    // lease and template refcount held. Release both before
+                    // reporting the refusal.
                     reconcile::release_unclaimed(&mut runtime, &*network, &cow_manager).await;
-                    let inactive = inactive?;
+                    if let Err(error) = normalized {
+                        reconcile::release_instances(&mut inactive, &*network, &cow_manager).await;
+                        return Err(error);
+                    }
                     // Publish before anything else can fail. The reclaimed
                     // sandboxes' only handles live in these instances, so a
                     // later error — a runtime directory that will not delete,
@@ -280,10 +286,12 @@ impl SandboxManager {
             // covered without threading the registry through each of them.
             execution::spawn_teardown_purge(Arc::clone(&executions), events_tx.subscribe());
         } else {
-            let inactive = reconcile::normalize_durable_records(
+            let mut inactive = Vec::new();
+            reconcile::normalize_durable_records(
                 &records,
                 Path::new(&config.firecracker.data_dir),
                 None,
+                &mut inactive,
             )?;
             reconcile_capability(&*network).replay_complete();
             instances.write().unwrap().extend(

--- a/computer/arcbox-computer-runtime/src/sandbox/boot.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/boot.rs
@@ -867,7 +867,7 @@ async fn do_boot(
     let journal_error = super::reconcile::SandboxStateRecord::new(
         id,
         process_pid,
-        net.map(|net| &net.lease),
+        net.map(NetworkAttachment::journaled),
         None,
         config,
         None,
@@ -946,7 +946,7 @@ async fn do_boot(
                     let record = super::reconcile::SandboxStateRecord::new(
                         id,
                         process_pid,
-                        net.map(|net| &net.lease),
+                        net.map(NetworkAttachment::journaled),
                         cow_handle.as_ref(),
                         config,
                         None,
@@ -974,7 +974,7 @@ async fn do_boot(
                             let record = super::reconcile::SandboxStateRecord::new(
                                 id,
                                 process_pid,
-                                net.map(|net| &net.lease),
+                                net.map(NetworkAttachment::journaled),
                                 None,
                                 config,
                                 None,
@@ -1011,7 +1011,7 @@ async fn do_boot(
                     let record = super::reconcile::SandboxStateRecord::new(
                         id,
                         process_pid,
-                        net.map(|net| &net.lease),
+                        net.map(NetworkAttachment::journaled),
                         cow_handle.as_ref(),
                         config,
                         None,

--- a/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
@@ -1,6 +1,7 @@
 use super::boot::{StageError, stage_rootfs_cow_or_copy};
 use super::policy::settle::{self, Capture, GuestHold, Settlement};
 use super::pool::PreparedSlot;
+use super::reconcile::JournaledLease;
 use super::record::{ProvisionIntent, SandboxProvisionOutcome, SandboxTransition};
 use super::types::action;
 use super::*;
@@ -353,6 +354,7 @@ impl SandboxManager {
         error: VmmError,
         prepared: Option<Arc<dyn PreparedVm>>,
         network: Option<NetworkLease>,
+        net_invariant: bool,
         cow_handle: Option<CowHandle>,
     ) -> VmmError {
         let arc = reservation.instance();
@@ -363,7 +365,9 @@ impl SandboxManager {
         let journal_error = super::reconcile::SandboxStateRecord::new(
             id,
             prepared.as_deref().and_then(super::journaled_pid),
-            network.as_ref(),
+            network
+                .as_ref()
+                .map(|lease| JournaledLease::from_snapshot(lease, net_invariant)),
             cow_handle.as_ref(),
             &self.config,
             None,
@@ -579,6 +583,10 @@ impl SandboxManager {
             .as_ref()
             .map(|lease| lease.ip.to_string())
             .unwrap_or_default();
+        // Every journal this restore writes records the lease the way the
+        // `activate` below attaches it: from the snapshot's own flag, never
+        // from a constant. One binding so the two cannot drift.
+        let net_invariant = snap_meta.net_invariant;
         // The NIC is tracked apart from the lease: the lease is owed back
         // to the pool from `reserve` on, so the rollback below must see one
         // whose TAP a failed journal write meant was never built.
@@ -588,7 +596,9 @@ impl SandboxManager {
             let cleanup_record = super::reconcile::SandboxStateRecord::new(
                 &new_id,
                 None,
-                lease.as_ref(),
+                lease
+                    .as_ref()
+                    .map(|lease| JournaledLease::from_snapshot(lease, net_invariant)),
                 None,
                 &self.config,
                 None,
@@ -610,7 +620,15 @@ impl SandboxManager {
         .await;
         if let Err(error) = setup {
             return Err(self
-                .rollback_restore(&new_id, reservation, error, None, lease, None)
+                .rollback_restore(
+                    &new_id,
+                    reservation,
+                    error,
+                    None,
+                    lease,
+                    snap_meta.net_invariant,
+                    None,
+                )
                 .await);
         }
         let fc_cfg = &self.config.firecracker;
@@ -642,7 +660,9 @@ impl SandboxManager {
                 let handover = super::reconcile::SandboxStateRecord::new(
                     &new_id,
                     super::journaled_pid(&*slot.prepared),
-                    lease.as_ref(),
+                    lease
+                        .as_ref()
+                        .map(|lease| JournaledLease::from_snapshot(lease, net_invariant)),
                     slot.cow_handle.as_ref(),
                     &self.config,
                     None,
@@ -696,6 +716,7 @@ impl SandboxManager {
                                 error,
                                 Some(slot_prepared),
                                 lease.clone(),
+                                snap_meta.net_invariant,
                                 pending_cow,
                             )
                             .await);
@@ -731,6 +752,7 @@ impl SandboxManager {
                                 error,
                                 None,
                                 lease.clone(),
+                                snap_meta.net_invariant,
                                 None,
                             )
                             .await);
@@ -742,7 +764,9 @@ impl SandboxManager {
                     super::reconcile::SandboxStateRecord::new(
                         &new_id,
                         pid,
-                        lease.as_ref(),
+                        lease
+                            .as_ref()
+                            .map(|lease| JournaledLease::from_snapshot(lease, net_invariant)),
                         cow,
                         &self.config,
                         None,
@@ -757,6 +781,7 @@ impl SandboxManager {
                             error,
                             Some(Arc::clone(&spawned_prepared)),
                             lease.clone(),
+                            snap_meta.net_invariant,
                             None,
                         )
                         .await);
@@ -826,6 +851,7 @@ impl SandboxManager {
                                 error,
                                 Some(Arc::clone(&spawned_prepared)),
                                 lease.clone(),
+                                snap_meta.net_invariant,
                                 pending_cow,
                             )
                             .await);
@@ -881,6 +907,7 @@ impl SandboxManager {
                         error,
                         Some(prepared),
                         lease.clone(),
+                        snap_meta.net_invariant,
                         pending_cow,
                     )
                     .await);
@@ -968,6 +995,7 @@ impl SandboxManager {
                         error,
                         Some(Arc::clone(&prepared)),
                         lease.clone(),
+                        snap_meta.net_invariant,
                         pending_cow,
                     )
                     .await);
@@ -979,17 +1007,19 @@ impl SandboxManager {
         // Persist cleanup metadata before handing runtime resources to the
         // instance. A failed durable write aborts and unwinds every resource.
         let adopted_slot = reservation.instance().lock().unwrap().pool_slot_id.clone();
-        let journaled = super::reconcile::SandboxStateRecord::new(
+        let final_journal = super::reconcile::SandboxStateRecord::new(
             &new_id,
             super::journaled_pid(&*prepared),
-            lease.as_ref(),
+            lease
+                .as_ref()
+                .map(|lease| JournaledLease::from_snapshot(lease, net_invariant)),
             pending_cow.as_ref(),
             &self.config,
             None,
         )
         .map(|record| record.with_pool_slot(adopted_slot.as_deref()))
         .and_then(|record| super::reconcile::write_state_record(&vm_dir, &record));
-        if let Err(error) = journaled {
+        if let Err(error) = final_journal {
             return Err(self
                 .rollback_restore(
                     &new_id,
@@ -997,6 +1027,7 @@ impl SandboxManager {
                     error,
                     Some(Arc::clone(&prepared)),
                     lease.clone(),
+                    snap_meta.net_invariant,
                     pending_cow,
                 )
                 .await);
@@ -1019,6 +1050,7 @@ impl SandboxManager {
                         error,
                         Some(Arc::clone(&prepared)),
                         lease.clone(),
+                        snap_meta.net_invariant,
                         pending_cow,
                     )
                     .await);

--- a/computer/arcbox-computer-runtime/src/sandbox/cleanup.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/cleanup.rs
@@ -1,6 +1,7 @@
 use super::record::{SandboxRecordStore, SandboxTransition};
 use super::types::{SandboxBootTask, action};
 use super::*;
+use arcbox_vm_driver::ShutdownMode;
 use arcbox_vm_driver::net::GuestNetwork;
 
 #[cfg(not(test))]
@@ -351,25 +352,45 @@ pub(super) fn chroot_owner(id: &str, arc: &Arc<Mutex<SandboxInstance>>) -> Strin
 /// stopped, paused or failed sandbox — so it is dropped here too, the one
 /// place both are let go.
 ///
+/// A sandbox this process adopted rather than booted has no `PreparedVm` —
+/// nothing hands the driver's grip on a *process* back across a restart — so
+/// its VM is killed through the handle, which reaps as well. Without that
+/// arm an adopted sandbox's Remove would report success while its VMM kept
+/// running, and the dm device and TAP would then be torn out from under a
+/// live guest.
+///
 /// Extracted so the pause path (which keeps the disk overlay) shares the exact
 /// kill/reap discipline with full release. A failed reap (the driver's
-/// bounded wait elapsed) restores the prepared VMM, and keeps the handle,
-/// so a retry can finish the job. Idempotent — the prepared VMM is
-/// `take()`n, and discarding an exited one just reports its status.
+/// bounded wait elapsed) restores whichever grip it took, and keeps the
+/// handle, so a retry can finish the job. Idempotent — both are `take()`n,
+/// and killing an exited VM just reports its status.
 pub(super) async fn kill_sandbox_process(
     id: &str,
     arc: &Arc<Mutex<SandboxInstance>>,
 ) -> Result<()> {
-    let prepared = arc.lock().unwrap().prepared.take();
+    let (prepared, handle) = {
+        let mut inst = arc.lock().unwrap();
+        let prepared = inst.prepared.take();
+        // Only the adopted case needs the handle: while a `PreparedVm` is
+        // present it owns the process, and discarding it is the whole kill.
+        let handle = prepared.is_none().then(|| inst.handle.clone()).flatten();
+        (prepared, handle)
+    };
     // Kill and await the exit outside the lock; the driver bounds the wait so
     // cleanup proceeds (and reports) even if the process is stuck in
     // uninterruptible sleep after SIGKILL.
-    if let Some(prepared) = prepared
-        && let Err(error) = prepared.discard().await
+    if let Some(prepared) = prepared {
+        if let Err(error) = prepared.discard().await {
+            arc.lock().unwrap().prepared = Some(prepared);
+            return Err(VmmError::Process(format!(
+                "release the vmm of sandbox {id}: {error}"
+            )));
+        }
+    } else if let Some(handle) = handle
+        && let Err(error) = handle.shutdown(ShutdownMode::Kill).await
     {
-        arc.lock().unwrap().prepared = Some(prepared);
         return Err(VmmError::Process(format!(
-            "release the vmm of sandbox {id}: {error}"
+            "release the adopted vmm of sandbox {id}: {error}"
         )));
     }
     {
@@ -412,6 +433,45 @@ mod tests {
     use crate::snapshot_cow::{CowOptions, CowTestProbe};
     use arcbox_vm_driver::testkit::FakeNetwork;
     use std::os::unix::fs::PermissionsExt;
+
+    /// A sandbox this process adopted rather than booted holds a handle and
+    /// no `PreparedVm`, and Remove must still reach its VMM: the old code
+    /// took the `None` arm, cleared the handle, and reported success while
+    /// Firecracker kept running — after which the dm device and TAP were
+    /// torn out from under a live guest.
+    #[tokio::test]
+    async fn removing_an_adopted_sandbox_kills_its_vm_through_the_handle() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let (manager, driver, probe) =
+            super::super::testing::fake_manager_direct(data_dir.path()).await;
+        let recorder = std::sync::OnceLock::new();
+        let (instance, _handle) =
+            super::super::testing::live_sandbox_with(&manager, &driver, "adopted", |inner| {
+                let (recording, handle) = super::super::testing::RecordsShutdown::wrap(inner);
+                let _ = recorder.set(recording);
+                handle
+            })
+            .await;
+        // What the startup sweep hands back: the VM's handle, and no grip on
+        // the process — nothing returns a `PreparedVm` across a restart.
+        instance.lock().unwrap().prepared = None;
+
+        manager
+            .remove_sandbox(&"adopted".to_owned(), false)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            recorder.get().unwrap().modes(),
+            vec![ShutdownMode::Kill],
+            "the adopted vm is killed through its own handle"
+        );
+        let inst = instance.lock().unwrap();
+        assert!(inst.handle.is_none(), "the dead VM's handle is dropped");
+        assert!(inst.cow_handle.is_none(), "the CoW overlay is released");
+        assert!(inst.network.is_none(), "the network lease is released");
+        assert_eq!(probe.teardown_count(), 1);
+    }
 
     fn instance(id: &str) -> Arc<Mutex<SandboxInstance>> {
         Arc::new(Mutex::new(SandboxInstance::new(

--- a/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
@@ -647,6 +647,51 @@ impl SandboxManager {
         Ok(())
     }
 
+    /// Give up ownership of every live VM without stopping it, so this
+    /// process can exit and the next one adopt them.
+    ///
+    /// The composer calls this on graceful shutdown. Without it a clean exit
+    /// unwinds into the driver handle's `Drop`, which kills — so the startup
+    /// sweep's adoption would only ever fire after a crash, never after the
+    /// binary upgrade or redeploy it mainly exists for.
+    ///
+    /// Best-effort per sandbox: one VM that refuses to be handed over must
+    /// not cost the others theirs, so failures are collected and reported
+    /// together. A driver without `Detach` runs its VMs in-process and has
+    /// nothing to hand over — the same reasoning the sweep applies to
+    /// `Adopt`. The `PreparedVm` a booted sandbox also holds needs no such
+    /// step: it kills on drop only while it is still unconsumed.
+    pub async fn detach_all(&self) -> Result<()> {
+        let live: Vec<(SandboxId, Arc<dyn VmHandle>)> = self
+            .instances
+            .read()
+            .unwrap()
+            .iter()
+            .filter_map(|(id, arc)| {
+                let handle = arc.lock().unwrap().handle.clone();
+                handle.map(|handle| (id.clone(), handle))
+            })
+            .collect();
+
+        let mut failures = Vec::new();
+        for (id, handle) in live {
+            let Some(detach) = handle.detach() else {
+                continue;
+            };
+            match detach.detach().await {
+                Ok(_) => info!(sandbox_id = %id, "handed the sandbox's vm to the next process"),
+                Err(error) => failures.push(format!("{id}: {error}")),
+            }
+        }
+        if failures.is_empty() {
+            return Ok(());
+        }
+        Err(VmmError::Unavailable(format!(
+            "some sandboxes could not be handed over and will be killed on exit: {}",
+            failures.join("; ")
+        )))
+    }
+
     /// Forcibly destroy a sandbox and release all resources immediately.
     pub async fn remove_sandbox(&self, id: &SandboxId, force: bool) -> Result<()> {
         self.await_reconcile().await?;
@@ -902,9 +947,40 @@ fn snapshot_files(info: &crate::snapshot::SnapshotInfo) -> Vec<PathBuf> {
 mod tests {
     use std::time::Duration;
 
-    use super::super::testing::{fake_manager_direct, fake_manager_with_agent};
+    use super::super::testing::{fake_manager_direct, fake_manager_with_agent, live_sandbox};
     use super::*;
     use crate::testkit::agent::{FakeAgentFactory, Reply};
+
+    /// A graceful exit must leave the guests running, or the startup sweep's
+    /// adoption is reachable only after a crash: the driver handle kills on
+    /// drop until it has been detached.
+    #[tokio::test]
+    async fn detach_all_hands_every_live_vm_to_the_next_process() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let (manager, driver, _probe) = fake_manager_direct(data_dir.path()).await;
+        let (instance, handle) = live_sandbox(&manager, &driver, "keeper").await;
+        let record = handle.record();
+
+        manager.detach_all().await.unwrap();
+
+        // Everything this process held is let go, the way an orderly exit
+        // unwinds it...
+        drop(handle);
+        drop(instance);
+        drop(manager);
+
+        // ...and the guest is still there for the next process to reclaim.
+        let adopted = driver
+            .adopt()
+            .expect("the fake driver adopts")
+            .adopt(&record)
+            .await
+            .unwrap();
+        assert!(
+            adopted.is_some(),
+            "the vm outlived the process that booted it"
+        );
+    }
 
     /// Wait for `action` on `id`, or fail the test.
     async fn await_action(

--- a/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
@@ -1,5 +1,6 @@
 use super::boot::boot_sandbox;
 use super::cleanup::{inst_to_info, remove_sandbox_impl};
+use super::reconcile::JournaledLease;
 use super::record::{ProvisionIntent, SandboxProvisionOutcome, SandboxTransition};
 use super::types::{SandboxBootTask, action};
 use super::*;
@@ -329,6 +330,11 @@ impl SandboxManager {
         // was never built — a journal write between the two can fail.
         let mut lease: Option<NetworkLease> = None;
         let mut nic: Option<NicSpec> = None;
+        // Whether this boot bakes the fixed invariant identity into the
+        // guest's command line (see do_boot); false when the caller brought
+        // their own `ip=`. Independent of the mode the host side is attached
+        // in, which is `Invariant` either way.
+        let invariant_identity = !spec.boot_args.contains("ip=");
         let setup = async {
             if spec.network.mode != "none" {
                 lease = Some(
@@ -346,7 +352,9 @@ impl SandboxManager {
             let cleanup_record = super::reconcile::SandboxStateRecord::new(
                 &id,
                 None,
-                lease.as_ref(),
+                lease
+                    .as_ref()
+                    .map(|lease| JournaledLease::cold_boot(lease, invariant_identity)),
                 None,
                 &self.config,
                 None,
@@ -439,13 +447,13 @@ impl SandboxManager {
                 lease,
                 nic,
                 identity,
+                invariant_identity,
             }
         });
         // The boot bakes the invariant `ip=` identity unless the caller
         // supplied an explicit ip= (see do_boot); record which one this guest
         // runs so checkpoints carry the right restore contract.
-        creating_instance.net_invariant =
-            creating_instance.network.is_some() && !spec.boot_args.contains("ip=");
+        creating_instance.net_invariant = creating_instance.network.is_some() && invariant_identity;
 
         // Retain the boot task so force/TTL removal can cancel and join it
         // before deleting the crash-recovery journal.

--- a/computer/arcbox-computer-runtime/src/sandbox/pause.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/pause.rs
@@ -29,6 +29,7 @@
 //! reconciliation, and `Remove` all see one naming scheme.
 
 use super::checkpoint::{CheckpointFailure, CheckpointRequest, checkpoint_impl};
+use super::reconcile::JournaledLease;
 use super::record::SandboxTransition;
 use super::spec::restore_spec;
 use super::types::action;
@@ -609,6 +610,10 @@ impl SandboxManager {
                 .map(|lease| lease.ip.to_string())
                 .unwrap_or_default();
             let journal = |pid: Option<i32>, cow: Option<&CowHandle>, net: Option<&NetworkLease>| {
+                // The lease attaches the way the snapshot says, exactly as
+                // the `activate` below does — the same expression, so the
+                // journal and the datapath cannot disagree.
+                let net = net.map(|lease| JournaledLease::from_snapshot(lease, snap_meta.net_invariant));
                 super::reconcile::SandboxStateRecord::new(id, pid, net, cow, &self.config, None)
                     .and_then(|record| super::reconcile::write_state_record(vm_dir, &record))
             };

--- a/computer/arcbox-computer-runtime/src/sandbox/policy.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/policy.rs
@@ -7,6 +7,10 @@
 
 pub(super) mod deadlines;
 pub(super) mod pool;
-pub(super) mod recovery;
+/// `pub` only in the lint's spelling: the `policy` module above is
+/// `pub(crate)`, so this reaches exactly `crate::lifecycle`, whose state
+/// machine seeds itself from [`recovery::plan`]'s verdicts and asserts
+/// against that function rather than a copy of it.
+pub mod recovery;
 pub(super) mod settle;
 pub(super) mod warm;

--- a/computer/arcbox-computer-runtime/src/sandbox/policy/recovery.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/policy/recovery.rs
@@ -13,7 +13,7 @@ use crate::sandbox::record::PersistPhase;
 /// What the orphan sweep established about one sandbox's runtime resources
 /// before recovery reads its durable record.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::sandbox) enum JournalEvidence {
+pub enum JournalEvidence {
     /// The sweep found this sandbox's cleanup journal and tore down
     /// everything it listed.
     Swept,
@@ -29,7 +29,7 @@ pub(in crate::sandbox) enum JournalEvidence {
 
 /// What startup recovery does with one durable record.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::sandbox) enum RecoveryAction {
+pub enum RecoveryAction {
     /// A create intent nobody acknowledged: left as it is, so the same
     /// request key still resumes it.
     LeaveResumable,
@@ -62,7 +62,11 @@ pub(in crate::sandbox) enum SweepAction {
 }
 
 /// Recovery's verdict on a record in `phase`, given what the sweep saw.
-pub(in crate::sandbox) fn plan(phase: PersistPhase, evidence: JournalEvidence) -> RecoveryAction {
+///
+/// Crate-visible, like the durable phase vocabulary it reads: the lifecycle
+/// state machine seeds itself from these verdicts and its invariant test
+/// asserts against this function rather than a copy of it.
+pub fn plan(phase: PersistPhase, evidence: JournalEvidence) -> RecoveryAction {
     match (phase, evidence) {
         // An adopted sandbox never stopped being usable: the sweep took its
         // VM back rather than tearing it down, so it is reinstated with the

--- a/computer/arcbox-computer-runtime/src/sandbox/policy/recovery.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/policy/recovery.rs
@@ -21,6 +21,10 @@ pub(in crate::sandbox) enum JournalEvidence {
     Unjournaled,
     /// No sweep ran, so nothing is known about its resources.
     Unchecked,
+    /// The sweep found this sandbox's VM still running and reclaimed it:
+    /// its handle, its lease's datapath and its disk overlay belong to this
+    /// process again, and nothing it listed was torn down.
+    Adopted,
 }
 
 /// What startup recovery does with one durable record.
@@ -41,6 +45,11 @@ pub(in crate::sandbox) enum RecoveryAction {
     /// cannot prove they are gone, so recovery refuses rather than declaring
     /// a sandbox failed while its VMM may still be running.
     RefuseUnjournaled,
+    /// The sweep reported adopting a sandbox from a phase it must not adopt.
+    /// Recovery refuses rather than guess: the alternatives are declaring a
+    /// live sandbox failed or claiming a readiness nobody established, and
+    /// the VM is safe meanwhile — this process holds its handle.
+    RefuseAdopted,
 }
 
 /// What the startup sweep does with one crash journal.
@@ -54,30 +63,46 @@ pub(in crate::sandbox) enum SweepAction {
 
 /// Recovery's verdict on a record in `phase`, given what the sweep saw.
 pub(in crate::sandbox) fn plan(phase: PersistPhase, evidence: JournalEvidence) -> RecoveryAction {
-    match phase {
-        PersistPhase::Creating => RecoveryAction::LeaveResumable,
+    match (phase, evidence) {
+        // An adopted sandbox never stopped being usable: the sweep took its
+        // VM back rather than tearing it down, so it is reinstated with the
+        // runtime state it already had. `Ready`, not `Running` — the
+        // workload the previous process was streaming did not survive it,
+        // and `Running` is what refuses the next `Run`.
+        (PersistPhase::Ready, JournalEvidence::Adopted) => {
+            RecoveryAction::Reinstate(SandboxState::Ready)
+        }
+        // The sweep adopts a durably `Ready` sandbox and nothing else
+        // (`reconcile::adopt_or_kill`), so this pairing is unreachable by
+        // construction rather than merely unusual.
+        (_, JournalEvidence::Adopted) => RecoveryAction::RefuseAdopted,
+
+        (PersistPhase::Creating, _) => RecoveryAction::LeaveResumable,
         // A live phase's runtime resources are journaled as they are
         // acquired, so a missing journal means the sweep never saw — and
         // never tore down — this sandbox's VMM, TAP and overlay.
-        PersistPhase::Starting | PersistPhase::Ready | PersistPhase::Stopping => match evidence {
-            JournalEvidence::Unjournaled => RecoveryAction::RefuseUnjournaled,
-            JournalEvidence::Swept | JournalEvidence::Unchecked => RecoveryAction::Fail,
-        },
+        (
+            PersistPhase::Starting | PersistPhase::Ready | PersistPhase::Stopping,
+            JournalEvidence::Unjournaled,
+        ) => RecoveryAction::RefuseUnjournaled,
+        (PersistPhase::Starting | PersistPhase::Ready | PersistPhase::Stopping, _) => {
+            RecoveryAction::Fail
+        }
         // An interrupted pause/resume died between resource states; the
         // sweep already tore down whatever its journal listed (including the
         // disk overlay), so the sandbox is unrecoverable. Unlike the live
         // phases above, a missing journal is normal here — a resume starts
         // from a Paused record whose journal was already cleared (after the
         // Paused commit) and re-journals as it re-allocates.
-        PersistPhase::Pausing | PersistPhase::Resuming => RecoveryAction::Fail,
+        (PersistPhase::Pausing | PersistPhase::Resuming, _) => RecoveryAction::Fail,
         // Paused commits only after every runtime resource was released, and
         // the sweep preserves durably Paused retained state (clearing any
         // stale journal), so a paused sandbox always survives a restart
         // resumable.
-        PersistPhase::Paused => RecoveryAction::Reinstate(SandboxState::Paused),
-        PersistPhase::Stopped => RecoveryAction::Reinstate(SandboxState::Stopped),
-        PersistPhase::Failed => RecoveryAction::Reinstate(SandboxState::Failed),
-        PersistPhase::Removing => RecoveryAction::FinishRemove,
+        (PersistPhase::Paused, _) => RecoveryAction::Reinstate(SandboxState::Paused),
+        (PersistPhase::Stopped, _) => RecoveryAction::Reinstate(SandboxState::Stopped),
+        (PersistPhase::Failed, _) => RecoveryAction::Reinstate(SandboxState::Failed),
+        (PersistPhase::Removing, _) => RecoveryAction::FinishRemove,
     }
 }
 
@@ -114,64 +139,78 @@ pub(in crate::sandbox) fn sweep_action(id: &str, retained: &HashSet<String>) -> 
 mod tests {
     use super::*;
 
+    /// All ten phases against all four evidences: every pairing has one
+    /// stated verdict, including the ones only a sweep bug could produce.
     #[test]
     fn every_durable_phase_has_one_recovery_action() {
         // (phase, verdict with a journal or with no sweep, verdict when the
-        // sweep ran and found no journal).
+        // sweep ran and found no journal, verdict when the sweep adopted the
+        // sandbox's live VM).
         let table = [
             (
                 PersistPhase::Creating,
                 RecoveryAction::LeaveResumable,
                 RecoveryAction::LeaveResumable,
+                RecoveryAction::RefuseAdopted,
             ),
             (
                 PersistPhase::Starting,
                 RecoveryAction::Fail,
                 RecoveryAction::RefuseUnjournaled,
+                RecoveryAction::RefuseAdopted,
             ),
             (
                 PersistPhase::Ready,
                 RecoveryAction::Fail,
                 RecoveryAction::RefuseUnjournaled,
+                RecoveryAction::Reinstate(SandboxState::Ready),
             ),
             (
                 PersistPhase::Stopping,
                 RecoveryAction::Fail,
                 RecoveryAction::RefuseUnjournaled,
+                RecoveryAction::RefuseAdopted,
             ),
             (
                 PersistPhase::Stopped,
                 RecoveryAction::Reinstate(SandboxState::Stopped),
                 RecoveryAction::Reinstate(SandboxState::Stopped),
+                RecoveryAction::RefuseAdopted,
             ),
             (
                 PersistPhase::Failed,
                 RecoveryAction::Reinstate(SandboxState::Failed),
                 RecoveryAction::Reinstate(SandboxState::Failed),
+                RecoveryAction::RefuseAdopted,
             ),
             (
                 PersistPhase::Removing,
                 RecoveryAction::FinishRemove,
                 RecoveryAction::FinishRemove,
+                RecoveryAction::RefuseAdopted,
             ),
             (
                 PersistPhase::Pausing,
                 RecoveryAction::Fail,
                 RecoveryAction::Fail,
+                RecoveryAction::RefuseAdopted,
             ),
             (
                 PersistPhase::Paused,
                 RecoveryAction::Reinstate(SandboxState::Paused),
                 RecoveryAction::Reinstate(SandboxState::Paused),
+                RecoveryAction::RefuseAdopted,
             ),
             (
                 PersistPhase::Resuming,
                 RecoveryAction::Fail,
                 RecoveryAction::Fail,
+                RecoveryAction::RefuseAdopted,
             ),
         ];
 
-        for (phase, journaled, unjournaled) in table {
+        assert_eq!(table.len(), 10, "every durable phase is covered");
+        for (phase, journaled, unjournaled, adopted) in table {
             for evidence in [JournalEvidence::Swept, JournalEvidence::Unchecked] {
                 assert_eq!(plan(phase, evidence), journaled, "{phase:?} {evidence:?}");
             }
@@ -179,6 +218,11 @@ mod tests {
                 plan(phase, JournalEvidence::Unjournaled),
                 unjournaled,
                 "{phase:?} unjournaled"
+            );
+            assert_eq!(
+                plan(phase, JournalEvidence::Adopted),
+                adopted,
+                "{phase:?} adopted"
             );
         }
     }

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -30,6 +30,15 @@
 //!
 //! Everything else is torn down as before, and then durable lifecycle
 //! records are normalized for replay and inspection.
+//!
+//! What a reclaim does *not* restore is the host's half: the composing host
+//! clears every sandbox's DNS record and port listeners on the startup
+//! handshake ([`SandboxHost::clear_host_state`]'s premise was that a
+//! restarting agent left nothing alive), so an adopted sandbox keeps
+//! running and stays reachable over vsock and at its address, but loses its
+//! name and its published ports until something re-registers them. Nothing
+//! leaks — the guest-side forwarding rules survive and a later Remove still
+//! sweeps them — and the fix belongs to the host half, not here.
 
 use std::collections::{HashMap, HashSet};
 use std::os::unix::fs::PermissionsExt;
@@ -745,7 +754,7 @@ fn adopted_instance(
 ///
 /// A handle that comes back is either reclaimed — with its datapath and its
 /// disk overlay — or killed and reaped, so the dm teardown that follows
-/// never hits EBUSY on an open block device. [`can_reclaim`] decides which,
+/// never hits EBUSY on an open block device. [`reclaim`] decides which,
 /// and every one of its refusals falls back to that kill: the behaviour this
 /// sweep had before adoption existed.
 async fn adopt_or_kill(
@@ -785,7 +794,7 @@ async fn adopt_or_kill(
     };
     let handle: Arc<dyn VmHandle> = Arc::from(handle);
 
-    match can_reclaim(network, cow_manager, record, phase, &handle).await {
+    match reclaim(network, cow_manager, record, phase, &handle).await {
         Ok(reclaimed) => {
             info!(sandbox_id = %record.id, vm = %vm_record.id, "reclaimed a sandbox whose vm outlived its agent");
             Ok(Some(reclaimed))
@@ -801,8 +810,8 @@ async fn adopt_or_kill(
     }
 }
 
-/// Whether this live VM can be handed back to the manager, and the runtime
-/// state that comes with it if so.
+/// Take this live VM and the host state it was running on back, or say why
+/// it cannot be taken.
 ///
 /// `Err` carries why not, and is never fatal — the caller kills instead,
 /// which is what this sweep always did. Nothing partial needs unwinding
@@ -810,7 +819,7 @@ async fn adopt_or_kill(
 /// template refcount) are released by exactly the teardown the kill path
 /// then runs, and releasing them here as well would double-drop the
 /// template's refcount.
-async fn can_reclaim(
+async fn reclaim(
     network: &dyn GuestNetwork,
     cow_manager: &CowManager,
     record: &SandboxStateRecord,

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -16,7 +16,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use arcbox_vm_driver::net::{GuestNetwork, NetworkLease};
+use arcbox_vm_driver::net::{AttachMode, GuestNetwork, NetworkLease};
 use arcbox_vm_driver::{ProcessRecord, ShutdownMode, VmDriver, VmId, VmRecord};
 use serde::{Deserialize, Serialize};
 use tracing::info;
@@ -132,6 +132,101 @@ pub(super) struct SandboxStateRecord {
     /// slot id the jailer chroot and dm/CoW names are keyed by.
     #[serde(default)]
     pub pool_slot_id: Option<String>,
+    /// The [`AttachMode`] this record's lease was activated as — what
+    /// [`GuestNetwork::adopt`] must re-establish for a sandbox the sweep
+    /// keeps alive.
+    ///
+    /// Emphatically **not** derivable from [`Self::net_invariant`]: a cold
+    /// boot always activates [`AttachMode::Invariant`], while that flag says
+    /// only whether the boot baked the invariant `ip=` into the guest's
+    /// command line — false whenever the caller supplied their own. Restore
+    /// and resume are the only paths that vary the mode, and they take it
+    /// from the *snapshot's* flag. Re-establishing `LegacySnapshot` on a TAP
+    /// that was activated `Invariant` is no translation at all, i.e. a live
+    /// guest nothing can reach.
+    ///
+    /// `None` for a networkless sandbox, and in every record written before
+    /// adoption existed. A record that names a lease without it is not
+    /// adoptable: the wrong datapath is worse than the teardown it replaces.
+    #[serde(default)]
+    pub attach_mode: Option<JournaledAttachMode>,
+    /// Whether the guest holds the fixed invariant identity (CORE-81).
+    ///
+    /// [`SandboxInstance::net_invariant`] as an adopted sandbox is rebuilt
+    /// with it, and so what that sandbox's next checkpoint records as its
+    /// restore contract. A different fact from [`Self::attach_mode`] — see
+    /// there.
+    #[serde(default)]
+    pub net_invariant: bool,
+}
+
+/// How a lease's host side was attached, in the journal's own vocabulary.
+///
+/// A journal-local mirror of [`AttachMode`], which carries no serde derives;
+/// mapped at the boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum JournaledAttachMode {
+    Invariant,
+    LegacySnapshot,
+}
+
+impl From<AttachMode> for JournaledAttachMode {
+    fn from(mode: AttachMode) -> Self {
+        match mode {
+            AttachMode::Invariant => Self::Invariant,
+            AttachMode::LegacySnapshot => Self::LegacySnapshot,
+        }
+    }
+}
+
+impl From<JournaledAttachMode> for AttachMode {
+    fn from(mode: JournaledAttachMode) -> Self {
+        match mode {
+            JournaledAttachMode::Invariant => Self::Invariant,
+            JournaledAttachMode::LegacySnapshot => Self::LegacySnapshot,
+        }
+    }
+}
+
+/// A lease as the journal records it: the address, the [`AttachMode`] its
+/// host side is activated as, and whether the guest holds the fixed
+/// invariant identity.
+///
+/// The three travel together because a restart that keeps the guest running
+/// must re-establish that exact datapath, and no two of them give the third.
+/// One parameter rather than a lease plus two loose flags is what stops a
+/// journal site from recording an address without saying how it is attached.
+#[derive(Clone, Copy)]
+pub(super) struct JournaledLease<'a> {
+    lease: &'a NetworkLease,
+    mode: AttachMode,
+    invariant_identity: bool,
+}
+
+impl<'a> JournaledLease<'a> {
+    /// A cold boot's lease. Its host side is always activated
+    /// [`AttachMode::Invariant`] (`lifecycle.rs`, unconditional);
+    /// `baked_invariant_ip` says only whether the boot also put that
+    /// identity on the guest's command line.
+    pub fn cold_boot(lease: &'a NetworkLease, baked_invariant_ip: bool) -> Self {
+        Self {
+            lease,
+            mode: AttachMode::Invariant,
+            invariant_identity: baked_invariant_ip,
+        }
+    }
+
+    /// A restore's or resume's lease: the snapshot's own flag decides both
+    /// the mode and the guest's identity — the same expression that feeds
+    /// the `activate` these journal writes precede.
+    pub fn from_snapshot(lease: &'a NetworkLease, net_invariant: bool) -> Self {
+        Self {
+            lease,
+            mode: super::attach_mode(net_invariant),
+            invariant_identity: net_invariant,
+        }
+    }
 }
 
 /// The TAP name an allocation for `ip` carries.
@@ -149,22 +244,24 @@ impl SandboxStateRecord {
     pub fn new(
         id: &str,
         pid: Option<i32>,
-        network: Option<&NetworkLease>,
+        network: Option<JournaledLease<'_>>,
         cow: Option<&CowHandle>,
         config: &VmmConfig,
         restore_origin_dir: Option<&Path>,
     ) -> Result<Self> {
-        let network = network
-            .map(|lease| legacy_allocation(lease, &config.network.dns))
+        let allocation = network
+            .map(|net| legacy_allocation(net.lease, &config.network.dns))
             .transpose()?;
         Ok(Self {
             id: id.to_owned(),
             pid,
-            network,
+            network: allocation,
             cow: cow.map(CowRecord::from_handle),
             jailer: config.firecracker.jailer.is_some(),
             restore_origin_dir: restore_origin_dir.map(Path::to_path_buf),
             pool_slot_id: None,
+            attach_mode: network.map(|net| net.mode.into()),
+            net_invariant: network.is_some_and(|net| net.invariant_identity),
         })
     }
 
@@ -617,9 +714,10 @@ mod tests {
         assert_eq!(lease.mac.to_string(), "02:fc:00:00:00:07");
         assert_eq!(lease.cleanup_token, "gen-1");
 
-        // ...and the record this agent writes from that lease is the same
-        // JSON, field for field — including the two the lease does not
-        // carry, which are reconstructed rather than dropped.
+        // ...and the record this agent writes from that lease still says
+        // everything the old shape said, field for field — including the two
+        // the lease does not carry, which are reconstructed rather than
+        // dropped. What adoption added is purely additive on top.
         let mut config = VmmConfig::default();
         config.network.dns = vec!["1.1.1.1".into()];
         config.firecracker.jailer = Some(crate::config::JailerConfig {
@@ -633,12 +731,84 @@ mod tests {
             parent_cgroup: None,
             resource_limits: vec![],
         });
-        let written =
-            SandboxStateRecord::new("box", Some(4242), Some(&lease), None, &config, None).unwrap();
+        let written = SandboxStateRecord::new(
+            "box",
+            Some(4242),
+            Some(JournaledLease::cold_boot(&lease, true)),
+            None,
+            &config,
+            None,
+        )
+        .unwrap();
+        let mut value = serde_json::to_value(&written).unwrap();
+        let fields = value.as_object_mut().unwrap();
         assert_eq!(
-            serde_json::to_value(&written).unwrap(),
+            fields.remove("attach_mode"),
+            Some(serde_json::json!("invariant"))
+        );
+        assert_eq!(
+            fields.remove("net_invariant"),
+            Some(serde_json::json!(true))
+        );
+        assert_eq!(
+            value,
             serde_json::from_str::<serde_json::Value>(LEGACY_RECORD).unwrap()
         );
+    }
+
+    /// The two fields adoption added default the way the record's
+    /// both-directions contract requires: a journal written before they
+    /// existed loads, and says it is not adoptable rather than guessing a
+    /// datapath.
+    #[test]
+    fn a_journal_without_an_attach_mode_loads_as_not_adoptable() {
+        let record: SandboxStateRecord = serde_json::from_str(LEGACY_RECORD).unwrap();
+        assert_eq!(record.attach_mode, None);
+        assert!(!record.net_invariant);
+    }
+
+    /// A cold boot always activates `Invariant`, whatever the guest's own
+    /// identity ends up being — the distinction the journal exists to keep.
+    #[test]
+    fn a_cold_boot_journals_the_invariant_mode_even_without_the_invariant_identity() {
+        let lease = NetworkLease {
+            vm: VmId::new("box").unwrap(),
+            ip: "172.20.0.7".parse().unwrap(),
+            prefix_len: 16,
+            gateway: "172.20.0.1".parse().unwrap(),
+            mac: "02:fc:00:00:00:07".parse().unwrap(),
+            cleanup_token: "gen-1".into(),
+        };
+        let config = VmmConfig::default();
+        for baked in [true, false] {
+            let record = SandboxStateRecord::new(
+                "box",
+                None,
+                Some(JournaledLease::cold_boot(&lease, baked)),
+                None,
+                &config,
+                None,
+            )
+            .unwrap();
+            assert_eq!(record.attach_mode, Some(JournaledAttachMode::Invariant));
+            assert_eq!(record.net_invariant, baked);
+        }
+        // A restore or resume is the only thing that varies the mode, and
+        // both halves come from the snapshot's flag there.
+        let legacy = SandboxStateRecord::new(
+            "box",
+            None,
+            Some(JournaledLease::from_snapshot(&lease, false)),
+            None,
+            &config,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            legacy.attach_mode,
+            Some(JournaledAttachMode::LegacySnapshot)
+        );
+        assert!(!legacy.net_invariant);
     }
 
     fn record_in_phase(store: &SandboxRecordStore, id: &str, phase: PersistPhase) -> SandboxRecord {
@@ -752,6 +922,8 @@ mod tests {
             jailer: true,
             restore_origin_dir: None,
             pool_slot_id: Some("pool-1".into()),
+            attach_mode: Some(JournaledAttachMode::Invariant),
+            net_invariant: true,
         };
         let bytes = serde_json::to_vec(&record).unwrap();
         let parsed: SandboxStateRecord = serde_json::from_slice(&bytes).unwrap();
@@ -786,6 +958,8 @@ mod tests {
             jailer: true,
             restore_origin_dir: None,
             pool_slot_id: slot.map(str::to_owned),
+            attach_mode: None,
+            net_invariant: false,
         };
 
         // Slot-keyed resources validate against the slot id, not the sandbox id.

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -49,7 +49,7 @@ use std::time::Duration;
 use arcbox_vm_driver::net::{AttachMode, GuestNetwork, NetworkIdentity, NetworkLease};
 use arcbox_vm_driver::{ProcessRecord, ShutdownMode, VmDriver, VmHandle, VmId, VmRecord, VmState};
 use serde::{Deserialize, Serialize};
-use tracing::info;
+use tracing::{info, warn};
 
 use super::policy::recovery::{self, JournalEvidence, RecoveryAction, SweepAction};
 use super::record::{SandboxRecord, SandboxRecordStore, SandboxTransition};
@@ -620,15 +620,19 @@ pub(super) struct SweptRuntime {
 /// failures; already inactive sandboxes are reconstructed without runtime
 /// handles. A create intent stays resumable, while an interrupted removal
 /// finishes as a durable tombstone.
+/// Takes `sweep` by `&mut` so that whatever this does not claim is still
+/// the caller's to dispose of — see [`release_unclaimed`], which the caller
+/// must run on both paths.
 pub(super) fn normalize_durable_records(
     store: &SandboxRecordStore,
     data_dir: &Path,
-    sweep: Option<SweptRuntime>,
+    sweep: Option<&mut SweptRuntime>,
 ) -> Result<Vec<SandboxInstance>> {
     let mut inactive = Vec::new();
-    let (swept, mut adopted) = match sweep {
-        Some(sweep) => (Some(sweep.swept), sweep.adopted),
-        None => (None, HashMap::new()),
+    let mut nothing_adopted = HashMap::new();
+    let (swept, adopted) = match sweep {
+        Some(sweep) => (Some(&sweep.swept), &mut sweep.adopted),
+        None => (None, &mut nothing_adopted),
     };
 
     for record in store.load_all()? {
@@ -680,6 +684,41 @@ pub(super) fn normalize_durable_records(
     }
 
     Ok(inactive)
+}
+
+/// Dispose of every reclaimed sandbox [`normalize_durable_records`] did not
+/// take: kill its VM and hand back the two resources the reclaim took.
+///
+/// A no-op on the happy path — normalization claims every adopted record —
+/// and the reason it is called on the error path too. Dropping the map
+/// there would kill each VM through the handle's `Drop` while leaving its
+/// lease live in the network and its template refcount held, which is the
+/// one shape this sweep must never produce: resources released by nobody,
+/// in a process whose reconciliation has already failed.
+///
+/// Best-effort per resource, because it runs while an error is already on
+/// its way out and each sandbox's journal survives to be swept again.
+pub(super) async fn release_unclaimed(
+    runtime: &mut SweptRuntime,
+    network: &dyn GuestNetwork,
+    cow_manager: &CowManager,
+) {
+    for (id, adopted) in runtime.adopted.drain() {
+        warn!(sandbox_id = %id, "releasing a reclaimed sandbox that recovery did not take");
+        if let Err(error) = adopted.handle.shutdown(ShutdownMode::Kill).await {
+            warn!(sandbox_id = %id, %error, "killing the reclaimed vmm failed");
+        }
+        if let Some(cow_handle) = &adopted.cow_handle
+            && let Err(error) = cow_manager.teardown_checked(cow_handle).await
+        {
+            warn!(sandbox_id = %id, %error, "releasing the reclaimed disk overlay failed");
+        }
+        if let Some(lease) = adopted.lease
+            && let Err(error) = network.quarantine(lease).await
+        {
+            warn!(sandbox_id = %id, %error, "quarantining the reclaimed lease failed");
+        }
+    }
 }
 
 fn inactive_instance(
@@ -1358,9 +1397,12 @@ mod tests {
         record_in_phase(&store, "mid-pause", PersistPhase::Pausing);
         record_in_phase(&store, "mid-resume", PersistPhase::Resuming);
 
-        let inactive =
-            normalize_durable_records(&store, data_dir.path(), Some(SweptRuntime::nothing_kept()))
-                .unwrap();
+        let inactive = normalize_durable_records(
+            &store,
+            data_dir.path(),
+            Some(&mut SweptRuntime::nothing_kept()),
+        )
+        .unwrap();
         let inactive: HashMap<_, _> = inactive
             .into_iter()
             .map(|instance| (instance.id.clone(), instance))
@@ -1532,10 +1574,12 @@ mod tests {
     async fn sweep_one(
         data_dir: &Path,
         case: &AdoptionCase,
+        unjournaled: &[(&str, PersistPhase)],
     ) -> (
         Box<dyn VmHandle>,
         super::super::SandboxManager,
         std::sync::Arc<arcbox_vm_driver::testkit::FakeNetwork>,
+        Result<()>,
     ) {
         use arcbox_vm_driver::testkit::{FakeDriver, FakeNetwork};
         use arcbox_vm_driver::{BootSpec, ConsoleSpec, IsolationSpec, VmSpec, VsockSpec};
@@ -1577,6 +1621,11 @@ mod tests {
         config.firecracker.data_dir = data_dir.to_string_lossy().into_owned();
         let store = SandboxRecordStore::new(data_dir).unwrap();
         record_in_phase(&store, "keeper", case.phase);
+        // Durable records with no journal at all, which is what makes
+        // recovery refuse to normalize and fails the whole reconciliation.
+        for (id, phase) in unjournaled {
+            record_in_phase(&store, id, *phase);
+        }
         drop(store);
 
         let lease = NetworkLease {
@@ -1614,8 +1663,8 @@ mod tests {
             },
         )
         .unwrap();
-        manager.await_reconcile().await.unwrap();
-        (vm, manager, network)
+        let reconciled = manager.await_reconcile().await;
+        (vm, manager, network, reconciled)
     }
 
     /// The payload: a `Ready` sandbox whose VM outlived its agent comes back
@@ -1623,7 +1672,9 @@ mod tests {
     #[tokio::test]
     async fn a_live_ready_sandbox_is_reclaimed_rather_than_killed() {
         let data_dir = tempfile::tempdir().unwrap();
-        let (vm, manager, network) = sweep_one(data_dir.path(), &AdoptionCase::live()).await;
+        let (vm, manager, network, reconciled) =
+            sweep_one(data_dir.path(), &AdoptionCase::live(), &[]).await;
+        reconciled.unwrap();
 
         assert_eq!(vm.state(), VmState::Running, "the guest was never killed");
         let instances = manager.instances.read().unwrap();
@@ -1655,6 +1706,41 @@ mod tests {
                 .join(STATE_FILE)
                 .exists(),
             "an adopted journal is live state, not debris"
+        );
+    }
+
+    /// Recovery can still refuse *after* the sweep reclaimed something — a
+    /// peer record in a live phase with no journal is enough. What the sweep
+    /// took must then be handed back explicitly: letting the map drop would
+    /// kill each VM through its handle while leaving the lease live in the
+    /// network and the template refcount held, i.e. resources nobody owns in
+    /// a process whose reconciliation has already failed.
+    #[tokio::test]
+    async fn a_failed_normalization_hands_back_what_the_sweep_reclaimed() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let (vm, _manager, network, reconciled) = sweep_one(
+            data_dir.path(),
+            &AdoptionCase::live(),
+            &[("ghost", PersistPhase::Ready)],
+        )
+        .await;
+
+        // `await_reconcile` reports the task's failure as text, so the
+        // message is what says which refusal it was.
+        let error = reconciled.expect_err("an unjournaled live record refuses normalization");
+        assert!(
+            error.to_string().contains("has no cleanup journal"),
+            "unexpected reconciliation failure: {error}"
+        );
+        assert_eq!(
+            vm.state(),
+            VmState::Exited(arcbox_vm_driver::ExitStatus::signaled(9)),
+            "the reclaimed vm is killed rather than left ownerless"
+        );
+        assert_eq!(
+            network.adopted_mode(&VmId::new("keeper").unwrap()),
+            None,
+            "and its lease is handed back rather than left live"
         );
     }
 
@@ -1693,7 +1779,8 @@ mod tests {
             ),
         ] {
             let data_dir = tempfile::tempdir().unwrap();
-            let (vm, manager, _) = sweep_one(data_dir.path(), &case).await;
+            let (vm, manager, _, reconciled) = sweep_one(data_dir.path(), &case, &[]).await;
+            reconciled.unwrap();
 
             assert_eq!(
                 vm.state(),
@@ -1722,7 +1809,11 @@ mod tests {
         record_in_phase(&store, "starting", PersistPhase::Starting);
 
         assert!(matches!(
-            normalize_durable_records(&store, data_dir.path(), Some(SweptRuntime::nothing_kept())),
+            normalize_durable_records(
+                &store,
+                data_dir.path(),
+                Some(&mut SweptRuntime::nothing_kept())
+            ),
             Err(crate::error::VmmError::Unavailable(_))
         ));
         assert_eq!(

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -659,15 +659,19 @@ pub(super) struct SweptRuntime {
 /// failures; already inactive sandboxes are reconstructed without runtime
 /// handles. A create intent stays resumable, while an interrupted removal
 /// finishes as a durable tombstone.
-/// Takes `sweep` by `&mut` so that whatever this does not claim is still
-/// the caller's to dispose of — see [`release_unclaimed`], which the caller
-/// must run on both paths.
+/// Both the sweep's runtime and the instances built from it are the
+/// caller's, so a refusal partway through loses neither: what was never
+/// claimed stays in `sweep` for [`release_unclaimed`], and what was already
+/// built is in `built` for [`release_instances`]. An adopted instance holds
+/// the only handle keeping its guest alive, so dropping either here would
+/// kill that guest with its lease and template refcount still held.
 pub(super) fn normalize_durable_records(
     store: &SandboxRecordStore,
     data_dir: &Path,
     sweep: Option<&mut SweptRuntime>,
-) -> Result<Vec<SandboxInstance>> {
-    let mut inactive = Vec::new();
+    built: &mut Vec<SandboxInstance>,
+) -> Result<()> {
+    let inactive = built;
     let mut nothing_adopted = HashMap::new();
     let (swept, adopted) = match sweep {
         Some(sweep) => (Some(&sweep.swept), &mut sweep.adopted),
@@ -722,7 +726,7 @@ pub(super) fn normalize_durable_records(
         }
     }
 
-    Ok(inactive)
+    Ok(())
 }
 
 /// Dispose of every reclaimed sandbox [`normalize_durable_records`] did not
@@ -763,20 +767,78 @@ async fn release_reclaimed(
     cow_manager: &CowManager,
 ) {
     for (id, adopted) in adopted.drain() {
-        warn!(sandbox_id = %id, "releasing a reclaimed sandbox that recovery did not take");
-        if let Err(error) = adopted.handle.shutdown(ShutdownMode::Kill).await {
-            warn!(sandbox_id = %id, %error, "killing the reclaimed vmm failed");
-        }
-        if let Some(cow_handle) = &adopted.cow_handle
-            && let Err(error) = cow_manager.teardown_checked(cow_handle).await
-        {
-            warn!(sandbox_id = %id, %error, "releasing the reclaimed disk overlay failed");
-        }
-        if let Some(lease) = adopted.lease
-            && let Err(error) = network.quarantine(lease).await
-        {
-            warn!(sandbox_id = %id, %error, "quarantining the reclaimed lease failed");
-        }
+        release_one(
+            &id,
+            &adopted.handle,
+            adopted.cow_handle.as_ref(),
+            adopted.lease,
+            network,
+            cow_manager,
+        )
+        .await;
+    }
+}
+
+/// The same, for reclaimed sandboxes that recovery already built instances
+/// for when it refused. They hold exactly what the map entries held —
+/// dropping the vector would lose them the same way.
+pub(super) async fn release_instances(
+    instances: &mut Vec<SandboxInstance>,
+    network: &dyn GuestNetwork,
+    cow_manager: &CowManager,
+) {
+    for instance in instances.drain(..) {
+        let mut instance = instance;
+        let Some(handle) = instance.handle.take() else {
+            continue;
+        };
+        release_one(
+            &instance.id,
+            &handle,
+            instance.cow_handle.as_ref(),
+            instance.network.take(),
+            network,
+            cow_manager,
+        )
+        .await;
+    }
+}
+
+/// Let go of one reclaimed sandbox: kill its VM, then hand back the disk
+/// overlay and the address it was running on.
+///
+/// The order is the one live teardown uses and is load-bearing in the same
+/// way — a VMM that is still alive holds its dm device open and its TAP fd,
+/// so a failed kill **stops** the release rather than continuing past it.
+/// Taking the disk and the address away from a guest that is still running
+/// would leave it alive and broken, which is worse than leaving all three
+/// for the next sweep: the sandbox's journal survives this path, so there
+/// is one.
+async fn release_one(
+    id: &str,
+    handle: &Arc<dyn VmHandle>,
+    cow_handle: Option<&CowHandle>,
+    lease: Option<NetworkLease>,
+    network: &dyn GuestNetwork,
+    cow_manager: &CowManager,
+) {
+    warn!(sandbox_id = %id, "releasing a reclaimed sandbox that recovery did not take");
+    if let Err(error) = handle.shutdown(ShutdownMode::Kill).await {
+        warn!(
+            sandbox_id = %id, %error,
+            "killing the reclaimed vmm failed; leaving its disk and address for the next sweep"
+        );
+        return;
+    }
+    if let Some(cow_handle) = cow_handle
+        && let Err(error) = cow_manager.teardown_checked(cow_handle).await
+    {
+        warn!(sandbox_id = %id, %error, "releasing the reclaimed disk overlay failed");
+    }
+    if let Some(lease) = lease
+        && let Err(error) = network.quarantine(lease).await
+    {
+        warn!(sandbox_id = %id, %error, "quarantining the reclaimed lease failed");
     }
 }
 
@@ -1413,7 +1475,8 @@ mod tests {
             record_in_phase(&store, id, phase);
         }
 
-        let inactive = normalize_durable_records(&store, data_dir.path(), None).unwrap();
+        let mut inactive = Vec::new();
+        normalize_durable_records(&store, data_dir.path(), None, &mut inactive).unwrap();
         let inactive: HashMap<_, _> = inactive
             .into_iter()
             .map(|instance| (instance.id.clone(), instance))
@@ -1456,10 +1519,12 @@ mod tests {
         record_in_phase(&store, "mid-pause", PersistPhase::Pausing);
         record_in_phase(&store, "mid-resume", PersistPhase::Resuming);
 
-        let inactive = normalize_durable_records(
+        let mut inactive = Vec::new();
+        normalize_durable_records(
             &store,
             data_dir.path(),
             Some(&mut SweptRuntime::nothing_kept()),
+            &mut inactive,
         )
         .unwrap();
         let inactive: HashMap<_, _> = inactive
@@ -1873,30 +1938,126 @@ mod tests {
     /// a process whose reconciliation has already failed.
     #[tokio::test]
     async fn a_failed_normalization_hands_back_what_the_sweep_reclaimed() {
-        let data_dir = tempfile::tempdir().unwrap();
-        let (vm, _manager, network, reconciled) = sweep_one(
-            data_dir.path(),
-            &AdoptionCase::live(),
-            &[("ghost", PersistPhase::Ready)],
-        )
-        .await;
+        // Durable records are normalized in sorted order, so the peer's id
+        // decides whether the refusal lands before `keeper` was claimed (it
+        // is still in the sweep's map) or after (it is already an instance).
+        // Both lose it if the loser is dropped rather than released.
+        for peer in ["aaa-ghost", "zzz-ghost"] {
+            let data_dir = tempfile::tempdir().unwrap();
+            let (vm, _manager, network, reconciled) = sweep_one(
+                data_dir.path(),
+                &AdoptionCase::live(),
+                &[(peer, PersistPhase::Ready)],
+            )
+            .await;
 
-        // `await_reconcile` reports the task's failure as text, so the
-        // message is what says which refusal it was.
-        let error = reconciled.expect_err("an unjournaled live record refuses normalization");
-        assert!(
-            error.to_string().contains("has no cleanup journal"),
-            "unexpected reconciliation failure: {error}"
+            // `await_reconcile` reports the task's failure as text, so the
+            // message is what says which refusal it was.
+            let error = reconciled.expect_err("an unjournaled live record refuses normalization");
+            assert!(
+                error.to_string().contains("has no cleanup journal"),
+                "{peer}: unexpected reconciliation failure: {error}"
+            );
+            assert_eq!(
+                vm.state(),
+                VmState::Exited(arcbox_vm_driver::ExitStatus::signaled(9)),
+                "{peer}: the reclaimed vm is killed rather than left ownerless"
+            );
+            assert_eq!(
+                network.adopted_mode(&VmId::new("keeper").unwrap()),
+                None,
+                "{peer}: its lease is handed back rather than left live"
+            );
+        }
+    }
+
+    /// A kill that fails leaves a guest running, and taking its disk and its
+    /// address away then would leave it alive and broken. The release stops
+    /// instead; the journal survives for the next sweep to retry.
+    #[tokio::test]
+    async fn a_release_whose_kill_fails_keeps_the_disk_and_the_address() {
+        use arcbox_vm_driver::testkit::{FakeDriver, FakeNetwork};
+
+        struct RefusesShutdown(Arc<dyn VmHandle>);
+
+        #[async_trait::async_trait]
+        impl VmHandle for RefusesShutdown {
+            fn id(&self) -> &VmId {
+                self.0.id()
+            }
+            fn record(&self) -> VmRecord {
+                self.0.record()
+            }
+            fn state(&self) -> VmState {
+                self.0.state()
+            }
+            fn events(&self) -> tokio::sync::broadcast::Receiver<arcbox_vm_driver::VmEvent> {
+                self.0.events()
+            }
+            async fn shutdown(
+                &self,
+                _mode: ShutdownMode,
+            ) -> arcbox_vm_driver::Result<arcbox_vm_driver::ExitStatus> {
+                Err(arcbox_vm_driver::Error::Driver {
+                    driver: "fake",
+                    message: "the reaper did not see it exit".into(),
+                    source: None,
+                })
+            }
+        }
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let driver = FakeDriver::new();
+        let network = FakeNetwork::new();
+        let probe = Arc::new(crate::snapshot_cow::CowTestProbe::default());
+        let cow_manager = CowManager::new_with_test_probe(
+            crate::snapshot_cow::CowOptions::new(data_dir.path()),
+            Arc::clone(&probe),
+        )
+        .unwrap();
+
+        let vm_dir = data_dir.path().join("sandboxes").join("stuck");
+        let vm = boot_previous_vm(&driver, &vm_dir, "stuck", true, true).await;
+        let lease = network
+            .reserve(
+                &VmId::new("stuck").unwrap(),
+                super::super::sandbox_network_policy(),
+            )
+            .await
+            .unwrap();
+        network.release(lease.clone()).await.unwrap();
+        network.adopt(&lease, AttachMode::Invariant).await.unwrap();
+
+        let mut adopted = HashMap::new();
+        adopted.insert(
+            "stuck".to_owned(),
+            AdoptedSandbox {
+                handle: Arc::new(RefusesShutdown(Arc::from(vm))),
+                lease: Some(lease),
+                identity: None,
+                cow_handle: Some(CowHandle {
+                    dm_name: "arcbox-snap-stuck".into(),
+                    dm_device: "/dev/mapper/arcbox-snap-stuck".into(),
+                    cow_loop: "/dev/loop7".into(),
+                    cow_file: data_dir.path().join("cow/arcbox-cow-stuck.img"),
+                    template_path: "/rootfs.ext4".into(),
+                }),
+                pool_slot_id: None,
+                net_invariant: true,
+            },
+        );
+
+        release_reclaimed(&mut adopted, &network, &cow_manager).await;
+
+        assert_eq!(
+            probe.teardown_count(),
+            0,
+            "a guest that is still running keeps its disk"
         );
         assert_eq!(
-            vm.state(),
-            VmState::Exited(arcbox_vm_driver::ExitStatus::signaled(9)),
-            "the reclaimed vm is killed rather than left ownerless"
-        );
-        assert_eq!(
-            network.adopted_mode(&VmId::new("keeper").unwrap()),
-            None,
-            "and its lease is handed back rather than left live"
+            network.adopted_mode(&VmId::new("stuck").unwrap()),
+            Some(AttachMode::Invariant),
+            "and its address"
         );
     }
 
@@ -1968,7 +2129,8 @@ mod tests {
             normalize_durable_records(
                 &store,
                 data_dir.path(),
-                Some(&mut SweptRuntime::nothing_kept())
+                Some(&mut SweptRuntime::nothing_kept()),
+                &mut Vec::new()
             ),
             Err(crate::error::VmmError::Unavailable(_))
         ));

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -100,17 +100,9 @@ impl CowRecord {
         }
     }
 
-    fn into_handle(self) -> CowHandle {
-        CowHandle {
-            dm_name: self.dm_name,
-            dm_device: self.dm_device,
-            cow_loop: self.cow_loop,
-            cow_file: self.cow_file,
-            template_path: self.template_path,
-        }
-    }
-
-    /// The same handle for a record the sweep keeps rather than consumes.
+    /// The handle this record stands for. By reference because the sweep
+    /// decides a record's fate before it disposes of it, so it still needs
+    /// the rest of the record afterwards.
     fn to_handle(&self) -> CowHandle {
         CowHandle {
             dm_name: self.dm_name.clone(),
@@ -498,6 +490,9 @@ pub(super) async fn sweep_orphans(
         validate_state_record(config, &sandboxes_dir, &dir, &record)?;
         records.push((dir, record));
     }
+    // `read_dir` order is arbitrary; a stable one makes a sweep that fails
+    // partway reproducible, and lets a test say which journal it failed on.
+    records.sort_by(|(_, left), (_, right)| left.id.cmp(&right.id));
 
     // Durable phases first: whether a journaled VM may be kept depends on
     // what its record says the sandbox was doing.
@@ -512,11 +507,59 @@ pub(super) async fn sweep_orphans(
         .map(|record| (record.id.as_str(), record.phase))
         .collect();
 
+    // From the first reclaim on, every error path has to hand back what it
+    // took: propagating out of here would drop the map, which kills each
+    // reclaimed guest through its handle while leaving its lease and
+    // template refcount held.
+    let mut adopted = HashMap::new();
+    let reaped = reap_orphans(
+        &records,
+        &mut adopted,
+        &retained,
+        &phases,
+        config,
+        driver,
+        network,
+        cow_manager,
+    )
+    .await;
+    let (swept, runtime_dirs) = match reaped {
+        Ok(reaped) => reaped,
+        Err(error) => {
+            release_reclaimed(&mut adopted, network, cow_manager).await;
+            return Err(error);
+        }
+    };
+
+    Ok(OrphanSweep {
+        ids: swept,
+        adopted,
+        runtime_dirs,
+    })
+}
+
+/// Decide each journal's fate and tear down everything not kept.
+///
+/// Split out so [`sweep_orphans`] has exactly one place to release what a
+/// failure leaves reclaimed but unowned.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the sweep's whole resource set, threaded rather than re-derived"
+)]
+async fn reap_orphans(
+    records: &[(PathBuf, SandboxStateRecord)],
+    adopted: &mut HashMap<String, AdoptedSandbox>,
+    retained: &HashSet<String>,
+    phases: &HashMap<&str, super::record::PersistPhase>,
+    config: &VmmConfig,
+    driver: &dyn VmDriver,
+    network: &dyn GuestNetwork,
+    cow_manager: &CowManager,
+) -> Result<(HashSet<String>, Vec<PathBuf>)> {
     // Every VM this sweep does not keep must be dead before the global CoW
     // sweep runs: a live VMM pins its dm device, and a pinned device turns
     // a reap into an error that fails the whole reconciliation.
-    let mut adopted = HashMap::new();
-    for (dir, record) in &records {
+    for (dir, record) in records {
         if let Some(reclaimed) = adopt_or_kill(
             driver,
             network,
@@ -547,22 +590,22 @@ pub(super) async fn sweep_orphans(
 
     let mut swept = HashSet::new();
     let mut runtime_dirs = Vec::new();
-    for (dir, mut record) in records {
+    for (dir, record) in records {
         // An adopted sandbox's journal names what this process now owns, so
         // it stays exactly where it is — as does its runtime directory,
         // which `finalize_sweep` only removes for the ids listed here.
         if adopted.contains_key(&record.id) {
             continue;
         }
-        if recovery::sweep_action(&record.id, &retained) == SweepAction::DropStaleJournal {
+        if recovery::sweep_action(&record.id, retained) == SweepAction::DropStaleJournal {
             info!(sandbox_id = %record.id, "dropping stale pause journal, keeping retained state");
-            clear_state_record(&dir)?;
+            clear_state_record(dir)?;
             continue;
         }
         info!(sandbox_id = %record.id, "reconciling orphaned sandbox");
 
-        if let Some(cow) = record.cow.take() {
-            cow_manager.teardown_checked(&cow.into_handle()).await?;
+        if let Some(cow) = &record.cow {
+            cow_manager.teardown_checked(&cow.to_handle()).await?;
         }
 
         if let Some(lease) = record.lease()? {
@@ -583,15 +626,11 @@ pub(super) async fn sweep_orphans(
             }
         }
 
-        runtime_dirs.push(dir);
-        swept.insert(record.id);
+        runtime_dirs.push(dir.clone());
+        swept.insert(record.id.clone());
     }
 
-    Ok(OrphanSweep {
-        ids: swept,
-        adopted,
-        runtime_dirs,
-    })
+    Ok((swept, runtime_dirs))
 }
 
 /// Deletes cleanup journals only after durable lifecycle normalization commits.
@@ -703,7 +742,27 @@ pub(super) async fn release_unclaimed(
     network: &dyn GuestNetwork,
     cow_manager: &CowManager,
 ) {
-    for (id, adopted) in runtime.adopted.drain() {
+    release_reclaimed(&mut runtime.adopted, network, cow_manager).await;
+}
+
+/// Give back the two resources a reclaim took, and kill the VM it took them
+/// for.
+///
+/// Every failure between reclaiming a sandbox and handing it to the instance
+/// map routes through here. Letting the map drop instead would kill each VM
+/// through its handle's `Drop` while leaving its lease live in the network
+/// and its template refcount held — resources released by nobody. Killing is
+/// the right disposition once nothing can own them; doing it silently, and
+/// only half of it, is not.
+///
+/// Best-effort per resource: it runs while an error is already on its way
+/// out, and every sandbox's journal survives to be swept again.
+async fn release_reclaimed(
+    adopted: &mut HashMap<String, AdoptedSandbox>,
+    network: &dyn GuestNetwork,
+    cow_manager: &CowManager,
+) {
+    for (id, adopted) in adopted.drain() {
         warn!(sandbox_id = %id, "releasing a reclaimed sandbox that recovery did not take");
         if let Err(error) = adopted.handle.shutdown(ShutdownMode::Kill).await {
             warn!(sandbox_id = %id, %error, "killing the reclaimed vmm failed");
@@ -1265,7 +1324,7 @@ mod tests {
         assert!(parsed.jailer);
         assert_eq!(parsed.pool_slot_id.as_deref(), Some("pool-1"));
         assert_eq!(parsed.resource_owner(), "pool-1");
-        let handle = parsed.cow.unwrap().into_handle();
+        let handle = parsed.cow.unwrap().to_handle();
         assert_eq!(handle.dm_name, "arcbox-snap-sb-1");
     }
 
@@ -1565,6 +1624,50 @@ mod tests {
         }
     }
 
+    /// A VM the previous agent booted in `vm_dir`, optionally handed over
+    /// rather than killed. Kept undetached, the fake driver refuses to adopt
+    /// it — which is how a sweep-time adopt failure is staged.
+    async fn boot_previous_vm(
+        driver: &arcbox_vm_driver::testkit::FakeDriver,
+        vm_dir: &Path,
+        id: &str,
+        vsock: bool,
+        handed_over: bool,
+    ) -> Box<dyn VmHandle> {
+        use arcbox_vm_driver::{BootSpec, ConsoleSpec, IsolationSpec, VmSpec, VsockSpec};
+
+        std::fs::create_dir_all(vm_dir).unwrap();
+        let vm = driver
+            .boot(
+                VmSpec {
+                    id: VmId::new(id).unwrap(),
+                    cpus: 1,
+                    memory_mib: 128,
+                    boot: BootSpec::Kernel {
+                        image: "/vmlinux".into(),
+                        cmdline: String::new(),
+                        initrd: None,
+                    },
+                    disks: vec![],
+                    nics: vec![],
+                    vsock: vsock.then_some(VsockSpec { guest_cid: 3 }),
+                    shares: vec![],
+                    console: ConsoleSpec::Off,
+                    balloon: false,
+                    entropy: false,
+                    dirty_tracking: false,
+                    isolation: IsolationSpec::None,
+                },
+                vm_dir,
+            )
+            .await
+            .unwrap();
+        if handed_over {
+            vm.detach().unwrap().detach().await.unwrap();
+        }
+        vm
+    }
+
     /// Plant one sandbox that outlived its agent — a detached VM, a durable
     /// record, and a crash journal naming both — then build a fresh manager
     /// over the same data directory and report what its sweep made of it.
@@ -1582,39 +1685,11 @@ mod tests {
         Result<()>,
     ) {
         use arcbox_vm_driver::testkit::{FakeDriver, FakeNetwork};
-        use arcbox_vm_driver::{BootSpec, ConsoleSpec, IsolationSpec, VmSpec, VsockSpec};
 
         let driver = FakeDriver::new();
         let network = std::sync::Arc::new(FakeNetwork::new());
         let vm_dir = data_dir.join("sandboxes").join("keeper");
-        std::fs::create_dir_all(&vm_dir).unwrap();
-        let vm = driver
-            .boot(
-                VmSpec {
-                    id: VmId::new("keeper").unwrap(),
-                    cpus: 1,
-                    memory_mib: 128,
-                    boot: BootSpec::Kernel {
-                        image: "/vmlinux".into(),
-                        cmdline: String::new(),
-                        initrd: None,
-                    },
-                    disks: vec![],
-                    nics: vec![],
-                    vsock: case.vsock.then_some(VsockSpec { guest_cid: 3 }),
-                    shares: vec![],
-                    console: ConsoleSpec::Off,
-                    balloon: false,
-                    entropy: false,
-                    dirty_tracking: false,
-                    isolation: IsolationSpec::None,
-                },
-                &vm_dir,
-            )
-            .await
-            .unwrap();
-        // The previous agent handed its VM over rather than killing it.
-        vm.detach().unwrap().detach().await.unwrap();
+        let vm = boot_previous_vm(&driver, &vm_dir, "keeper", case.vsock, true).await;
         let pid = vm.record().process.map(|process| process.pid).unwrap();
 
         let mut config = VmmConfig::default();
@@ -1706,6 +1781,87 @@ mod tests {
                 .join(STATE_FILE)
                 .exists(),
             "an adopted journal is live state, not debris"
+        );
+    }
+
+    /// The sweep itself can fail after reclaiming: an orphan the driver
+    /// refuses to adopt aborts it, and what it already took must be handed
+    /// back rather than dropped. Deterministic because the sweep sorts its
+    /// journals, so `keeper` is reclaimed before `zzz-broken` fails.
+    #[tokio::test]
+    async fn a_failed_sweep_hands_back_what_it_already_reclaimed() {
+        use arcbox_vm_driver::testkit::{FakeDriver, FakeNetwork};
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let driver = FakeDriver::new();
+        let network = std::sync::Arc::new(FakeNetwork::new());
+        let mut config = VmmConfig::default();
+        config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
+
+        let keeper_dir = data_dir.path().join("sandboxes").join("keeper");
+        let keeper = boot_previous_vm(&driver, &keeper_dir, "keeper", true, true).await;
+        let lease = NetworkLease {
+            vm: VmId::new("keeper").unwrap(),
+            ip: "10.200.0.9".parse().unwrap(),
+            prefix_len: 16,
+            gateway: "10.200.0.1".parse().unwrap(),
+            mac: "02:fc:00:00:00:09".parse().unwrap(),
+            cleanup_token: "gen-1".into(),
+        };
+        write_state_record(
+            &keeper_dir,
+            &SandboxStateRecord::new(
+                "keeper",
+                keeper
+                    .record()
+                    .process
+                    .map(|process| i32::try_from(process.pid).unwrap()),
+                Some(JournaledLease::cold_boot(&lease, true)),
+                None,
+                &config,
+                None,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        // Still owned by a live handle, which the fake driver refuses to
+        // adopt — the sweep's own error, after `keeper` was reclaimed.
+        let broken_dir = data_dir.path().join("sandboxes").join("zzz-broken");
+        let _broken = boot_previous_vm(&driver, &broken_dir, "zzz-broken", true, false).await;
+        write_state_record(
+            &broken_dir,
+            &SandboxStateRecord::new("zzz-broken", None, None, None, &config, None).unwrap(),
+        )
+        .unwrap();
+
+        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        record_in_phase(&store, "keeper", PersistPhase::Ready);
+        drop(store);
+
+        let manager = super::super::SandboxManager::with_environment(
+            config,
+            crate::SandboxEnvironment {
+                driver: Some(std::sync::Arc::new(driver)),
+                network: Some(std::sync::Arc::clone(&network) as std::sync::Arc<dyn GuestNetwork>),
+                ..crate::SandboxEnvironment::default()
+            },
+        )
+        .unwrap();
+
+        manager
+            .await_reconcile()
+            .await
+            .expect_err("an orphan the driver cannot adopt fails the sweep");
+        assert_eq!(
+            keeper.state(),
+            VmState::Exited(arcbox_vm_driver::ExitStatus::signaled(9)),
+            "the reclaimed vm is killed rather than left ownerless"
+        );
+        assert_eq!(
+            network.adopted_mode(&VmId::new("keeper").unwrap()),
+            None,
+            "and its lease is handed back rather than left live"
         );
     }
 

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -2,22 +2,43 @@
 //!
 //! `SandboxManager` state is in-memory; if the agent restarts (crash,
 //! supervision respawn) the VMM processes, TAP devices, dm-snapshot
-//! devices, and jailer chroots of running sandboxes leak, and fresh IP
-//! allocations can collide with orphaned TAPs. To recover, every successful
-//! boot/restore persists a small `state.json` next to the sandbox's runtime
-//! files, and a new manager sweeps those records: orphaned VMMs are found
-//! and killed through the driver's `Adopt` capability, and every held
-//! resource is torn down. Sandboxes are not live-reconciled yet: startup
-//! destroys orphaned runtime resources, then normalizes durable lifecycle
-//! records for replay and inspection.
+//! devices, and jailer chroots of running sandboxes are left with no owner,
+//! and fresh IP allocations can collide with orphaned TAPs. To recover,
+//! every successful boot/restore persists a small `state.json` next to the
+//! sandbox's runtime files, and a new manager sweeps those records.
+//!
+//! A sandbox whose VM is *still running* is reclaimed rather than
+//! destroyed, so a crash or an upgrade of the composing process does not
+//! cost every guest on the node its work (CORE-135). One journal is adopted
+//! when all of these hold, and killed the moment any of them does not —
+//! every refusal falls back to the teardown this sweep did before adoption
+//! existed, because re-establishing the wrong host state is worse than
+//! starting over:
+//!
+//! - the driver's `Adopt` capability found and reconnected to the VMM;
+//! - that handle reports [`VmState::Running`] — a quiesced guest is a
+//!   checkpoint that died between the pause and the resume;
+//! - the handle has vsock, which is what separates a full one from the
+//!   process-only fallback an orphan with a dead API yields: without it
+//!   nothing can be run, paused or checkpointed in the sandbox, only killed;
+//! - the durable record is `Ready`. `Starting` died with the boot task that
+//!   was driving it and nothing here finishes one; the transitional phases
+//!   died between resource states;
+//! - the journal says how its lease attaches ([`SandboxStateRecord::attach_mode`]),
+//!   and the guest network takes that lease back under exactly that mode;
+//! - the CoW manager re-registers the dm-snapshot the guest is running on.
+//!
+//! Everything else is torn down as before, and then durable lifecycle
+//! records are normalized for replay and inspection.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
-use arcbox_vm_driver::net::{AttachMode, GuestNetwork, NetworkLease};
-use arcbox_vm_driver::{ProcessRecord, ShutdownMode, VmDriver, VmId, VmRecord};
+use arcbox_vm_driver::net::{AttachMode, GuestNetwork, NetworkIdentity, NetworkLease};
+use arcbox_vm_driver::{ProcessRecord, ShutdownMode, VmDriver, VmHandle, VmId, VmRecord, VmState};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
@@ -77,6 +98,17 @@ impl CowRecord {
             cow_loop: self.cow_loop,
             cow_file: self.cow_file,
             template_path: self.template_path,
+        }
+    }
+
+    /// The same handle for a record the sweep keeps rather than consumes.
+    fn to_handle(&self) -> CowHandle {
+        CowHandle {
+            dm_name: self.dm_name.clone(),
+            dm_device: self.dm_device.clone(),
+            cow_loop: self.cow_loop.clone(),
+            cow_file: self.cow_file.clone(),
+            template_path: self.template_path.clone(),
         }
     }
 }
@@ -356,16 +388,62 @@ pub(super) fn clear_state_record(vm_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// One sandbox whose VM outlived the process that booted it, with every
+/// runtime resource the sweep took back for it.
+pub(super) struct AdoptedSandbox {
+    handle: Arc<dyn VmHandle>,
+    lease: Option<NetworkLease>,
+    identity: Option<NetworkIdentity>,
+    cow_handle: Option<CowHandle>,
+    pool_slot_id: Option<String>,
+    net_invariant: bool,
+}
+
 pub(super) struct OrphanSweep {
     pub ids: HashSet<String>,
+    /// Sandboxes reclaimed alive, by id. Their journals stay on disk — they
+    /// are live state again, not debris — and so do their runtime dirs.
+    pub adopted: HashMap<String, AdoptedSandbox>,
     runtime_dirs: Vec<PathBuf>,
 }
 
-/// Sweep `<data_dir>/sandboxes/*/state.json` and tear down every leftover,
-/// plus snapshots a checkpoint never finished writing.
+impl SweptRuntime {
+    /// A sweep that reclaimed nothing and kept nothing alive.
+    #[cfg(test)]
+    fn nothing_kept() -> Self {
+        Self {
+            swept: HashSet::new(),
+            adopted: HashMap::new(),
+        }
+    }
+}
+
+impl OrphanSweep {
+    fn empty() -> Self {
+        Self {
+            ids: HashSet::new(),
+            adopted: HashMap::new(),
+            runtime_dirs: Vec::new(),
+        }
+    }
+
+    /// What [`normalize_durable_records`] needs, taken out so the runtime
+    /// directories stay here for [`finalize_sweep`] — which must not run
+    /// until normalization has committed.
+    pub(super) fn take_runtime(&mut self) -> SweptRuntime {
+        SweptRuntime {
+            swept: std::mem::take(&mut self.ids),
+            adopted: std::mem::take(&mut self.adopted),
+        }
+    }
+}
+
+/// Sweep `<data_dir>/sandboxes/*/state.json`: reclaim every sandbox whose VM
+/// is still running, tear down everything else, and drop the snapshots a
+/// checkpoint never finished writing.
 ///
 /// Runs once per manager construction, in the background. Ordering per
-/// sandbox mirrors live teardown: kill the VMM → wait for exit → dm
+/// killed sandbox mirrors live teardown: kill the VMM → wait for exit → dm
 /// teardown → TAP release → chroot + directory removal.
 pub(super) async fn sweep_orphans(
     config: &VmmConfig,
@@ -383,10 +461,7 @@ pub(super) async fn sweep_orphans(
     let entries = match std::fs::read_dir(&sandboxes_dir) {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(OrphanSweep {
-                ids: HashSet::new(),
-                runtime_dirs: Vec::new(),
-            });
+            return Ok(OrphanSweep::empty());
         }
         Err(error) => return Err(error.into()),
     };
@@ -408,25 +483,61 @@ pub(super) async fn sweep_orphans(
         records.push((dir, record));
     }
 
-    // The VMM pins dm devices, so every owned process must be dead before
-    // the global CoW sweep can report meaningful cleanup failures.
-    for (dir, record) in &records {
-        kill_orphaned_vmm(driver, dir, record).await?;
-    }
+    // Durable phases first: whether a journaled VM may be kept depends on
+    // what its record says the sandbox was doing.
     let durable = store.load_all()?;
     let retained = recovery::retained_ids(
         durable
             .iter()
             .map(|record| (record.id.as_str(), record.phase)),
     );
-    // No sandbox is kept alive across this sweep yet, so no dm device is in
-    // use by a running VM — every one of them is an orphan to reap (CORE-135
-    // part 2b decides adopt-or-kill and fills this in).
-    cow_manager.reconcile_stale(&retained, &HashSet::new())?;
+    let phases: HashMap<&str, _> = durable
+        .iter()
+        .map(|record| (record.id.as_str(), record.phase))
+        .collect();
+
+    // Every VM this sweep does not keep must be dead before the global CoW
+    // sweep runs: a live VMM pins its dm device, and a pinned device turns
+    // a reap into an error that fails the whole reconciliation.
+    let mut adopted = HashMap::new();
+    for (dir, record) in &records {
+        if let Some(reclaimed) = adopt_or_kill(
+            driver,
+            network,
+            cow_manager,
+            dir,
+            record,
+            phases.get(record.id.as_str()).copied(),
+        )
+        .await?
+        {
+            adopted.insert(record.id.clone(), reclaimed);
+        }
+    }
+
+    // The dm devices an adopted VM is running on, keyed the way the CoW
+    // manager names them. Their overlay files are kept too — the two sets
+    // are distinct because a paused sandbox has a retained file and no
+    // device, so folding them together would leave the device of a sandbox
+    // that crashed mid-pause unreaped.
+    let live_devices: HashSet<String> = records
+        .iter()
+        .filter(|(_, record)| adopted.contains_key(&record.id))
+        .map(|(_, record)| record.resource_owner().to_owned())
+        .collect();
+    let mut keep_cow_files = retained.clone();
+    keep_cow_files.extend(live_devices.iter().cloned());
+    cow_manager.reconcile_stale(&keep_cow_files, &live_devices)?;
 
     let mut swept = HashSet::new();
     let mut runtime_dirs = Vec::new();
     for (dir, mut record) in records {
+        // An adopted sandbox's journal names what this process now owns, so
+        // it stays exactly where it is — as does its runtime directory,
+        // which `finalize_sweep` only removes for the ids listed here.
+        if adopted.contains_key(&record.id) {
+            continue;
+        }
         if recovery::sweep_action(&record.id, &retained) == SweepAction::DropStaleJournal {
             info!(sandbox_id = %record.id, "dropping stale pause journal, keeping retained state");
             clear_state_record(&dir)?;
@@ -462,6 +573,7 @@ pub(super) async fn sweep_orphans(
 
     Ok(OrphanSweep {
         ids: swept,
+        adopted,
         runtime_dirs,
     })
 }
@@ -474,21 +586,39 @@ pub(super) async fn finalize_sweep(sweep: OrphanSweep) -> Result<()> {
     Ok(())
 }
 
-/// Normalizes durable records after orphan resources have been swept.
+/// What the sweep established, for the normalization that follows it.
 ///
-/// Interrupted live phases become inspectable failures; already inactive
-/// sandboxes are reconstructed without runtime handles. A create intent stays
-/// resumable, while an interrupted removal finishes as a durable tombstone.
+/// Split from [`OrphanSweep`] because the adopted runtime state is moved
+/// onto the instances built here while the runtime directories it also
+/// carries are needed afterwards, by [`finalize_sweep`].
+pub(super) struct SweptRuntime {
+    pub swept: HashSet<String>,
+    pub adopted: HashMap<String, AdoptedSandbox>,
+}
+
+/// Normalizes durable records after the orphan sweep decided each sandbox's
+/// fate.
+///
+/// A sandbox whose VM the sweep reclaimed comes back live, with the runtime
+/// state that came with it. Interrupted live phases become inspectable
+/// failures; already inactive sandboxes are reconstructed without runtime
+/// handles. A create intent stays resumable, while an interrupted removal
+/// finishes as a durable tombstone.
 pub(super) fn normalize_durable_records(
     store: &SandboxRecordStore,
     data_dir: &Path,
-    swept: Option<&HashSet<String>>,
+    sweep: Option<SweptRuntime>,
 ) -> Result<Vec<SandboxInstance>> {
     let mut inactive = Vec::new();
+    let (swept, mut adopted) = match sweep {
+        Some(sweep) => (Some(sweep.swept), sweep.adopted),
+        None => (None, HashMap::new()),
+    };
 
     for record in store.load_all()? {
-        let evidence = match swept {
+        let evidence = match &swept {
             None => JournalEvidence::Unchecked,
+            Some(_) if adopted.contains_key(&record.id) => JournalEvidence::Adopted,
             Some(ids) if ids.contains(&record.id) => JournalEvidence::Swept,
             Some(_) => JournalEvidence::Unjournaled,
         };
@@ -497,6 +627,13 @@ pub(super) fn normalize_durable_records(
             RecoveryAction::RefuseUnjournaled => {
                 return Err(crate::error::VmmError::Unavailable(format!(
                     "sandbox {} is {} but has no cleanup journal",
+                    record.id,
+                    record.phase.as_str()
+                )));
+            }
+            RecoveryAction::RefuseAdopted => {
+                return Err(crate::error::VmmError::Unavailable(format!(
+                    "sandbox {} is {}, a phase the startup sweep must not adopt",
                     record.id,
                     record.phase.as_str()
                 )));
@@ -512,7 +649,11 @@ pub(super) fn normalize_durable_records(
                 inactive.push(inactive_instance(record, SandboxState::Failed, data_dir));
             }
             RecoveryAction::Reinstate(state) => {
-                inactive.push(inactive_instance(record, state, data_dir));
+                let instance = match adopted.remove(&record.id) {
+                    Some(reclaimed) => adopted_instance(record, state, data_dir, reclaimed),
+                    None => inactive_instance(record, state, data_dir),
+                };
+                inactive.push(instance);
             }
             RecoveryAction::FinishRemove => {
                 store
@@ -551,24 +692,65 @@ fn inactive_instance(
     instance
 }
 
-/// Kill the VMM a cleanup journal names, if it outlived the agent.
+/// [`inactive_instance`] plus everything the sweep reclaimed: the VM's
+/// handle, the lease whose datapath was re-established and the identity the
+/// guest holds over it, the disk overlay, and the slot the resources are
+/// named after.
+///
+/// `prepared` stays `None` — a `PreparedVm` is the driver's grip on the VMM
+/// *process*, and nothing hands one back across a restart; teardown of an
+/// adopted sandbox goes through the handle instead (`cleanup.rs`). `ready_at`
+/// is not journaled, so it stays `None` rather than being invented from this
+/// restart's clock.
+fn adopted_instance(
+    record: SandboxRecord,
+    state: SandboxState,
+    data_dir: &Path,
+    adopted: AdoptedSandbox,
+) -> SandboxInstance {
+    let AdoptedSandbox {
+        handle,
+        lease,
+        identity,
+        cow_handle,
+        pool_slot_id,
+        net_invariant,
+    } = adopted;
+    let mut instance = inactive_instance(record, state, data_dir);
+    instance.handle = Some(handle);
+    instance.network = lease;
+    instance.net_identity = identity;
+    instance.cow_handle = cow_handle;
+    instance.pool_slot_id = pool_slot_id;
+    instance.net_invariant = net_invariant;
+    instance
+}
+
+/// Reclaim the VM a cleanup journal names, or kill it.
 ///
 /// The driver's `Adopt` capability finds it — the journaled pid when it is
 /// still that VMM (a pid recycled since the record was written is not), else
 /// whatever the driver recognises as the VM by the record's identity: the
 /// id the resources are keyed by (the adopted pool slot's, for a claimed
-/// sandbox) and its runtime directory — and its handle kills and reaps it,
-/// so the dm teardown that follows never hits EBUSY on the open block
-/// device. Nothing found is the common case: the VMM died with the agent.
-/// A driver without `Adopt` runs its VMs in-process, and those died with
-/// the agent by construction.
-async fn kill_orphaned_vmm(
+/// sandbox) and its runtime directory. Nothing found is the common case:
+/// the VMM died with the agent. A driver without `Adopt` runs its VMs
+/// in-process, and those died with the agent by construction.
+///
+/// A handle that comes back is either reclaimed — with its datapath and its
+/// disk overlay — or killed and reaped, so the dm teardown that follows
+/// never hits EBUSY on an open block device. [`can_reclaim`] decides which,
+/// and every one of its refusals falls back to that kill: the behaviour this
+/// sweep had before adoption existed.
+async fn adopt_or_kill(
     driver: &dyn VmDriver,
+    network: &dyn GuestNetwork,
+    cow_manager: &CowManager,
     runtime_dir: &Path,
     record: &SandboxStateRecord,
-) -> Result<()> {
+    phase: Option<super::record::PersistPhase>,
+) -> Result<Option<AdoptedSandbox>> {
     let Some(adopt) = driver.adopt() else {
-        return Ok(());
+        return Ok(None);
     };
     let vm_record = VmRecord {
         id: VmId::new(record.resource_owner())?,
@@ -591,11 +773,103 @@ async fn kill_orphaned_vmm(
                 ADOPT_TIMEOUT.as_secs()
             ))
         })??;
-    if let Some(handle) = adopted {
-        info!(sandbox_id = %record.id, vm = %vm_record.id, "killing the orphaned vmm");
-        handle.shutdown(ShutdownMode::Kill).await?;
+    let Some(handle) = adopted else {
+        return Ok(None);
+    };
+    let handle: Arc<dyn VmHandle> = Arc::from(handle);
+
+    match can_reclaim(network, cow_manager, record, phase, &handle).await {
+        Ok(reclaimed) => {
+            info!(sandbox_id = %record.id, vm = %vm_record.id, "reclaimed a sandbox whose vm outlived its agent");
+            Ok(Some(reclaimed))
+        }
+        Err(reason) => {
+            info!(
+                sandbox_id = %record.id, vm = %vm_record.id, %reason,
+                "killing the orphaned vmm"
+            );
+            handle.shutdown(ShutdownMode::Kill).await?;
+            Ok(None)
+        }
     }
-    Ok(())
+}
+
+/// Whether this live VM can be handed back to the manager, and the runtime
+/// state that comes with it if so.
+///
+/// `Err` carries why not, and is never fatal — the caller kills instead,
+/// which is what this sweep always did. Nothing partial needs unwinding
+/// here either: the two resources this takes (the lease's datapath, the
+/// template refcount) are released by exactly the teardown the kill path
+/// then runs, and releasing them here as well would double-drop the
+/// template's refcount.
+async fn can_reclaim(
+    network: &dyn GuestNetwork,
+    cow_manager: &CowManager,
+    record: &SandboxStateRecord,
+    phase: Option<super::record::PersistPhase>,
+    handle: &Arc<dyn VmHandle>,
+) -> std::result::Result<AdoptedSandbox, String> {
+    // A guest that is quiesced (a checkpoint that died between the pause and
+    // the resume) or gone answers nothing; only a running one is usable.
+    match handle.state() {
+        VmState::Running => {}
+        state => return Err(format!("its vm is {state}")),
+    }
+    // What separates a full handle from the process-only fallback an orphan
+    // whose API never answered yields: without vsock nothing can be run,
+    // paused or checkpointed in this sandbox, only killed. Adopting one
+    // would leave a sandbox that answers `inspect` and fails everything else.
+    if handle.vsock().is_none() {
+        return Err("its vmm's api never answered, so only a kill can be driven through it".into());
+    }
+    // `Ready` and nothing else. `Starting` died with the boot task that was
+    // driving it and no path here finishes one; the transitional phases died
+    // between resource states, so what their journals name is half-built.
+    match phase {
+        Some(super::record::PersistPhase::Ready) => {}
+        Some(phase) => return Err(format!("its durable record is {}", phase.as_str())),
+        None => return Err("it has no durable record".into()),
+    }
+
+    let lease = record.lease().map_err(|error| error.to_string())?;
+    let mode = match (&lease, record.attach_mode) {
+        (Some(_), None) => {
+            return Err(
+                "its journal predates adoption and does not say how its network attaches".into(),
+            );
+        }
+        (_, mode) => mode.map(AttachMode::from),
+    };
+    // Re-establish the host state that died with the previous process. Not
+    // idempotent by design: an adapter that cannot take the lease back says
+    // so rather than leaving a live guest unreachable.
+    let identity = match (&lease, mode) {
+        (Some(lease), Some(mode)) => {
+            network
+                .adopt(lease, mode)
+                .await
+                .map_err(|error| format!("its network could not be re-established: {error}"))?;
+            Some(network.identity(lease, mode))
+        }
+        _ => None,
+    };
+
+    let cow_handle = record.cow.as_ref().map(CowRecord::to_handle);
+    if let Some(cow_handle) = &cow_handle {
+        cow_manager
+            .adopt(cow_handle)
+            .map_err(|error| format!("its disk overlay could not be re-registered: {error}"))?;
+    }
+
+    Ok(AdoptedSandbox {
+        handle: Arc::clone(handle),
+        lease,
+        identity,
+        cow_handle,
+        pool_slot_id: record.pool_slot_id.clone(),
+        net_invariant: record.net_invariant,
+    })
 }
 
 async fn remove_dir_if_present(path: &Path) -> Result<()> {
@@ -1065,7 +1339,8 @@ mod tests {
         record_in_phase(&store, "mid-resume", PersistPhase::Resuming);
 
         let inactive =
-            normalize_durable_records(&store, data_dir.path(), Some(&HashSet::new())).unwrap();
+            normalize_durable_records(&store, data_dir.path(), Some(SweptRuntime::nothing_kept()))
+                .unwrap();
         let inactive: HashMap<_, _> = inactive
             .into_iter()
             .map(|instance| (instance.id.clone(), instance))
@@ -1207,7 +1482,7 @@ mod tests {
         record_in_phase(&store, "starting", PersistPhase::Starting);
 
         assert!(matches!(
-            normalize_durable_records(&store, data_dir.path(), Some(&HashSet::new())),
+            normalize_durable_records(&store, data_dir.path(), Some(SweptRuntime::nothing_kept())),
             Err(crate::error::VmmError::Unavailable(_))
         ));
         assert_eq!(

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -399,11 +399,18 @@ pub(super) struct AdoptedSandbox {
     net_invariant: bool,
 }
 
+/// What one sweep did, in the two pieces its caller needs at different
+/// moments: [`OrphanSweep::take_runtime`] first, for normalization, and the
+/// runtime directories afterwards, for [`finalize_sweep`].
+///
+/// Both halves are private so neither can be read after the first has been
+/// taken out.
 pub(super) struct OrphanSweep {
-    pub ids: HashSet<String>,
+    /// Ids whose journaled resources were torn down.
+    ids: HashSet<String>,
     /// Sandboxes reclaimed alive, by id. Their journals stay on disk — they
     /// are live state again, not debris — and so do their runtime dirs.
-    pub adopted: HashMap<String, AdoptedSandbox>,
+    adopted: HashMap<String, AdoptedSandbox>,
     runtime_dirs: Vec<PathBuf>,
 }
 
@@ -592,8 +599,8 @@ pub(super) async fn finalize_sweep(sweep: OrphanSweep) -> Result<()> {
 /// onto the instances built here while the runtime directories it also
 /// carries are needed afterwards, by [`finalize_sweep`].
 pub(super) struct SweptRuntime {
-    pub swept: HashSet<String>,
-    pub adopted: HashMap<String, AdoptedSandbox>,
+    swept: HashSet<String>,
+    adopted: HashMap<String, AdoptedSandbox>,
 }
 
 /// Normalizes durable records after the orphan sweep decided each sandbox's

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -804,6 +804,34 @@ pub(super) async fn release_instances(
     }
 }
 
+/// Kill this VM, and when the kill fails hand it to the next process instead
+/// of letting go of it.
+///
+/// Every path that reaches here owns the last handle, and a handle that is
+/// merely dropped kills — unreaped, and with its vsock socket unlinked. After
+/// a kill that already failed, that leaves the guest alive and unreachable:
+/// the damaged-guest outcome, arrived at silently. Detaching first makes the
+/// drop a no-op, and the sandbox's journal survives every path that can reach
+/// here, so the next sweep finds the VM again. A driver without `Detach` runs
+/// its VMs in-process and never produced a handle for this sweep to reclaim,
+/// so there is nothing to hand over there.
+///
+/// `Err` means the VM is still alive. Whether that is fatal is the caller's:
+/// [`release_one`] is best-effort and warns, [`adopt_or_kill`] has to stop the
+/// sweep, because a live VMM pins the dm device the global CoW reap is about
+/// to walk.
+async fn kill_or_hand_over(id: &str, handle: &Arc<dyn VmHandle>) -> Result<()> {
+    let Err(error) = handle.shutdown(ShutdownMode::Kill).await else {
+        return Ok(());
+    };
+    if let Some(detach) = handle.detach()
+        && let Err(error) = detach.detach().await
+    {
+        warn!(sandbox_id = %id, %error, "handing the vmm over failed; dropping it kills it");
+    }
+    Err(error.into())
+}
+
 /// Let go of one reclaimed sandbox: kill its VM, then hand back the disk
 /// overlay and the address it was running on.
 ///
@@ -814,14 +842,6 @@ pub(super) async fn release_instances(
 /// would leave it alive and broken, which is worse than leaving all three
 /// for the next sweep: the sandbox's journal survives this path, so there
 /// is one.
-///
-/// Stopping means giving the VM up as well, not just declining to touch the
-/// other two. The caller owns the last handle by then, and a handle that is
-/// merely dropped kills — unreaped, and with its vsock socket unlinked —
-/// which would leave exactly the damaged guest this stop exists to prevent,
-/// plus the disk and address still held. So the handle is detached first. A
-/// driver without `Detach` runs its VMs in-process and never produced a
-/// handle for this sweep to reclaim, so there is nothing to hand over there.
 async fn release_one(
     id: &str,
     handle: &Arc<dyn VmHandle>,
@@ -831,16 +851,11 @@ async fn release_one(
     cow_manager: &CowManager,
 ) {
     warn!(sandbox_id = %id, "releasing a reclaimed sandbox that recovery did not take");
-    if let Err(error) = handle.shutdown(ShutdownMode::Kill).await {
+    if let Err(error) = kill_or_hand_over(id, handle).await {
         warn!(
             sandbox_id = %id, %error,
             "killing the reclaimed vmm failed; leaving it, its disk and its address for the next sweep"
         );
-        if let Some(detach) = handle.detach()
-            && let Err(error) = detach.detach().await
-        {
-            warn!(sandbox_id = %id, %error, "handing the reclaimed vmm over failed; dropping it kills it");
-        }
         return;
     }
     if let Some(cow_handle) = cow_handle
@@ -977,7 +992,14 @@ async fn adopt_or_kill(
                 sandbox_id = %record.id, vm = %vm_record.id, %reason,
                 "killing the orphaned vmm"
             );
-            handle.shutdown(ShutdownMode::Kill).await?;
+            // A kill that fails leaves the VM alive and still pinning its dm
+            // device, so the sweep stops here rather than walking into the
+            // global CoW reap. Stopping means giving the VM up as well: this
+            // is the only handle, and dropping it undetached would kill it
+            // unreaped and unlink its vsock — alive and unreachable. What
+            // `reclaim` re-established before it refused stays for the next
+            // sweep, which the surviving journal guarantees there is.
+            kill_or_hand_over(&record.id, &handle).await?;
             Ok(None)
         }
     }
@@ -1676,6 +1698,40 @@ mod tests {
 
     /// How the adoption tests below differ from one another, each shifting
     /// exactly one predicate away from the case that is kept alive.
+    /// A VM whose kill never succeeds — the reaper never sees it exit.
+    /// Wrapping a real fake handle keeps `detach` live, so a test can tell
+    /// "handed over" from "dropped, and therefore killed".
+    struct RefusesShutdown(Arc<dyn VmHandle>);
+
+    #[async_trait::async_trait]
+    impl VmHandle for RefusesShutdown {
+        fn id(&self) -> &VmId {
+            self.0.id()
+        }
+        fn record(&self) -> VmRecord {
+            self.0.record()
+        }
+        fn state(&self) -> VmState {
+            self.0.state()
+        }
+        fn events(&self) -> tokio::sync::broadcast::Receiver<arcbox_vm_driver::VmEvent> {
+            self.0.events()
+        }
+        async fn shutdown(
+            &self,
+            _mode: ShutdownMode,
+        ) -> arcbox_vm_driver::Result<arcbox_vm_driver::ExitStatus> {
+            Err(arcbox_vm_driver::Error::Driver {
+                driver: "fake",
+                message: "the reaper did not see it exit".into(),
+                source: None,
+            })
+        }
+        fn detach(&self) -> Option<&dyn arcbox_vm_driver::Detach> {
+            self.0.detach()
+        }
+    }
+
     struct AdoptionCase {
         /// Whether the VM the previous agent left behind has vsock — i.e.
         /// whether the driver hands back a full handle or the process-only
@@ -1991,37 +2047,6 @@ mod tests {
     async fn a_release_whose_kill_fails_keeps_the_disk_and_the_address() {
         use arcbox_vm_driver::testkit::{FakeDriver, FakeNetwork};
 
-        struct RefusesShutdown(Arc<dyn VmHandle>);
-
-        #[async_trait::async_trait]
-        impl VmHandle for RefusesShutdown {
-            fn id(&self) -> &VmId {
-                self.0.id()
-            }
-            fn record(&self) -> VmRecord {
-                self.0.record()
-            }
-            fn state(&self) -> VmState {
-                self.0.state()
-            }
-            fn events(&self) -> tokio::sync::broadcast::Receiver<arcbox_vm_driver::VmEvent> {
-                self.0.events()
-            }
-            async fn shutdown(
-                &self,
-                _mode: ShutdownMode,
-            ) -> arcbox_vm_driver::Result<arcbox_vm_driver::ExitStatus> {
-                Err(arcbox_vm_driver::Error::Driver {
-                    driver: "fake",
-                    message: "the reaper did not see it exit".into(),
-                    source: None,
-                })
-            }
-            fn detach(&self) -> Option<&dyn arcbox_vm_driver::Detach> {
-                self.0.detach()
-            }
-        }
-
         let data_dir = tempfile::tempdir().unwrap();
         let driver = FakeDriver::new();
         let network = FakeNetwork::new();
@@ -2090,6 +2115,44 @@ mod tests {
         assert!(
             readopted.is_some(),
             "the vm is still there for the next sweep to retry"
+        );
+    }
+
+    /// The kill every adoption refusal falls back to can itself fail, and by
+    /// then the sweep owns the only handle on a VM that is still running.
+    /// Dropping it would kill unreaped and unlink the vsock — a guest left
+    /// alive and unreachable, which is the outcome this whole path exists to
+    /// prevent. So the fallback hands the VM over and reports the failure;
+    /// the caller decides what to do with it.
+    #[tokio::test]
+    async fn a_kill_that_fails_hands_the_vm_over_instead_of_dropping_it() {
+        use arcbox_vm_driver::testkit::FakeDriver;
+
+        let data_dir = tempfile::tempdir().unwrap();
+        let driver = FakeDriver::new();
+        let vm_dir = data_dir.path().join("sandboxes").join("stuck");
+        // Still owned: the fake driver refuses to adopt an owned VM, so a
+        // later adopt succeeding is proof the handover happened.
+        let vm = boot_previous_vm(&driver, &vm_dir, "stuck", true, false).await;
+        let vm_record = vm.record();
+        let handle: Arc<dyn VmHandle> = Arc::new(RefusesShutdown(Arc::from(vm)));
+
+        let failed = kill_or_hand_over("stuck", &handle).await;
+
+        assert!(
+            failed.is_err(),
+            "a vm that is still alive is reported, not swallowed"
+        );
+        drop(handle);
+        let readopted = driver
+            .adopt()
+            .expect("the fake driver adopts")
+            .adopt(&vm_record)
+            .await
+            .unwrap();
+        assert!(
+            readopted.is_some(),
+            "the vm was handed over, so letting go of the handle did not kill it"
         );
     }
 

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -826,6 +826,10 @@ async fn can_reclaim(
     // `Ready` and nothing else. `Starting` died with the boot task that was
     // driving it and no path here finishes one; the transitional phases died
     // between resource states, so what their journals name is half-built.
+    // `Starting` also covers the pool-slot handover window, where the slot's
+    // journal and the claiming sandbox's briefly name one VMM (`checkpoint.rs`
+    // documents why both exist): reclaiming through one while the other kills
+    // is precisely what that window must stay safe against.
     match phase {
         Some(super::record::PersistPhase::Ready) => {}
         Some(phase) => return Err(format!("its durable record is {}", phase.as_str())),

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -1475,6 +1475,226 @@ mod tests {
         assert!(!vm_dir.join(STATE_FILE).exists(), "the journal is cleared");
     }
 
+    /// How the adoption tests below differ from one another, each shifting
+    /// exactly one predicate away from the case that is kept alive.
+    struct AdoptionCase {
+        /// Whether the VM the previous agent left behind has vsock — i.e.
+        /// whether the driver hands back a full handle or the process-only
+        /// fallback of an orphan whose API never answered.
+        vsock: bool,
+        /// The durable phase the sandbox's record is in.
+        phase: PersistPhase,
+        /// Whether the journal says how its lease attaches. A record written
+        /// before adoption existed does not.
+        journal_attach_mode: bool,
+        /// Whether the guest network can take the lease back.
+        network_adopts: bool,
+    }
+
+    impl AdoptionCase {
+        /// The case adoption exists for: a `Ready` sandbox whose VM answers.
+        fn live() -> Self {
+            Self {
+                vsock: true,
+                phase: PersistPhase::Ready,
+                journal_attach_mode: true,
+                network_adopts: true,
+            }
+        }
+    }
+
+    /// Plant one sandbox that outlived its agent — a detached VM, a durable
+    /// record, and a crash journal naming both — then build a fresh manager
+    /// over the same data directory and report what its sweep made of it.
+    ///
+    /// Returns the previous agent's view of the VM and the manager, so a
+    /// caller can tell "reclaimed" from "killed" by the VM's own state.
+    async fn sweep_one(
+        data_dir: &Path,
+        case: &AdoptionCase,
+    ) -> (
+        Box<dyn VmHandle>,
+        super::super::SandboxManager,
+        std::sync::Arc<arcbox_vm_driver::testkit::FakeNetwork>,
+    ) {
+        use arcbox_vm_driver::testkit::{FakeDriver, FakeNetwork};
+        use arcbox_vm_driver::{BootSpec, ConsoleSpec, IsolationSpec, VmSpec, VsockSpec};
+
+        let driver = FakeDriver::new();
+        let network = std::sync::Arc::new(FakeNetwork::new());
+        let vm_dir = data_dir.join("sandboxes").join("keeper");
+        std::fs::create_dir_all(&vm_dir).unwrap();
+        let vm = driver
+            .boot(
+                VmSpec {
+                    id: VmId::new("keeper").unwrap(),
+                    cpus: 1,
+                    memory_mib: 128,
+                    boot: BootSpec::Kernel {
+                        image: "/vmlinux".into(),
+                        cmdline: String::new(),
+                        initrd: None,
+                    },
+                    disks: vec![],
+                    nics: vec![],
+                    vsock: case.vsock.then_some(VsockSpec { guest_cid: 3 }),
+                    shares: vec![],
+                    console: ConsoleSpec::Off,
+                    balloon: false,
+                    entropy: false,
+                    dirty_tracking: false,
+                    isolation: IsolationSpec::None,
+                },
+                &vm_dir,
+            )
+            .await
+            .unwrap();
+        // The previous agent handed its VM over rather than killing it.
+        vm.detach().unwrap().detach().await.unwrap();
+        let pid = vm.record().process.map(|process| process.pid).unwrap();
+
+        let mut config = VmmConfig::default();
+        config.firecracker.data_dir = data_dir.to_string_lossy().into_owned();
+        let store = SandboxRecordStore::new(data_dir).unwrap();
+        record_in_phase(&store, "keeper", case.phase);
+        drop(store);
+
+        let lease = NetworkLease {
+            vm: VmId::new("keeper").unwrap(),
+            ip: "10.200.0.9".parse().unwrap(),
+            prefix_len: 16,
+            gateway: "10.200.0.1".parse().unwrap(),
+            mac: "02:fc:00:00:00:09".parse().unwrap(),
+            cleanup_token: "gen-1".into(),
+        };
+        let mut record = SandboxStateRecord::new(
+            "keeper",
+            Some(i32::try_from(pid).unwrap()),
+            Some(JournaledLease::cold_boot(&lease, true)),
+            None,
+            &config,
+            None,
+        )
+        .unwrap();
+        if !case.journal_attach_mode {
+            record.attach_mode = None;
+            record.net_invariant = false;
+        }
+        write_state_record(&vm_dir, &record).unwrap();
+
+        if !case.network_adopts {
+            network.fail_adopt_once();
+        }
+        let manager = super::super::SandboxManager::with_environment(
+            config,
+            crate::SandboxEnvironment {
+                driver: Some(std::sync::Arc::new(driver)),
+                network: Some(std::sync::Arc::clone(&network) as std::sync::Arc<dyn GuestNetwork>),
+                ..crate::SandboxEnvironment::default()
+            },
+        )
+        .unwrap();
+        manager.await_reconcile().await.unwrap();
+        (vm, manager, network)
+    }
+
+    /// The payload: a `Ready` sandbox whose VM outlived its agent comes back
+    /// with everything it was running on, and its journal stays where it is.
+    #[tokio::test]
+    async fn a_live_ready_sandbox_is_reclaimed_rather_than_killed() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let (vm, manager, network) = sweep_one(data_dir.path(), &AdoptionCase::live()).await;
+
+        assert_eq!(vm.state(), VmState::Running, "the guest was never killed");
+        let instances = manager.instances.read().unwrap();
+        let inst = instances["keeper"].lock().unwrap();
+        // `Ready`, not `Running`: the workload the previous process was
+        // streaming did not survive it, and `Running` refuses the next `Run`.
+        assert_eq!(inst.state, SandboxState::Ready);
+        assert!(inst.handle.is_some(), "the VM's handle came back");
+        assert!(inst.prepared.is_none(), "no PreparedVm crosses a restart");
+        assert_eq!(
+            inst.network.as_ref().map(|lease| lease.ip.to_string()),
+            Some("10.200.0.9".to_owned()),
+            "the lease came back"
+        );
+        assert!(
+            inst.net_identity.is_some(),
+            "the guest is described the way its boot described it"
+        );
+        assert!(inst.net_invariant, "and under the identity it holds");
+        assert_eq!(
+            network.adopted_mode(&VmId::new("keeper").unwrap()),
+            Some(AttachMode::Invariant),
+            "the datapath is re-established as the journal says it was built"
+        );
+        assert!(
+            data_dir
+                .path()
+                .join("sandboxes/keeper")
+                .join(STATE_FILE)
+                .exists(),
+            "an adopted journal is live state, not debris"
+        );
+    }
+
+    /// Each predicate on its own: shift one away from the live case and the
+    /// sweep falls back to the teardown it did before adoption existed.
+    #[tokio::test]
+    async fn every_adoption_predicate_falls_back_to_the_kill() {
+        for (what, case) in [
+            (
+                "a process-only handle whose api never answered",
+                AdoptionCase {
+                    vsock: false,
+                    ..AdoptionCase::live()
+                },
+            ),
+            (
+                "a boot that never reached ready",
+                AdoptionCase {
+                    phase: PersistPhase::Starting,
+                    ..AdoptionCase::live()
+                },
+            ),
+            (
+                "a journal that predates adoption",
+                AdoptionCase {
+                    journal_attach_mode: false,
+                    ..AdoptionCase::live()
+                },
+            ),
+            (
+                "a network that cannot take the lease back",
+                AdoptionCase {
+                    network_adopts: false,
+                    ..AdoptionCase::live()
+                },
+            ),
+        ] {
+            let data_dir = tempfile::tempdir().unwrap();
+            let (vm, manager, _) = sweep_one(data_dir.path(), &case).await;
+
+            assert_eq!(
+                vm.state(),
+                VmState::Exited(arcbox_vm_driver::ExitStatus::signaled(9)),
+                "{what}: the vm is killed through its adopted handle"
+            );
+            assert!(
+                !data_dir
+                    .path()
+                    .join("sandboxes/keeper")
+                    .join(STATE_FILE)
+                    .exists(),
+                "{what}: the journal is cleared"
+            );
+            let instances = manager.instances.read().unwrap();
+            let inst = instances["keeper"].lock().unwrap();
+            assert_eq!(inst.state, SandboxState::Failed, "{what}");
+            assert!(inst.handle.is_none(), "{what}");
+        }
+    }
+
     #[test]
     fn active_record_without_cleanup_journal_blocks_normalization() {
         let data_dir = tempfile::tempdir().unwrap();

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -814,6 +814,14 @@ pub(super) async fn release_instances(
 /// would leave it alive and broken, which is worse than leaving all three
 /// for the next sweep: the sandbox's journal survives this path, so there
 /// is one.
+///
+/// Stopping means giving the VM up as well, not just declining to touch the
+/// other two. The caller owns the last handle by then, and a handle that is
+/// merely dropped kills — unreaped, and with its vsock socket unlinked —
+/// which would leave exactly the damaged guest this stop exists to prevent,
+/// plus the disk and address still held. So the handle is detached first. A
+/// driver without `Detach` runs its VMs in-process and never produced a
+/// handle for this sweep to reclaim, so there is nothing to hand over there.
 async fn release_one(
     id: &str,
     handle: &Arc<dyn VmHandle>,
@@ -826,8 +834,13 @@ async fn release_one(
     if let Err(error) = handle.shutdown(ShutdownMode::Kill).await {
         warn!(
             sandbox_id = %id, %error,
-            "killing the reclaimed vmm failed; leaving its disk and address for the next sweep"
+            "killing the reclaimed vmm failed; leaving it, its disk and its address for the next sweep"
         );
+        if let Some(detach) = handle.detach()
+            && let Err(error) = detach.detach().await
+        {
+            warn!(sandbox_id = %id, %error, "handing the reclaimed vmm over failed; dropping it kills it");
+        }
         return;
     }
     if let Some(cow_handle) = cow_handle
@@ -2004,6 +2017,9 @@ mod tests {
                     source: None,
                 })
             }
+            fn detach(&self) -> Option<&dyn arcbox_vm_driver::Detach> {
+                self.0.detach()
+            }
         }
 
         let data_dir = tempfile::tempdir().unwrap();
@@ -2017,7 +2033,11 @@ mod tests {
         .unwrap();
 
         let vm_dir = data_dir.path().join("sandboxes").join("stuck");
-        let vm = boot_previous_vm(&driver, &vm_dir, "stuck", true, true).await;
+        // Still owned, so that giving ownership up is observable: the fake
+        // driver refuses to adopt an owned VM, and a dropped-not-detached
+        // handle kills it.
+        let vm = boot_previous_vm(&driver, &vm_dir, "stuck", true, false).await;
+        let vm_record = vm.record();
         let lease = network
             .reserve(
                 &VmId::new("stuck").unwrap(),
@@ -2058,6 +2078,18 @@ mod tests {
             network.adopted_mode(&VmId::new("stuck").unwrap()),
             Some(AttachMode::Invariant),
             "and its address"
+        );
+        // And the guest itself: the release let go of it rather than
+        // dropping the handle, which would have killed it unreaped.
+        let readopted = driver
+            .adopt()
+            .expect("the fake driver adopts")
+            .adopt(&vm_record)
+            .await
+            .unwrap();
+        assert!(
+            readopted.is_some(),
+            "the vm is still there for the next sweep to retry"
         );
     }
 

--- a/computer/arcbox-computer-runtime/src/sandbox/spec.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/spec.rs
@@ -145,6 +145,7 @@ mod tests {
                 dns: vec![crate::network::invariant::GUEST_GATEWAY.into()],
                 mac: "02:fc:00:00:00:07".parse().unwrap(),
             },
+            invariant_identity: true,
         }
     }
 

--- a/computer/arcbox-computer-runtime/src/sandbox/testing.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/testing.rs
@@ -15,7 +15,7 @@ use arcbox_vm_driver::{
 use async_trait::async_trait;
 use tokio::sync::broadcast;
 
-use super::reconcile::{SandboxStateRecord, write_state_record};
+use super::reconcile::{JournaledLease, SandboxStateRecord, write_state_record};
 use super::record::{ProvisionIntent, SandboxProvisionOutcome, SandboxTransition};
 use super::{SandboxInstance, SandboxManager, SandboxSpec, SandboxState};
 use crate::config::{JailerConfig, VmmConfig};
@@ -264,7 +264,10 @@ pub(super) async fn live_sandbox_with(
         &SandboxStateRecord::new(
             id,
             super::journaled_pid(&*prepared),
-            Some(&lease),
+            // A cold boot with the invariant identity baked in, which is
+            // what `live_sandbox` stands for and what the identity below
+            // is read under.
+            Some(JournaledLease::cold_boot(&lease, true)),
             Some(&cow_handle),
             &manager.config,
             None,

--- a/computer/arcbox-computer-runtime/src/sandbox/testing.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/testing.rs
@@ -191,6 +191,57 @@ impl Checkpoint for FrozenOnCheckpoint {
     }
 }
 
+/// A handle that remembers how it was asked to shut down.
+///
+/// The fake VM reports the same exit status whether it was killed or merely
+/// dropped, so a test that must prove a kill *was asked for* — rather than
+/// that a handle went out of scope — reads it here.
+pub(super) struct RecordsShutdown {
+    inner: Arc<dyn VmHandle>,
+    modes: Mutex<Vec<ShutdownMode>>,
+}
+
+impl RecordsShutdown {
+    /// Wrap `inner`, handing back both the recorder and the handle to
+    /// install — [`live_sandbox_with`] only returns the erased one.
+    pub(super) fn wrap(inner: Arc<dyn VmHandle>) -> (Arc<Self>, Arc<dyn VmHandle>) {
+        let recorder = Arc::new(Self {
+            inner,
+            modes: Mutex::new(Vec::new()),
+        });
+        (Arc::clone(&recorder), recorder)
+    }
+
+    /// How this handle was shut down, in order.
+    pub(super) fn modes(&self) -> Vec<ShutdownMode> {
+        self.modes.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl VmHandle for RecordsShutdown {
+    fn id(&self) -> &VmId {
+        self.inner.id()
+    }
+
+    fn record(&self) -> VmRecord {
+        self.inner.record()
+    }
+
+    fn state(&self) -> VmState {
+        self.inner.state()
+    }
+
+    fn events(&self) -> broadcast::Receiver<VmEvent> {
+        self.inner.events()
+    }
+
+    async fn shutdown(&self, mode: ShutdownMode) -> arcbox_vm_driver::Result<ExitStatus> {
+        self.modes.lock().unwrap().push(mode);
+        self.inner.shutdown(mode).await
+    }
+}
+
 /// [`live_sandbox_with`] over the fake VM's own handle.
 pub(super) async fn live_sandbox(
     manager: &SandboxManager,

--- a/computer/arcbox-computer-runtime/src/sandbox/types.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/types.rs
@@ -22,6 +22,22 @@ pub struct NetworkAttachment {
     /// [`GuestNetwork::identity`](arcbox_vm_driver::net::GuestNetwork::identity)
     /// under the mode it was activated in.
     pub identity: NetworkIdentity,
+    /// Whether this boot bakes the fixed invariant identity (CORE-81) into
+    /// the guest's command line, which it does not when the caller supplied
+    /// their own `ip=`.
+    ///
+    /// Carried beside the mode rather than confused with it: the host side
+    /// of a cold boot is *always* activated
+    /// [`AttachMode::Invariant`](arcbox_vm_driver::net::AttachMode::Invariant),
+    /// so this flag says something about the guest, not about the datapath.
+    pub invariant_identity: bool,
+}
+
+impl NetworkAttachment {
+    /// This attachment as the crash journal records it.
+    pub(super) fn journaled(&self) -> super::reconcile::JournaledLease<'_> {
+        super::reconcile::JournaledLease::cold_boot(&self.lease, self.invariant_identity)
+    }
 }
 
 pub(super) struct SandboxBootTask {

--- a/computer/arcbox-computer-runtime/tests/e2e.rs
+++ b/computer/arcbox-computer-runtime/tests/e2e.rs
@@ -358,3 +358,157 @@ async fn e2e_run_command() {
 
     mgr.remove_sandbox(&id, true).await.unwrap();
 }
+
+/// The VMM pid the sandbox's crash journal names, so the test can prove a
+/// process outlived its manager — and, later, that Remove reaped it.
+#[cfg(target_os = "linux")]
+fn journaled_pid(data_dir: &std::path::Path, id: &str) -> i32 {
+    let journal = data_dir.join("sandboxes").join(id).join("state.json");
+    let bytes = std::fs::read(&journal)
+        .unwrap_or_else(|error| panic!("read {}: {error}", journal.display()));
+    serde_json::from_slice::<serde_json::Value>(&bytes).unwrap()["pid"]
+        .as_i64()
+        .expect("a journaled vmm pid") as i32
+}
+
+/// Whether `pid` is still a live Firecracker, rather than merely a live pid
+/// the kernel handed to something else since.
+#[cfg(target_os = "linux")]
+fn firecracker_alive(pid: i32) -> bool {
+    std::fs::read_to_string(format!("/proc/{pid}/comm"))
+        .map(|comm| comm.trim_start().starts_with("firecracker"))
+        .unwrap_or(false)
+}
+
+/// CORE-135's acceptance test: a sandbox survives the process that booted
+/// it. Boot one, hand its VM over the way a graceful shutdown does, drop the
+/// manager, and build a fresh one over the same data directory — the sandbox
+/// is still running, its host-side datapath is still in place, an exec still
+/// works through it, and removing it still leaves no Firecracker behind.
+///
+/// Requires root: the reclaimed resources are a TAP interface and (where
+/// dmsetup is available) a dm-snapshot, and only a real one proves adoption.
+#[tokio::test]
+#[ignore = "requires FC_BINARY/FC_KERNEL/FC_ROOTFS environment variables, root, and vm-agent in rootfs"]
+async fn e2e_sandbox_outlives_its_manager_and_is_adopted() {
+    #[cfg(target_os = "linux")]
+    if !common::is_root() {
+        eprintln!("SKIP e2e_sandbox_outlives_its_manager_and_is_adopted — requires root");
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let data_dir = dir.path().to_owned();
+    let Some(cfg) = try_config(data_dir.to_str().unwrap()) else {
+        eprintln!(
+            "SKIP e2e_sandbox_outlives_its_manager_and_is_adopted — FC_BINARY/FC_KERNEL/FC_ROOTFS not set"
+        );
+        return;
+    };
+
+    let (id, ip) = {
+        let mgr = SandboxManager::new(cfg).unwrap();
+        finalize_startup_cleanup(&mgr).await;
+        let mut events = mgr.subscribe_events();
+        let (id, ip) = mgr.create_sandbox(SandboxSpec::default()).await.unwrap();
+        assert!(
+            wait_for_event(&mut events, &id, "ready").await,
+            "sandbox did not reach ready"
+        );
+        // What a graceful shutdown owes the next process: without this the
+        // manager's handles kill their VMs as they unwind, and there is
+        // nothing left to adopt.
+        mgr.detach_all().await.unwrap();
+        (id, ip)
+    };
+
+    #[cfg(target_os = "linux")]
+    let pid = journaled_pid(&data_dir, &id);
+    #[cfg(target_os = "linux")]
+    let tap_name = {
+        let octets = ip
+            .parse::<std::net::Ipv4Addr>()
+            .expect("tap mode assigns a pool address")
+            .octets();
+        format!("vmtap{}-{}", octets[2], octets[3])
+    };
+    #[cfg(target_os = "linux")]
+    assert!(
+        firecracker_alive(pid),
+        "the vmm outlives the manager that booted it"
+    );
+
+    // The next process: same data directory, nothing else carried over.
+    let cfg = try_config(data_dir.to_str().unwrap()).unwrap();
+    let mgr = SandboxManager::new(cfg).unwrap();
+    // Awaits the startup sweep, which is where adoption happens.
+    if let Some(token) = mgr.startup_cleanup_token().await.unwrap() {
+        mgr.finalize_startup_cleanup(&token).await.unwrap();
+    }
+
+    let info = mgr.inspect_sandbox(&id).unwrap();
+    assert_eq!(
+        info.state,
+        SandboxState::Ready,
+        "the sandbox is usable again, not failed"
+    );
+    assert_eq!(
+        info.network.as_ref().map(|net| net.ip_address.clone()),
+        Some(ip),
+        "it kept the address its guest is configured with"
+    );
+    #[cfg(target_os = "linux")]
+    assert!(
+        common::iface_exists(&tap_name),
+        "TAP {tap_name} survived the restart rather than being swept"
+    );
+    #[cfg(target_os = "linux")]
+    assert!(firecracker_alive(pid), "the guest was never restarted");
+
+    // An exec proves the vsock path was re-established, not just that the
+    // process is alive: this agent was built from the adopted handle.
+    let mut rx = mgr
+        .run_in_sandbox(
+            &id,
+            vec!["echo".into(), "still here".into()],
+            HashMap::new(),
+            "/".into(),
+            "root".into(),
+            false,
+            None,
+            30,
+        )
+        .await
+        .unwrap();
+    let mut stdout = String::new();
+    let mut exit_code: i32 = -1;
+    while let Some(result) = rx.recv().await {
+        match result.unwrap() {
+            arcbox_computer_runtime::OutputChunk::Stdout(data) => {
+                stdout.push_str(&String::from_utf8_lossy(&data));
+            }
+            arcbox_computer_runtime::OutputChunk::Exit(status) => {
+                exit_code = status.conventional_code();
+            }
+            arcbox_computer_runtime::OutputChunk::Stderr(_) => {}
+        }
+    }
+    assert!(
+        stdout.contains("still here"),
+        "expected 'still here' in stdout, got: {stdout:?}"
+    );
+    assert_eq!(exit_code, 0);
+
+    // And the adopted sandbox is still removable — through the handle, since
+    // no PreparedVm crosses a restart.
+    mgr.remove_sandbox(&id, true).await.unwrap();
+    assert!(mgr.inspect_sandbox(&id).is_err());
+    #[cfg(target_os = "linux")]
+    {
+        assert!(!firecracker_alive(pid), "remove left a firecracker behind");
+        assert!(
+            !common::iface_exists(&tap_name),
+            "TAP {tap_name} survived the removal"
+        );
+    }
+}

--- a/computer/arcbox-computer-runtime/tests/e2e.rs
+++ b/computer/arcbox-computer-runtime/tests/e2e.rs
@@ -404,8 +404,16 @@ fn firecracker_alive(pid: i32) -> bool {
 /// is still running, its host-side datapath is still in place, an exec still
 /// works through it, and removing it still leaves no Firecracker behind.
 ///
-/// Requires root: the reclaimed resources are a TAP interface and (where
-/// dmsetup is available) a dm-snapshot, and only a real one proves adoption.
+/// Requires root: the reclaimed resource this proves is a real TAP interface,
+/// and only a real one proves adoption.
+///
+/// The reclaimed *dm-snapshot* is not covered here. `CowManager` reaches
+/// losetup through `BusyboxBlockTools`, which needs `/bin/busybox`; this
+/// suite's runner does not install it (the `integration` job does), so the
+/// boot falls back to using the rootfs directly and `CowManager::adopt` is
+/// never called. Installing busybox in this job would extend the test to
+/// that half — and would put every other test in this file on dm-snapshot
+/// too, which is why it is a change of its own rather than a line here.
 #[tokio::test]
 #[ignore = "requires FC_BINARY/FC_KERNEL/FC_ROOTFS environment variables, root, and vm-agent in rootfs"]
 async fn e2e_sandbox_outlives_its_manager_and_is_adopted() {

--- a/computer/arcbox-computer-runtime/tests/e2e.rs
+++ b/computer/arcbox-computer-runtime/tests/e2e.rs
@@ -371,13 +371,31 @@ fn journaled_pid(data_dir: &std::path::Path, id: &str) -> i32 {
         .expect("a journaled vmm pid") as i32
 }
 
-/// Whether `pid` is still a live Firecracker, rather than merely a live pid
-/// the kernel handed to something else since.
+/// Whether `pid` is still a live Firecracker, rather than a pid the kernel
+/// handed to something else since — or a zombie.
+///
+/// Both managers in this test run in one process, so nothing `waitpid()`s a
+/// VMM that Remove killed and it lingers unreaped, still named
+/// "firecracker". The state letter is what says it is gone, exactly as the
+/// driver's own liveness probe reads it.
 #[cfg(target_os = "linux")]
 fn firecracker_alive(pid: i32) -> bool {
-    std::fs::read_to_string(format!("/proc/{pid}/comm"))
-        .map(|comm| comm.trim_start().starts_with("firecracker"))
-        .unwrap_or(false)
+    // `/proc/<pid>/stat` is "<pid> (<comm>) <state> ...", and comm may itself
+    // contain spaces or parens — split at the LAST ')'.
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        return false;
+    };
+    let Some((named, rest)) = stat.rsplit_once(')') else {
+        return false;
+    };
+    let is_firecracker = named
+        .split_once('(')
+        .is_some_and(|(_, comm)| comm.starts_with("firecracker"));
+    let is_live = rest
+        .split_whitespace()
+        .next()
+        .is_some_and(|state| state != "Z" && state != "X");
+    is_firecracker && is_live
 }
 
 /// CORE-135's acceptance test: a sandbox survives the process that booted

--- a/computer/arcbox-computer/src/host.rs
+++ b/computer/arcbox-computer/src/host.rs
@@ -26,7 +26,21 @@ pub trait SandboxHost: Send + Sync {
     fn lock_host_state(&self) -> impl Future<Output = Self::StateGuard<'_>> + Send;
 
     /// Drops every sandbox-owned host resource (listeners, DNS): the
-    /// agent-startup handshake, when the guest has no sandboxes left.
+    /// agent-startup handshake.
+    ///
+    /// Written for an agent whose restart left no sandbox alive. Since
+    /// CORE-135 the guest's startup sweep reclaims a sandbox whose VM is
+    /// still running, and this call still drops that sandbox's DNS record
+    /// and host port listeners — it keeps running, and stays reachable over
+    /// vsock and at its address, but its name and its published ports go
+    /// until something re-registers them. Its guest-side forwarding rules
+    /// are not affected (the guest half of the startup ticket sweeps only
+    /// legacy-format rules), so nothing leaks; a later Remove still cleans
+    /// them through `remove_orphan_rules_for`.
+    ///
+    /// Restoring the host half is its own change — the host would have to
+    /// learn which sandboxes survived and replay their DNS and bindings —
+    /// and belongs here rather than in the runtime that adopts them.
     fn clear_host_state(&self) -> impl Future<Output = ()> + Send;
 
     /// Removes the host port listeners owned by one sandbox.


### PR DESCRIPTION
Closes CORE-135 (part 2b — the payload). Stacked on part 1 (#670,
`GuestNetwork::adopt`) and part 2a (#672, `CowManager::adopt`), both merged.

The startup sweep killed every VMM its journals named, so a crash or an
upgrade of the composing process cost every guest on the node its work. It
now reclaims a sandbox whose VM is still running, and kills only what it
cannot.

## Adopt-or-kill, as implemented

A journal is reclaimed when **all** of these hold, and killed the moment any
does not. Every refusal is a fall-back to the teardown this sweep already
did — re-establishing the wrong host state leaves a live guest nothing can
reach, which is strictly worse than starting over:

- the driver's `Adopt` capability found and reconnected to the VMM;
- the handle reports `VmState::Running`;
- the handle has vsock — what separates a full handle from the process-only
  fallback of an orphan whose API never answered. Without it nothing can be
  run, paused or checkpointed in the sandbox, only killed;
- the durable record is `Ready`;
- the journal says how its lease attaches, and the guest network takes the
  lease back under exactly that mode;
- the CoW manager re-registers the dm-snapshot the guest runs on.

Nothing partial needs unwinding: the two resources a reclaim takes (the
lease's datapath, the template refcount) are released by exactly the teardown
the kill path then runs, and releasing them here as well would double-drop
the refcount.

## The journal records the attach mode, not `net_invariant`

`net_invariant` is not the activation mode. A cold boot *always* activates
`AttachMode::Invariant`, while that flag records only whether the boot baked
the invariant `ip=` into the guest's cmdline — false whenever the caller
supplied their own. Feeding it to `GuestNetwork::adopt` would re-establish
`LegacySnapshot` — no translation at all — on an invariant TAP, for every
cold-booted sandbox with a caller-supplied `ip=`.

So the record carries both facts, each `#[serde(default)]` so a pre-upgrade
journal still loads and simply reports itself unadoptable.
`SandboxStateRecord::new` takes them as one `JournaledLease` parameter with a
constructor per situation (`cold_boot` hard-codes `Invariant`,
`from_snapshot` reads the snapshot's flag), so a journal site cannot record
an address without saying how it attaches. The adopted instance's
`net_identity` is read back under that same mode, for the reason PR-D's doc
comment gives.

## Two deliberate departures from the plan

- **`Reinstate(Ready)`, not `Running`.** `require_ready_agent` and
  `claim_workload` both gate on `Ready`; reinstating `Running` would make
  every `Run`/`Exec` on an adopted sandbox fail `WrongState` — i.e. it would
  fail the issue's own acceptance criterion. The durable phase can never say
  `Running` anyway (a workload keeps it at `Ready`), and the workload the
  previous process was streaming did not survive it.
- **`Starting` is not adoptable.** It died with the boot task that was
  driving it and nothing here finishes one, so reinstating it as `Ready`
  claims a readiness nobody established, and reinstating it as `Starting`
  leaves a sandbox no operation can move. It is killed, exactly as today.

## Also here

- `remove_sandbox` on an adopted sandbox killed nothing: it went through the
  driver's `PreparedVm`, which nothing hands back across a restart, so it
  took the `None` arm, reported success, and then tore the dm device and TAP
  out from under a live guest. It now kills through the handle, which reaps.
- `SandboxManager::detach_all` — without it a graceful exit unwinds into the
  handle's `Drop`, which kills, and adoption would only ever fire after a
  crash rather than after the upgrade or redeploy it mainly exists for.
  Whether the composer calls it is the composer's business (PLAT-194 for the
  platform node agent); the verb belongs where the handles are, and it is the
  next caller's turn.

## One invariant the review pass made explicit

Between reclaiming a sandbox and handing it to the instance map, four paths
could still fail — an adopt that fails on a later journal, a normalization
that refuses on an unrelated record, a runtime directory that will not delete,
and normalization's own partially-built instances. Each of them used to let
the reclaimed sandbox *drop*, which kills its guest through the handle's
`Drop` while leaving its lease live in the network and its template refcount
held: resources released by nobody.

There is now exactly one moment of transfer — the publish into the instance
map, moved ahead of `finalize_sweep` — a reclaimed sandbox lives in exactly
one of two places until then (the sweep's map, or a built instance), and every
failure releases both through the same `release_one`: kill, tear down the
overlay, quarantine the lease. A kill that *fails* stops that release rather
than continuing past it — taking the disk and address from a guest that is
still running would leave it alive and broken, which is the one outcome worse
than the kill this feature replaces — and stopping means *detaching* the
handle, not merely declining to touch the other two: the caller owns the last
one by then, and a handle that is only dropped kills unreaped and unlinks its
vsock socket. The surviving journal is what makes "leave all three for the
next sweep" a real answer. Journals are also swept in a stable order so a
partial failure is reproducible and a test can pin it.

## Rebased onto R3 PR-E, with the widening it asked for

`policy::recovery`'s `plan`, `RecoveryAction` and `JournalEvidence` were
`pub(in crate::sandbox)`, so PR-E's `lifecycle/tests/invariants.rs` had to
hand-mirror the verdict table with a comment naming the widening that would
fix it. This PR adds a `JournalEvidence` variant, which is exactly the change
a mirror does not survive, so the widening landed here: `policy` is
`pub(crate)` and the chain caps at crate scope, the crate's public API is
unchanged, and the mirror is now a call to the real function.

## Known follow-up: the host's half of an adopted sandbox

`SandboxHost::clear_host_state` was written for an agent whose restart left no
sandbox alive, and the startup handshake still calls it: a reclaimed sandbox
keeps running and stays reachable over vsock and at its address, but loses its
DNS name and its host port listeners. Nothing leaks — the guest-side
forwarding rules survive (the guest half of that ticket sweeps only
legacy-format comments) and a later Remove still cleans them — and it is an
incompleteness of the new capability, not a regression: that sandbox used to
be destroyed outright. Restoring it means teaching the host which sandboxes
survived and replaying their DNS and bindings, which belongs in
`computer/arcbox-computer` next to `register_live_sandbox_dns`, not in the
runtime that adopts. Both doc sites now say so.

## Tests

- Unit, against the fakes: one fixture plants a sandbox that outlived its
  agent and rebuilds a manager over the same data directory, so the verdict
  is read off the VM's own state rather than off a call count. The live case
  proves the guest was never killed and that handle, lease, identity and
  attach mode all came back; the table beside it shifts one predicate at a
  time and proves each falls back to the kill. `remove_sandbox` on an adopted
  instance asserts the handle observed a `Kill`. The recovery table now
  covers all 40 (phase, evidence) pairs, and two regressions pin the
  release-on-failure invariant above (`a_failed_sweep_hands_back_what_it_already_reclaimed`,
  `a_failed_normalization_hands_back_what_the_sweep_reclaimed`) — each fails
  without its fix on the lease still reading `Some(Invariant)`, since the VM
  is killed by `Drop` either way.
- **`test-vm-linux`'s e2e job is the oracle**:
  `e2e_sandbox_outlives_its_manager_and_is_adopted` boots a sandbox with a
  real TAP, hands the VM over, drops the manager, and rebuilds — the
  journaled Firecracker pid is still alive, the TAP survived the sweep, an
  exec still works through the adopted handle's vsock, and Remove leaves
  neither process nor interface behind. Confirmed running rather than
  skipping (`6 passed; 0 ignored`).

  It does **not** reach the dm-snapshot half, and I corrected an earlier
  claim in this description that said it did: `CowManager` reaches losetup
  through `BusyboxBlockTools`, and this job installs no busybox (only the
  `integration` job does), so the boot falls back to the rootfs directly and
  `CowManager::adopt` is never called. Installing busybox here would extend
  the test to that half *and* put every other test in the file on
  dm-snapshot, so it is a change of its own. Noted at the test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core startup reconciliation, VM ownership across process restarts, and teardown ordering; incorrect adopt/kill or release-on-error paths could leave live guests unreachable or leak network/CoW resources.
> 
> **Overview**
> **Startup reconciliation** no longer kills every journaled VMM on agent restart. The sweep **adopts** sandboxes whose Firecracker process is still **running**, durable phase is **`Ready`**, the handle has **vsock**, and the crash journal records **`attach_mode`** plus network/CoW state that can be re-established; everything else is torn down as before. Adopted guests are reinstated as **`Ready`** (not `Running`) so `Run`/`Exec` work after upgrade.
> 
> **Journaling** now records **`JournaledLease`** (attach mode + invariant guest identity) separately from **`net_invariant`**, so adoption does not confuse cold-boot invariant TAP activation with caller-supplied `ip=`. Boot, restore, resume, and checkpoint paths write journals through this helper.
> 
> **Lifecycle additions:** **`detach_all`** detaches VM handles on graceful shutdown so guests survive process exit; **`kill_sandbox_process`** kills adopted sandboxes through the **handle** when there is no `PreparedVm`. Reconcile publishes adopted instances **before** `finalize_sweep` and **releases** reclaimed VMs on partial failure (kill, overlay teardown, lease quarantine) instead of dropping handles and leaking leases.
> 
> **Policy:** `recovery::plan` and related types are **crate-visible**; lifecycle invariant tests call the real `plan` instead of a mirrored table. **`JournalEvidence::Adopted`** drives `Reinstate(Ready)` for the one legal adopt case; other adopt pairings **`RefuseAdopted`**.
> 
> **Tests:** broad unit coverage for adopt predicates and failure release paths; e2e **`e2e_sandbox_outlives_its_manager_and_is_adopted`** (detach → new manager → exec → remove). Host **`clear_host_state`** docs note DNS/listeners are still cleared for adopted sandboxes (known follow-up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8fbad85d5c25d3a0b066ed09f6f5753f4d727d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->