### PR TITLE
feat(computer): the computer lifecycle as a statig state machine (R3, PR-E)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "statig",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/computer/arcbox-computer-runtime/Cargo.toml
+++ b/computer/arcbox-computer-runtime/Cargo.toml
@@ -36,6 +36,7 @@ toml.workspace         = true
 sha2.workspace         = true
 oci2rootfs = { version = "0.2.1", default-features = false }
 arcbox-ext4 = "0.1.2"
+statig = "0.4.1"
 
 [dev-dependencies]
 # The crate's own tests always exercise the testkit: a path-only self

--- a/computer/arcbox-computer-runtime/src/lib.rs
+++ b/computer/arcbox-computer-runtime/src/lib.rs
@@ -56,6 +56,7 @@ pub mod agent;
 pub mod config;
 pub mod environment;
 pub mod error;
+mod lifecycle;
 pub mod rootfs;
 pub mod sandbox;
 #[cfg(feature = "testkit")]

--- a/computer/arcbox-computer-runtime/src/lifecycle.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle.rs
@@ -55,3 +55,4 @@
 
 mod effect;
 mod event;
+mod machine;

--- a/computer/arcbox-computer-runtime/src/lifecycle.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle.rs
@@ -56,3 +56,7 @@
 mod effect;
 mod event;
 mod machine;
+mod projection;
+
+#[cfg(test)]
+mod tests;

--- a/computer/arcbox-computer-runtime/src/lifecycle.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle.rs
@@ -1,0 +1,57 @@
+//! The computer lifecycle: the decision core the per-computer actor will
+//! drive (vm-stack-redesign R3).
+//!
+//! `machine` is a `statig` hierarchical state machine. Its handlers are pure
+//! transition logic: they take an [`Event`] and emit [`Effect`]s into the
+//! externally-owned [`Effects`] context, never touching a driver, a record
+//! store, the network or a task. All I/O belongs to the actor (R3 PR-F), which
+//! owns that buffer, reads it after every `handle_with_context`, and applies
+//! the effects — so the machine holds no `Arc`s, channels or timers and the
+//! whole table is testable with nothing but a scratch buffer. Same library and
+//! same discipline as `arcbox-engine`'s `vm_lifecycle::machine`.
+//!
+//! ```text
+//! computer                              Remove / TtlExpired / Failure, anywhere
+//!  ├─ provisioning, staging             Provision → staging → booting|restoring
+//!  ├─ launching ─ booting, restoring    AgentReady | Restored → gating
+//!  ├─ gating                            Gated → ready (READY withheld until here)
+//!  ├─ active ──── ready, running,       Stop → stopping; Pause → capturing
+//!  │              checkpointing
+//!  ├─ suspending ─ capturing, releasing CaptureDone → releasing → paused
+//!  ├─ paused, resuming                  Resume → resuming; Restored → ready
+//!  ├─ stopping                          StopDone → stopped
+//!  ├─ resting ─── stopped, failed       terminal, still removable
+//!  ├─ removing                          RemoveDone → gone
+//!  └─ gone                              the record is forgotten
+//! ```
+//!
+//! `Handled` with no effects means the machine has nothing to do; whether the
+//! caller then gets `Ok` (an idempotent `Pause` of a paused computer) or
+//! `WrongState` (a non-forced `Remove` of a busy one) is the actor's reply, as
+//! `sandbox::cleanup::begin_removal` decides it today. The attributes today's
+//! events carry (`reason` on PAUSING, `error` on FAILED, `exit_code` on IDLE)
+//! likewise stay actor-side: [`Notify`] is 1:1 with `sandbox::types::action`
+//! and the actor holds the context.
+//!
+//! `projection` answers the two questions the rest of the system asks about
+//! a state — what a caller sees, and what a crash-restart reads back.
+//!
+//! Nothing consumes any of it yet: the machine lands with its transition table
+//! pinned by tests so the flows can move onto an already-specified machine one
+//! file at a time, rather than being rewritten and re-specified at once.
+//!
+//! [`Event`]: event::Event
+//! [`Effect`]: effect::Effect
+//! [`Effects`]: effect::Effects
+//! [`Notify`]: effect::Notify
+
+// R3 PR-F moves the flows onto this machine one file at a time; a machine
+// specified only once it has a caller cannot be the specification those moves
+// are reviewed against.
+#![allow(
+    dead_code,
+    reason = "R3 PR-E lands the HSM with its tests; PR-F wires the actor"
+)]
+
+mod effect;
+mod event;

--- a/computer/arcbox-computer-runtime/src/lifecycle/effect.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/effect.rs
@@ -1,0 +1,181 @@
+//! What the computer lifecycle asks for: the effects a transition emits, and
+//! the buffer the actor reads them out of.
+//!
+//! The machine only *describes* what should happen. The actor owns the driver
+//! handle, the record store, the network, the timers and the event bus, and is
+//! the sole executor.
+
+use super::event::RestoreOrigin;
+use crate::sandbox::record::PersistPhase;
+
+/// Lifecycle notification a transition asks the actor to publish. 1:1 with
+/// `sandbox::types::action`; the actor adds the event's attributes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Notify {
+    Created,
+    Ready,
+    Running,
+    Idle,
+    Stopping,
+    Stopped,
+    Failed,
+    Removed,
+    Pausing,
+    Paused,
+    Resumed,
+}
+
+/// How hard a durable write is pushed — the three shapes today's code has.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Durability {
+    /// Warn and continue: `Stopping`, `Pausing`, `Removing`, the two reverts.
+    Warn,
+    /// The crash journal may only be cleared once the write is confirmed:
+    /// `Stopped`, `Paused`, `Failed`.
+    GateJournal,
+    /// An unconfirmed write is reported to the caller.
+    Report(Unconfirmed),
+}
+
+/// What an unconfirmed durable write costs the caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Unconfirmed {
+    /// Visible but not proven durable (`AckUnconfirmed`).
+    Ack,
+    /// Refuse the operation (`Unavailable`) — the READY commit.
+    Unavailable,
+    /// Park the record back at `Paused` and refuse: the restart sweep trusts
+    /// the phase, so an unconfirmed `Resuming` would read as cleanly paused
+    /// and the restore's journaled resources would never be released.
+    RevertToPaused,
+}
+
+/// Which resources a release drops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ReleaseScope {
+    /// VMM, CoW, TAP + IP and chroot; the record stays inspectable.
+    Runtime,
+    /// The pause release: the same, but the disk overlay is retained.
+    KeepDisk,
+    /// Everything, including retained pause state and the working directory.
+    Full,
+}
+
+/// How a durable record ends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RecordEnd {
+    /// `abort_provision`: an intent nobody acknowledged.
+    Aborted,
+    /// `finish_remove`: the tombstone of a completed removal.
+    Removed,
+}
+
+/// The two lifecycle timers: the hard lifetime cap, and the idle window that
+/// is armed only while `ready`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Timer {
+    Ttl,
+    Idle,
+}
+
+/// A reply a transition owes parked callers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Answer {
+    Ready,
+    Resumed,
+    Paused,
+    Stopped,
+    Removed,
+}
+
+/// A side effect emitted by a transition, executed by the actor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Effect {
+    PersistPhase {
+        phase: PersistPhase,
+        durability: Durability,
+    },
+    /// `Ready` reached in one hop from `Creating`: the restore path's atomic
+    /// commit, which carries the provision outcome the skipped `Starting`
+    /// write would have persisted. It is the one durable move outside the
+    /// edge set — `SandboxRecord::apply` allows it only from `Creating`
+    /// (`atomic_ready`), so no other state may emit it.
+    CommitRestored {
+        durability: Durability,
+    },
+    ForgetRecord(RecordEnd),
+    SpawnBoot {
+        warm: bool,
+    },
+    SpawnRestore {
+        origin: RestoreOrigin,
+    },
+    /// Warm publish, initial `cmd`, ready probe.
+    SpawnGate,
+    /// `hold` keeps the guest quiesced afterwards (the pause path): guest
+    /// progress past the memory image would diverge from the retained overlay.
+    SpawnCheckpoint {
+        hold: bool,
+    },
+    SpawnResume,
+    SpawnStop {
+        budget_ms: u64,
+    },
+    SpawnRelease {
+        scope: ReleaseScope,
+    },
+    /// Wait out the boot task's resource handoff, then abort it.
+    AbortInflight,
+    Publish(Notify),
+    ArmTimer(Timer),
+    CancelTimer(Timer),
+    Answer(Answer),
+    /// Clear the crash journal — only ever after a confirmed durable write.
+    ClearJournal,
+}
+
+/// External context: the effect sink a dispatch writes into. Owned by the
+/// actor and passed by `&mut` to every `handle_with_context`.
+#[derive(Debug, Default)]
+pub(super) struct Effects {
+    items: Vec<Effect>,
+}
+
+impl Effects {
+    pub(super) fn emit(&mut self, effect: Effect) {
+        self.items.push(effect);
+    }
+
+    pub(super) fn persist(&mut self, phase: PersistPhase, durability: Durability) {
+        self.emit(Effect::PersistPhase { phase, durability });
+    }
+
+    pub(super) fn release(&mut self, scope: ReleaseScope) {
+        self.emit(Effect::SpawnRelease { scope });
+    }
+
+    /// Shared teardown: what `remove_sandbox_impl` does once its busy gate has
+    /// passed. The bounded handoff wait lives inside `AbortInflight`.
+    pub(super) fn removal(&mut self) {
+        self.emit(Effect::AbortInflight);
+        self.emit(Effect::CancelTimer(Timer::Ttl));
+        self.emit(Effect::CancelTimer(Timer::Idle));
+        self.persist(PersistPhase::Removing, Durability::Warn);
+        self.release(ReleaseScope::Full);
+    }
+
+    /// Shared failure: `sandbox::boot::fail_live_sandbox` — persist `Failed`,
+    /// release the runtime, drop the timers, publish FAILED.
+    pub(super) fn failure(&mut self) {
+        self.persist(PersistPhase::Failed, Durability::GateJournal);
+        self.release(ReleaseScope::Runtime);
+        self.emit(Effect::CancelTimer(Timer::Idle));
+        self.emit(Effect::CancelTimer(Timer::Ttl));
+        self.emit(Effect::Publish(Notify::Failed));
+    }
+
+    /// Drains the effects accumulated since the last call.
+    pub(super) fn take(&mut self) -> Vec<Effect> {
+        std::mem::take(&mut self.items)
+    }
+}

--- a/computer/arcbox-computer-runtime/src/lifecycle/effect.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/effect.rs
@@ -165,10 +165,14 @@ impl Effects {
     }
 
     /// Shared failure: `sandbox::boot::fail_live_sandbox` — persist `Failed`,
-    /// release the runtime, drop the timers, publish FAILED.
+    /// release the runtime, clear the journal behind both, drop the timers,
+    /// publish FAILED. The journal clear is gated on the write being
+    /// confirmed *and* the release completing: what it records is the
+    /// resources a restart would otherwise have to reclaim.
     pub(super) fn failure(&mut self) {
         self.persist(PersistPhase::Failed, Durability::GateJournal);
         self.release(ReleaseScope::Runtime);
+        self.emit(Effect::ClearJournal);
         self.emit(Effect::CancelTimer(Timer::Idle));
         self.emit(Effect::CancelTimer(Timer::Ttl));
         self.emit(Effect::Publish(Notify::Failed));

--- a/computer/arcbox-computer-runtime/src/lifecycle/event.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/event.rs
@@ -1,0 +1,110 @@
+//! What the computer lifecycle is told: manager commands, sub-task
+//! completions, and observations. Every variant has a producer; none is dead
+//! vocabulary.
+
+use crate::sandbox::record::PersistPhase;
+use crate::sandbox::workload::WorkloadClaim;
+use crate::sandbox::{IdleAction, pause_reason};
+
+/// How a provisioned computer comes up. The two arms carry what the flows
+/// decide before the machine is driven: whether a warm-publish ticket was
+/// taken, and which restore this is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Provision {
+    /// `warm` = a warm-snapshot publish ticket was taken, so the boot tail
+    /// must checkpoint the idle guest before announcing readiness.
+    Boot {
+        warm: bool,
+    },
+    Restore {
+        origin: RestoreOrigin,
+    },
+}
+
+/// Why a restore is running. Mirrors `sandbox::checkpoint::RestoreOrigin`,
+/// which is `pub(in crate::sandbox)` and so unreachable from here; PR-F
+/// unifies them when the restore task moves into this module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RestoreOrigin {
+    /// The Restore RPC: the computer announces itself with READY alone.
+    Restore,
+    /// The warm-create reroute (CORE-77): watchers must see CREATED then
+    /// READY, and the spec's initial `cmd` runs after Ready.
+    WarmCreate,
+}
+
+/// Why a pause is running; projects onto the PAUSING event's `reason`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PauseReason {
+    Requested,
+    IdleTimeout,
+}
+
+impl PauseReason {
+    /// The wire reason the PAUSING event reports.
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Requested => pause_reason::PAUSE,
+            Self::IdleTimeout => pause_reason::IDLE_TIMEOUT,
+        }
+    }
+}
+
+/// A lifecycle event: a manager command, a sub-task completion, or an
+/// observation. Every variant has a producer; none is dead vocabulary.
+#[derive(Debug, Clone)]
+pub(super) enum Event {
+    // Manager commands. `ProvisionIntent` answers `Replay`/`Blocked` from the
+    // record store without driving a machine at all.
+    Provision(Provision),
+    Checkpoint,
+    Pause {
+        reason: PauseReason,
+    },
+    Resume,
+    /// `budget_ms` covers workload drain plus guest shutdown.
+    Stop {
+        budget_ms: u64,
+    },
+    /// `force: false` is refused while the computer is busy.
+    Remove {
+        force: bool,
+    },
+    ClaimWorkload {
+        claim: WorkloadClaim,
+    },
+    WorkloadExited,
+    // Sub-task completions.
+    /// The boot task transferred every cleanup resource onto the computer, so
+    /// aborting it can no longer strand one.
+    ResourcesHandedOff,
+    /// The guest agent dialed back: the readiness gate accepted.
+    AgentReady,
+    /// A restore — from a checkpoint, or of a paused computer — completed.
+    Restored,
+    /// The readiness gate finished (warm publish, initial `cmd`, ready probe),
+    /// so READY may be announced.
+    Gated,
+    CaptureDone {
+        snapshot_id: String,
+    },
+    ReleasedForPause,
+    StopDone,
+    RemoveDone,
+    /// A recoverable failure: whatever usable state the computer had survives.
+    Failure,
+    /// The guest is quiesced with no verb able to thaw it — the port is
+    /// hold-then-kill by design, so it cannot go back to `Ready`.
+    Frozen,
+    // Observations.
+    /// The VM exited without being asked to.
+    VmExited,
+    TtlExpired,
+    IdleExpired {
+        action: IdleAction,
+    },
+    /// Startup recovery reconstructed a computer from its durable record.
+    Recovered {
+        phase: PersistPhase,
+    },
+}

--- a/computer/arcbox-computer-runtime/src/lifecycle/machine.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/machine.rs
@@ -113,7 +113,7 @@ impl ComputerLifecycle {
         match event {
             Event::AgentReady => {
                 context.emit(Effect::SpawnGate);
-                Transition(State::gating())
+                Transition(State::gating(false))
             }
             _ => Super,
         }
@@ -128,7 +128,7 @@ impl ComputerLifecycle {
                 });
                 context.emit(Effect::ArmTimer(Timer::Ttl));
                 context.emit(Effect::SpawnGate);
-                Transition(State::gating())
+                Transition(State::gating(true))
             }
             // A restore that fails before its commit is rolled back, not
             // failed in place: `rollback_restore` force-removes the record and
@@ -148,13 +148,24 @@ impl ComputerLifecycle {
     /// and the initial `cmd` owns the workload slot, so a client acting on an
     /// early READY would hit a stopped guest or steal that slot.
     #[state(superstate = "computer")]
-    fn gating(event: &Event, context: &mut Effects) -> Outcome {
+    #[allow(
+        clippy::trivially_copy_pass_by_ref,
+        reason = "statig passes state-local storage by reference"
+    )]
+    fn gating(committed: &bool, event: &Event, context: &mut Effects) -> Outcome {
         match event {
             Event::Gated => {
-                context.persist(
-                    PersistPhase::Ready,
-                    Durability::Report(Unconfirmed::Unavailable),
-                );
+                // A cold boot commits `Ready` here, after the probe, so a
+                // probe failure fails from the recorded `Starting`. A restore
+                // committed it in one hop before the gate ran: writing it
+                // again would put an fsync on the restore's hot path and could
+                // refuse a computer that is already durably `Ready`.
+                if !*committed {
+                    context.persist(
+                        PersistPhase::Ready,
+                        Durability::Report(Unconfirmed::Unavailable),
+                    );
+                }
                 context.emit(Effect::Publish(Notify::Ready));
                 context.emit(Effect::Answer(Answer::Ready));
                 context.emit(Effect::ArmTimer(Timer::Idle));
@@ -196,6 +207,7 @@ impl ComputerLifecycle {
             }
             Event::Pause { .. } => {
                 context.persist(PersistPhase::Pausing, Durability::Warn);
+                context.emit(Effect::CancelTimer(Timer::Idle));
                 context.emit(Effect::Publish(Notify::Pausing));
                 context.emit(Effect::SpawnCheckpoint { hold: true });
                 Transition(State::capturing())

--- a/computer/arcbox-computer-runtime/src/lifecycle/machine.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/machine.rs
@@ -1,0 +1,399 @@
+//! The computer lifecycle as a `statig` hierarchical state machine: the
+//! transition table itself. The hierarchy, the effect discipline and what the
+//! actor answers rather than the machine are in the module docs.
+
+use statig::prelude::*;
+
+use super::effect::{
+    Answer, Durability, Effect, Effects, Notify, RecordEnd, ReleaseScope, Timer, Unconfirmed,
+};
+use super::event::{Event, PauseReason, Provision};
+use crate::sandbox::IdleAction;
+use crate::sandbox::record::PersistPhase;
+use crate::sandbox::workload::WorkloadClaim;
+
+pub(super) type Outcome = statig::Outcome<State>;
+
+/// Zero-sized `statig` shared storage: every durable value lives on the actor
+/// and transition outputs flow through [`Effects`].
+#[derive(Debug, Default)]
+pub(super) struct ComputerLifecycle;
+
+#[state_machine(
+    initial = "State::provisioning()",
+    state(derive(Debug, Clone, Copy, PartialEq, Eq)),
+    superstate(derive(Debug))
+)]
+impl ComputerLifecycle {
+    /// A forced `Remove` and the TTL cap destroy from anywhere; every failure
+    /// class degrades to `failed` unless a state below claims it (a recoverable
+    /// capture failure, a resume that unwound). The final arm swallows the
+    /// rest: a command a state does not act on is the actor's to answer, and an
+    /// observation nobody waits for is noise.
+    #[superstate]
+    fn computer(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            // A non-forced remove that reaches here passed the busy gate — the
+            // states projecting Starting/Running refuse it below — so it does
+            // exactly what a forced one does.
+            Event::Remove { .. } | Event::TtlExpired => {
+                context.removal();
+                Transition(State::removing())
+            }
+            Event::Frozen | Event::Failure | Event::VmExited => {
+                context.failure();
+                Transition(State::failed())
+            }
+            _ => Handled,
+        }
+    }
+
+    /// The durable intent (`Creating`) exists and nothing else does.
+    #[state(superstate = "computer")]
+    fn provisioning(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            Event::Provision(Provision::Boot { warm }) => {
+                context.persist(PersistPhase::Starting, Durability::Report(Unconfirmed::Ack));
+                context.emit(Effect::SpawnBoot { warm: *warm });
+                context.emit(Effect::Publish(Notify::Created));
+                context.emit(Effect::ArmTimer(Timer::Ttl));
+                Transition(State::staging())
+            }
+            // The restore path commits `ReadyWithOutcome` in one hop from
+            // `Creating`, so it writes nothing on the way in.
+            Event::Provision(Provision::Restore { origin }) => {
+                context.emit(Effect::SpawnRestore { origin: *origin });
+                Transition(State::restoring())
+            }
+            Event::Failure => {
+                context.emit(Effect::ForgetRecord(RecordEnd::Aborted));
+                Transition(State::gone())
+            }
+            // Recovery already applied its own durable verdict
+            // (`policy::recovery::plan`); the machine adopts what it left.
+            Event::Recovered { phase } => match phase {
+                PersistPhase::Creating => Handled,
+                PersistPhase::Starting
+                | PersistPhase::Ready
+                | PersistPhase::Stopping
+                | PersistPhase::Pausing
+                | PersistPhase::Resuming
+                | PersistPhase::Failed => Transition(State::failed()),
+                PersistPhase::Stopped => Transition(State::stopped()),
+                PersistPhase::Paused => Transition(State::paused()),
+                PersistPhase::Removing => Transition(State::removing()),
+            },
+            Event::Remove { force: false } => Handled,
+            _ => Super,
+        }
+    }
+
+    /// Resources are being acquired but are still local to the boot task, so
+    /// an abort could strand one: `ResourcesHandedOff` makes it abortable.
+    #[state(superstate = "computer")]
+    fn staging(event: &Event) -> Outcome {
+        match event {
+            Event::ResourcesHandedOff => Transition(State::booting()),
+            Event::Remove { force: false } => Handled,
+            _ => Super,
+        }
+    }
+
+    #[superstate(superstate = "computer")]
+    fn launching(event: &Event) -> Outcome {
+        match event {
+            // Already past staging; a duplicate signal is noise.
+            Event::ResourcesHandedOff | Event::Remove { force: false } => Handled,
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "launching")]
+    fn booting(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            Event::AgentReady => {
+                context.emit(Effect::SpawnGate);
+                Transition(State::gating())
+            }
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "launching")]
+    fn restoring(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            Event::Restored => {
+                context.emit(Effect::CommitRestored {
+                    durability: Durability::Report(Unconfirmed::Ack),
+                });
+                context.emit(Effect::ArmTimer(Timer::Ttl));
+                context.emit(Effect::SpawnGate);
+                Transition(State::gating())
+            }
+            _ => Super,
+        }
+    }
+
+    /// The VM is up and READY is withheld: the warm publish freezes the guest
+    /// and the initial `cmd` owns the workload slot, so a client acting on an
+    /// early READY would hit a stopped guest or steal that slot.
+    #[state(superstate = "computer")]
+    fn gating(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            Event::Gated => {
+                context.persist(
+                    PersistPhase::Ready,
+                    Durability::Report(Unconfirmed::Unavailable),
+                );
+                context.emit(Effect::Publish(Notify::Ready));
+                context.emit(Effect::Answer(Answer::Ready));
+                context.emit(Effect::ArmTimer(Timer::Idle));
+                Transition(State::ready())
+            }
+            // The slot is reserved for this boot's own `cmd`; an API claim
+            // cannot reach a computer that has not announced READY.
+            Event::ClaimWorkload {
+                claim: WorkloadClaim::Initial,
+            }
+            | Event::Remove { force: false } => Handled,
+            _ => Super,
+        }
+    }
+
+    #[superstate(superstate = "computer")]
+    fn active(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            Event::Stop { budget_ms } => {
+                context.persist(PersistPhase::Stopping, Durability::Warn);
+                context.emit(Effect::CancelTimer(Timer::Idle));
+                context.emit(Effect::Publish(Notify::Stopping));
+                context.emit(Effect::SpawnStop {
+                    budget_ms: *budget_ms,
+                });
+                Transition(State::stopping())
+            }
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "active")]
+    fn ready(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            Event::ClaimWorkload { .. } => {
+                context.emit(Effect::CancelTimer(Timer::Idle));
+                context.emit(Effect::Publish(Notify::Running));
+                Transition(State::running())
+            }
+            Event::Pause { .. } => {
+                context.persist(PersistPhase::Pausing, Durability::Warn);
+                context.emit(Effect::Publish(Notify::Pausing));
+                context.emit(Effect::SpawnCheckpoint { hold: true });
+                Transition(State::capturing())
+            }
+            Event::IdleExpired {
+                action: IdleAction::Pause,
+            } => Self::ready(
+                &Event::Pause {
+                    reason: PauseReason::IdleTimeout,
+                },
+                context,
+            ),
+            Event::IdleExpired {
+                action: IdleAction::Kill,
+            } => {
+                context.removal();
+                Transition(State::removing())
+            }
+            Event::Checkpoint => {
+                context.emit(Effect::SpawnCheckpoint { hold: false });
+                Transition(State::checkpointing())
+            }
+            _ => Super,
+        }
+    }
+
+    /// The workload hot path: no record write, so a crash here reads `Ready`.
+    #[state(superstate = "active")]
+    fn running(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            Event::WorkloadExited => {
+                context.emit(Effect::Publish(Notify::Idle));
+                context.emit(Effect::ArmTimer(Timer::Idle));
+                Transition(State::ready())
+            }
+            // One workload at a time, and neither pause nor checkpoint may
+            // freeze a guest that is running one.
+            Event::ClaimWorkload { .. }
+            | Event::Pause { .. }
+            | Event::Checkpoint
+            | Event::IdleExpired { .. }
+            | Event::Remove { force: false } => Handled,
+            _ => Super,
+        }
+    }
+
+    /// Holds `Ready` for the duration of a capture, closing the race where a
+    /// `Run` claims the slot while the guest is frozen (`to_public` still
+    /// answers `Ready`, so the wire is unchanged).
+    #[state(superstate = "active")]
+    fn checkpointing(event: &Event) -> Outcome {
+        match event {
+            // A recoverable capture failure leaves the guest running and the
+            // computer usable; only `Frozen` degrades it, through `computer`.
+            Event::CaptureDone { .. } | Event::Failure => Transition(State::ready()),
+            Event::ClaimWorkload { .. }
+            | Event::Pause { .. }
+            | Event::Checkpoint
+            | Event::IdleExpired { .. } => Handled,
+            _ => Super,
+        }
+    }
+
+    /// A pause in flight is not interruptible: `Pausing` has no durable edge to
+    /// `Stopping`, and the guest is on its way to being released.
+    #[superstate(superstate = "computer")]
+    fn suspending(event: &Event) -> Outcome {
+        match event {
+            Event::Stop { .. } => Handled,
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "suspending")]
+    fn capturing(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            Event::CaptureDone { .. } => {
+                context.release(ReleaseScope::KeepDisk);
+                Transition(State::releasing())
+            }
+            // Recoverable: the driver resumed the guest itself, so a failed
+            // pause must leave a usable computer behind.
+            Event::Failure => {
+                context.persist(PersistPhase::Ready, Durability::Warn);
+                context.emit(Effect::Publish(Notify::Ready));
+                context.emit(Effect::ArmTimer(Timer::Idle));
+                Transition(State::ready())
+            }
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "suspending")]
+    fn releasing(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            Event::ReleasedForPause => {
+                context.persist(PersistPhase::Paused, Durability::GateJournal);
+                context.emit(Effect::ClearJournal);
+                context.emit(Effect::Publish(Notify::Paused));
+                context.emit(Effect::Answer(Answer::Paused));
+                Transition(State::paused())
+            }
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "computer")]
+    fn paused(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            Event::Resume => {
+                context.persist(
+                    PersistPhase::Resuming,
+                    Durability::Report(Unconfirmed::RevertToPaused),
+                );
+                context.emit(Effect::SpawnResume);
+                Transition(State::resuming())
+            }
+            // Idempotent.
+            Event::Pause { .. } => Handled,
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "computer")]
+    fn resuming(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            Event::Restored => {
+                context.persist(PersistPhase::Ready, Durability::Warn);
+                context.emit(Effect::Publish(Notify::Resumed));
+                context.emit(Effect::Answer(Answer::Resumed));
+                context.emit(Effect::ArmTimer(Timer::Idle));
+                Transition(State::ready())
+            }
+            // The restore unwound: retained state is intact, so park back at
+            // `Paused` — which keeps its original `paused_at` — and let a retry
+            // or a Remove work.
+            Event::Failure => {
+                context.persist(PersistPhase::Paused, Durability::Warn);
+                context.emit(Effect::Publish(Notify::Paused));
+                Transition(State::paused())
+            }
+            Event::Remove { force: false } => Handled,
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "computer")]
+    fn stopping(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            Event::StopDone => {
+                context.persist(PersistPhase::Stopped, Durability::GateJournal);
+                context.emit(Effect::ClearJournal);
+                context.emit(Effect::CancelTimer(Timer::Ttl));
+                context.emit(Effect::Publish(Notify::Stopped));
+                context.emit(Effect::Answer(Answer::Stopped));
+                Transition(State::stopped())
+            }
+            // Expected: we asked for it.
+            Event::VmExited => Handled,
+            _ => Super,
+        }
+    }
+
+    /// Nothing left to expire, nothing left to fail: only `Remove` acts.
+    #[superstate(superstate = "computer")]
+    fn resting(event: &Event) -> Outcome {
+        match event {
+            Event::TtlExpired
+            | Event::IdleExpired { .. }
+            | Event::VmExited
+            | Event::Failure
+            | Event::Frozen => Handled,
+            _ => Super,
+        }
+    }
+
+    #[state(superstate = "resting")]
+    fn stopped() -> Outcome {
+        Super
+    }
+
+    #[state(superstate = "resting")]
+    fn failed() -> Outcome {
+        Super
+    }
+
+    #[state(superstate = "computer")]
+    fn removing(event: &Event, context: &mut Effects) -> Outcome {
+        match event {
+            Event::RemoveDone => {
+                context.emit(Effect::ForgetRecord(RecordEnd::Removed));
+                context.emit(Effect::Publish(Notify::Removed));
+                context.emit(Effect::Answer(Answer::Removed));
+                Transition(State::gone())
+            }
+            // Coalesce concurrent removals and anything the teardown trips.
+            Event::Remove { .. }
+            | Event::TtlExpired
+            | Event::Failure
+            | Event::Frozen
+            | Event::VmExited => Handled,
+            _ => Super,
+        }
+    }
+
+    /// The record is forgotten; the actor is on its way out.
+    #[state]
+    fn gone() -> Outcome {
+        Handled
+    }
+}

--- a/computer/arcbox-computer-runtime/src/lifecycle/machine.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/machine.rs
@@ -130,6 +130,16 @@ impl ComputerLifecycle {
                 context.emit(Effect::SpawnGate);
                 Transition(State::gating())
             }
+            // A restore that fails before its commit is rolled back, not
+            // failed in place: `rollback_restore` force-removes the record and
+            // every artefact, so the id and its request key are free again and
+            // a warm create can fall back to a cold boot. (Failing before any
+            // resource exists is `abort_provision` today — the same end, one
+            // durable write cheaper.)
+            Event::Failure | Event::VmExited | Event::Frozen => {
+                context.removal();
+                Transition(State::removing())
+            }
             _ => Super,
         }
     }
@@ -205,6 +215,7 @@ impl ComputerLifecycle {
                 Transition(State::removing())
             }
             Event::Checkpoint => {
+                context.emit(Effect::CancelTimer(Timer::Idle));
                 context.emit(Effect::SpawnCheckpoint { hold: false });
                 Transition(State::checkpointing())
             }
@@ -236,11 +247,18 @@ impl ComputerLifecycle {
     /// `Run` claims the slot while the guest is frozen (`to_public` still
     /// answers `Ready`, so the wire is unchanged).
     #[state(superstate = "active")]
-    fn checkpointing(event: &Event) -> Outcome {
+    fn checkpointing(event: &Event, context: &mut Effects) -> Outcome {
         match event {
             // A recoverable capture failure leaves the guest running and the
             // computer usable; only `Frozen` degrades it, through `computer`.
-            Event::CaptureDone { .. } | Event::Failure => Transition(State::ready()),
+            // Either way the idle window restarts: it is cancelled on the way
+            // in, and the expiry swallowed below would otherwise be lost —
+            // the timer is one-shot, so a computer that idled through a
+            // checkpoint would never idle again.
+            Event::CaptureDone { .. } | Event::Failure => {
+                context.emit(Effect::ArmTimer(Timer::Idle));
+                Transition(State::ready())
+            }
             Event::ClaimWorkload { .. }
             | Event::Pause { .. }
             | Event::Checkpoint

--- a/computer/arcbox-computer-runtime/src/lifecycle/projection.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/projection.rs
@@ -18,7 +18,7 @@ impl State {
             | Self::Staging {}
             | Self::Booting {}
             | Self::Restoring {}
-            | Self::Gating {}
+            | Self::Gating { .. }
             | Self::Resuming {} => SandboxState::Starting,
             Self::Ready {} | Self::Checkpointing {} => SandboxState::Ready,
             Self::Running {} => SandboxState::Running,
@@ -38,17 +38,25 @@ impl State {
     /// `Ready`, and `provisioning`/`restoring` sit on the `Creating` intent
     /// reserved before the machine was driven.
     ///
-    /// `gating` is the one leaf whose durable phase its identity does not fix,
-    /// and deliberately so: a cold boot commits `Ready` *after* the ready probe
-    /// (so a probe failure fails from the recorded `Starting`) while a restore
-    /// commits it *before* (so a crash mid-probe reconciles as a dead-but-Ready
-    /// computer). Both orderings are documented at their sites; the machine
-    /// cannot collapse them into one answer.
+    /// `gating` is the leaf a computer reaches by two paths whose durable
+    /// phase differs — a cold boot commits `Ready` *after* the ready probe, so
+    /// a probe failure fails from the recorded `Starting`, while a restore
+    /// commits it *before*, so a crash mid-probe reconciles as a dead-but-Ready
+    /// computer. Both orderings are load-bearing and documented at their sites,
+    /// which is why the state carries the discriminator rather than the
+    /// projection guessing.
     pub(super) fn durable(self) -> Option<PersistPhase> {
         match self {
             Self::Provisioning {} | Self::Restoring {} => Some(PersistPhase::Creating),
             Self::Staging {} | Self::Booting {} => Some(PersistPhase::Starting),
-            Self::Gating {} | Self::Gone {} => None,
+            // A cold boot arrives here still `Starting` and commits `Ready`
+            // after the probe; a restore arrives already committed.
+            Self::Gating { committed } => Some(if committed {
+                PersistPhase::Ready
+            } else {
+                PersistPhase::Starting
+            }),
+            Self::Gone {} => None,
             Self::Ready {} | Self::Running {} | Self::Checkpointing {} => Some(PersistPhase::Ready),
             Self::Capturing {} | Self::Releasing {} => Some(PersistPhase::Pausing),
             Self::Paused {} => Some(PersistPhase::Paused),

--- a/computer/arcbox-computer-runtime/src/lifecycle/projection.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/projection.rs
@@ -1,0 +1,62 @@
+//! The two questions asked about a lifecycle state: what a caller sees, and
+//! what a crash-restart reads back.
+//!
+//! They are deliberately different. `running` is the workload hot path and
+//! writes no record, so it is durably `Ready`; `gating` and `removing` have no
+//! `SandboxState` of their own.
+
+use super::machine::State;
+use crate::sandbox::SandboxState;
+use crate::sandbox::record::PersistPhase;
+
+impl State {
+    /// What a caller sees. Today a gated computer reads `Starting` (a boot
+    /// owing its initial `cmd` holds it there) and a removal writes `Stopping`.
+    pub(super) fn to_public(self) -> SandboxState {
+        match self {
+            Self::Provisioning {}
+            | Self::Staging {}
+            | Self::Booting {}
+            | Self::Restoring {}
+            | Self::Gating {}
+            | Self::Resuming {} => SandboxState::Starting,
+            Self::Ready {} | Self::Checkpointing {} => SandboxState::Ready,
+            Self::Running {} => SandboxState::Running,
+            Self::Capturing {} | Self::Releasing {} => SandboxState::Pausing,
+            Self::Paused {} => SandboxState::Paused,
+            Self::Stopping {} | Self::Removing {} => SandboxState::Stopping,
+            // A removed computer is gone from the map; nothing reads `gone`.
+            Self::Stopped {} | Self::Gone {} => SandboxState::Stopped,
+            Self::Failed {} => SandboxState::Failed,
+        }
+    }
+
+    /// What a crash-restart reads back, or `None` when no record answers.
+    ///
+    /// The phase **in effect** while the machine sits here, not the one its
+    /// entry writes: `running`/`checkpointing` write nothing and are durably
+    /// `Ready`, and `provisioning`/`restoring` sit on the `Creating` intent
+    /// reserved before the machine was driven.
+    ///
+    /// `gating` is the one leaf whose durable phase its identity does not fix,
+    /// and deliberately so: a cold boot commits `Ready` *after* the ready probe
+    /// (so a probe failure fails from the recorded `Starting`) while a restore
+    /// commits it *before* (so a crash mid-probe reconciles as a dead-but-Ready
+    /// computer). Both orderings are documented at their sites; the machine
+    /// cannot collapse them into one answer.
+    pub(super) fn durable(self) -> Option<PersistPhase> {
+        match self {
+            Self::Provisioning {} | Self::Restoring {} => Some(PersistPhase::Creating),
+            Self::Staging {} | Self::Booting {} => Some(PersistPhase::Starting),
+            Self::Gating {} | Self::Gone {} => None,
+            Self::Ready {} | Self::Running {} | Self::Checkpointing {} => Some(PersistPhase::Ready),
+            Self::Capturing {} | Self::Releasing {} => Some(PersistPhase::Pausing),
+            Self::Paused {} => Some(PersistPhase::Paused),
+            Self::Resuming {} => Some(PersistPhase::Resuming),
+            Self::Stopping {} => Some(PersistPhase::Stopping),
+            Self::Stopped {} => Some(PersistPhase::Stopped),
+            Self::Failed {} => Some(PersistPhase::Failed),
+            Self::Removing {} => Some(PersistPhase::Removing),
+        }
+    }
+}

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests.rs
@@ -3,6 +3,7 @@
 //! `harness` is the scratch buffer and the exhaustive walk; the tests beside
 //! it either check what must hold in every state, or pin one flow at a time.
 
+mod flows;
 mod harness;
 mod invariants;
 mod projections;

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests.rs
@@ -1,0 +1,6 @@
+//! The transition table, read off today's flows.
+//!
+//! `harness` is the scratch buffer and the exhaustive walk; the tests beside
+//! it either check what must hold in every state, or pin one flow at a time.
+
+mod harness;

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests.rs
@@ -4,3 +4,5 @@
 //! it either check what must hold in every state, or pin one flow at a time.
 
 mod harness;
+mod invariants;
+mod projections;

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/flows.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/flows.rs
@@ -241,7 +241,13 @@ fn a_user_checkpoint_holds_ready_and_writes_no_record() {
     let (mut sm, mut context) = ready_machine();
     let (state, effects) = step(&mut sm, &mut context, &Event::Checkpoint);
     assert_eq!(state.to_public(), SandboxState::Ready);
-    assert_eq!(effects, vec![Effect::SpawnCheckpoint { hold: false }]);
+    assert_eq!(
+        effects,
+        vec![
+            Effect::CancelTimer(Timer::Idle),
+            Effect::SpawnCheckpoint { hold: false },
+        ]
+    );
 
     // The race this state exists to close: a Run cannot claim the slot while
     // the guest is frozen, and the idle policy cannot fire either.
@@ -262,10 +268,11 @@ fn a_user_checkpoint_holds_ready_and_writes_no_record() {
     }
 
     // A recoverable failure returns to Ready without a record write, exactly
-    // as `checkpoint_sandbox` does today.
+    // as `checkpoint_sandbox` does today — with the idle window restarted,
+    // since the expiry swallowed above consumed a one-shot timer.
     let (state, effects) = step(&mut sm, &mut context, &Event::Failure);
     assert_eq!(state.to_public(), SandboxState::Ready);
-    assert!(effects.is_empty());
+    assert_eq!(effects, vec![Effect::ArmTimer(Timer::Idle)]);
 }
 
 #[test]
@@ -366,4 +373,33 @@ fn an_unacknowledged_provision_forgets_its_record() {
 fn the_pause_reasons_are_the_ones_the_event_stream_carries() {
     assert_eq!(PauseReason::Requested.as_str(), "pause");
     assert_eq!(PauseReason::IdleTimeout.as_str(), "idle_timeout");
+}
+
+#[test]
+fn a_restore_that_fails_before_its_commit_is_rolled_back_not_parked() {
+    // `rollback_restore` force-removes: the record and every artefact go, so
+    // the id and its request key are free for a retry (and a warm create can
+    // fall back to a cold boot). Parking at `Failed` would hold both.
+    for failure in [Event::Failure, Event::VmExited, Event::Frozen] {
+        let (mut sm, mut context) = reach(&[Event::Provision(Provision::Restore {
+            origin: RestoreOrigin::WarmCreate,
+        })]);
+        let (state, effects) = step(&mut sm, &mut context, &failure);
+        assert!(matches!(state, State::Removing {}), "{failure:?}");
+        assert_eq!(
+            effects,
+            vec![
+                Effect::AbortInflight,
+                Effect::CancelTimer(Timer::Ttl),
+                Effect::CancelTimer(Timer::Idle),
+                persist(PersistPhase::Removing, Durability::Warn),
+                release(ReleaseScope::Full),
+            ],
+            "{failure:?}"
+        );
+
+        let (state, effects) = step(&mut sm, &mut context, &Event::RemoveDone);
+        assert!(matches!(state, State::Gone {}), "{failure:?}");
+        assert_eq!(effects[0], Effect::ForgetRecord(RecordEnd::Removed));
+    }
 }

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/flows.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/flows.rs
@@ -1,0 +1,369 @@
+//! One flow at a time, with its exact effect vector — what a reviewer diffs
+//! against the code PR-F moves onto the machine.
+
+use super::harness::{BUDGET_MS, machine, persist, reach, ready_machine, release, step};
+use crate::lifecycle::effect::{
+    Answer, Durability, Effect, Effects, Notify, RecordEnd, ReleaseScope, Timer, Unconfirmed,
+};
+use crate::lifecycle::event::{Event, PauseReason, Provision, RestoreOrigin};
+use crate::lifecycle::machine::State;
+use crate::sandbox::record::PersistPhase;
+use crate::sandbox::workload::WorkloadClaim;
+use crate::sandbox::{IdleAction, SandboxState};
+
+#[test]
+fn a_cold_create_stages_boots_gates_and_only_then_announces_ready() {
+    let mut context = Effects::default();
+    let mut sm = machine(&mut context);
+
+    let (state, effects) = step(
+        &mut sm,
+        &mut context,
+        &Event::Provision(Provision::Boot { warm: true }),
+    );
+    assert_eq!(state.to_public(), SandboxState::Starting);
+    assert_eq!(
+        effects,
+        vec![
+            persist(PersistPhase::Starting, Durability::Report(Unconfirmed::Ack)),
+            Effect::SpawnBoot { warm: true },
+            Effect::Publish(Notify::Created),
+            Effect::ArmTimer(Timer::Ttl),
+        ]
+    );
+
+    // The handoff is what makes the boot task safely abortable.
+    let (state, effects) = step(&mut sm, &mut context, &Event::ResourcesHandedOff);
+    assert!(matches!(state, State::Booting {}));
+    assert!(effects.is_empty());
+
+    let (_, effects) = step(&mut sm, &mut context, &Event::AgentReady);
+    assert_eq!(effects, vec![Effect::SpawnGate]);
+
+    // READY is withheld until the gate (warm publish, initial cmd, probe) is
+    // through, and its durable commit refuses on an unconfirmed write.
+    let (state, effects) = step(&mut sm, &mut context, &Event::Gated);
+    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(
+        effects,
+        vec![
+            persist(
+                PersistPhase::Ready,
+                Durability::Report(Unconfirmed::Unavailable)
+            ),
+            Effect::Publish(Notify::Ready),
+            Effect::Answer(Answer::Ready),
+            Effect::ArmTimer(Timer::Idle),
+        ]
+    );
+}
+
+#[test]
+fn a_restore_commits_ready_in_one_hop_before_its_gate() {
+    let mut context = Effects::default();
+    let mut sm = machine(&mut context);
+    let (_, effects) = step(
+        &mut sm,
+        &mut context,
+        &Event::Provision(Provision::Restore {
+            origin: RestoreOrigin::WarmCreate,
+        }),
+    );
+    assert_eq!(
+        effects,
+        vec![Effect::SpawnRestore {
+            origin: RestoreOrigin::WarmCreate
+        }]
+    );
+
+    let (state, effects) = step(&mut sm, &mut context, &Event::Restored);
+    assert_eq!(state.to_public(), SandboxState::Starting);
+    assert_eq!(
+        effects,
+        vec![
+            // Not a `PersistPhase`: `Creating -> Ready` is not in the edge
+            // set, and the store waives it only for this commit.
+            Effect::CommitRestored {
+                durability: Durability::Report(Unconfirmed::Ack),
+            },
+            Effect::ArmTimer(Timer::Ttl),
+            Effect::SpawnGate,
+        ]
+    );
+}
+
+#[test]
+fn the_boots_own_cmd_claims_the_slot_the_gate_reserved_for_it() {
+    // The reservation `gating` names is this claim, and today
+    // `workload::claim_workload` takes it by flipping the instance to
+    // `Running` (publishing RUNNING; the exit publishes IDLE). The machine
+    // swallows it instead, so nothing carries the claim past `Gated` — the
+    // actor has to, when the boot tail moves onto the machine.
+    let (mut sm, mut context) = reach(&[
+        Event::Provision(Provision::Boot { warm: false }),
+        Event::ResourcesHandedOff,
+        Event::AgentReady,
+    ]);
+    let (state, effects) = step(
+        &mut sm,
+        &mut context,
+        &Event::ClaimWorkload {
+            claim: WorkloadClaim::Initial,
+        },
+    );
+    assert!(matches!(state, State::Gating {}));
+    assert!(effects.is_empty());
+}
+
+#[test]
+fn a_workload_round_trip_cancels_and_re_arms_the_idle_timer() {
+    let (mut sm, mut context) = ready_machine();
+    let (state, effects) = step(
+        &mut sm,
+        &mut context,
+        &Event::ClaimWorkload {
+            claim: WorkloadClaim::Api,
+        },
+    );
+    assert_eq!(state.to_public(), SandboxState::Running);
+    assert_eq!(
+        effects,
+        vec![
+            Effect::CancelTimer(Timer::Idle),
+            Effect::Publish(Notify::Running),
+        ]
+    );
+
+    let (state, effects) = step(&mut sm, &mut context, &Event::WorkloadExited);
+    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(
+        effects,
+        vec![Effect::Publish(Notify::Idle), Effect::ArmTimer(Timer::Idle)]
+    );
+}
+
+#[test]
+fn a_pause_captures_releases_and_parks_at_paused() {
+    let (mut sm, mut context) = ready_machine();
+    let (state, effects) = step(
+        &mut sm,
+        &mut context,
+        &Event::Pause {
+            reason: PauseReason::Requested,
+        },
+    );
+    assert_eq!(state.to_public(), SandboxState::Pausing);
+    assert_eq!(
+        effects,
+        vec![
+            persist(PersistPhase::Pausing, Durability::Warn),
+            Effect::Publish(Notify::Pausing),
+            Effect::SpawnCheckpoint { hold: true },
+        ]
+    );
+
+    let (state, effects) = step(
+        &mut sm,
+        &mut context,
+        &Event::CaptureDone {
+            snapshot_id: "snap".to_owned(),
+        },
+    );
+    assert_eq!(state.to_public(), SandboxState::Pausing);
+    assert_eq!(effects, vec![release(ReleaseScope::KeepDisk)]);
+
+    // Paused commits only once every runtime resource is gone, and the crash
+    // journal is cleared only behind that confirmed write.
+    let (state, effects) = step(&mut sm, &mut context, &Event::ReleasedForPause);
+    assert_eq!(state.to_public(), SandboxState::Paused);
+    assert_eq!(
+        effects,
+        vec![
+            persist(PersistPhase::Paused, Durability::GateJournal),
+            Effect::ClearJournal,
+            Effect::Publish(Notify::Paused),
+            Effect::Answer(Answer::Paused),
+        ]
+    );
+}
+
+#[test]
+fn a_recoverable_capture_failure_leaves_a_usable_computer() {
+    let (mut sm, mut context) = ready_machine();
+    step(
+        &mut sm,
+        &mut context,
+        &Event::Pause {
+            reason: PauseReason::Requested,
+        },
+    );
+    let (state, effects) = step(&mut sm, &mut context, &Event::Failure);
+    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(
+        effects,
+        vec![
+            persist(PersistPhase::Ready, Durability::Warn),
+            Effect::Publish(Notify::Ready),
+            Effect::ArmTimer(Timer::Idle),
+        ]
+    );
+}
+
+#[test]
+fn a_frozen_guest_fails_the_computer_from_either_capture_path() {
+    for pause in [true, false] {
+        let (mut sm, mut context) = ready_machine();
+        let event = if pause {
+            Event::Pause {
+                reason: PauseReason::Requested,
+            }
+        } else {
+            Event::Checkpoint
+        };
+        step(&mut sm, &mut context, &event);
+        let (state, effects) = step(&mut sm, &mut context, &Event::Frozen);
+        assert_eq!(state.to_public(), SandboxState::Failed, "pause={pause}");
+        assert_eq!(
+            effects,
+            vec![
+                persist(PersistPhase::Failed, Durability::GateJournal),
+                release(ReleaseScope::Runtime),
+                Effect::CancelTimer(Timer::Idle),
+                Effect::CancelTimer(Timer::Ttl),
+                Effect::Publish(Notify::Failed),
+            ]
+        );
+    }
+}
+
+#[test]
+fn a_user_checkpoint_holds_ready_and_writes_no_record() {
+    let (mut sm, mut context) = ready_machine();
+    let (state, effects) = step(&mut sm, &mut context, &Event::Checkpoint);
+    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(effects, vec![Effect::SpawnCheckpoint { hold: false }]);
+
+    // The race this state exists to close: a Run cannot claim the slot while
+    // the guest is frozen, and the idle policy cannot fire either.
+    for blocked in [
+        Event::ClaimWorkload {
+            claim: WorkloadClaim::Api,
+        },
+        Event::Pause {
+            reason: PauseReason::Requested,
+        },
+        Event::IdleExpired {
+            action: IdleAction::Kill,
+        },
+    ] {
+        let (state, effects) = step(&mut sm, &mut context, &blocked);
+        assert!(matches!(state, State::Checkpointing {}), "{blocked:?}");
+        assert!(effects.is_empty(), "{blocked:?}");
+    }
+
+    // A recoverable failure returns to Ready without a record write, exactly
+    // as `checkpoint_sandbox` does today.
+    let (state, effects) = step(&mut sm, &mut context, &Event::Failure);
+    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert!(effects.is_empty());
+}
+
+#[test]
+fn resume_reverts_to_paused_when_the_restore_unwinds() {
+    let (mut sm, mut context) = reach(&[Event::Recovered {
+        phase: PersistPhase::Paused,
+    }]);
+    let (state, effects) = step(&mut sm, &mut context, &Event::Resume);
+    assert_eq!(state.to_public(), SandboxState::Starting);
+    assert_eq!(
+        effects,
+        vec![
+            persist(
+                PersistPhase::Resuming,
+                Durability::Report(Unconfirmed::RevertToPaused)
+            ),
+            Effect::SpawnResume,
+        ]
+    );
+
+    let (state, effects) = step(&mut sm, &mut context, &Event::Failure);
+    assert_eq!(state.to_public(), SandboxState::Paused);
+    assert_eq!(
+        effects,
+        vec![
+            persist(PersistPhase::Paused, Durability::Warn),
+            Effect::Publish(Notify::Paused),
+        ]
+    );
+
+    // ...and a second attempt still resumes to Ready.
+    step(&mut sm, &mut context, &Event::Resume);
+    let (state, effects) = step(&mut sm, &mut context, &Event::Restored);
+    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(
+        effects,
+        vec![
+            persist(PersistPhase::Ready, Durability::Warn),
+            Effect::Publish(Notify::Resumed),
+            Effect::Answer(Answer::Resumed),
+            Effect::ArmTimer(Timer::Idle),
+        ]
+    );
+}
+
+#[test]
+fn a_stop_drains_through_stopping_and_clears_the_journal() {
+    let (mut sm, mut context) = ready_machine();
+    let (state, effects) = step(
+        &mut sm,
+        &mut context,
+        &Event::Stop {
+            budget_ms: BUDGET_MS,
+        },
+    );
+    assert_eq!(state.to_public(), SandboxState::Stopping);
+    assert_eq!(
+        effects,
+        vec![
+            persist(PersistPhase::Stopping, Durability::Warn),
+            Effect::CancelTimer(Timer::Idle),
+            Effect::Publish(Notify::Stopping),
+            Effect::SpawnStop {
+                budget_ms: BUDGET_MS
+            },
+        ]
+    );
+
+    // The VM exiting is what we asked for, not a failure.
+    let (state, effects) = step(&mut sm, &mut context, &Event::VmExited);
+    assert_eq!(state.to_public(), SandboxState::Stopping);
+    assert!(effects.is_empty());
+
+    let (state, effects) = step(&mut sm, &mut context, &Event::StopDone);
+    assert_eq!(state.to_public(), SandboxState::Stopped);
+    assert_eq!(
+        effects,
+        vec![
+            persist(PersistPhase::Stopped, Durability::GateJournal),
+            Effect::ClearJournal,
+            Effect::CancelTimer(Timer::Ttl),
+            Effect::Publish(Notify::Stopped),
+            Effect::Answer(Answer::Stopped),
+        ]
+    );
+}
+
+#[test]
+fn an_unacknowledged_provision_forgets_its_record() {
+    let mut context = Effects::default();
+    let mut sm = machine(&mut context);
+    let (state, effects) = step(&mut sm, &mut context, &Event::Failure);
+    assert!(matches!(state, State::Gone {}));
+    assert_eq!(effects, vec![Effect::ForgetRecord(RecordEnd::Aborted)]);
+}
+
+#[test]
+fn the_pause_reasons_are_the_ones_the_event_stream_carries() {
+    assert_eq!(PauseReason::Requested.as_str(), "pause");
+    assert_eq!(PauseReason::IdleTimeout.as_str(), "idle_timeout");
+}

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/flows.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/flows.rs
@@ -78,6 +78,7 @@ fn a_restore_commits_ready_in_one_hop_before_its_gate() {
 
     let (state, effects) = step(&mut sm, &mut context, &Event::Restored);
     assert_eq!(state.to_public(), SandboxState::Starting);
+    assert!(matches!(state, State::Gating { committed: true }));
     assert_eq!(
         effects,
         vec![
@@ -88,6 +89,20 @@ fn a_restore_commits_ready_in_one_hop_before_its_gate() {
             },
             Effect::ArmTimer(Timer::Ttl),
             Effect::SpawnGate,
+        ]
+    );
+
+    // The gate then announces READY without writing the record again: a
+    // second write would put an fsync on the restore's hot path and could
+    // refuse a computer that is already durably `Ready`.
+    let (state, effects) = step(&mut sm, &mut context, &Event::Gated);
+    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(
+        effects,
+        vec![
+            Effect::Publish(Notify::Ready),
+            Effect::Answer(Answer::Ready),
+            Effect::ArmTimer(Timer::Idle),
         ]
     );
 }
@@ -111,7 +126,7 @@ fn the_boots_own_cmd_claims_the_slot_the_gate_reserved_for_it() {
             claim: WorkloadClaim::Initial,
         },
     );
-    assert!(matches!(state, State::Gating {}));
+    assert!(matches!(state, State::Gating { committed: false }));
     assert!(effects.is_empty());
 }
 
@@ -157,6 +172,7 @@ fn a_pause_captures_releases_and_parks_at_paused() {
         effects,
         vec![
             persist(PersistPhase::Pausing, Durability::Warn),
+            Effect::CancelTimer(Timer::Idle),
             Effect::Publish(Notify::Pausing),
             Effect::SpawnCheckpoint { hold: true },
         ]
@@ -228,6 +244,7 @@ fn a_frozen_guest_fails_the_computer_from_either_capture_path() {
             vec![
                 persist(PersistPhase::Failed, Durability::GateJournal),
                 release(ReleaseScope::Runtime),
+                Effect::ClearJournal,
                 Effect::CancelTimer(Timer::Idle),
                 Effect::CancelTimer(Timer::Ttl),
                 Effect::Publish(Notify::Failed),

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/harness.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/harness.rs
@@ -1,0 +1,234 @@
+//! The scratch harness every lifecycle test drives the machine through, plus
+//! the exhaustive walk the invariant tests are written against.
+
+use statig::prelude::*;
+
+use crate::lifecycle::effect::{Durability, Effect, Effects, ReleaseScope};
+use crate::lifecycle::event::{Event, PauseReason, Provision, RestoreOrigin};
+use crate::lifecycle::machine::{ComputerLifecycle, State};
+use crate::sandbox::IdleAction;
+use crate::sandbox::record::PersistPhase;
+use crate::sandbox::workload::WorkloadClaim;
+
+pub(super) type Machine = statig::blocking::InitializedStateMachine<ComputerLifecycle>;
+
+pub(super) const BUDGET_MS: u64 = 30_000;
+
+/// A durable write, as a test reads it back off the effect vector.
+pub(super) fn persist(phase: PersistPhase, durability: Durability) -> Effect {
+    Effect::PersistPhase { phase, durability }
+}
+
+pub(super) fn release(scope: ReleaseScope) -> Effect {
+    Effect::SpawnRelease { scope }
+}
+
+pub(super) fn machine(context: &mut Effects) -> Machine {
+    ComputerLifecycle
+        .uninitialized_state_machine()
+        .init_with_context(context)
+}
+
+/// Replays `events` from a fresh machine, discarding what they emitted.
+pub(super) fn reach(events: &[Event]) -> (Machine, Effects) {
+    let mut context = Effects::default();
+    let mut sm = machine(&mut context);
+    for event in events {
+        sm.handle_with_context(event, &mut context);
+    }
+    context.take();
+    (sm, context)
+}
+
+/// Dispatches `event`, returning the resulting state and its effects.
+pub(super) fn step(sm: &mut Machine, context: &mut Effects, event: &Event) -> (State, Vec<Effect>) {
+    sm.handle_with_context(event, context);
+    (*sm.state(), context.take())
+}
+
+/// Every leaf, identified by an ordinal. The exhaustive match is what stops a
+/// new state from being added without a row in the tables below.
+pub(super) fn ordinal(state: State) -> usize {
+    match state {
+        State::Provisioning {} => 0,
+        State::Staging {} => 1,
+        State::Booting {} => 2,
+        State::Restoring {} => 3,
+        State::Gating {} => 4,
+        State::Ready {} => 5,
+        State::Running {} => 6,
+        State::Checkpointing {} => 7,
+        State::Capturing {} => 8,
+        State::Releasing {} => 9,
+        State::Paused {} => 10,
+        State::Resuming {} => 11,
+        State::Stopping {} => 12,
+        State::Stopped {} => 13,
+        State::Failed {} => 14,
+        State::Removing {} => 15,
+        State::Gone {} => 16,
+    }
+}
+
+pub(super) const LEAVES: usize = 17;
+
+/// One event of every shape the actor can deliver. `Recovered` is excluded:
+/// it seeds a machine rather than moving one, and has its own table.
+pub(super) fn alphabet() -> Vec<Event> {
+    vec![
+        Event::Provision(Provision::Boot { warm: false }),
+        Event::Provision(Provision::Boot { warm: true }),
+        Event::Provision(Provision::Restore {
+            origin: RestoreOrigin::Restore,
+        }),
+        Event::Provision(Provision::Restore {
+            origin: RestoreOrigin::WarmCreate,
+        }),
+        Event::ResourcesHandedOff,
+        Event::AgentReady,
+        Event::Restored,
+        Event::Gated,
+        Event::ClaimWorkload {
+            claim: WorkloadClaim::Api,
+        },
+        Event::ClaimWorkload {
+            claim: WorkloadClaim::Initial,
+        },
+        Event::WorkloadExited,
+        Event::Checkpoint,
+        Event::CaptureDone {
+            snapshot_id: "snap".to_owned(),
+        },
+        Event::Pause {
+            reason: PauseReason::Requested,
+        },
+        Event::Pause {
+            reason: PauseReason::IdleTimeout,
+        },
+        Event::ReleasedForPause,
+        Event::Resume,
+        Event::Stop {
+            budget_ms: BUDGET_MS,
+        },
+        Event::StopDone,
+        Event::Remove { force: false },
+        Event::Remove { force: true },
+        Event::RemoveDone,
+        Event::Failure,
+        Event::Frozen,
+        Event::VmExited,
+        Event::TtlExpired,
+        Event::IdleExpired {
+            action: IdleAction::Kill,
+        },
+        Event::IdleExpired {
+            action: IdleAction::Pause,
+        },
+    ]
+}
+
+pub(super) const ALL_PHASES: [PersistPhase; 10] = [
+    PersistPhase::Creating,
+    PersistPhase::Starting,
+    PersistPhase::Ready,
+    PersistPhase::Stopping,
+    PersistPhase::Stopped,
+    PersistPhase::Failed,
+    PersistPhase::Removing,
+    PersistPhase::Pausing,
+    PersistPhase::Paused,
+    PersistPhase::Resuming,
+];
+
+/// A reachable configuration: a state, the durable phase in effect there, and
+/// the events that reach it.
+#[derive(Debug, Clone)]
+pub(super) struct Node {
+    pub(super) state: State,
+    pub(super) phase: Option<PersistPhase>,
+    pub(super) path: Vec<Event>,
+}
+
+/// Walks every configuration reachable from a fresh machine and from each
+/// recovery seeding, asserting as it goes that **every** durable write the
+/// machine asks for is a legal move from the phase then in effect
+/// (`sandbox::record::phase`'s edge set, the table PR-A pinned over all 30
+/// pairs). A wrong `PersistPhase` on any edge fails here rather than as a
+/// `WrongState` at runtime.
+pub(super) fn explore() -> Vec<Node> {
+    let mut queue: Vec<Node> = vec![Node {
+        state: *reach(&[]).0.state(),
+        phase: Some(PersistPhase::Creating),
+        path: Vec::new(),
+    }];
+    // Recovery reconstructs a computer straight into a phase, so those states
+    // are roots of their own rather than reachable from `provisioning`.
+    for phase in ALL_PHASES {
+        let path = vec![Event::Recovered { phase }];
+        let (sm, _) = reach(&path);
+        queue.push(Node {
+            state: *sm.state(),
+            phase: sm.state().durable(),
+            path,
+        });
+    }
+
+    let mut seen: Vec<(State, Option<PersistPhase>)> = Vec::new();
+    let mut nodes: Vec<Node> = Vec::new();
+    while let Some(node) = queue.pop() {
+        if seen.contains(&(node.state, node.phase)) {
+            continue;
+        }
+        seen.push((node.state, node.phase));
+        nodes.push(node.clone());
+
+        for event in alphabet() {
+            let (mut sm, mut context) = reach(&node.path);
+            let (state, effects) = step(&mut sm, &mut context, &event);
+            let mut phase = node.phase;
+            for effect in &effects {
+                match effect {
+                    Effect::PersistPhase { phase: next, .. } => {
+                        let from = phase.expect("a durable write needs a record to write to");
+                        assert!(
+                            from.can_transition_to(*next),
+                            "{:?} then {event:?}: {} -> {} is not a durable edge",
+                            node.state,
+                            from.as_str(),
+                            next.as_str()
+                        );
+                        phase = Some(*next);
+                    }
+                    // The one move outside the edge set: `SandboxRecord::
+                    // apply` waives it for `ReadyWithOutcome`, and only from
+                    // `Creating`, so the machine must never emit it elsewhere.
+                    Effect::CommitRestored { .. } => {
+                        assert_eq!(
+                            phase,
+                            Some(PersistPhase::Creating),
+                            "{:?} then {event:?}: an atomic Ready commit is only legal from Creating",
+                            node.state
+                        );
+                        phase = Some(PersistPhase::Ready);
+                    }
+                    Effect::ForgetRecord(_) => phase = None,
+                    _ => {}
+                }
+            }
+            let mut path = node.path.clone();
+            path.push(event);
+            queue.push(Node { state, phase, path });
+        }
+    }
+    nodes
+}
+
+/// Drives a cold create through to `ready`, discarding effects.
+pub(super) fn ready_machine() -> (Machine, Effects) {
+    reach(&[
+        Event::Provision(Provision::Boot { warm: false }),
+        Event::ResourcesHandedOff,
+        Event::AgentReady,
+        Event::Gated,
+    ])
+}

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/harness.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/harness.rs
@@ -54,7 +54,7 @@ pub(super) fn ordinal(state: State) -> usize {
         State::Staging {} => 1,
         State::Booting {} => 2,
         State::Restoring {} => 3,
-        State::Gating {} => 4,
+        State::Gating { .. } => 4,
         State::Ready {} => 5,
         State::Running {} => 6,
         State::Checkpointing {} => 7,

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
@@ -82,8 +82,10 @@ fn recovery_seeds_the_state_its_own_verdict_leaves_behind() {
 /// Drives a cold create through to `ready`, discarding effects.
 #[test]
 fn a_stop_only_acts_while_the_guest_serves() {
-    // `stop_sandbox` accepts Ready/Running/Stopping and answers WrongState
-    // everywhere else; the machine swallows the rest for the actor to answer.
+    // `stop_sandbox` accepts Ready/Running/Stopping (and retries idempotently
+    // from Stopped), answering WrongState elsewhere. Only the first two are a
+    // state change, so re-entering `stopping` emits nothing; everything else
+    // the machine swallows for the actor to answer.
     for node in explore() {
         let (mut sm, mut context) = reach(&node.path);
         let (state, effects) = step(

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
@@ -1,0 +1,233 @@
+//! The rules that must hold in every state: recovery's seeding, and the gates
+//! `stop_sandbox`, `cleanup::begin_removal` and the two deadline timers apply.
+
+use super::harness::{ALL_PHASES, BUDGET_MS, explore, ordinal, reach, ready_machine, step};
+use crate::lifecycle::effect::{
+    Answer, Durability, Effect, Effects, Notify, RecordEnd, ReleaseScope, Timer,
+};
+use crate::lifecycle::event::Event;
+use crate::lifecycle::machine::State;
+use crate::sandbox::record::PersistPhase;
+use crate::sandbox::{IdleAction, SandboxState};
+
+/// `sandbox::policy::recovery::plan`'s verdict per phase, mirrored.
+///
+/// Those items are `pub(in crate::sandbox)`, so this table cannot call the
+/// real one — it is checked by eye against `sandbox/policy/recovery.rs`, whose
+/// own exhaustive test pins `plan`. Widening `plan`, `RecoveryAction` and
+/// `JournalEvidence` to `pub(crate)` would make this an assertion instead of a
+/// mirror; PR-F should do it when the recovery applier moves here.
+#[derive(Debug, PartialEq, Eq)]
+enum Recovery {
+    LeaveResumable,
+    Fail,
+    Reinstate(SandboxState),
+    FinishRemove,
+}
+
+fn recovery_plan(phase: PersistPhase) -> Recovery {
+    match phase {
+        PersistPhase::Creating => Recovery::LeaveResumable,
+        PersistPhase::Starting
+        | PersistPhase::Ready
+        | PersistPhase::Stopping
+        | PersistPhase::Pausing
+        | PersistPhase::Resuming => Recovery::Fail,
+        PersistPhase::Stopped => Recovery::Reinstate(SandboxState::Stopped),
+        PersistPhase::Failed => Recovery::Reinstate(SandboxState::Failed),
+        PersistPhase::Paused => Recovery::Reinstate(SandboxState::Paused),
+        PersistPhase::Removing => Recovery::FinishRemove,
+    }
+}
+
+#[test]
+fn recovery_seeds_the_state_its_own_verdict_leaves_behind() {
+    for phase in ALL_PHASES {
+        let (sm, _) = reach(&[Event::Recovered { phase }]);
+        let state = *sm.state();
+        match recovery_plan(phase) {
+            // Nobody acknowledged the intent, so the same request key still
+            // resumes it: the machine stays where a fresh one starts.
+            Recovery::LeaveResumable => {
+                assert_eq!(state.durable(), Some(PersistPhase::Creating), "{phase:?}");
+                assert_eq!(state.to_public(), SandboxState::Starting, "{phase:?}");
+            }
+            // Recovery already wrote `Failed`; the machine only adopts it.
+            Recovery::Fail => {
+                assert_eq!(state.durable(), Some(PersistPhase::Failed), "{phase:?}");
+                assert_eq!(state.to_public(), SandboxState::Failed, "{phase:?}");
+            }
+            Recovery::Reinstate(public) => {
+                assert_eq!(state.durable(), Some(phase), "{phase:?}");
+                assert_eq!(state.to_public(), public, "{phase:?}");
+            }
+            Recovery::FinishRemove => {
+                assert_eq!(state.durable(), Some(PersistPhase::Removing), "{phase:?}");
+            }
+        }
+        // A seeded machine must still be drivable to its end.
+        let mut context = Effects::default();
+        let mut sm = sm;
+        step(&mut sm, &mut context, &Event::Remove { force: true });
+        let (state, _) = step(&mut sm, &mut context, &Event::RemoveDone);
+        assert!(
+            matches!(state, State::Gone {} | State::Provisioning {}),
+            "{phase:?} did not reach a terminal state"
+        );
+    }
+}
+
+// ----- narrative flows -----
+
+/// Drives a cold create through to `ready`, discarding effects.
+#[test]
+fn a_stop_only_acts_while_the_guest_serves() {
+    // `stop_sandbox` accepts Ready/Running/Stopping and answers WrongState
+    // everywhere else; the machine swallows the rest for the actor to answer.
+    for node in explore() {
+        let (mut sm, mut context) = reach(&node.path);
+        let (state, effects) = step(
+            &mut sm,
+            &mut context,
+            &Event::Stop {
+                budget_ms: BUDGET_MS,
+            },
+        );
+        let acts = matches!(
+            node.state.to_public(),
+            SandboxState::Ready | SandboxState::Running
+        );
+        assert_eq!(
+            !effects.is_empty(),
+            acts,
+            "stop from {:?} emitted {effects:?}",
+            node.state
+        );
+        if !acts {
+            assert_eq!(ordinal(state), ordinal(node.state), "{:?}", node.state);
+        }
+    }
+}
+
+#[test]
+fn a_non_forced_remove_is_refused_exactly_where_the_computer_is_busy() {
+    // `cleanup::begin_removal` refuses `!force` on Running and Starting; the
+    // machine mirrors that on the states projecting them. A removal already
+    // under way (or done) coalesces instead.
+    for node in explore() {
+        let (mut sm, mut context) = reach(&node.path);
+        let (_, effects) = step(&mut sm, &mut context, &Event::Remove { force: false });
+        let busy = matches!(
+            node.state.to_public(),
+            SandboxState::Starting | SandboxState::Running
+        ) || matches!(node.state, State::Removing {} | State::Gone {});
+        assert_eq!(
+            effects.is_empty(),
+            busy,
+            "non-forced remove from {:?} emitted {effects:?}",
+            node.state
+        );
+    }
+}
+
+#[test]
+fn a_forced_remove_tears_down_from_every_live_state() {
+    for node in explore() {
+        if matches!(node.state, State::Removing {} | State::Gone {}) {
+            continue;
+        }
+        let (mut sm, mut context) = reach(&node.path);
+        let (state, effects) = step(&mut sm, &mut context, &Event::Remove { force: true });
+        assert!(matches!(state, State::Removing {}), "{:?}", node.state);
+        assert_eq!(
+            effects,
+            vec![
+                // The bounded handoff wait is inside AbortInflight: a boot
+                // that has not handed its resources over cannot be aborted.
+                Effect::AbortInflight,
+                Effect::CancelTimer(Timer::Ttl),
+                Effect::CancelTimer(Timer::Idle),
+                Effect::PersistPhase {
+                    phase: PersistPhase::Removing,
+                    durability: Durability::Warn,
+                },
+                Effect::SpawnRelease {
+                    scope: ReleaseScope::Full
+                },
+            ],
+            "{:?}",
+            node.state
+        );
+
+        let (state, effects) = step(&mut sm, &mut context, &Event::RemoveDone);
+        assert!(matches!(state, State::Gone {}));
+        assert_eq!(
+            effects,
+            vec![
+                Effect::ForgetRecord(RecordEnd::Removed),
+                Effect::Publish(Notify::Removed),
+                Effect::Answer(Answer::Removed),
+            ]
+        );
+    }
+}
+
+#[test]
+fn the_ttl_cap_destroys_everywhere_except_a_resting_or_removed_computer() {
+    for node in explore() {
+        let (mut sm, mut context) = reach(&node.path);
+        let (_, effects) = step(&mut sm, &mut context, &Event::TtlExpired);
+        // `deadlines::ttl_due` drops the timer once a computer is terminal,
+        // and a removal in flight coalesces.
+        let inert = matches!(
+            node.state,
+            State::Stopped {} | State::Failed {} | State::Removing {} | State::Gone {}
+        );
+        assert_eq!(
+            effects.is_empty(),
+            inert,
+            "ttl from {:?} emitted {effects:?}",
+            node.state
+        );
+    }
+}
+
+#[test]
+fn the_idle_policy_only_fires_on_a_ready_computer() {
+    // `deadlines::idle_due` arms the timer only while Ready, and
+    // `apply_idle_policy` re-checks Ready before acting.
+    for node in explore() {
+        for action in [IdleAction::Kill, IdleAction::Pause] {
+            let (mut sm, mut context) = reach(&node.path);
+            let (_, effects) = step(&mut sm, &mut context, &Event::IdleExpired { action });
+            assert_eq!(
+                !effects.is_empty(),
+                matches!(node.state, State::Ready {}),
+                "idle {action:?} from {:?} emitted {effects:?}",
+                node.state
+            );
+        }
+    }
+
+    // The two policies: pause reuses the pause path verbatim, kill removes.
+    let (mut sm, mut context) = ready_machine();
+    let (state, effects) = step(
+        &mut sm,
+        &mut context,
+        &Event::IdleExpired {
+            action: IdleAction::Pause,
+        },
+    );
+    assert_eq!(state.to_public(), SandboxState::Pausing);
+    assert_eq!(effects[1], Effect::Publish(Notify::Pausing));
+
+    let (mut sm, mut context) = ready_machine();
+    let (state, _) = step(
+        &mut sm,
+        &mut context,
+        &Event::IdleExpired {
+            action: IdleAction::Kill,
+        },
+    );
+    assert!(matches!(state, State::Removing {}));
+}

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
@@ -221,7 +221,7 @@ fn the_idle_policy_only_fires_on_a_ready_computer() {
         },
     );
     assert_eq!(state.to_public(), SandboxState::Pausing);
-    assert_eq!(effects[1], Effect::Publish(Notify::Pausing));
+    assert!(effects.contains(&Effect::Publish(Notify::Pausing)));
 
     let (mut sm, mut context) = ready_machine();
     let (state, _) = step(

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/projections.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/projections.rs
@@ -1,7 +1,6 @@
 //! Reachability, and the two projections over every leaf.
 
 use super::harness::{LEAVES, explore, ordinal};
-use crate::lifecycle::machine::State;
 use crate::sandbox::SandboxState;
 use crate::sandbox::record::PersistPhase;
 
@@ -55,47 +54,41 @@ fn every_leaf_projects_onto_a_public_state() {
 #[test]
 fn every_leaf_projects_onto_a_durable_phase() {
     use PersistPhase as P;
-    let expected = [
-        (0, Some(P::Creating)),  // provisioning: the reserved intent
-        (1, Some(P::Starting)),  // staging
-        (2, Some(P::Starting)),  // booting
-        (3, Some(P::Creating)),  // restoring: commits Ready in one hop
-        (4, None),               // gating: Starting on a boot, Ready on a restore
-        (5, Some(P::Ready)),     // ready
-        (6, Some(P::Ready)),     // running: the hot path writes nothing
-        (7, Some(P::Ready)),     // checkpointing
-        (8, Some(P::Pausing)),   // capturing
-        (9, Some(P::Pausing)),   // releasing
-        (10, Some(P::Paused)),   // paused
-        (11, Some(P::Resuming)), // resuming
-        (12, Some(P::Stopping)), // stopping
-        (13, Some(P::Stopped)),  // stopped
-        (14, Some(P::Failed)),   // failed
-        (15, Some(P::Removing)), // removing
-        (16, None),              // gone: the record is forgotten
+    // Indexed by `ordinal`. `gating` is the one leaf two paths reach on
+    // different phases, so it carries the discriminator and lists both; the
+    // walk below pins which one each path actually holds.
+    let expected: [&[Option<P>]; LEAVES] = [
+        &[Some(P::Creating)],                 // provisioning: the reserved intent
+        &[Some(P::Starting)],                 // staging
+        &[Some(P::Starting)],                 // booting
+        &[Some(P::Creating)],                 // restoring: commits Ready in one hop
+        &[Some(P::Starting), Some(P::Ready)], // gating
+        &[Some(P::Ready)],                    // ready
+        &[Some(P::Ready)],                    // running: the hot path writes nothing
+        &[Some(P::Ready)],                    // checkpointing
+        &[Some(P::Pausing)],                  // capturing
+        &[Some(P::Pausing)],                  // releasing
+        &[Some(P::Paused)],                   // paused
+        &[Some(P::Resuming)],                 // resuming
+        &[Some(P::Stopping)],                 // stopping
+        &[Some(P::Stopped)],                  // stopped
+        &[Some(P::Failed)],                   // failed
+        &[Some(P::Removing)],                 // removing
+        &[None],                              // gone: the record is forgotten
     ];
-    assert_eq!(expected.len(), LEAVES);
     for node in explore() {
-        let (_, durable) = expected[ordinal(node.state)];
-        assert_eq!(node.state.durable(), durable, "{:?}", node.state);
+        let durable = node.state.durable();
+        assert!(
+            expected[ordinal(node.state)].contains(&durable),
+            "{:?} projects {durable:?}",
+            node.state
+        );
     }
 }
 
 #[test]
 fn the_durable_projection_is_the_phase_actually_in_effect() {
     for node in explore() {
-        if matches!(node.state, State::Gating {}) {
-            // The exception `durable` documents: a cold boot arrives here on
-            // `Starting` and commits `Ready` after the probe, a restore
-            // arrives already `Ready`. Both really happen.
-            assert!(
-                node.phase == Some(PersistPhase::Starting)
-                    || node.phase == Some(PersistPhase::Ready),
-                "gating reached on {:?}",
-                node.phase
-            );
-            continue;
-        }
         assert_eq!(
             node.state.durable(),
             node.phase,

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/projections.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/projections.rs
@@ -1,0 +1,107 @@
+//! Reachability, and the two projections over every leaf.
+
+use super::harness::{LEAVES, explore, ordinal};
+use crate::lifecycle::machine::State;
+use crate::sandbox::SandboxState;
+use crate::sandbox::record::PersistPhase;
+
+#[test]
+fn every_leaf_is_reachable_by_driving_events() {
+    let mut seen = [false; LEAVES];
+    for node in explore() {
+        seen[ordinal(node.state)] = true;
+    }
+    assert!(
+        seen.iter().all(|reached| *reached),
+        "unreachable leaves: {:?}",
+        seen.iter()
+            .enumerate()
+            .filter(|(_, reached)| !**reached)
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn every_leaf_projects_onto_a_public_state() {
+    // An arm nobody projects is how a state becomes invisible to callers, so
+    // this asserts the whole table rather than sampling it.
+    let expected = [
+        (0, SandboxState::Starting),  // provisioning
+        (1, SandboxState::Starting),  // staging
+        (2, SandboxState::Starting),  // booting
+        (3, SandboxState::Starting),  // restoring
+        (4, SandboxState::Starting),  // gating
+        (5, SandboxState::Ready),     // ready
+        (6, SandboxState::Running),   // running
+        (7, SandboxState::Ready),     // checkpointing
+        (8, SandboxState::Pausing),   // capturing
+        (9, SandboxState::Pausing),   // releasing
+        (10, SandboxState::Paused),   // paused
+        (11, SandboxState::Starting), // resuming
+        (12, SandboxState::Stopping), // stopping
+        (13, SandboxState::Stopped),  // stopped
+        (14, SandboxState::Failed),   // failed
+        (15, SandboxState::Stopping), // removing
+        (16, SandboxState::Stopped),  // gone
+    ];
+    assert_eq!(expected.len(), LEAVES);
+    for node in explore() {
+        let (_, public) = expected[ordinal(node.state)];
+        assert_eq!(node.state.to_public(), public, "{:?}", node.state);
+    }
+}
+
+#[test]
+fn every_leaf_projects_onto_a_durable_phase() {
+    use PersistPhase as P;
+    let expected = [
+        (0, Some(P::Creating)),  // provisioning: the reserved intent
+        (1, Some(P::Starting)),  // staging
+        (2, Some(P::Starting)),  // booting
+        (3, Some(P::Creating)),  // restoring: commits Ready in one hop
+        (4, None),               // gating: Starting on a boot, Ready on a restore
+        (5, Some(P::Ready)),     // ready
+        (6, Some(P::Ready)),     // running: the hot path writes nothing
+        (7, Some(P::Ready)),     // checkpointing
+        (8, Some(P::Pausing)),   // capturing
+        (9, Some(P::Pausing)),   // releasing
+        (10, Some(P::Paused)),   // paused
+        (11, Some(P::Resuming)), // resuming
+        (12, Some(P::Stopping)), // stopping
+        (13, Some(P::Stopped)),  // stopped
+        (14, Some(P::Failed)),   // failed
+        (15, Some(P::Removing)), // removing
+        (16, None),              // gone: the record is forgotten
+    ];
+    assert_eq!(expected.len(), LEAVES);
+    for node in explore() {
+        let (_, durable) = expected[ordinal(node.state)];
+        assert_eq!(node.state.durable(), durable, "{:?}", node.state);
+    }
+}
+
+#[test]
+fn the_durable_projection_is_the_phase_actually_in_effect() {
+    for node in explore() {
+        if matches!(node.state, State::Gating {}) {
+            // The exception `durable` documents: a cold boot arrives here on
+            // `Starting` and commits `Ready` after the probe, a restore
+            // arrives already `Ready`. Both really happen.
+            assert!(
+                node.phase == Some(PersistPhase::Starting)
+                    || node.phase == Some(PersistPhase::Ready),
+                "gating reached on {:?}",
+                node.phase
+            );
+            continue;
+        }
+        assert_eq!(
+            node.state.durable(),
+            node.phase,
+            "{:?} reached via {:?}",
+            node.state,
+            node.path
+        );
+    }
+}

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -52,7 +52,7 @@ mod pause;
 mod policy;
 mod pool;
 mod reconcile;
-mod record;
+pub(crate) mod record;
 mod spec;
 mod templates;
 #[cfg(test)]
@@ -60,7 +60,7 @@ mod testing;
 mod timers;
 mod types;
 mod warm;
-mod workload;
+pub(crate) mod workload;
 
 pub use execution::{
     ExecutionChannel, ExecutionOutput, ExecutionSnapshot, ExecutionSpec, StdinState,

--- a/computer/arcbox-computer-runtime/src/sandbox/record.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/record.rs
@@ -8,7 +8,8 @@
 mod phase;
 mod store;
 
+pub use phase::PersistPhase;
 pub(super) use phase::{
-    PersistPhase, ProvisionIntent, SandboxProvisionOutcome, SandboxRecord, SandboxTransition,
+    ProvisionIntent, SandboxProvisionOutcome, SandboxRecord, SandboxTransition,
 };
 pub(super) use store::SandboxRecordStore;

--- a/computer/arcbox-computer-runtime/src/sandbox/record/phase.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/record/phase.rs
@@ -19,7 +19,7 @@ pub(super) const RECORD_VERSION: u32 = 1;
 /// phase at `Ready`, avoiding record writes on the execution hot path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub(in crate::sandbox) enum SandboxPhase {
+pub enum SandboxPhase {
     Creating,
     Starting,
     Ready,
@@ -45,7 +45,12 @@ pub(in crate::sandbox) enum SandboxPhase {
 /// enum is `SandboxPhase`, and this alias — the only one of the two
 /// [`super`] re-exports — is what every other module says. R3's rename
 /// then has one module to touch.
-pub(in crate::sandbox) type PersistPhase = SandboxPhase;
+///
+/// Crate-visible rather than `pub(in crate::sandbox)`: `crate::lifecycle`'s
+/// state machine projects onto these phases and its table test is written
+/// against [`SandboxPhase::can_transition_to`], so the durable vocabulary
+/// has to reach one module outside `sandbox`.
+pub type PersistPhase = SandboxPhase;
 
 /// The stable result returned once a provisioning request has been accepted.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -248,7 +253,7 @@ impl SandboxRecord {
 }
 
 impl SandboxPhase {
-    fn can_transition_to(self, next: Self) -> bool {
+    pub fn can_transition_to(self, next: Self) -> bool {
         self == next
             || matches!(
                 (self, next),
@@ -276,7 +281,7 @@ impl SandboxPhase {
             )
     }
 
-    pub(in crate::sandbox) fn as_str(self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Creating => "creating",
             Self::Starting => "starting",

--- a/computer/arcbox-computer-runtime/src/sandbox/workload.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/workload.rs
@@ -2,8 +2,8 @@ use super::types::action;
 use super::*;
 
 /// Which caller is taking the single-workload slot.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(super) enum WorkloadClaim {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkloadClaim {
     /// The public Run/Exec surface: claims from `Ready` only.
     Api,
     /// The boot/restore pipeline's own initial cmd: additionally claims


### PR DESCRIPTION
R3 PR-E of the vm-stack-redesign: the computer lifecycle as a `statig`
hierarchical state machine, landed with its transition table and **no
consumers**. That is the design's own risk mitigation — PR-F moves the flows
onto a machine that is already specified, one file at a time, instead of
rewriting and re-specifying them at once.

Same library, same idiom and same discipline as `arcbox-engine`'s
`vm_lifecycle::machine`: zero-sized shared storage, pure handlers, every
durable write / notification / timer move / caller reply is an `Effect` the
actor (PR-F) executes.

## What is here

| file | what |
|---|---|
| `lifecycle/event.rs` | manager commands, sub-task completions, observations |
| `lifecycle/effect.rs` | the effects a transition emits, and the buffer the actor drains |
| `lifecycle/machine.rs` | the 17 leaves and 5 superstates |
| `lifecycle/projection.rs` | `to_public()` and `durable()` |
| `lifecycle/tests/` | the harness, the exhaustive invariants, the per-flow effect vectors |

Three leaves name behaviour that has no in-memory identity today:

- **`staging`** — the window a create occupies while the boot task's resources
  are still local to it. It ends on `ResourcesHandedOff`
  (`boot.rs`'s handoff oneshot), which is exactly the point
  `cleanup::cancel_and_join_boot` may abort rather than join.
- **`gating`** — VM up, READY withheld for the warm publish, the initial `cmd`
  and the ready probe.
- **`removing`** — `SandboxPhase::Removing` gets a state instead of borrowing
  `Stopping` (`cleanup.rs` writes `inst.state = Stopping` today).

`running` writes **no** durable record: it is the workload hot path, and
keeping record writes off it is a property of the current design.

## The consistency check

`tests/harness.rs::explore` walks every reachable `(state, durable phase)`
pair and asserts on **every** edge that the phase the machine asks to persist
is a legal move from the phase then in effect — `record::phase`'s edge set,
the same 30-pair table PR-A pinned. Both projections are asserted over all 17
leaves, and the busy gates (`stop_sandbox`, `cleanup::begin_removal`,
`deadlines::{ttl_due, idle_due}`) are asserted as rules over every state
rather than at a handful of samples.

It caught one immediately: **`restoring -> gating` writes `Ready` while the
record still says `Creating`, and `Creating -> Ready` is not an edge.** That
commit is the restore path's `ReadyWithOutcome`, which `SandboxRecord::apply`
waives (`atomic_ready`) and *only* from `Creating`. The plan's
`Effect::PersistPhase { phase, durability }` cannot express it, so it is a
distinct `Effect::CommitRestored` and the walk asserts nothing else emits it.

The recovery half is a **mirror, not an assertion**:
`policy::recovery::{plan, RecoveryAction, JournalEvidence}` are
`pub(in crate::sandbox)` and cannot be called from `crate::lifecycle`. The
table in `tests/invariants.rs` reproduces `plan`'s verdicts and says so;
widening those three items to `pub(crate)` turns it into a real assertion and
belongs with the recovery applier's own move (that file is owned by an
in-flight PR).

## Where today's code and the plan's §A disagree

Encoded today's behaviour where §A.2's structure allowed it, and reported the
rest rather than picking a side.

**Corrected in the machine** (§A.2 would have changed behaviour):

1. `checkpointing` handles `Failure` by returning to `ready`. §A.2 left it to
   the root superstate, which fails the computer — but today a
   `CheckpointFailure::Recoverable` leaves the sandbox `Ready` and only
   returns an error (`checkpoint.rs`). Only `Frozen` degrades it.
2. `resuming`'s unwind publishes `Notify::Paused`. Today's `resume_sandbox`
   emits the PAUSED event on that branch; §A.2 emitted only the durable write.
3. `restoring -> gating` arms the TTL timer. Both restore flavours call
   `arm_ttl_timer` today; §A.2 armed it only on the cold path.
4. `Remove { force: false }` is refused on the states projecting
   `Starting`/`Running`, not on `active`. `begin_removal` refuses exactly
   `Running` and `Starting` — so §A.2's placement both refused a remove today
   allows (from `Ready`, i.e. `ready`/`checkpointing`) and force-removed ones
   today refuses (`booting`, `gating`, `resuming`, …). This is the divergence
   with teeth: getting it wrong destroys a computer where today an error is
   returned. There is now an exhaustive test for the rule.
5. `staging` is wired (§A.1 lists it; §A.2 transitions `provisioning` straight
   to `booting`, leaving the leaf unreachable and `ResourcesHandedOff` inert).
6. `Event::Recovered` is wired (§A.2 declares it and no state handles it).
   It seeds the state recovery's own verdict already left behind, emitting
   nothing — the durable write is `policy::recovery`'s, not the machine's.
7. `restoring` takes every failure class itself and runs the removal path.
   §A.2 left it to the root superstate, which parks at `Failed` — but a
   pre-commit restore failure never leaves a durable `Failed`:
   `rollback_restore` force-removes (and the earliest case is
   `abort_provision`), so the id and its request key are freed and a warm
   create can fall back to a cold boot. A cold *boot* failure does park at
   `Failed` (`fail_live_sandbox`), so `booting` keeps the inherited arm.
   (Codex P1.)
8. The idle window is cancelled entering `checkpointing` and restarted on both
   ways out. The state swallows an idle expiry so a capture cannot race the
   policy, but `LifecycleTimers` slots are one-shot, so returning to `ready`
   without re-arming left a computer that idled through a checkpoint exempt
   from its `on_idle` policy for good. (Codex P2.)
9. `gating` carries whether `Ready` is already committed, and only the cold
   path writes it on `Gated`. A restore commits `ReadyWithOutcome` in one hop
   *before* the gate runs (`SandboxTransition::Ready` appears nowhere in
   `checkpoint.rs`), so re-persisting it afterwards put an fsync on the
   restore's hot path and, under `Report(Unavailable)`, could refuse a
   computer that is already durably `Ready`. The discriminator is on the
   state, not the event, so the two cannot be paired wrongly — and `durable()`
   now answers exactly for `gating`, which removes the walk's one exception.
   (Bugbot, high.)
10. `Pause` cancels the idle window, as `on_lifecycle_event` does on the
    PAUSING action; without it an expiry due mid-pause was swallowed and lost.
    (Bugbot.)
11. `failure()` clears the crash journal, behind the same confirmed-write +
    completed-release gate `fail_live_sandbox` uses. `removal()` still does
    not, and should not: `remove_sandbox_impl` deletes the whole `vm_dir`.
    (Bugbot.)
12. `Provision { restore: bool }` became `Provision(Provision::{Boot { warm },
   Restore { origin }})`: `SpawnBoot`'s warm flag was hardcoded `true` in the
   sketch, and `SpawnRestore` needs an origin that has to come from somewhere.

**Reported, not fixed** — each needs new structure or vocabulary that belongs
with the flow it serves:

1. **The initial `cmd`'s claim does not survive `Gated`.** §A.2 has `gating`
   swallow `ClaimWorkload { Initial }`. Today that claim flips the instance to
   `Running` and publishes RUNNING (`workload::start_run_workload`), and the
   exit publishes IDLE. Under the machine as specified, `Gated` lands in
   `ready` with the workload still running, so `WorkloadExited` arrives in
   `ready` and the IDLE publish is dropped. Fixing it needs `gating` to carry
   the reservation so `Gated` can land in `running` — cheap now that the state
   already carries `committed`, but it belongs with the boot tail's own move.
   Pinned by `the_boots_own_cmd_claims_the_slot_the_gate_reserved_for_it`.
2. **A resume failure is two-valued and `Event::Failure` is not.** Today
   `resume_sandbox` parks at `Paused` when the restore unwound and at `Failed`
   when it did not. §A.2 has one arm (→ `Paused`). Encoding only that would
   record a half-allocated computer as cleanly `Paused`, which recovery then
   `Reinstate`s as resumable — a crash-safety divergence, not a cosmetic one.
   Needs a discriminator on the event, as `capturing` already has
   (`Failure` vs `Frozen`, mirroring `CheckpointFailure`).
3. **The warm-create restore's CREATED event is unmodelled.** Today a
   `RestoreOrigin::WarmCreate` publishes CREATED before READY (the Create
   event contract); a plain Restore does not. `Event::Restored` carries no
   origin, so `restoring` cannot tell them apart without state-local storage.
4. **`Stop` during a boot.** §A.2 says the actor defers it; today
   `stop_sandbox` answers `WrongState` for anything outside
   `Ready`/`Running`/`Stopping`. The machine swallows it either way, so this
   is a decision PR-F's actor has to make explicitly.
5. **The idle `Kill` policy is a non-forced remove today**
   (`expire_sandbox(.., force = false)`), while the TTL cap is forced. Both
   reach the same effects from `ready`, so nothing diverges in practice — but
   the plan describes both as `force_remove`.
6. **§A.1 and §A.4 disagree with each other** on where `ReadyWithOutcome`
   lands: A.1 gives `gating` no entry write, A.4 puts it on
   `restoring -> gating`. Encoded as A.4 (that is what the code does).

## What the plan got wrong about the codebase

- **Every `virt/arcbox-vm/...` path is stale** (now
  `computer/arcbox-computer-runtime/...`) and every line number in §A is off
  by tens of lines after PR-D. Located everything by behaviour instead.
- **"the rest of the crate byte-identical apart from `lib.rs`" is not
  achievable.** `PersistPhase`, `SandboxPhase::can_transition_to` and
  `WorkloadClaim` are `pub(in crate::sandbox)`, so a top-level
  `crate::lifecycle` cannot name them. Four one-line visibility widenings
  (`record`, `workload`, the phase enum + alias, `can_transition_to`/
  `as_str`); `SandboxPhase`/`PersistPhase` themselves are unchanged, and no
  file another PR is editing was touched.
- **`RestoreOrigin` and `pause::reason` are unreachable too** — both live in
  private `sandbox` modules. `PauseReason` here maps onto the real
  `pause_reason` constants; `RestoreOrigin` is mirrored with a comment, and
  PR-F unifies them when the restore task moves into this module.
- **The size estimate (E1 ~380, E2 ~330) is roughly half.** The vocabulary
  alone is ~290 lines and the machine ~400, so this is five commits, each
  under the repo's 400-line limit, rather than two.

## Checks

`cargo fmt --all`, `cargo clippy -p arcbox-computer-runtime --all-targets
--all-features -- -D warnings`, `cargo test -p arcbox-computer-runtime
--all-features` (186 passed), `cargo check -p arcbox-agent --target
aarch64-unknown-linux-musl --all-targets`, `cargo run -p xtask --
check-layers` — all green before each commit. The HSM tests need no KVM, no
root and no Firecracker.
