### PR TITLE
feat(vm-driver): a Staging capability and a driver-declared id budget (R3, PR-G1)

### DIFF
--- a/engine/arcbox-snapshot/src/snapshot_cow/block_tools.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow/block_tools.rs
@@ -435,7 +435,39 @@ mod tests {
         )
         .unwrap();
         std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        wait_until_executable(&script);
+        // The probe ran the script, so every test starts from an empty record.
+        std::fs::remove_file(&calls).ok();
         (BusyboxBlockTools::new(script), calls)
+    }
+
+    /// Run the freshly written `script` until the kernel stops refusing it.
+    ///
+    /// A sibling test thread that forks — `CowManager::new` probes every
+    /// `dmsetup` candidate, so most of this crate's tests do — between this
+    /// thread's `create` and `close` leaves its child holding a write fd to
+    /// the script, and Linux will not exec a file that is open for writing
+    /// (`ETXTBSY`). The window closes as soon as that child execs and never
+    /// reopens, since nothing writes the script again; exec'ing it until it
+    /// runs is what proves the window is shut.
+    fn wait_until_executable(script: &Path) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match Command::new(script).output() {
+                Err(error) if error.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "{} stayed busy for 5s",
+                        script.display()
+                    );
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                other => {
+                    other.unwrap();
+                    return;
+                }
+            }
+        }
     }
 
     fn attach_calls(calls: &Path) -> Vec<String> {

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -22,7 +22,7 @@ removes — and the only other things it depends on are the port and
 | `config` | `FcDriverConfig` — binaries, seccomp, log level, API-socket wait, jailer resource limits |
 | `error` | `FcError`, folded into the port's `Error::Driver { driver: "firecracker", .. }` |
 | `render` | `VmLayout` (every path Firecracker sees, and the jailer's relativity), `VmSpec` → `FcPlan`, `RestoreSpec` → `FcRestorePlan` |
-| `jail` | chroot layout, the id budget the API socket's path leaves, and staging (link-or-copy, copy, block-device node, move-in), `apply` for a rendered plan, `move_file` out of a jail |
+| `jail` | chroot layout, the id budget the longest jail socket leaves, and staging (link-or-copy, copy, block-device node, move-in), `apply` for a rendered plan, `move_file` out of a jail |
 | `spawn` | `firecracker` / `jailer` process spawn from a `SpawnPlan` |
 | `vsock` | the `CONNECT <port>` handshake and the `{uds}_{port}` listener |
 | `process` | the process guard: waiter task, exit watch + event, kill / wait, detach |

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -6,7 +6,8 @@ jailer) chroot-relative paths, owns the `firecracker`/`jailer` process,
 and serves the port's capabilities over it: `Vsock` and `VsockListen`
 through the hybrid-vsock Unix socket, `Checkpoint` through
 pause → snapshot → resume, `Prepare` for warm pools that spawn ahead of a
-boot, `Adopt`/`Detach` for VMs that outlive the process that booted them.
+boot, `Staging` for bringing that boot's files into the jail before it,
+`Adopt`/`Detach` for VMs that outlive the process that booted them.
 
 Nothing above this crate names Firecracker. The sandbox manager
 (`arcbox-computer-runtime`) reaches it through `dyn VmDriver` — during the
@@ -21,7 +22,7 @@ removes — and the only other things it depends on are the port and
 | `config` | `FcDriverConfig` — binaries, seccomp, log level, API-socket wait, jailer resource limits |
 | `error` | `FcError`, folded into the port's `Error::Driver { driver: "firecracker", .. }` |
 | `render` | `VmLayout` (every path Firecracker sees, and the jailer's relativity), `VmSpec` → `FcPlan`, `RestoreSpec` → `FcRestorePlan` |
-| `jail` | chroot layout and staging (link-or-copy, copy, block-device node), `apply` for a rendered plan, `move_file` out of a jail |
+| `jail` | chroot layout, the id budget the API socket's path leaves, and staging (link-or-copy, copy, block-device node, move-in), `apply` for a rendered plan, `move_file` out of a jail |
 | `spawn` | `firecracker` / `jailer` process spawn from a `SpawnPlan` |
 | `vsock` | the `CONNECT <port>` handshake and the `{uds}_{port}` listener |
 | `process` | the process guard: waiter task, exit watch + event, kill / wait, detach |
@@ -29,7 +30,7 @@ removes — and the only other things it depends on are the port and
 | `listener` | the port's `VsockListener` over a `{uds}_{port}` socket |
 | `discover` | finding a Firecracker that outlived its booter: the recorded pid and any `/proc` candidate, held to the same `--id` / `--api-sock` / jail-root test |
 | `adopt` | rebuilding a handle over what `discover` found: a bounded API reconnect for the full `FcHandle`, else `FcProcessHandle` over the process alone |
-| `prepared` | `FcPrepared: PreparedVm` — a spawned VMM waiting for a spec |
+| `prepared` | `FcPrepared: PreparedVm + VsockListen + Staging` — a spawned VMM waiting for a spec, and the jail its files are staged into |
 | `handle` | `FcHandle: VmHandle + Vsock + VsockListen + Checkpoint + Detach`; `FcProcessHandle: VmHandle + Detach`, over a VMM whose API is unreachable |
 | `driver` | `FcDriver: VmDriver + Prepare + Adopt` |
 
@@ -104,6 +105,18 @@ this.
   checkpoint to `/snapshots/{image dir name}/{vmstate,mem}`. The API socket
   is `{jail}/run/firecracker.socket`, the vsock socket
   `/run/firecracker.vsock` inside and `{jail}/run/firecracker.vsock` outside.
+
+  `Staging` on a prepared VM stages the same files under the same names
+  ahead of the boot that renders them, which is how a warm pool pays for a
+  checkpoint's memory file before a restore asks for it; `discard` removes
+  the whole `{chroot_base}/{binary}/{id}` tree, so a disk that must outlive
+  the VM leaves through `unstage_disk` first. Without a jail every staging
+  verb is the identity.
+
+  That API socket is also what bounds a VM id: it must fit AF_UNIX's 107
+  bytes, so `id_budget` answers with what the chroot base and binary name
+  leave — `0` for a base that spends it all, since the alternative is ids
+  that look fine and never connect.
 
 A VM `id` and a disk `id` must each be a plain name: the first is the jail's
 directory, the second a device id in the API URL and the file the disk is

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -108,15 +108,17 @@ this.
 
   `Staging` on a prepared VM stages the same files under the same names
   ahead of the boot that renders them, which is how a warm pool pays for a
-  checkpoint's memory file before a restore asks for it; `discard` removes
-  the whole `{chroot_base}/{binary}/{id}` tree, so a disk that must outlive
-  the VM leaves through `unstage_disk` first. Without a jail every staging
-  verb is the identity.
+  checkpoint's memory file before a restore asks for it; `unstage_disk`
+  takes a disk back out of the jail, so it survives the VM. Without a jail
+  every staging verb is the identity. Removing the jail itself is still
+  the caller's, not `discard`'s — see the note on `FcPrepared::discard`.
 
-  That API socket is also what bounds a VM id: it must fit AF_UNIX's 107
+  Those sockets are also what bounds a VM id: each must fit AF_UNIX's 107
   bytes, so `id_budget` answers with what the chroot base and binary name
-  leave — `0` for a base that spends it all, since the alternative is ids
-  that look fine and never connect.
+  leave for the longest of them — the guest dial-out listener,
+  `{jail}/run/firecracker.vsock_{port}`, not the API socket — and `0` for
+  a base that spends it all, since the alternative is ids that look fine
+  and never connect.
 
 A VM `id` and a disk `id` must each be a plain name: the first is the jail's
 directory, the second a device id in the API URL and the file the disk is

--- a/virt/arcbox-fc-driver/src/driver.rs
+++ b/virt/arcbox-fc-driver/src/driver.rs
@@ -107,10 +107,10 @@ impl VmDriver for FcDriver {
         Some(self)
     }
 
-    /// Under the jailer, what the API socket's path leaves for the id
-    /// ([`jail::id_budget`]) — so a longer chroot base or a longer binary
-    /// name tightens the budget rather than silently reintroducing the
-    /// connect timeout it exists to prevent.
+    /// Under the jailer, what the longest socket path in the jail leaves
+    /// for the id ([`jail::id_budget`]) — so a longer chroot base or a
+    /// longer binary name tightens the budget rather than silently
+    /// reintroducing the connect timeout it exists to prevent.
     ///
     /// Nothing bounds the id in direct mode: the API socket and the vsock
     /// live in the runtime dir, where the id is not part of the path. An

--- a/virt/arcbox-fc-driver/src/driver.rs
+++ b/virt/arcbox-fc-driver/src/driver.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use crate::config::FcDriverConfig;
 use crate::prepared::FcPrepared;
 use crate::render;
-use crate::{CHECKPOINT_FORMAT, NAME, adopt, discover};
+use crate::{CHECKPOINT_FORMAT, NAME, adopt, discover, jail};
 
 /// The Firecracker adapter.
 ///
@@ -65,7 +65,7 @@ impl VmDriver for FcDriver {
             diff_checkpoint: false,
             adopt: true,
             prepare: true,
-            staging: false,
+            staging: true,
             balloon: false,
             console: false,
             debug: false,
@@ -105,6 +105,25 @@ impl VmDriver for FcDriver {
 
     fn prepare(&self) -> Option<&dyn Prepare> {
         Some(self)
+    }
+
+    /// Under the jailer, what the API socket's path leaves for the id
+    /// ([`jail::id_budget`]) — so a longer chroot base or a longer binary
+    /// name tightens the budget rather than silently reintroducing the
+    /// connect timeout it exists to prevent.
+    ///
+    /// Nothing bounds the id in direct mode: the API socket and the vsock
+    /// live in the runtime dir, where the id is not part of the path. An
+    /// isolation this driver cannot run at all is refused when its layout
+    /// is built, not here.
+    fn id_budget(&self, isolation: &IsolationSpec) -> Option<usize> {
+        match isolation {
+            IsolationSpec::Jailer { chroot_base, .. } => Some(jail::id_budget(
+                &self.config.firecracker_binary,
+                chroot_base,
+            )),
+            _ => None,
+        }
     }
 }
 
@@ -190,7 +209,7 @@ mod tests {
         assert_eq!(driver.name(), "firecracker");
         let caps = driver.capabilities();
         assert!(caps.vsock && caps.vsock_listen);
-        assert!(caps.adopt && caps.prepare);
+        assert!(caps.adopt && caps.prepare && caps.staging);
         assert!(!caps.diff_checkpoint && !caps.balloon && !caps.console && !caps.debug);
         assert!(VmDriver::adopt(&driver).is_some() && VmDriver::prepare(&driver).is_some());
         // Checkpoints go with the jailer: without one nothing could be
@@ -199,6 +218,39 @@ mod tests {
         let mut config = FcDriverConfig::new("/nonexistent/arcbox-fc-driver/firecracker");
         config.jailer_binary = Some("/nonexistent/arcbox-fc-driver/jailer".into());
         assert!(FcDriver::new(config).capabilities().checkpoint);
+    }
+
+    #[test]
+    fn the_id_budget_is_the_jails_and_direct_mode_has_none() {
+        let driver = driver();
+        // Nothing in a direct-mode VM's paths carries the id.
+        assert_eq!(driver.id_budget(&IsolationSpec::None), None);
+
+        let jailed = |chroot_base: &str| IsolationSpec::Jailer {
+            uid: 0,
+            gid: 0,
+            chroot_base: chroot_base.into(),
+            netns: None,
+            new_pid_ns: false,
+            cgroup: None,
+        };
+        assert_eq!(
+            driver.id_budget(&jailed("/srv/jailer")),
+            Some(crate::jail::id_budget(
+                "/nonexistent/arcbox-fc-driver/firecracker",
+                "/srv/jailer"
+            ))
+        );
+        // A deeper base is a tighter budget, and a deep enough one leaves
+        // nothing: the caller must refuse every id rather than mint one.
+        assert!(
+            driver.id_budget(&jailed("/srv/jailer/nested/deeper"))
+                < driver.id_budget(&jailed("/srv/jailer"))
+        );
+        assert_eq!(
+            driver.id_budget(&jailed(&format!("/{}", "d".repeat(200)))),
+            Some(0)
+        );
     }
 
     #[tokio::test]

--- a/virt/arcbox-fc-driver/src/driver.rs
+++ b/virt/arcbox-fc-driver/src/driver.rs
@@ -65,6 +65,7 @@ impl VmDriver for FcDriver {
             diff_checkpoint: false,
             adopt: true,
             prepare: true,
+            staging: false,
             balloon: false,
             console: false,
             debug: false,

--- a/virt/arcbox-fc-driver/src/jail.rs
+++ b/virt/arcbox-fc-driver/src/jail.rs
@@ -6,7 +6,8 @@
 //! checkpoint's vmstate and mem — is staged in first, owned by the jailed
 //! uid/gid, and named to Firecracker by its chroot-relative path. This
 //! module is that staging: the layout, and one primitive per way a file
-//! can be brought in (hard link or copy, plain copy, block-device node).
+//! can be brought in (hard link or copy, plain copy, block-device node,
+//! or the file itself moved in when the caller gives it up).
 
 use std::path::{Path, PathBuf};
 
@@ -87,6 +88,35 @@ pub fn api_socket_path(chroot_root: &Path) -> PathBuf {
 /// [`VSOCK_UDS_IN_JAIL`].
 pub fn vsock_uds_path(chroot_root: &Path) -> PathBuf {
     chroot_root.join("run/firecracker.vsock")
+}
+
+/// What AF_UNIX leaves for a path: `sun_path` is 108 bytes, and the last
+/// one is the terminator.
+const SUN_PATH: usize = 107;
+
+/// The longest VM id this jailer layout leaves room for.
+///
+/// The id is a directory component of the chroot, and the longest path
+/// under it that has a hard limit is the API socket — the jail's two
+/// sockets both live in `{jail}/run/`, and `firecracker.socket` is the
+/// longer name. A chroot base that spends the budget makes that socket
+/// unaddressable, and nothing says so: the jailer creates the path and
+/// Firecracker binds it from inside the chroot, where the name is short,
+/// while every `connect` from the host fails. What that looks like is a
+/// VMM that is up and answering nothing — a boot that timed out.
+///
+/// Saturating on purpose. A base deep enough to spend all 107 bytes
+/// leaves room for no id at all, and `0` is the answer that says so; the
+/// subtraction wrapping into a huge budget would hand out ids that cannot
+/// work. A chroot base under a deep temporary directory reaches this in
+/// tests long before production does.
+pub fn id_budget(fc_binary: impl AsRef<Path>, chroot_base_dir: impl AsRef<Path>) -> usize {
+    // Everything around the id, measured on a one-byte id.
+    let fixed = api_socket_path(&chroot_root(fc_binary, chroot_base_dir, "x"))
+        .as_os_str()
+        .len()
+        .saturating_sub(1);
+    SUN_PATH.saturating_sub(fixed)
 }
 
 /// Where the vsock Unix socket lives from inside the jail.
@@ -207,6 +237,29 @@ pub async fn copy_for_jailer(src: &Path, dst: &Path, uid: u32, gid: u32) -> Resu
     Ok(())
 }
 
+/// Move a file the caller hands over into the jail and give it to the
+/// jailed uid/gid — the file itself, not a copy of it, so a disk the size
+/// of a guest's rootfs comes back without being duplicated.
+///
+/// A stale entry at the destination is removed first, exactly as a copy or
+/// a device node would: a `rename` onto a directory left by a crash fails,
+/// and one onto a stale block device node would replace it silently.
+pub async fn move_into_jail(src: &Path, dst: &Path, uid: u32, gid: u32) -> Result<()> {
+    if let Err(e) = tokio::fs::remove_file(dst).await
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(Error::Io(e));
+    }
+    move_file(src, dst).await.map_err(Error::Io)?;
+    chown(dst, Some(Uid::from_raw(uid)), Some(Gid::from_raw(gid))).map_err(|source| {
+        FcError::Chown {
+            path: dst.to_path_buf(),
+            source,
+        }
+    })?;
+    Ok(())
+}
+
 /// Create a block device node in the jailer chroot pointing to a dm device.
 ///
 /// Returns the chroot-relative rootfs path (`"/rootfs.ext4"`).
@@ -277,6 +330,7 @@ pub async fn apply(jail: &Jail, plans: &[StagePlan]) -> Result<()> {
             StageKind::BlockNode => {
                 mknod_for_jailer(&plan.src, &plan.dst, jail.uid, jail.gid).await?;
             }
+            StageKind::Move => move_into_jail(&plan.src, &plan.dst, jail.uid, jail.gid).await?,
             StageKind::Alias => alias_in_jail(&plan.src, &plan.dst, jail.uid, jail.gid).await?,
         }
     }
@@ -368,6 +422,62 @@ mod tests {
             Some("/snapshots/abc/vmstate")
         );
         assert_eq!(jail.view(Path::new("/images/vmlinux")), None);
+    }
+
+    #[test]
+    fn the_id_budget_is_what_the_socket_leaves_and_never_wraps() {
+        let budget = id_budget("/opt/fc/firecracker", "/srv/jailer");
+        assert_eq!(
+            budget,
+            SUN_PATH - "/srv/jailer/firecracker//root/run/firecracker.socket".len()
+        );
+        // An id of exactly the budget fills `sun_path` and no more.
+        let fits = api_socket_path(&chroot_root(
+            "/opt/fc/firecracker",
+            "/srv/jailer",
+            &"a".repeat(budget),
+        ));
+        assert_eq!(fits.as_os_str().len(), SUN_PATH);
+
+        // A chroot base deep enough spends the whole budget: zero, not a
+        // wrap into a length that would look generous and never connect.
+        // A temp dir a few levels down is already most of the way there,
+        // which is how a test suite meets this before production does.
+        let deep = PathBuf::from("/").join("d".repeat(200));
+        assert_eq!(id_budget("/opt/fc/firecracker", deep), 0);
+    }
+
+    #[tokio::test]
+    async fn a_handed_over_file_is_moved_in_and_replaces_what_it_finds() {
+        let dir = tempfile::tempdir().unwrap();
+        let parked = dir.path().join("parked.ext4");
+        std::fs::write(&parked, b"the disk itself").unwrap();
+        let root = dir.path().join("jail/firecracker/box/root");
+        std::fs::create_dir_all(&root).unwrap();
+        // A leftover at the destination from the run that parked it.
+        std::fs::write(root.join("rootfs.ext4"), b"stale").unwrap();
+        let jail = Jail {
+            root: root.clone(),
+            uid: nix::unistd::getuid().as_raw(),
+            gid: nix::unistd::getgid().as_raw(),
+        };
+
+        apply(
+            &jail,
+            &[StagePlan {
+                src: parked.clone(),
+                dst: root.join("rootfs.ext4"),
+                kind: StageKind::Move,
+            }],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(root.join("rootfs.ext4")).unwrap(),
+            b"the disk itself"
+        );
+        assert!(!parked.exists(), "a handed-over disk is moved, not copied");
     }
 
     #[tokio::test]

--- a/virt/arcbox-fc-driver/src/jail.rs
+++ b/virt/arcbox-fc-driver/src/jail.rs
@@ -94,28 +94,49 @@ pub fn vsock_uds_path(chroot_root: &Path) -> PathBuf {
 /// one is the terminator.
 const SUN_PATH: usize = 107;
 
+/// The widest listener port [`id_budget`] leaves room for.
+///
+/// [`VsockListen::listen`](arcbox_vm_driver::VsockListen::listen) takes a
+/// `u32`, but reserving all ten digits costs ten bytes of id — on the
+/// stock layout the difference between accepting and refusing the 36-byte
+/// UUIDs an orchestrator mints. Refusing every id is a worse failure than
+/// the `ENAMETOOLONG` a wider port would raise at bind time, which names
+/// the path it could not bind; no consumer of this driver listens above
+/// `u16::MAX`.
+const WIDEST_RESERVED_PORT: u32 = u16::MAX as u32;
+
 /// The longest VM id this jailer layout leaves room for.
 ///
-/// The id is a directory component of the chroot, and the longest path
-/// under it that has a hard limit is the API socket — the jail's two
-/// sockets both live in `{jail}/run/`, and `firecracker.socket` is the
-/// longer name. A chroot base that spends the budget makes that socket
-/// unaddressable, and nothing says so: the jailer creates the path and
-/// Firecracker binds it from inside the chroot, where the name is short,
-/// while every `connect` from the host fails. What that looks like is a
-/// VMM that is up and answering nothing — a boot that timed out.
+/// The id is a directory component of the chroot, so every socket bound
+/// under it carries the id in its path and has 107 bytes to fit in. Two
+/// do: the API socket, and the guest dial-out listener — the vsock UDS
+/// plus Firecracker's `_{port}` suffix ([`crate::vsock::listener_socket_path`]),
+/// which is the longer of the two and is bound *before* the guest starts.
+/// The budget is measured against whichever is longer, so it cannot be
+/// invalidated by renaming one of them.
 ///
-/// Saturating on purpose. A base deep enough to spend all 107 bytes
-/// leaves room for no id at all, and `0` is the answer that says so; the
+/// Getting this wrong does not announce itself. The jailer creates the
+/// path and Firecracker binds it from inside the chroot, where the name is
+/// short, while every `connect` from the host fails — a VMM that is up and
+/// answering nothing, read as a boot that timed out.
+///
+/// Saturating on purpose. A base deep enough to spend all 107 bytes leaves
+/// room for no id at all, and `0` is the answer that says so; the
 /// subtraction wrapping into a huge budget would hand out ids that cannot
 /// work. A chroot base under a deep temporary directory reaches this in
 /// tests long before production does.
 pub fn id_budget(fc_binary: impl AsRef<Path>, chroot_base_dir: impl AsRef<Path>) -> usize {
     // Everything around the id, measured on a one-byte id.
-    let fixed = api_socket_path(&chroot_root(fc_binary, chroot_base_dir, "x"))
-        .as_os_str()
-        .len()
-        .saturating_sub(1);
+    let root = chroot_root(fc_binary, chroot_base_dir, "x");
+    let fixed = [
+        api_socket_path(&root),
+        crate::vsock::listener_socket_path(&vsock_uds_path(&root), WIDEST_RESERVED_PORT),
+    ]
+    .iter()
+    .map(|path| path.as_os_str().len())
+    .max()
+    .unwrap_or_default()
+    .saturating_sub(1);
     SUN_PATH.saturating_sub(fixed)
 }
 
@@ -425,19 +446,25 @@ mod tests {
     }
 
     #[test]
-    fn the_id_budget_is_what_the_socket_leaves_and_never_wraps() {
+    fn the_id_budget_is_what_the_longest_socket_leaves_and_never_wraps() {
         let budget = id_budget("/opt/fc/firecracker", "/srv/jailer");
+        // The dial-out listener, not the API socket, is what the budget is
+        // measured against: it is the longer path, and it is bound before
+        // the guest starts.
+        assert!(
+            "/run/firecracker.vsock_65535".len() > "/run/firecracker.socket".len(),
+            "the API socket became the longer path; the budget must follow it"
+        );
         assert_eq!(
             budget,
-            SUN_PATH - "/srv/jailer/firecracker//root/run/firecracker.socket".len()
+            SUN_PATH - "/srv/jailer/firecracker//root/run/firecracker.vsock_65535".len()
         );
-        // An id of exactly the budget fills `sun_path` and no more.
-        let fits = api_socket_path(&chroot_root(
-            "/opt/fc/firecracker",
-            "/srv/jailer",
-            &"a".repeat(budget),
-        ));
+        // An id of exactly the budget fills `sun_path` for that listener
+        // and leaves the API socket comfortably inside it.
+        let root = chroot_root("/opt/fc/firecracker", "/srv/jailer", &"a".repeat(budget));
+        let fits = crate::vsock::listener_socket_path(&vsock_uds_path(&root), 65535);
         assert_eq!(fits.as_os_str().len(), SUN_PATH);
+        assert!(api_socket_path(&root).as_os_str().len() < SUN_PATH);
 
         // A chroot base deep enough spends the whole budget: zero, not a
         // wrap into a length that would look generous and never connect.

--- a/virt/arcbox-fc-driver/src/jail.rs
+++ b/virt/arcbox-fc-driver/src/jail.rs
@@ -34,11 +34,41 @@ pub struct Jail {
 impl Jail {
     /// `host` as Firecracker sees it, when `host` is already inside the
     /// jail: `/` + its path relative to the root.
+    ///
+    /// Decided on the resolved path. `strip_prefix` compares components,
+    /// so `{root}/../elsewhere` names the root on the way past and would
+    /// otherwise answer `Some("/../elsewhere")` — a path Firecracker's
+    /// chroot resolves to something else entirely, for a file that was
+    /// never brought in. Every decision this jail makes about a host path
+    /// asks through here, so the question cannot be asked the wrong way.
+    ///
+    /// Symlinks are deliberately not followed: a symlink inside the jail
+    /// is a file the jailed Firecracker can open, which is exactly what is
+    /// being asked.
     pub fn view(&self, host: &Path) -> Option<String> {
-        host.strip_prefix(&self.root)
+        lexically_resolved(host)
+            .strip_prefix(&self.root)
             .ok()
             .map(|rel| format!("/{}", rel.display()))
     }
+}
+
+/// `path` with its `.` and `..` components resolved as far as they can be
+/// without touching the filesystem.
+pub(crate) fn lexically_resolved(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !out.pop() {
+                    out.push(component);
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    out
 }
 
 /// The jailer's own default chroot base, used when a config names none.
@@ -443,6 +473,14 @@ mod tests {
             Some("/snapshots/abc/vmstate")
         );
         assert_eq!(jail.view(Path::new("/images/vmlinux")), None);
+        // A path that names the root on its way past it is not in the
+        // jail, however its components read — every decision the jail
+        // makes about a host path is this one, so it resolves here.
+        assert_eq!(jail.view(&root.join("../../../outside.ext4")), None);
+        assert_eq!(
+            jail.view(&root.join("snapshots/../rootfs.ext4")).as_deref(),
+            Some("/rootfs.ext4")
+        );
     }
 
     #[test]

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -17,8 +17,8 @@
 //!   and [`RestoreSpec`](arcbox_vm_driver::RestoreSpec) →
 //!   [`render::FcRestorePlan`]: every path Firecracker sees, and the
 //!   jailer's chroot relativity, is decided there and nowhere else.
-//! - [`jail`] — the jailer's chroot layout, the id budget its API socket
-//!   path leaves ([`jail::id_budget`]), and how host files are staged into
+//! - [`jail`] — the jailer's chroot layout, the id budget its longest
+//!   socket path leaves ([`jail::id_budget`]), and how host files are staged into
 //!   it (link-or-copy, copy, block-device node, move-in), including
 //!   [`jail::apply`] for a rendered plan.
 //! - [`spawn`] — the `firecracker` / `jailer` process spawn from a
@@ -38,8 +38,7 @@
 //!   a VMM process whose API is unreachable — kill, observe, detach.
 //! - [`prepared`] — [`FcPrepared`], the port's `PreparedVm`: a spawned
 //!   VMM waiting for a spec, listeners bound before the guest starts, and
-//!   the `Staging` capability over its jail — `discard` takes the jail
-//!   with it.
+//!   the `Staging` capability over its jail.
 //! - [`discover`] — finding a Firecracker that outlived the process which
 //!   booted it: the recorded pid when it is a Firecracker the record names,
 //!   else a `/proc` scan for one, by `--id`, `--api-sock`, or jail root.

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -17,8 +17,9 @@
 //!   and [`RestoreSpec`](arcbox_vm_driver::RestoreSpec) →
 //!   [`render::FcRestorePlan`]: every path Firecracker sees, and the
 //!   jailer's chroot relativity, is decided there and nowhere else.
-//! - [`jail`] — the jailer's chroot layout and how host files are staged
-//!   into it (link-or-copy, copy, block-device node), including
+//! - [`jail`] — the jailer's chroot layout, the id budget its API socket
+//!   path leaves ([`jail::id_budget`]), and how host files are staged into
+//!   it (link-or-copy, copy, block-device node, move-in), including
 //!   [`jail::apply`] for a rendered plan.
 //! - [`spawn`] — the `firecracker` / `jailer` process spawn from a
 //!   [`render::SpawnPlan`].
@@ -36,7 +37,9 @@
 //!   and detach capabilities; and [`FcProcessHandle`], the same port over
 //!   a VMM process whose API is unreachable — kill, observe, detach.
 //! - [`prepared`] — [`FcPrepared`], the port's `PreparedVm`: a spawned
-//!   VMM waiting for a spec, listeners bound before the guest starts.
+//!   VMM waiting for a spec, listeners bound before the guest starts, and
+//!   the `Staging` capability over its jail — `discard` takes the jail
+//!   with it.
 //! - [`discover`] — finding a Firecracker that outlived the process which
 //!   booted it: the recorded pid when it is a Firecracker the record names,
 //!   else a `/proc` scan for one, by `--id`, `--api-sock`, or jail root.

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -301,13 +301,13 @@ impl Staging for FcPrepared {
         let Some(jail) = self.layout.jail() else {
             return Ok(image.clone());
         };
-        // Resolved, for the same reason `place` resolves: a dir spelled
-        // through the jail root but landing outside it has to be brought
-        // in, not loaded from where the VMM cannot reach.
-        let resolved = render::lexically_resolved(&image.dir);
-        if jail.view(&resolved).is_some() {
+        // Through the jail's own question, which resolves: a dir spelled
+        // through the root but landing outside it has to be brought in,
+        // not loaded from where the VMM cannot reach. The answer is where
+        // the files are, which is what the image must name.
+        if let Some(view) = jail.view(&image.dir) {
             return Ok(CheckpointImage {
-                dir: resolved,
+                dir: self.layout.host_view(&view),
                 ..image.clone()
             });
         }

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -124,13 +124,7 @@ impl FcPrepared {
     /// instead of being copied onto itself.
     async fn bring_in(&self, src: &Path, in_jail: &str, kind: StageKind) -> Result<PathBuf> {
         let mut stage = Vec::new();
-        // Resolved first: `place` decides "already in the jail" by
-        // stripping the root as written, so `{jail}/../elsewhere` would
-        // pass for a file inside it — named to Firecracker as a path its
-        // chroot cannot reach, and, for a handover, never moved at all.
-        let named =
-            self.layout
-                .place(&render::lexically_resolved(src), in_jail, kind, &mut stage)?;
+        let named = self.layout.place(src, in_jail, kind, &mut stage)?;
         if let Some(jail) = self.layout.jail() {
             jail::apply(jail, &stage).await?;
         }
@@ -307,8 +301,15 @@ impl Staging for FcPrepared {
         let Some(jail) = self.layout.jail() else {
             return Ok(image.clone());
         };
-        if jail.view(&image.dir).is_some() {
-            return Ok(image.clone());
+        // Resolved, for the same reason `place` resolves: a dir spelled
+        // through the jail root but landing outside it has to be brought
+        // in, not loaded from where the VMM cannot reach.
+        let resolved = render::lexically_resolved(&image.dir);
+        if jail.view(&resolved).is_some() {
+            return Ok(CheckpointImage {
+                dir: resolved,
+                ..image.clone()
+            });
         }
         let name = image
             .dir

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -1,13 +1,14 @@
 //! [`FcPrepared`]: a spawned Firecracker waiting for a spec — the port's
 //! [`PreparedVm`].
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use arcbox_vm_driver::{
-    CheckpointImage, Error, ExitStatus, IsolationSpec, PreparedVm, ProcessRecord, RestoreSpec,
-    Result, VmHandle, VmId, VmRecord, VmSpec, VmState, VsockListen, VsockListener,
+    CheckpointImage, DiskSource, Error, ExitStatus, IsolationSpec, PreparedVm, ProcessRecord,
+    RestoreSpec, Result, Staging, VmHandle, VmId, VmRecord, VmSpec, VmState, VsockListen,
+    VsockListener,
 };
 use async_trait::async_trait;
 use fc_sdk::VmBuilder;
@@ -17,7 +18,7 @@ use crate::error::FcError;
 use crate::handle::FcHandle;
 use crate::listener::VsockEndpoint;
 use crate::process::FcProcess;
-use crate::render::{self, VmLayout};
+use crate::render::{self, StageKind, VmLayout};
 use crate::{NAME, api, jail, listener, spawn};
 
 /// A spawned VMM process with its API socket up and nothing loaded yet.
@@ -113,6 +114,23 @@ impl FcPrepared {
         Ok(())
     }
 
+    /// Brings `src` into the jail at `in_jail` and answers with the host
+    /// path it landed at — the path a spec must name for it, which
+    /// rendering then passes to Firecracker chroot-relative.
+    ///
+    /// Goes through [`VmLayout::place`] rather than staging directly, so
+    /// every path decision stays in `render`: without a jail this is the
+    /// identity, and a source already inside the jail is named where it is
+    /// instead of being copied onto itself.
+    async fn bring_in(&self, src: &Path, in_jail: &str, kind: StageKind) -> Result<PathBuf> {
+        let mut stage = Vec::new();
+        let named = self.layout.place(src, in_jail, kind, &mut stage)?;
+        if let Some(jail) = self.layout.jail() {
+            jail::apply(jail, &stage).await?;
+        }
+        Ok(self.layout.host_view(&named))
+    }
+
     fn handle(&self, client: fc_sdk::Client, has_vsock: bool) -> FcHandle {
         self.consumed.store(true, Ordering::Release);
         FcHandle::new(
@@ -149,6 +167,10 @@ impl PreparedVm for FcPrepared {
     }
 
     fn vsock_listener(&self) -> Option<&dyn VsockListen> {
+        Some(self)
+    }
+
+    fn staging(&self) -> Option<&dyn Staging> {
         Some(self)
     }
 
@@ -225,8 +247,100 @@ impl PreparedVm for FcPrepared {
         Ok(Box::new(self.handle(client, has_vsock)))
     }
 
+    /// Kills the VMM, then removes the jail the spawn created — the whole
+    /// `{chroot base}/{binary}/{id}` tree, staged files and all.
+    ///
+    /// The kill comes first: a live Firecracker holds its disks open, and
+    /// the jail is its root. Removal failures are reported rather than
+    /// warned about, because the caller's remedy is to call again — this
+    /// is idempotent, and a second kill just reports the same status.
     async fn discard(&self) -> Result<ExitStatus> {
-        Ok(self.process.kill().await?)
+        let status = self.process.kill().await?;
+        if let Some(jail) = self.layout.jail()
+            && let Some(dir) = jail.root.parent()
+            && let Err(e) = tokio::fs::remove_dir_all(dir).await
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(Error::Io(e));
+        }
+        Ok(status)
+    }
+}
+
+/// The jail is the staging area: files land under its root, named as
+/// [`render`] would have named them for a boot, so a spec that carries
+/// what these hand back is rendered without staging anything twice.
+/// Without a jail every verb is the identity — the VMM reads host paths as
+/// they are, and there is nothing to bring anywhere.
+#[async_trait]
+impl Staging for FcPrepared {
+    async fn stage_kernel(&self, src: &Path) -> Result<PathBuf> {
+        self.bring_in(src, render::KERNEL_FILE, StageKind::LinkOrCopy)
+            .await
+    }
+
+    async fn stage_disk(&self, id: &str, source: DiskSource<'_>) -> Result<PathBuf> {
+        let kind = match source {
+            DiskSource::Device(_) => StageKind::BlockNode,
+            // Never a hard link: Firecracker writes guest blocks into a
+            // disk, and a link would write them into the caller's file.
+            DiskSource::Image(_) => StageKind::Copy,
+            DiskSource::Handover(_) => StageKind::Move,
+        };
+        self.bring_in(source.path(), &render::disk_file(id), kind)
+            .await
+    }
+
+    async fn unstage_disk(&self, id: &str, dst: &Path) -> Result<bool> {
+        let Some(jail) = self.layout.jail() else {
+            return Ok(false);
+        };
+        let staged = jail.root.join(render::disk_file(id));
+        if !tokio::fs::try_exists(&staged).await.unwrap_or(false) {
+            return Ok(false);
+        }
+        // The jail is its own vfsmount, so this crosses one even on the
+        // same filesystem; `move_file` handles the EXDEV that follows.
+        jail::move_file(&staged, dst).await.map_err(Error::Io)?;
+        Ok(true)
+    }
+
+    async fn stage_checkpoint(&self, image: &CheckpointImage) -> Result<CheckpointImage> {
+        let Some(jail) = self.layout.jail() else {
+            return Ok(image.clone());
+        };
+        if jail.view(&image.dir).is_some() {
+            return Ok(image.clone());
+        }
+        let name = image
+            .dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| {
+                Error::InvalidSpec(format!(
+                    "{NAME}: checkpoint dir {} has no usable name",
+                    image.dir.display()
+                ))
+            })?;
+        let in_jail = render::checkpoint_dir(name);
+        // Both files are read-only to Firecracker (mem is mapped
+        // MAP_PRIVATE on load), so a root jailer links instead of copying
+        // — the mem file is the guest's whole memory.
+        self.bring_in(
+            &image.dir.join("vmstate"),
+            &format!("{in_jail}/vmstate"),
+            StageKind::LinkOrCopy,
+        )
+        .await?;
+        let mem = image.dir.join("mem");
+        if tokio::fs::try_exists(&mem).await.unwrap_or(false) {
+            self.bring_in(&mem, &format!("{in_jail}/mem"), StageKind::LinkOrCopy)
+                .await?;
+        }
+        Ok(CheckpointImage {
+            dir: jail.root.join(&in_jail),
+            ..image.clone()
+        })
     }
 }
 

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -292,10 +292,9 @@ impl Staging for FcPrepared {
     }
 
     async fn unstage_disk(&self, id: &str, dst: &Path) -> Result<bool> {
-        let Some(jail) = self.layout.jail() else {
+        let Some(staged) = self.layout.jail_path(&render::disk_file(id))? else {
             return Ok(false);
         };
-        let staged = jail.root.join(render::disk_file(id));
         if !tokio::fs::try_exists(&staged).await.unwrap_or(false) {
             return Ok(false);
         }

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -247,23 +247,16 @@ impl PreparedVm for FcPrepared {
         Ok(Box::new(self.handle(client, has_vsock)))
     }
 
-    /// Kills the VMM, then removes the jail the spawn created — the whole
-    /// `{chroot base}/{binary}/{id}` tree, staged files and all.
-    ///
-    /// The kill comes first: a live Firecracker holds its disks open, and
-    /// the jail is its root. Removal failures are reported rather than
-    /// warned about, because the caller's remedy is to call again — this
-    /// is idempotent, and a second kill just reports the same status.
+    /// Kills the VMM. The jail it was spawned into outlives it: the one
+    /// caller still removes the chroot itself, and its copy-mode pause
+    /// path takes the sandbox's only writable disk out of that chroot
+    /// *after* discarding, so a `discard` that removed the jail here would
+    /// destroy the disk it is about to park — silently, since the move is
+    /// guarded by an existence check. Removing the jail moves onto this
+    /// verb in the same change that reorders those call sites onto
+    /// [`Staging::unstage_disk`] (vm-stack-redesign R3, PR-G2).
     async fn discard(&self) -> Result<ExitStatus> {
-        let status = self.process.kill().await?;
-        if let Some(jail) = self.layout.jail()
-            && let Some(dir) = jail.root.parent()
-            && let Err(e) = tokio::fs::remove_dir_all(dir).await
-            && e.kind() != std::io::ErrorKind::NotFound
-        {
-            return Err(Error::Io(e));
-        }
-        Ok(status)
+        Ok(self.process.kill().await?)
     }
 }
 
@@ -287,12 +280,12 @@ impl Staging for FcPrepared {
             DiskSource::Image(_) => StageKind::Copy,
             DiskSource::Handover(_) => StageKind::Move,
         };
-        self.bring_in(source.path(), &render::disk_file(id), kind)
+        self.bring_in(source.path(), &render::staged_disk_file(id)?, kind)
             .await
     }
 
     async fn unstage_disk(&self, id: &str, dst: &Path) -> Result<bool> {
-        let Some(staged) = self.layout.jail_path(&render::disk_file(id))? else {
+        let Some(staged) = self.layout.jail_path(&render::staged_disk_file(id)?)? else {
             return Ok(false);
         };
         if !tokio::fs::try_exists(&staged).await.unwrap_or(false) {

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -124,7 +124,13 @@ impl FcPrepared {
     /// instead of being copied onto itself.
     async fn bring_in(&self, src: &Path, in_jail: &str, kind: StageKind) -> Result<PathBuf> {
         let mut stage = Vec::new();
-        let named = self.layout.place(src, in_jail, kind, &mut stage)?;
+        // Resolved first: `place` decides "already in the jail" by
+        // stripping the root as written, so `{jail}/../elsewhere` would
+        // pass for a file inside it — named to Firecracker as a path its
+        // chroot cannot reach, and, for a handover, never moved at all.
+        let named =
+            self.layout
+                .place(&render::lexically_resolved(src), in_jail, kind, &mut stage)?;
         if let Some(jail) = self.layout.jail() {
             jail::apply(jail, &stage).await?;
         }

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -199,6 +199,25 @@ impl VmLayout {
         });
         Ok(format!("/{in_jail}"))
     }
+
+    /// The host path `in_jail` names inside the jail, or `None` when the VM
+    /// has none.
+    ///
+    /// The read-only counterpart of [`place`](Self::place), for asking
+    /// about a file already staged rather than bringing one in — and it
+    /// holds `in_jail` to the same rule, because a caller that can name a
+    /// staged file can otherwise name one outside the jail and move it.
+    pub fn jail_path(&self, in_jail: &str) -> Result<Option<PathBuf>> {
+        let Some(jail) = &self.jail else {
+            return Ok(None);
+        };
+        if !is_inside_jail(in_jail) {
+            return Err(unsupported(&format!(
+                "`{in_jail}` does not name a path inside the jail"
+            )));
+        }
+        Ok(Some(jail.root.join(in_jail)))
+    }
 }
 
 /// Renders a boot: the API payloads for `spec` and the files a jail needs

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -175,12 +175,9 @@ impl VmLayout {
     /// mknods at the destination, so a `..` in it would reach a host file
     /// outside the jail.
     ///
-    /// Whether `host` is already inside is decided on its resolved form:
-    /// `strip_prefix` compares components, so `{jail}/../elsewhere` names
-    /// the jail on the way past and would otherwise be passed to
-    /// Firecracker as a path its chroot cannot reach — never staged, and
-    /// for a move, never moved. The file is staged *from* `host` as given,
-    /// which is the path the caller named.
+    /// Whether `host` is already inside is [`Jail::view`]'s question, and
+    /// it resolves the path to answer it. The file is staged *from*
+    /// `host` as given, which is the path the caller named.
     pub fn place(
         &self,
         host: &Path,
@@ -196,7 +193,7 @@ impl VmLayout {
                 "`{in_jail}` does not name a path inside the jail"
             )));
         }
-        if let Some(view) = jail.view(&lexically_resolved(host)) {
+        if let Some(view) = jail.view(host) {
             return Ok(view);
         }
         stage.push(StagePlan {
@@ -538,33 +535,6 @@ fn tap_name(nic: &NicSpec) -> Result<String> {
             nic.id
         ))),
     }
-}
-
-/// `path` with its `.` and `..` components resolved as far as they can be
-/// without touching the filesystem.
-///
-/// Used for one question only — is this path inside the jail — because
-/// `strip_prefix` compares components and `..` walks out of a directory
-/// the components still name. Symlinks are deliberately not followed: a
-/// symlink inside the jail is a file the jailed VMM can open, which is
-/// exactly the question being asked, and resolving one would answer a
-/// different one. That is also why nothing stages *from* the resolved
-/// path: reading the file is a different question, and the caller named
-/// the path it meant.
-pub(crate) fn lexically_resolved(path: &Path) -> PathBuf {
-    let mut out = PathBuf::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                if !out.pop() {
-                    out.push(component);
-                }
-            }
-            other => out.push(other),
-        }
-    }
-    out
 }
 
 /// True when `name` is one plain path component: no separator, no `.` or

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -229,7 +229,12 @@ pub fn fc_config(spec: &VmSpec, config: &FcDriverConfig, runtime_dir: &Path) -> 
             cmdline,
             initrd,
         } => BootSource {
-            kernel_image_path: layout.place(image, "vmlinux", StageKind::LinkOrCopy, &mut stage)?,
+            kernel_image_path: layout.place(
+                image,
+                KERNEL_FILE,
+                StageKind::LinkOrCopy,
+                &mut stage,
+            )?,
             boot_args: Some(cmdline.clone()),
             initrd_path: initrd
                 .as_deref()
@@ -322,15 +327,16 @@ pub fn fc_restore(
             ))
         })?;
     let mut stage = Vec::new();
+    let dir = checkpoint_dir(name);
     let snapshot_path = layout.place(
         &image.dir.join("vmstate"),
-        &format!("snapshots/{name}/vmstate"),
+        &format!("{dir}/vmstate"),
         StageKind::LinkOrCopy,
         &mut stage,
     )?;
     let mem_file_path = layout.place(
         &image.dir.join("mem"),
-        &format!("snapshots/{name}/mem"),
+        &format!("{dir}/mem"),
         StageKind::LinkOrCopy,
         &mut stage,
     )?;
@@ -387,10 +393,35 @@ pub fn fc_restore(
     })
 }
 
+/// The file the kernel is staged as inside the jail.
+pub const KERNEL_FILE: &str = "vmlinux";
+
+/// The file a disk with this id is staged as inside the jail, and so the
+/// name a checkpoint of this driver records for it: `{id}.ext4`.
+///
+/// Shared with [`Staging::stage_disk`](arcbox_vm_driver::Staging::stage_disk):
+/// a disk staged ahead of a boot must land where rendering that boot would
+/// have put it, or the render stages a second copy of it beside the first.
+pub fn disk_file(id: &str) -> String {
+    format!("{id}.ext4")
+}
+
+/// The directory a checkpoint whose image dir is named `name` is staged
+/// into inside the jail.
+///
+/// Shared with
+/// [`Staging::stage_checkpoint`](arcbox_vm_driver::Staging::stage_checkpoint)
+/// for the same reason as [`disk_file`], and here it is load-bearing
+/// twice: a warm pool stages an image into a slot long before the restore
+/// that loads it renders the same paths.
+pub fn checkpoint_dir(name: &str) -> String {
+    format!("snapshots/{name}")
+}
+
 /// The file a disk is staged as inside the jail, and so the name a
-/// checkpoint of this driver records for it: `{id}.ext4`.
+/// checkpoint of this driver records for it.
 fn recorded_file(disk: &DiskSpec) -> String {
-    format!("{}.ext4", disk.id)
+    disk_file(&disk.id)
 }
 
 /// [`recorded_file`] as Firecracker names it: `/{id}.ext4`.

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -533,6 +533,32 @@ fn tap_name(nic: &NicSpec) -> Result<String> {
     }
 }
 
+/// `path` with its `.` and `..` components resolved as far as they can be
+/// without touching the filesystem.
+///
+/// [`VmLayout::place`] decides whether a file is already inside the jail
+/// by stripping the root off the path *as written*, and `..` walks out of
+/// a directory the components still name. Staging resolves its source
+/// first so that short-circuit answers about where the file is, not about
+/// how it was spelled. Symlinks are deliberately not followed: a symlink
+/// inside the jail is a file the jailed VMM can open, which is the
+/// question being asked.
+pub fn lexically_resolved(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !out.pop() {
+                    out.push(component);
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
 /// True when `name` is one plain path component: no separator, no `.` or
 /// `..`, no root, nothing a jail-relative path may not be made of.
 fn is_plain_component(name: &str) -> bool {

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -425,6 +425,20 @@ pub fn disk_file(id: &str) -> String {
     format!("{id}.ext4")
 }
 
+/// [`disk_file`] for an id that came from a staging caller rather than
+/// from a validated spec: refused unless it is a plain name.
+///
+/// `drive` holds a spec's disk id to the same rule, and `place` refuses a
+/// traversing destination — but only under a jail, since without one it
+/// stages nothing. Staging is asked for an id in both modes, so the rule
+/// is checked here, where it does not depend on a confinement existing.
+pub fn staged_disk_file(id: &str) -> Result<String> {
+    if !is_plain_component(id) {
+        return Err(unsupported(&format!("disk id `{id}` must be a plain name")));
+    }
+    Ok(disk_file(id))
+}
+
 /// The directory a checkpoint whose image dir is named `name` is staged
 /// into inside the jail.
 ///

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -543,7 +543,7 @@ fn tap_name(nic: &NicSpec) -> Result<String> {
 /// how it was spelled. Symlinks are deliberately not followed: a symlink
 /// inside the jail is a file the jailed VMM can open, which is the
 /// question being asked.
-pub fn lexically_resolved(path: &Path) -> PathBuf {
+pub(crate) fn lexically_resolved(path: &Path) -> PathBuf {
     let mut out = PathBuf::new();
     for component in path.components() {
         match component {

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -174,6 +174,13 @@ impl VmLayout {
     /// come from the spec (a disk `id`), and staging writes, replaces, and
     /// mknods at the destination, so a `..` in it would reach a host file
     /// outside the jail.
+    ///
+    /// Whether `host` is already inside is decided on its resolved form:
+    /// `strip_prefix` compares components, so `{jail}/../elsewhere` names
+    /// the jail on the way past and would otherwise be passed to
+    /// Firecracker as a path its chroot cannot reach — never staged, and
+    /// for a move, never moved. The file is staged *from* `host` as given,
+    /// which is the path the caller named.
     pub fn place(
         &self,
         host: &Path,
@@ -189,7 +196,7 @@ impl VmLayout {
                 "`{in_jail}` does not name a path inside the jail"
             )));
         }
-        if let Some(view) = jail.view(host) {
+        if let Some(view) = jail.view(&lexically_resolved(host)) {
             return Ok(view);
         }
         stage.push(StagePlan {
@@ -536,13 +543,14 @@ fn tap_name(nic: &NicSpec) -> Result<String> {
 /// `path` with its `.` and `..` components resolved as far as they can be
 /// without touching the filesystem.
 ///
-/// [`VmLayout::place`] decides whether a file is already inside the jail
-/// by stripping the root off the path *as written*, and `..` walks out of
-/// a directory the components still name. Staging resolves its source
-/// first so that short-circuit answers about where the file is, not about
-/// how it was spelled. Symlinks are deliberately not followed: a symlink
-/// inside the jail is a file the jailed VMM can open, which is the
-/// question being asked.
+/// Used for one question only — is this path inside the jail — because
+/// `strip_prefix` compares components and `..` walks out of a directory
+/// the components still name. Symlinks are deliberately not followed: a
+/// symlink inside the jail is a file the jailed VMM can open, which is
+/// exactly the question being asked, and resolving one would answer a
+/// different one. That is also why nothing stages *from* the resolved
+/// path: reading the file is a different question, and the caller named
+/// the path it meant.
 pub(crate) fn lexically_resolved(path: &Path) -> PathBuf {
     let mut out = PathBuf::new();
     for component in path.components() {

--- a/virt/arcbox-fc-driver/src/render/plan.rs
+++ b/virt/arcbox-fc-driver/src/render/plan.rs
@@ -66,6 +66,12 @@ pub enum StageKind {
     /// A device node with the source's major/minor — for a block device
     /// (a device-mapper rootfs).
     BlockNode,
+    /// The source itself, moved in and chowned — for a disk the caller
+    /// hands over instead of keeping: the one an earlier VM's jail was
+    /// emptied into, coming back. Never rendered from a spec; only
+    /// [`Staging::stage_disk`](arcbox_vm_driver::Staging::stage_disk) asks
+    /// for it, because only the caller knows it is giving the file up.
+    Move,
     /// A second name, inside the jail, for a disk that is already in it: a
     /// hard link (a device node for a block device, a copy when neither is
     /// possible), owned like the original. A restore uses it so the load

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -439,6 +439,25 @@ fn a_disk_id_cannot_reach_out_of_the_jail() {
     // from, so the rule would otherwise hold in one isolation mode only.
     assert!(invalid(staged_disk_file("../escape")).contains("plain name"));
     assert_eq!(staged_disk_file("rootfs").unwrap(), "rootfs.ext4");
+
+    // A source spelled through the jail root but resolving outside it is
+    // not already in the jail; `place` compares components, so staging
+    // resolves first — otherwise a handover would be reported as a move
+    // that never happened.
+    let outside = base.join("firecracker/box/root/../../../outside.ext4");
+    assert!(
+        layout.jail().unwrap().view(&outside).is_some(),
+        "as written"
+    );
+    assert_eq!(lexically_resolved(&outside), base.join("outside.ext4"));
+    assert!(
+        layout
+            .jail()
+            .unwrap()
+            .view(&lexically_resolved(&outside))
+            .is_none(),
+        "resolved, it is outside the jail and has to be staged"
+    );
     assert_eq!(
         layout.jail_path(&disk_file("rootfs")).unwrap(),
         Some(base.join("firecracker/box/root/rootfs.ext4"))

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -441,22 +441,31 @@ fn a_disk_id_cannot_reach_out_of_the_jail() {
     assert_eq!(staged_disk_file("rootfs").unwrap(), "rootfs.ext4");
 
     // A source spelled through the jail root but resolving outside it is
-    // not already in the jail; `place` compares components, so staging
-    // resolves first — otherwise a handover would be reported as a move
-    // that never happened.
+    // not already in the jail, so `place` stages it rather than naming it
+    // where the components pretend it is — otherwise Firecracker is told
+    // a path its chroot cannot reach, and a move never happens at all.
     let outside = base.join("firecracker/box/root/../../../outside.ext4");
     assert!(
         layout.jail().unwrap().view(&outside).is_some(),
-        "as written"
+        "as written it passes for a file in the jail"
     );
     assert_eq!(lexically_resolved(&outside), base.join("outside.ext4"));
-    assert!(
+    let mut planned = Vec::new();
+    assert_eq!(
         layout
-            .jail()
-            .unwrap()
-            .view(&lexically_resolved(&outside))
-            .is_none(),
-        "resolved, it is outside the jail and has to be staged"
+            .place(&outside, "rootfs.ext4", StageKind::Copy, &mut planned)
+            .unwrap(),
+        "/rootfs.ext4"
+    );
+    assert_eq!(
+        planned,
+        vec![StagePlan {
+            // Staged from the path as given: which file to read is not
+            // the question the resolution answers.
+            src: outside,
+            dst: base.join("firecracker/box/root/rootfs.ext4"),
+            kind: StageKind::Copy,
+        }]
     );
     assert_eq!(
         layout.jail_path(&disk_file("rootfs")).unwrap(),

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -417,7 +417,10 @@ fn a_disk_id_cannot_reach_out_of_the_jail() {
         assert!(invalid(fc_config(&s, &config(), Path::new("/run/vms/box"))).contains("disk id"));
     }
 
-    // The same guard covers every staged name, whoever supplies it.
+    // The same guard covers every staged name, whoever supplies it —
+    // including a caller asking where a staged file went, which is how a
+    // disk leaves the jail again.
+    let direct = layout(&IsolationSpec::None);
     let layout = layout(&jailed(&base));
     let mut stage = Vec::new();
     assert!(
@@ -430,6 +433,16 @@ fn a_disk_id_cannot_reach_out_of_the_jail() {
         .contains("inside the jail")
     );
     assert!(stage.is_empty());
+    assert!(invalid(layout.jail_path("../rootfs.ext4")).contains("inside the jail"));
+    assert_eq!(
+        layout.jail_path(&disk_file("rootfs")).unwrap(),
+        Some(base.join("firecracker/box/root/rootfs.ext4"))
+    );
+    assert_eq!(
+        direct.jail_path("rootfs.ext4").unwrap(),
+        None,
+        "a VM with no jail has nothing staged anywhere"
+    );
 }
 
 #[test]

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -446,10 +446,14 @@ fn a_disk_id_cannot_reach_out_of_the_jail() {
     // a path its chroot cannot reach, and a move never happens at all.
     let outside = base.join("firecracker/box/root/../../../outside.ext4");
     assert!(
-        layout.jail().unwrap().view(&outside).is_some(),
+        outside.starts_with(layout.jail().unwrap().root.as_path()),
         "as written it passes for a file in the jail"
     );
-    assert_eq!(lexically_resolved(&outside), base.join("outside.ext4"));
+    assert_eq!(
+        layout.jail().unwrap().view(&outside),
+        None,
+        "resolved, it is not in the jail"
+    );
     let mut planned = Vec::new();
     assert_eq!(
         layout

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -434,6 +434,11 @@ fn a_disk_id_cannot_reach_out_of_the_jail() {
     );
     assert!(stage.is_empty());
     assert!(invalid(layout.jail_path("../rootfs.ext4")).contains("inside the jail"));
+    // A staging caller's disk id is refused without reference to a jail:
+    // `place` guards the destination only when there is one to escape
+    // from, so the rule would otherwise hold in one isolation mode only.
+    assert!(invalid(staged_disk_file("../escape")).contains("plain name"));
+    assert_eq!(staged_disk_file("rootfs").unwrap(), "rootfs.ext4");
     assert_eq!(
         layout.jail_path(&disk_file("rootfs")).unwrap(),
         Some(base.join("firecracker/box/root/rootfs.ext4"))

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -321,6 +321,33 @@ fn jailer_mode_stages_outside_files_and_relativizes_inside_ones() {
 
 #[cfg(target_os = "linux")]
 #[test]
+fn a_boot_whose_files_are_already_staged_plans_no_staging() {
+    // What `Staging` puts in the jail lands at the names rendering uses,
+    // so a spec carrying them is rendered without staging a second copy —
+    // the property a warm slot's pre-staged boot depends on. Both sides
+    // read the same names from `KERNEL_FILE` / `disk_file`.
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().join("jail");
+    let root = base.join("firecracker/box/root");
+    std::fs::create_dir_all(&root).unwrap();
+    let kernel = root.join(KERNEL_FILE);
+    let rootfs = root.join(disk_file("rootfs"));
+    std::fs::write(&kernel, b"kernel").unwrap();
+    std::fs::write(&rootfs, b"disk").unwrap();
+
+    let mut s = spec("box", jailed(&base), rootfs);
+    s.boot = BootSpec::Kernel {
+        image: kernel,
+        cmdline: "console=ttyS0".into(),
+        initrd: None,
+    };
+    let plan = fc_config(&s, &config(), Path::new("/run/vms/box")).unwrap();
+    assert!(plan.stage.is_empty(), "{:?}", plan.stage);
+    assert_eq!(plan.boot_source.kernel_image_path, "/vmlinux");
+    assert_eq!(plan.drives[0].path_on_host.as_deref(), Some("/rootfs.ext4"));
+}
+
+#[test]
 fn jailer_mode_mirrors_a_block_device_as_a_node() {
     use std::os::unix::fs::FileTypeExt as _;
     let Some(device) = std::fs::read_dir("/dev")

--- a/virt/arcbox-fc-driver/tests/contract.rs
+++ b/virt/arcbox-fc-driver/tests/contract.rs
@@ -250,5 +250,5 @@ contract_modes! {
     discard_kills_a_prepared_vm,
     restore_reattaches_disks,
     a_staged_spec_boots,
-    discard_removes_what_was_staged,
+    a_staged_disk_can_be_taken_back_out,
 }

--- a/virt/arcbox-fc-driver/tests/contract.rs
+++ b/virt/arcbox-fc-driver/tests/contract.rs
@@ -251,4 +251,5 @@ contract_modes! {
     restore_reattaches_disks,
     a_staged_spec_boots,
     a_staged_disk_can_be_taken_back_out,
+    a_staged_checkpoint_restores,
 }

--- a/virt/arcbox-fc-driver/tests/contract.rs
+++ b/virt/arcbox-fc-driver/tests/contract.rs
@@ -249,4 +249,6 @@ contract_modes! {
     prepared_listener_is_live_before_boot,
     discard_kills_a_prepared_vm,
     restore_reattaches_disks,
+    a_staged_spec_boots,
+    discard_removes_what_was_staged,
 }

--- a/virt/arcbox-vm-driver/README.md
+++ b/virt/arcbox-vm-driver/README.md
@@ -35,9 +35,16 @@ that the flags and the accessors agree.
 | `Checkpoint` | `handle.checkpoint()` | capture to disk; `Resume` or `HoldQuiesced` afterwards |
 | `Adopt` / `Detach` | `driver.adopt()` / `handle.detach()` | VMs that outlive the process (external VMMs) |
 | `Prepare` | `driver.prepare()` | spawn the VMM ahead of a boot: pid journaled and READY listener bound before the guest starts; `boot` is exactly prepare-then-boot |
+| `Staging` | `prepared.staging()` | bring the kernel, the disks and a checkpoint into the area this VM's VMM can reach, and name each as its spec must; `unstage_disk` takes a disk back out, `discard` removes the rest |
 | `Balloon` | `handle.balloon()` | set/read the memory balloon |
 | `Console` | `handle.console()` | read guest console output |
 | `DebugSnapshot` | `handle.debug()` | driver-specific JSON for post-mortems |
+
+`VmDriver::id_budget(&isolation)` is the one thing a driver knows about
+ids that the port's own `VmId` rule does not: the longest id its layout
+leaves room for, or `None` when it imposes no limit. `Some(0)` is a real
+answer — a chroot base deep enough to spend the whole AF_UNIX path budget
+leaves room for no id at all.
 
 `net::GuestNetwork` is the second port: reserve a lease, activate it into
 a `NicSpec`, adopt one whose guest outlived the process that activated it

--- a/virt/arcbox-vm-driver/README.md
+++ b/virt/arcbox-vm-driver/README.md
@@ -35,7 +35,7 @@ that the flags and the accessors agree.
 | `Checkpoint` | `handle.checkpoint()` | capture to disk; `Resume` or `HoldQuiesced` afterwards |
 | `Adopt` / `Detach` | `driver.adopt()` / `handle.detach()` | VMs that outlive the process (external VMMs) |
 | `Prepare` | `driver.prepare()` | spawn the VMM ahead of a boot: pid journaled and READY listener bound before the guest starts; `boot` is exactly prepare-then-boot |
-| `Staging` | `prepared.staging()` | bring the kernel, the disks and a checkpoint into the area this VM's VMM can reach, and name each as its spec must; `unstage_disk` takes a disk back out, `discard` removes the rest |
+| `Staging` | `prepared.staging()` | bring the kernel, the disks and a checkpoint into the area this VM's VMM can reach, and name each as its spec must; `unstage_disk` takes a disk back out, so it outlives the VM |
 | `Balloon` | `handle.balloon()` | set/read the memory balloon |
 | `Console` | `handle.console()` | read guest console output |
 | `DebugSnapshot` | `handle.debug()` | driver-specific JSON for post-mortems |

--- a/virt/arcbox-vm-driver/src/capability.rs
+++ b/virt/arcbox-vm-driver/src/capability.rs
@@ -76,6 +76,12 @@ pub trait PreparedVm: Send + Sync {
         None
     }
 
+    /// Bring the files this VM boots from into the area its VMM can reach.
+    /// `Some` iff [`crate::DriverCapabilities::staging`].
+    fn staging(&self) -> Option<&dyn Staging> {
+        None
+    }
+
     /// Boots `spec` on this process. `spec.id` and `spec.isolation` must
     /// equal what `prepare` was given ([`crate::Error::InvalidSpec`]
     /// otherwise); the handle shares this process. At most one `boot` or
@@ -89,9 +95,107 @@ pub trait PreparedVm: Send + Sync {
         spec: RestoreSpec,
     ) -> Result<Box<dyn VmHandle>>;
 
-    /// Kills and reaps the process now. Idempotent, and valid after a boot
-    /// too (it kills that VM); the status is how the process ended.
+    /// Kills and reaps the process now, and removes everything the VM was
+    /// given: its [`Staging`] area and, with it, whatever was staged
+    /// there. Idempotent, and valid after a boot too (it kills that VM);
+    /// the status is how the process ended.
+    ///
+    /// The removal is the reason a caller does not have to know what a
+    /// confinement is made of — but it is also unconditional, so a disk
+    /// that must outlive the VM is taken out with
+    /// [`Staging::unstage_disk`] *before* this, not after.
     async fn discard(&self) -> Result<ExitStatus>;
+}
+
+/// Bring the files a VM boots from into the private area its VMM can
+/// reach.
+///
+/// A confined VMM — Firecracker under the jailer, chrooted into a per-VM
+/// directory — can open nothing outside that area, so its kernel, its
+/// disks, and a checkpoint's files have to be inside before the VM is told
+/// about them. *Which* files those are is the orchestrator's business;
+/// where they must be, and how they get there (a hard link, a private
+/// copy, a device node), is the driver's. This capability is that split:
+/// the caller says what a file is, and gets back the path its spec must
+/// name for it. It never learns whether a confinement exists.
+///
+/// Present iff [`crate::DriverCapabilities::staging`]. A driver whose VMs
+/// read host paths as they are still offers it, as the identity: staging
+/// such a file is a no-op that answers with the path it was given. That is
+/// what lets an orchestrator stage unconditionally instead of branching on
+/// a confinement it is not supposed to know about.
+///
+/// Staging a file that is already in the VM's area leaves it alone and
+/// names it where it is — so a caller may stage what an earlier stage, or
+/// a warm slot it claimed, already put there.
+///
+/// Everything staged lives and dies with the VM: [`PreparedVm::discard`]
+/// removes the area whole.
+#[async_trait]
+pub trait Staging: Send + Sync {
+    /// Stages `src` as this VM's kernel image, and returns the path the
+    /// spec's [`BootSpec::Kernel`](crate::BootSpec::Kernel) must name.
+    async fn stage_kernel(&self, src: &Path) -> Result<PathBuf>;
+
+    /// Stages `source` as this VM's disk `id`, and returns the path the
+    /// [`DiskSpec`](crate::DiskSpec) carrying that id must name.
+    ///
+    /// `id` is the disk id the spec will carry, not a file name. A driver
+    /// that records disk paths in its checkpoints (Firecracker does)
+    /// records the name it staged the disk under, and a restore reproduces
+    /// that name from the same id — so a disk staged under one id and
+    /// specced under another is a checkpoint that will not restore.
+    async fn stage_disk(&self, id: &str, source: DiskSource<'_>) -> Result<PathBuf>;
+
+    /// Moves this VM's disk `id` back out to `dst`, so it survives
+    /// [`PreparedVm::discard`].
+    ///
+    /// The disk is gone from the VM's area once this returns; putting it
+    /// back into a later VM is [`DiskSource::Handover`]. `Ok(false)` means
+    /// there was no such disk staged — for a driver that stages nothing,
+    /// or a disk that was never brought in — which is an outcome, not a
+    /// failure.
+    ///
+    /// The VM must not be writing to the disk. A caller takes a disk out
+    /// of a VM it is about to discard, and the guest is already stopped or
+    /// [`Quiesced`](crate::VmState::Quiesced) by then.
+    async fn unstage_disk(&self, id: &str, dst: &Path) -> Result<bool>;
+
+    /// Stages `image`'s files, and returns the image as this VM must name
+    /// it for [`PreparedVm::restore`].
+    ///
+    /// A warm pool stages a checkpoint into a slot long before any restore
+    /// is asked for, and that — not the confinement — is what makes this a
+    /// verb of its own: the memory file is the guest's entire RAM, so
+    /// bringing it in is the expensive half of a restore, and a slot that
+    /// paid for it up front restores in milliseconds.
+    async fn stage_checkpoint(&self, image: &CheckpointImage) -> Result<CheckpointImage>;
+}
+
+/// What a disk being staged is — which decides what the VM gets, and what
+/// happens to the caller's own copy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiskSource<'a> {
+    /// A block device — a device-mapper volume, a loop device — that the
+    /// VM must open as one. Mirrored, never copied.
+    Device(&'a Path),
+    /// A file the caller keeps: the VM gets a private copy, so guest
+    /// writes never reach the original.
+    Image(&'a Path),
+    /// A file the caller gives up: it is moved in, and no longer exists at
+    /// the source once staging returns. The counterpart of
+    /// [`Staging::unstage_disk`] — the disk of a discarded VM, parked
+    /// outside, coming back into a fresh one.
+    Handover(&'a Path),
+}
+
+impl<'a> DiskSource<'a> {
+    /// The host path this source names.
+    pub fn path(&self) -> &'a Path {
+        match self {
+            Self::Device(path) | Self::Image(path) | Self::Handover(path) => path,
+        }
+    }
 }
 
 /// Accept vsock connections the guest initiates (the READY dial-out).

--- a/virt/arcbox-vm-driver/src/capability.rs
+++ b/virt/arcbox-vm-driver/src/capability.rs
@@ -95,15 +95,8 @@ pub trait PreparedVm: Send + Sync {
         spec: RestoreSpec,
     ) -> Result<Box<dyn VmHandle>>;
 
-    /// Kills and reaps the process now, and removes everything the VM was
-    /// given: its [`Staging`] area and, with it, whatever was staged
-    /// there. Idempotent, and valid after a boot too (it kills that VM);
-    /// the status is how the process ended.
-    ///
-    /// The removal is the reason a caller does not have to know what a
-    /// confinement is made of — but it is also unconditional, so a disk
-    /// that must outlive the VM is taken out with
-    /// [`Staging::unstage_disk`] *before* this, not after.
+    /// Kills and reaps the process now. Idempotent, and valid after a boot
+    /// too (it kills that VM); the status is how the process ended.
     async fn discard(&self) -> Result<ExitStatus>;
 }
 
@@ -129,8 +122,11 @@ pub trait PreparedVm: Send + Sync {
 /// names it where it is — so a caller may stage what an earlier stage, or
 /// a warm slot it claimed, already put there.
 ///
-/// Everything staged lives and dies with the VM: [`PreparedVm::discard`]
-/// removes the area whole.
+/// The area belongs to the VM and does not outlive it, so a disk that must
+/// is taken back out with [`unstage_disk`](Self::unstage_disk). Which verb
+/// removes the area is the driver's business, and today it is not
+/// [`PreparedVm::discard`] on every adapter — do not read the absence of a
+/// disk after a discard as "the driver kept it".
 #[async_trait]
 pub trait Staging: Send + Sync {
     /// Stages `src` as this VM's kernel image, and returns the path the
@@ -140,15 +136,17 @@ pub trait Staging: Send + Sync {
     /// Stages `source` as this VM's disk `id`, and returns the path the
     /// [`DiskSpec`](crate::DiskSpec) carrying that id must name.
     ///
-    /// `id` is the disk id the spec will carry, not a file name. A driver
-    /// that records disk paths in its checkpoints (Firecracker does)
-    /// records the name it staged the disk under, and a restore reproduces
-    /// that name from the same id — so a disk staged under one id and
-    /// specced under another is a checkpoint that will not restore.
+    /// `id` is the disk id the spec will carry, not a file name, and a
+    /// plain one — the same rule [`DiskSpec::id`](crate::DiskSpec) is held
+    /// to, refused rather than resolved by an adapter, since staging
+    /// writes and replaces at the name it makes from it. A driver that
+    /// records disk paths in its checkpoints (Firecracker does) records
+    /// the name it staged the disk under, and a restore reproduces that
+    /// name from the same id — so a disk staged under one id and specced
+    /// under another is a checkpoint that will not restore.
     async fn stage_disk(&self, id: &str, source: DiskSource<'_>) -> Result<PathBuf>;
 
-    /// Moves this VM's disk `id` back out to `dst`, so it survives
-    /// [`PreparedVm::discard`].
+    /// Moves this VM's disk `id` back out to `dst`, so it survives the VM.
     ///
     /// The disk is gone from the VM's area once this returns; putting it
     /// back into a later VM is [`DiskSource::Handover`]. `Ok(false)` means
@@ -159,6 +157,11 @@ pub trait Staging: Send + Sync {
     /// The VM must not be writing to the disk. A caller takes a disk out
     /// of a VM it is about to discard, and the guest is already stopped or
     /// [`Quiesced`](crate::VmState::Quiesced) by then.
+    ///
+    /// `id` is a disk id, held to the same rule as
+    /// [`DiskSpec::id`](crate::DiskSpec) — a plain name. An adapter
+    /// refuses anything else rather than resolving it against its own
+    /// layout, because this verb *moves a file*.
     async fn unstage_disk(&self, id: &str, dst: &Path) -> Result<bool>;
 
     /// Stages `image`'s files, and returns the image as this VM must name

--- a/virt/arcbox-vm-driver/src/capability.rs
+++ b/virt/arcbox-vm-driver/src/capability.rs
@@ -122,11 +122,13 @@ pub trait PreparedVm: Send + Sync {
 /// names it where it is — so a caller may stage what an earlier stage, or
 /// a warm slot it claimed, already put there.
 ///
-/// The area belongs to the VM and does not outlive it, so a disk that must
-/// is taken back out with [`unstage_disk`](Self::unstage_disk). Which verb
-/// removes the area is the driver's business, and today it is not
-/// [`PreparedVm::discard`] on every adapter — do not read the absence of a
-/// disk after a discard as "the driver kept it".
+/// Everything staged belongs to the VM's area, so a disk that has to
+/// outlive the VM is taken back out with
+/// [`unstage_disk`](Self::unstage_disk) first. When that area is removed,
+/// and by which verb, is the driver's own business — it is not
+/// [`PreparedVm::discard`] on every adapter today, so a caller may assume
+/// neither that a discard took the area with it nor that it left the area
+/// standing.
 #[async_trait]
 pub trait Staging: Send + Sync {
     /// Stages `src` as this VM's kernel image, and returns the path the

--- a/virt/arcbox-vm-driver/src/driver.rs
+++ b/virt/arcbox-vm-driver/src/driver.rs
@@ -67,6 +67,28 @@ pub trait VmDriver: Send + Sync {
     fn prepare(&self) -> Option<&dyn Prepare> {
         None
     }
+
+    /// The longest [`VmId`] this driver can run under an isolation, when
+    /// it has a limit of its own.
+    ///
+    /// A driver's layout can bound the id even though the port does not:
+    /// Firecracker's jailer puts the API socket at
+    /// `{chroot base}/{binary}/{id}/root/run/firecracker.socket`, and
+    /// AF_UNIX leaves 107 bytes for a path, so a long chroot base or a
+    /// long id makes that socket unaddressable. The failure does not name
+    /// itself — the VMM comes up and binds inside its chroot while every
+    /// `connect` from outside fails, which reads as a boot that timed out.
+    /// An orchestrator minting ids asks here instead of guessing.
+    ///
+    /// `None` means this driver imposes no limit of its own, not that the
+    /// question is unsupported; everything else an id must be is
+    /// [`VmId`]'s own rule. `Some(0)` is a real answer: a layout whose
+    /// fixed part already spends the whole budget leaves room for no id at
+    /// all, and a caller must then refuse every id rather than let the
+    /// arithmetic wrap into a plausible one.
+    fn id_budget(&self, _isolation: &IsolationSpec) -> Option<usize> {
+        None
+    }
 }
 
 /// A running (or just-exited) VM.
@@ -167,6 +189,10 @@ pub struct DriverCapabilities {
     pub adopt: bool,
     /// The VMM can be spawned ahead of a boot ([`Prepare`]).
     pub prepare: bool,
+    /// Prepared VMs expose [`Staging`](crate::Staging): the files a VM
+    /// boots from are brought into an area of its own and named by where
+    /// they landed.
+    pub staging: bool,
     /// Handles expose a memory balloon.
     pub balloon: bool,
     /// Handles expose the guest console output.

--- a/virt/arcbox-vm-driver/src/driver.rs
+++ b/virt/arcbox-vm-driver/src/driver.rs
@@ -72,13 +72,13 @@ pub trait VmDriver: Send + Sync {
     /// it has a limit of its own.
     ///
     /// A driver's layout can bound the id even though the port does not:
-    /// Firecracker's jailer puts the API socket at
-    /// `{chroot base}/{binary}/{id}/root/run/firecracker.socket`, and
-    /// AF_UNIX leaves 107 bytes for a path, so a long chroot base or a
-    /// long id makes that socket unaddressable. The failure does not name
-    /// itself — the VMM comes up and binds inside its chroot while every
-    /// `connect` from outside fails, which reads as a boot that timed out.
-    /// An orchestrator minting ids asks here instead of guessing.
+    /// Firecracker's jailer puts its sockets under
+    /// `{chroot base}/{binary}/{id}/root/run/`, and AF_UNIX leaves 107
+    /// bytes for a path, so a long chroot base or a long id makes them
+    /// unaddressable. The failure does not name itself — the VMM comes up
+    /// and binds inside its chroot while every `connect` from outside
+    /// fails, which reads as a boot that timed out. An orchestrator
+    /// minting ids asks here instead of guessing.
     ///
     /// `None` means this driver imposes no limit of its own, not that the
     /// question is unsupported; everything else an id must be is

--- a/virt/arcbox-vm-driver/src/lib.rs
+++ b/virt/arcbox-vm-driver/src/lib.rs
@@ -18,9 +18,10 @@
 //!   [`VmRecord`]) and [`DriverCapabilities`], what a driver claims.
 //! - [`capability`] — everything optional, one trait each: [`Vsock`],
 //!   [`VsockListen`], [`Checkpoint`], [`Adopt`]/[`Detach`], [`Prepare`],
-//!   [`Balloon`], [`Console`], [`DebugSnapshot`]. A handle (or the driver,
-//!   for `Adopt` and `Prepare`) exposes each through an `Option<&dyn Cap>`
-//!   accessor, `Some` only when the driver can and the spec asked;
+//!   [`Staging`], [`Balloon`], [`Console`], [`DebugSnapshot`]. A handle —
+//!   or the driver, for `Adopt` and `Prepare`; or the prepared VM, for
+//!   `Staging` — exposes each through an `Option<&dyn Cap>` accessor,
+//!   `Some` only when the driver can and the spec asked;
 //!   `capabilities()` must agree with the accessors.
 //! - [`net`] — the second port: [`net::GuestNetwork`] plans and builds
 //!   what a NIC is attached to and hands the driver a [`NicSpec`];
@@ -55,8 +56,8 @@ pub mod testkit;
 
 pub use capability::{
     Adopt, AfterCheckpoint, Balloon, BalloonStats, Checkpoint, CheckpointFormat, CheckpointImage,
-    CheckpointKind, CheckpointOptions, Console, DebugSnapshot, Detach, Prepare, PreparedVm, Vsock,
-    VsockListen, VsockListener,
+    CheckpointKind, CheckpointOptions, Console, DebugSnapshot, Detach, DiskSource, Prepare,
+    PreparedVm, Staging, Vsock, VsockListen, VsockListener,
 };
 pub use driver::{
     DriverCapabilities, ExitStatus, IoMode, NestedVirt, ProcessRecord, RestoreSpec, ShutdownMode,

--- a/virt/arcbox-vm-driver/src/testkit/contract.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract.rs
@@ -203,7 +203,7 @@ macro_rules! driver_contract {
                 discard_kills_a_prepared_vm,
                 restore_reattaches_disks,
                 a_staged_spec_boots,
-                discard_removes_what_was_staged,
+                a_staged_disk_can_be_taken_back_out,
             }
         }
     };

--- a/virt/arcbox-vm-driver/src/testkit/contract.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract.rs
@@ -106,13 +106,13 @@ impl ContractHarness for FakeHarness {
             cpus: 1,
             memory_mib: 128,
             boot: BootSpec::Kernel {
-                image: "/fake/vmlinux".into(),
+                image: self.file("vmlinux"),
                 cmdline: "console=hvc0".into(),
                 initrd: None,
             },
             disks: vec![DiskSpec {
                 id: "rootfs".into(),
-                path: self.disk_file("rootfs.ext4"),
+                path: self.file("rootfs.ext4"),
                 read_only: false,
                 root: true,
                 cache: CacheMode::Unsafe,
@@ -159,8 +159,9 @@ impl ContractHarness for FakeHarness {
 
 impl FakeHarness {
     /// A real (empty) file under the harness root, so a contract check that
-    /// copies a disk for a restore has something to copy.
-    fn disk_file(&self, name: &str) -> PathBuf {
+    /// copies a disk for a restore, or stages the spec's own files, has
+    /// something to copy.
+    fn file(&self, name: &str) -> PathBuf {
         let path = self.root.path().join(name);
         if !path.exists() {
             std::fs::write(&path, b"").expect("disk file under the harness root");
@@ -201,6 +202,8 @@ macro_rules! driver_contract {
                 prepared_listener_is_live_before_boot,
                 discard_kills_a_prepared_vm,
                 restore_reattaches_disks,
+                a_staged_spec_boots,
+                discard_removes_what_was_staged,
             }
         }
     };

--- a/virt/arcbox-vm-driver/src/testkit/contract.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract.rs
@@ -204,6 +204,7 @@ macro_rules! driver_contract {
                 restore_reattaches_disks,
                 a_staged_spec_boots,
                 a_staged_disk_can_be_taken_back_out,
+                a_staged_checkpoint_restores,
             }
         }
     };

--- a/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
@@ -8,10 +8,11 @@ use std::time::Duration;
 use super::ContractHarness;
 use crate::capability::{
     AfterCheckpoint, CheckpointFormat, CheckpointImage, CheckpointKind, CheckpointOptions,
+    DiskSource,
 };
 use crate::driver::{RestoreSpec, ShutdownMode, VmEvent, VmHandle, VmRecord, VmState};
 use crate::error::Error;
-use crate::spec::VmId;
+use crate::spec::{BootSpec, VmId};
 
 /// How long a check waits for something the guest or VMM must do.
 const DEADLINE: Duration = Duration::from_secs(60);
@@ -80,6 +81,10 @@ pub async fn capabilities_agree_with_accessors(h: &dyn ContractHarness) {
     assert_eq!(caps.console, vm.console().is_some(), "console");
     assert_eq!(caps.debug, vm.debug().is_some(), "debug");
     assert_eq!(caps.prepare, driver.prepare().is_some(), "prepare");
+    // Staging is reached through a prepared VM, so its accessor is checked
+    // in `a_staged_spec_boots`; claiming it without `Prepare` leaves no way
+    // to reach it at all.
+    assert!(caps.prepare || !caps.staging, "staging without prepare");
     vm.shutdown(ShutdownMode::Kill).await.expect("kill");
 }
 
@@ -449,4 +454,169 @@ pub async fn restore_reattaches_disks(h: &dyn ContractHarness) {
     assert_eq!(restored.state(), VmState::Running);
     h.ready(&*restored).await;
     restored.shutdown(ShutdownMode::Kill).await.expect("kill");
+}
+
+/// A spec that names what [`Staging`](crate::Staging) brought in boots:
+/// the paths it hands back are the ones the VM's own spec must carry.
+///
+/// The capability's accessor and the driver's claim agree here rather than
+/// in `capabilities_agree_with_accessors`, which has a handle and not the
+/// prepared VM this one lives on.
+pub async fn a_staged_spec_boots(h: &dyn ContractHarness) {
+    let driver = h.driver();
+    let Some(prepare) = driver.prepare() else {
+        assert!(!driver.capabilities().prepare);
+        return;
+    };
+    let mut spec = h.spec(&id("staged-boot"));
+    let prepared = prepare
+        .prepare(&spec.id, &spec.isolation, &h.runtime_dir())
+        .await
+        .expect("prepare");
+    let staging = prepared.staging();
+    assert_eq!(driver.capabilities().staging, staging.is_some(), "staging");
+    let Some(staging) = staging else {
+        return;
+    };
+
+    // Exactly what an orchestrator does before it boots: bring the spec's
+    // own files in, and let each answer replace the path it was named by.
+    if let BootSpec::Kernel { image, .. } = &mut spec.boot {
+        *image = staging.stage_kernel(image).await.expect("stage the kernel");
+    }
+    for disk in &mut spec.disks {
+        let staged = staging
+            .stage_disk(&disk.id, DiskSource::Image(&disk.path))
+            .await
+            .expect("stage a disk");
+        disk.path = staged;
+    }
+
+    let vm = prepared.boot(spec).await.expect("boot from staged paths");
+    h.ready(&*vm).await;
+    assert_eq!(vm.state(), VmState::Running);
+    vm.shutdown(ShutdownMode::Kill).await.expect("kill");
+}
+
+/// `unstage_disk` takes a disk back out intact, and `discard` removes
+/// whatever is still staged.
+///
+/// The two halves of the same rule: everything staged for a VM dies with
+/// it, so anything that must outlive it leaves first. A driver that stages
+/// nothing answers the identity — nothing to take out, and the caller's
+/// own file untouched by the discard.
+pub async fn discard_removes_what_was_staged(h: &dyn ContractHarness) {
+    const CONTENT: &[u8] = b"a disk staged by the contract";
+
+    let driver = h.driver();
+    let Some(prepare) = driver.prepare() else {
+        assert!(!driver.capabilities().prepare);
+        return;
+    };
+    let spec = h.spec(&id("staged-discard"));
+    let dir = h.runtime_dir();
+    let prepared = prepare
+        .prepare(&spec.id, &spec.isolation, &dir)
+        .await
+        .expect("prepare");
+    let Some(staging) = prepared.staging() else {
+        assert!(!driver.capabilities().staging);
+        return;
+    };
+
+    // A file of the check's own, outside anything the VM was given.
+    let source = dir.join("staging-source.ext4");
+    tokio::fs::write(&source, CONTENT)
+        .await
+        .expect("a file to stage");
+    let staged = staging
+        .stage_disk("data", DiskSource::Image(&source))
+        .await
+        .expect("stage a disk");
+    assert!(
+        tokio::fs::try_exists(&source).await.unwrap_or(false),
+        "an Image source is the caller's to keep"
+    );
+    assert_eq!(
+        tokio::fs::read(&staged)
+            .await
+            .expect("read the staged disk"),
+        CONTENT
+    );
+
+    if staged == source {
+        // Identity staging: the file was already where the VM reads it, so
+        // there is nothing to take out and nothing for `discard` to remove.
+        assert!(
+            !staging
+                .unstage_disk("data", &dir.join("parked.ext4"))
+                .await
+                .expect("unstage what was never staged")
+        );
+        prepared.discard().await.expect("discard");
+        assert!(
+            tokio::fs::try_exists(&source).await.unwrap_or(false),
+            "a driver that stages nothing must not remove the caller's file"
+        );
+        return;
+    }
+
+    // Staging what is already in the VM's area names it where it is —
+    // never a copy of a file onto itself, which would truncate it.
+    assert_eq!(
+        staging
+            .stage_disk("data", DiskSource::Image(&staged))
+            .await
+            .expect("stage what is already staged"),
+        staged
+    );
+    assert_eq!(
+        tokio::fs::read(&staged)
+            .await
+            .expect("read the staged disk"),
+        CONTENT
+    );
+
+    let parked = dir.join("parked.ext4");
+    assert!(
+        staging
+            .unstage_disk("data", &parked)
+            .await
+            .expect("unstage the disk"),
+        "a staged disk is reported as taken out"
+    );
+    assert_eq!(
+        tokio::fs::read(&parked)
+            .await
+            .expect("read the parked disk"),
+        CONTENT
+    );
+    assert!(
+        !staging
+            .unstage_disk("data", &parked)
+            .await
+            .expect("unstage twice"),
+        "nothing is left to take out"
+    );
+
+    // And back in, consuming the parked copy.
+    let back = staging
+        .stage_disk("data", DiskSource::Handover(&parked))
+        .await
+        .expect("hand the disk back in");
+    assert!(
+        !tokio::fs::try_exists(&parked).await.unwrap_or(true),
+        "a handed-over disk is moved, not copied"
+    );
+
+    let status = prepared.discard().await.expect("discard");
+    assert!(
+        !tokio::fs::try_exists(&back).await.unwrap_or(true),
+        "discard left a staged disk behind"
+    );
+    assert_eq!(
+        prepared.discard().await.expect("second discard"),
+        status,
+        "discard is idempotent once it has removed the staging area"
+    );
 }

--- a/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
@@ -634,9 +634,21 @@ pub async fn a_staged_disk_can_be_taken_back_out(h: &dyn ContractHarness) {
 /// The warm-pool path, and the reason [`Staging::stage_checkpoint`] is a
 /// verb of its own: a slot brings the image in — the memory file is the
 /// guest's entire RAM — long before any restore is asked for, and the
-/// restore then loads what is already there. Nothing else in this
-/// contract touches that verb, so an image that comes back naming a
-/// directory the files never reached would pass everything else.
+/// restore then loads what is already there.
+///
+/// So the check deletes the source image once staging says it has been
+/// brought in, and only then restores. That is the property, and nothing
+/// weaker states it: a `stage_checkpoint` that copied nothing and handed
+/// its argument straight back would otherwise pass, because both a jailed
+/// restore and a plain one will bring the files in themselves — leaving
+/// the copy on the restore's critical path, exactly where a warm slot
+/// exists to take it off.
+///
+/// A driver with no confinement legitimately stages nothing and answers
+/// with the image it was given. The check asks it which it is by staging
+/// a file of its own first and seeing whether that moved — taking the
+/// answer from a verb it cannot fake, rather than from this one, which is
+/// the verb under test.
 ///
 /// [`Staging::stage_checkpoint`]: crate::Staging::stage_checkpoint
 pub async fn a_staged_checkpoint_restores(h: &dyn ContractHarness) {
@@ -676,12 +688,37 @@ pub async fn a_staged_checkpoint_restores(h: &dyn ContractHarness) {
         .await
         .expect("prepare");
     let staging = prepared.staging().expect("the driver claims staging");
+
+    // Does this driver's staging area move anything at all? Asked of a
+    // disk, because a checkpoint is what is under test here — and the
+    // answer must not differ between the two.
+    let probe = h.runtime_dir().join("probe.ext4");
+    tokio::fs::write(&probe, b"probe")
+        .await
+        .expect("a file to probe staging with");
+    let confined = staging
+        .stage_disk("probe", DiskSource::Image(&probe))
+        .await
+        .expect("stage a probe disk")
+        != probe;
+
     let staged = staging
         .stage_checkpoint(&image)
         .await
         .expect("stage the checkpoint");
     assert_eq!(staged.format, image.format);
     assert_eq!(staged.kind, image.kind);
+    if confined {
+        assert_ne!(
+            staged.dir, image.dir,
+            "a driver that brings a disk in must bring a checkpoint in too"
+        );
+        // Brought in, so the source is expendable from here — which is
+        // what "the slot already paid for it" means.
+        tokio::fs::remove_dir_all(&image.dir)
+            .await
+            .expect("the source image is no longer needed once staged");
+    }
     let mut disks = Vec::new();
     for mut disk in template.disks {
         disk.path = staging

--- a/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
@@ -498,14 +498,14 @@ pub async fn a_staged_spec_boots(h: &dyn ContractHarness) {
     vm.shutdown(ShutdownMode::Kill).await.expect("kill");
 }
 
-/// `unstage_disk` takes a disk back out intact, and `discard` removes
-/// whatever is still staged.
+/// `unstage_disk` takes a staged disk back out intact, and
+/// [`DiskSource::Handover`] puts it back by moving it.
 ///
-/// The two halves of the same rule: everything staged for a VM dies with
-/// it, so anything that must outlive it leaves first. A driver that stages
-/// nothing answers the identity — nothing to take out, and the caller's
-/// own file untouched by the discard.
-pub async fn discard_removes_what_was_staged(h: &dyn ContractHarness) {
+/// The way anything survives the VM it was staged for: the area belongs to
+/// the VM, and a disk that must outlive it leaves first. A driver that
+/// stages nothing answers the identity instead — nothing to take out, and
+/// the caller's own file where it always was.
+pub async fn a_staged_disk_can_be_taken_back_out(h: &dyn ContractHarness) {
     const CONTENT: &[u8] = b"a disk staged by the contract";
 
     let driver = h.driver();
@@ -513,7 +513,7 @@ pub async fn discard_removes_what_was_staged(h: &dyn ContractHarness) {
         assert!(!driver.capabilities().prepare);
         return;
     };
-    let spec = h.spec(&id("staged-discard"));
+    let spec = h.spec(&id("staged-unstage"));
     let dir = h.runtime_dir();
     let prepared = prepare
         .prepare(&spec.id, &spec.isolation, &dir)
@@ -544,20 +544,31 @@ pub async fn discard_removes_what_was_staged(h: &dyn ContractHarness) {
         CONTENT
     );
 
+    // A disk id names a file the driver writes, replaces and moves, so one
+    // that is not a plain name is refused rather than resolved.
+    assert!(
+        staging
+            .stage_disk("../escape", DiskSource::Image(&source))
+            .await
+            .is_err(),
+        "a traversing disk id was staged"
+    );
+    assert!(
+        staging.unstage_disk("../escape", &dir).await.is_err(),
+        "a traversing disk id was unstaged"
+    );
+
+    let parked = dir.join("parked.ext4");
     if staged == source {
         // Identity staging: the file was already where the VM reads it, so
-        // there is nothing to take out and nothing for `discard` to remove.
+        // there is nothing to take out and nothing was moved.
         assert!(
             !staging
-                .unstage_disk("data", &dir.join("parked.ext4"))
+                .unstage_disk("data", &parked)
                 .await
                 .expect("unstage what was never staged")
         );
-        prepared.discard().await.expect("discard");
-        assert!(
-            tokio::fs::try_exists(&source).await.unwrap_or(false),
-            "a driver that stages nothing must not remove the caller's file"
-        );
+        assert!(tokio::fs::try_exists(&source).await.unwrap_or(false));
         return;
     }
 
@@ -577,7 +588,6 @@ pub async fn discard_removes_what_was_staged(h: &dyn ContractHarness) {
         CONTENT
     );
 
-    let parked = dir.join("parked.ext4");
     assert!(
         staging
             .unstage_disk("data", &parked)
@@ -590,6 +600,10 @@ pub async fn discard_removes_what_was_staged(h: &dyn ContractHarness) {
             .await
             .expect("read the parked disk"),
         CONTENT
+    );
+    assert!(
+        !tokio::fs::try_exists(&staged).await.unwrap_or(true),
+        "the disk is gone from the vm's area"
     );
     assert!(
         !staging
@@ -608,15 +622,9 @@ pub async fn discard_removes_what_was_staged(h: &dyn ContractHarness) {
         !tokio::fs::try_exists(&parked).await.unwrap_or(true),
         "a handed-over disk is moved, not copied"
     );
-
-    let status = prepared.discard().await.expect("discard");
-    assert!(
-        !tokio::fs::try_exists(&back).await.unwrap_or(true),
-        "discard left a staged disk behind"
-    );
     assert_eq!(
-        prepared.discard().await.expect("second discard"),
-        status,
-        "discard is idempotent once it has removed the staging area"
+        tokio::fs::read(&back).await.expect("read the disk back in"),
+        CONTENT
     );
+    prepared.discard().await.expect("discard");
 }

--- a/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
@@ -628,3 +628,83 @@ pub async fn a_staged_disk_can_be_taken_back_out(h: &dyn ContractHarness) {
     );
     prepared.discard().await.expect("discard");
 }
+
+/// A checkpoint staged into a prepared VM restores from where it landed.
+///
+/// The warm-pool path, and the reason [`Staging::stage_checkpoint`] is a
+/// verb of its own: a slot brings the image in — the memory file is the
+/// guest's entire RAM — long before any restore is asked for, and the
+/// restore then loads what is already there. Nothing else in this
+/// contract touches that verb, so an image that comes back naming a
+/// directory the files never reached would pass everything else.
+///
+/// [`Staging::stage_checkpoint`]: crate::Staging::stage_checkpoint
+pub async fn a_staged_checkpoint_restores(h: &dyn ContractHarness) {
+    let driver = h.driver();
+    if !driver.capabilities().checkpoint || !driver.capabilities().staging {
+        return;
+    }
+    let Some(prepare) = driver.prepare() else {
+        assert!(!driver.capabilities().prepare);
+        return;
+    };
+
+    let source = boot(h, "staged-restore-src").await;
+    let Some(cp) = source.checkpoint() else {
+        assert!(!driver.capabilities().checkpoint);
+        source.shutdown(ShutdownMode::Kill).await.expect("kill");
+        return;
+    };
+    let opts = CheckpointOptions {
+        after: AfterCheckpoint::HoldQuiesced,
+        kind: CheckpointKind::Full,
+    };
+    let image = cp
+        .checkpoint(&h.runtime_dir().join("checkpoint"), opts)
+        .await
+        .expect("checkpoint");
+    source
+        .shutdown(ShutdownMode::Kill)
+        .await
+        .expect("kill source");
+
+    // The slot: prepared, then handed the image and the disks it will run
+    // on, with nothing left for the restore to bring in.
+    let template = h.spec(&id("staged-restore-dst"));
+    let prepared = prepare
+        .prepare(&template.id, &template.isolation, &h.runtime_dir())
+        .await
+        .expect("prepare");
+    let staging = prepared.staging().expect("the driver claims staging");
+    let staged = staging
+        .stage_checkpoint(&image)
+        .await
+        .expect("stage the checkpoint");
+    assert_eq!(staged.format, image.format);
+    assert_eq!(staged.kind, image.kind);
+    let mut disks = Vec::new();
+    for mut disk in template.disks {
+        disk.path = staging
+            .stage_disk(&disk.id, DiskSource::Image(&disk.path))
+            .await
+            .expect("stage a disk for the restore");
+        disks.push(disk);
+    }
+
+    let restored = prepared
+        .restore(
+            &staged,
+            RestoreSpec {
+                id: id("staged-restore-dst"),
+                nics: template.nics,
+                disks,
+                isolation: template.isolation,
+            },
+        )
+        .await
+        .expect("restore from the staged image");
+    assert_eq!(*restored.id(), id("staged-restore-dst"));
+    assert_eq!(restored.state(), VmState::Running);
+    h.ready(&*restored).await;
+    restored.shutdown(ShutdownMode::Kill).await.expect("kill");
+}

--- a/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
@@ -36,7 +36,9 @@ pub(super) struct Knobs {
 /// `checkpoint.json` that `restore` reads back; `Adopt`/`Detach` go through
 /// the driver's registry; `Prepare` hands out a process with a synthetic
 /// pid that `boot`/`restore` then run on — the driver's own `boot` is
-/// exactly that pair; `Console` returns what [`FakeDriver::push_console`]
+/// exactly that pair; `Staging` copies files into a `staged/` directory
+/// under the runtime dir, which `discard` then removes; `Console` returns
+/// what [`FakeDriver::push_console`]
 /// pushed. [`FakeDriver::builder`] scripts failures and narrows the claimed
 /// capabilities — the accessors follow the claims, so the contract can be
 /// run against a reduced set.
@@ -124,6 +126,7 @@ impl FakeDriver {
                 diff_checkpoint: true,
                 adopt: true,
                 prepare: true,
+                staging: true,
                 balloon: true,
                 console: true,
                 debug: true,

--- a/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
@@ -36,12 +36,12 @@ pub(super) struct Knobs {
 /// `checkpoint.json` that `restore` reads back; `Adopt`/`Detach` go through
 /// the driver's registry; `Prepare` hands out a process with a synthetic
 /// pid that `boot`/`restore` then run on — the driver's own `boot` is
-/// exactly that pair; `Staging` copies files into a `staged/` directory
-/// under the runtime dir, which `discard` then removes; `Console` returns
-/// what [`FakeDriver::push_console`]
-/// pushed. [`FakeDriver::builder`] scripts failures and narrows the claimed
-/// capabilities — the accessors follow the claims, so the contract can be
-/// run against a reduced set.
+/// exactly that pair; `Staging` brings files into a `staged/` directory
+/// under the runtime dir, which outlives the discard as a real driver's
+/// staging area does today; `Console` returns what
+/// [`FakeDriver::push_console`] pushed. [`FakeDriver::builder`] scripts
+/// failures and narrows the claimed capabilities — the accessors follow
+/// the claims, so the contract can be run against a reduced set.
 ///
 /// The driver's name is `"fake"`; its checkpoint format is `"fake/v1"`.
 #[derive(Clone)]

--- a/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
@@ -213,9 +213,11 @@ impl PreparedFake {
         // Against the resolved path, not the written one: `starts_with`
         // compares components, so `{staged}/../elsewhere` would look like
         // it is already inside the area and be left where it is — and a
-        // `Handover` would then report a move that never happened.
-        if lexically_resolved(src).starts_with(self.staging_root()) {
-            return Ok(src.to_path_buf());
+        // `Handover` would then report a move that never happened. The
+        // answer names where the file is, not how it was spelled.
+        let resolved = lexically_resolved(src);
+        if resolved.starts_with(self.staging_root()) {
+            return Ok(resolved);
         }
         if let Some(parent) = dst.parent() {
             tokio::fs::create_dir_all(parent).await?;
@@ -368,8 +370,12 @@ impl Staging for PreparedFake {
 
     async fn stage_checkpoint(&self, image: &CheckpointImage) -> Result<CheckpointImage> {
         let root = self.staging_root();
-        if image.dir.starts_with(&root) {
-            return Ok(image.clone());
+        let resolved = lexically_resolved(&image.dir);
+        if resolved.starts_with(&root) {
+            return Ok(CheckpointImage {
+                dir: resolved,
+                ..image.clone()
+            });
         }
         let name = image.dir.file_name().ok_or_else(|| {
             Error::InvalidSpec(format!(

--- a/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
@@ -165,38 +165,55 @@ impl PreparedFake {
         self.record.runtime_dir.join("staged")
     }
 
-    /// Brings `src` into the staging area at `rel`, and answers with where
+    /// Where the disk `id` sits in the staging area.
+    ///
+    /// Refuses an id that is not a plain name, exactly as a real adapter
+    /// must: staging writes and replaces at this path and unstaging moves
+    /// what it finds there, so a `..` would reach a file outside the area.
+    /// The fake enforces it because it is the reference driver — a gap it
+    /// shares with the adapters is a gap no contract check can see.
+    fn staged_disk(&self, id: &str) -> Result<PathBuf> {
+        let mut components = Path::new(id).components();
+        if !matches!(components.next(), Some(std::path::Component::Normal(_)))
+            || components.next().is_some()
+        {
+            return Err(Error::InvalidSpec(format!(
+                "disk id `{id}` must be a plain name"
+            )));
+        }
+        Ok(self.staging_root().join(format!("{id}.ext4")))
+    }
+
+    /// Brings `src` into the staging area at `dst`, and answers with where
     /// it landed. A source already inside the area is left where it is —
     /// the same short-circuit a real confinement makes.
-    async fn bring_in(&self, src: &Path, rel: &str, how: Bring) -> Result<PathBuf> {
-        let root = self.staging_root();
-        if src.starts_with(&root) {
+    async fn bring_in(&self, src: &Path, dst: &Path, how: Bring) -> Result<PathBuf> {
+        if src.starts_with(self.staging_root()) {
             return Ok(src.to_path_buf());
         }
-        let dst = root.join(rel);
         if let Some(parent) = dst.parent() {
             tokio::fs::create_dir_all(parent).await?;
         }
-        match tokio::fs::remove_file(&dst).await {
+        match tokio::fs::remove_file(dst).await {
             Err(e) if e.kind() != std::io::ErrorKind::NotFound => return Err(Error::Io(e)),
             _ => {}
         }
         match how {
             // A device node is not something a fake can make; a symlink is
             // the stand-in, and it is visibly not a copy.
-            Bring::Device => tokio::fs::symlink(src, &dst).await?,
+            Bring::Device => tokio::fs::symlink(src, dst).await?,
             Bring::Copy => {
-                tokio::fs::copy(src, &dst).await?;
+                tokio::fs::copy(src, dst).await?;
             }
-            Bring::Move => match tokio::fs::rename(src, &dst).await {
+            Bring::Move => match tokio::fs::rename(src, dst).await {
                 Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
-                    tokio::fs::copy(src, &dst).await?;
+                    tokio::fs::copy(src, dst).await?;
                     tokio::fs::remove_file(src).await?;
                 }
                 other => other?,
             },
         }
-        Ok(dst)
+        Ok(dst.to_path_buf())
     }
 
     /// Kills whatever `phase` says is running: the booted VM, or the bare
@@ -285,12 +302,7 @@ impl PreparedVm for PreparedFake {
     }
 
     async fn discard(&self) -> Result<ExitStatus> {
-        let status = self.kill(&mut lock(&self.phase));
-        match tokio::fs::remove_dir_all(self.staging_root()).await {
-            Err(e) if e.kind() != std::io::ErrorKind::NotFound => return Err(Error::Io(e)),
-            _ => {}
-        }
-        Ok(status)
+        Ok(self.kill(&mut lock(&self.phase)))
     }
 }
 
@@ -299,7 +311,8 @@ impl PreparedVm for PreparedFake {
 #[async_trait]
 impl Staging for PreparedFake {
     async fn stage_kernel(&self, src: &Path) -> Result<PathBuf> {
-        self.bring_in(src, "vmlinux", Bring::Copy).await
+        self.bring_in(src, &self.staging_root().join("vmlinux"), Bring::Copy)
+            .await
     }
 
     async fn stage_disk(&self, id: &str, source: DiskSource<'_>) -> Result<PathBuf> {
@@ -308,12 +321,12 @@ impl Staging for PreparedFake {
             DiskSource::Image(_) => Bring::Copy,
             DiskSource::Handover(_) => Bring::Move,
         };
-        self.bring_in(source.path(), &format!("{id}.ext4"), how)
-            .await
+        let into = self.staged_disk(id)?;
+        self.bring_in(source.path(), &into, how).await
     }
 
     async fn unstage_disk(&self, id: &str, dst: &Path) -> Result<bool> {
-        let staged = self.staging_root().join(format!("{id}.ext4"));
+        let staged = self.staged_disk(id)?;
         if !tokio::fs::try_exists(&staged).await.unwrap_or(false) {
             return Ok(false);
         }

--- a/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
@@ -1,7 +1,7 @@
 //! The fake's `Prepare` capability: a "spawned" VMM waiting for a spec.
 
 use std::collections::BTreeSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
@@ -11,13 +11,26 @@ use super::fake_driver::{DriverInner, NAME};
 use super::fake_vm::{CHECKPOINT_FORMAT, CheckpointFile, FakeVm, VmInner};
 use super::fake_vsock::{FakeListener, Inbound};
 use super::lock;
-use crate::capability::{CheckpointImage, Prepare, PreparedVm, VsockListen, VsockListener};
+use crate::capability::{
+    CheckpointImage, DiskSource, Prepare, PreparedVm, Staging, VsockListen, VsockListener,
+};
 use crate::driver::{ExitStatus, ProcessRecord, RestoreSpec, VmHandle, VmRecord, VmState};
 use crate::error::{Error, Result};
 use crate::spec::{IsolationSpec, VmId, VmSpec};
 
 /// What `discard` reports for a process killed before or after its boot.
 const SIGKILL: i32 = 9;
+
+/// How a staged file gets into the staging area.
+#[derive(Debug, Clone, Copy)]
+enum Bring {
+    /// A stand-in for a device node.
+    Device,
+    /// A private copy; the source stays.
+    Copy,
+    /// The source is consumed.
+    Move,
+}
 
 /// The `Prepare` capability, on its own type so its `prepare` method does
 /// not shadow the driver's accessor of the same name.
@@ -146,6 +159,46 @@ impl PreparedFake {
         Ok(Box::new(FakeVm::new(vm)))
     }
 
+    /// The VM's staging area: a directory of its own under the runtime
+    /// dir, standing in for a jail's chroot.
+    fn staging_root(&self) -> PathBuf {
+        self.record.runtime_dir.join("staged")
+    }
+
+    /// Brings `src` into the staging area at `rel`, and answers with where
+    /// it landed. A source already inside the area is left where it is —
+    /// the same short-circuit a real confinement makes.
+    async fn bring_in(&self, src: &Path, rel: &str, how: Bring) -> Result<PathBuf> {
+        let root = self.staging_root();
+        if src.starts_with(&root) {
+            return Ok(src.to_path_buf());
+        }
+        let dst = root.join(rel);
+        if let Some(parent) = dst.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        match tokio::fs::remove_file(&dst).await {
+            Err(e) if e.kind() != std::io::ErrorKind::NotFound => return Err(Error::Io(e)),
+            _ => {}
+        }
+        match how {
+            // A device node is not something a fake can make; a symlink is
+            // the stand-in, and it is visibly not a copy.
+            Bring::Device => tokio::fs::symlink(src, &dst).await?,
+            Bring::Copy => {
+                tokio::fs::copy(src, &dst).await?;
+            }
+            Bring::Move => match tokio::fs::rename(src, &dst).await {
+                Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
+                    tokio::fs::copy(src, &dst).await?;
+                    tokio::fs::remove_file(src).await?;
+                }
+                other => other?,
+            },
+        }
+        Ok(dst)
+    }
+
     /// Kills whatever `phase` says is running: the booted VM, or the bare
     /// process itself.
     fn kill(&self, phase: &mut Phase) -> ExitStatus {
@@ -194,6 +247,10 @@ impl PreparedVm for PreparedFake {
         self.driver.caps.vsock_listen.then_some(self)
     }
 
+    fn staging(&self) -> Option<&dyn Staging> {
+        self.driver.caps.staging.then_some(self)
+    }
+
     async fn boot(&self, spec: VmSpec) -> Result<Box<dyn VmHandle>> {
         let balloon_target_bytes = u64::from(spec.memory_mib) << 20;
         self.launch(spec, balloon_target_bytes)
@@ -228,7 +285,71 @@ impl PreparedVm for PreparedFake {
     }
 
     async fn discard(&self) -> Result<ExitStatus> {
-        Ok(self.kill(&mut lock(&self.phase)))
+        let status = self.kill(&mut lock(&self.phase));
+        match tokio::fs::remove_dir_all(self.staging_root()).await {
+            Err(e) if e.kind() != std::io::ErrorKind::NotFound => return Err(Error::Io(e)),
+            _ => {}
+        }
+        Ok(status)
+    }
+}
+
+/// Files land in `{runtime_dir}/staged`, under the names a jail would give
+/// them: `vmlinux`, `{disk id}.ext4`, `snapshots/{image dir name}`.
+#[async_trait]
+impl Staging for PreparedFake {
+    async fn stage_kernel(&self, src: &Path) -> Result<PathBuf> {
+        self.bring_in(src, "vmlinux", Bring::Copy).await
+    }
+
+    async fn stage_disk(&self, id: &str, source: DiskSource<'_>) -> Result<PathBuf> {
+        let how = match source {
+            DiskSource::Device(_) => Bring::Device,
+            DiskSource::Image(_) => Bring::Copy,
+            DiskSource::Handover(_) => Bring::Move,
+        };
+        self.bring_in(source.path(), &format!("{id}.ext4"), how)
+            .await
+    }
+
+    async fn unstage_disk(&self, id: &str, dst: &Path) -> Result<bool> {
+        let staged = self.staging_root().join(format!("{id}.ext4"));
+        if !tokio::fs::try_exists(&staged).await.unwrap_or(false) {
+            return Ok(false);
+        }
+        match tokio::fs::rename(&staged, dst).await {
+            Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
+                tokio::fs::copy(&staged, dst).await?;
+                tokio::fs::remove_file(&staged).await?;
+            }
+            other => other?,
+        }
+        Ok(true)
+    }
+
+    async fn stage_checkpoint(&self, image: &CheckpointImage) -> Result<CheckpointImage> {
+        let root = self.staging_root();
+        if image.dir.starts_with(&root) {
+            return Ok(image.clone());
+        }
+        let name = image.dir.file_name().ok_or_else(|| {
+            Error::InvalidSpec(format!(
+                "checkpoint dir {} has no usable name",
+                image.dir.display()
+            ))
+        })?;
+        let dir = root.join("snapshots").join(name);
+        tokio::fs::create_dir_all(&dir).await?;
+        let mut entries = tokio::fs::read_dir(&image.dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            if entry.file_type().await?.is_file() {
+                tokio::fs::copy(entry.path(), dir.join(entry.file_name())).await?;
+            }
+        }
+        Ok(CheckpointImage {
+            dir,
+            ..image.clone()
+        })
     }
 }
 

--- a/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
@@ -21,6 +21,28 @@ use crate::spec::{IsolationSpec, VmId, VmSpec};
 /// What `discard` reports for a process killed before or after its boot.
 const SIGKILL: i32 = 9;
 
+/// `path` with its `.` and `..` components resolved as far as they can be
+/// without touching the filesystem.
+///
+/// Enough for deciding whether a path lands inside a directory: a `..`
+/// that walks out of one is what the check exists to catch, and symlinks
+/// are beyond what a fake needs to model.
+fn lexically_resolved(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !out.pop() {
+                    out.push(component);
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
 /// How a staged file gets into the staging area.
 #[derive(Debug, Clone, Copy)]
 enum Bring {
@@ -188,7 +210,11 @@ impl PreparedFake {
     /// it landed. A source already inside the area is left where it is —
     /// the same short-circuit a real confinement makes.
     async fn bring_in(&self, src: &Path, dst: &Path, how: Bring) -> Result<PathBuf> {
-        if src.starts_with(self.staging_root()) {
+        // Against the resolved path, not the written one: `starts_with`
+        // compares components, so `{staged}/../elsewhere` would look like
+        // it is already inside the area and be left where it is — and a
+        // `Handover` would then report a move that never happened.
+        if lexically_resolved(src).starts_with(self.staging_root()) {
             return Ok(src.to_path_buf());
         }
         if let Some(parent) = dst.parent() {


### PR DESCRIPTION
The computer runtime depends on the Firecracker adapter for one reason:
it stages files into a jailer chroot itself, and asks the adapter how
long a sandbox id may be. Both are things the port should carry. This
adds them; G2/G3 convert the call sites, and the `check-layers`
exception goes with them.

## `Staging`, on `PreparedVm`

```rust
fn staging(&self) -> Option<&dyn Staging>;              // capability accessor

trait Staging {
    async fn stage_kernel(&self, src: &Path) -> Result<PathBuf>;
    async fn stage_disk(&self, id: &str, source: DiskSource<'_>) -> Result<PathBuf>;
    async fn unstage_disk(&self, id: &str, dst: &Path) -> Result<bool>;
    async fn stage_checkpoint(&self, image: &CheckpointImage) -> Result<CheckpointImage>;
}

enum DiskSource<'a> { Device(&'a Path), Image(&'a Path), Handover(&'a Path) }
```

The caller says what a file *is* — a block device, a file it keeps, a
file it gives up — and gets back the path its spec must name. It never
learns whether a confinement exists: without a jail every verb is the
identity, so an orchestrator stages unconditionally instead of branching
on a chroot it is not supposed to know about. Staging a file already in
the VM's area names it where it is, which is both what a claimed warm
slot needs and what keeps a copy from truncating its own source.

`unstage_disk` is how anything survives the VM it was staged for — pause
parks its copy-mode rootfs exactly that way.

### What this PR does *not* do: `discard` does not remove the jail yet

The plan has `discard` owning the jail, and it must, or the runtime can
never stop naming chroots. It cannot land here. `release_for_pause` kills
the VMM through `discard` and only *then* moves the copy-mode rootfs —
the sandbox's only writable disk — out of the chroot, guarded by an
existence check. With the jail already gone that check is false, so the
move is skipped, pause reports success, and the disk is gone; resume then
fails with "neither a preserved overlay nor a parked rootfs".
`unwind_resume` has the same shape. Both are silent, and neither is
reachable from a change confined to the port and the adapter.

So the removal belongs in the same change that reorders those two call
sites onto `unstage_disk` — PR-G2, which was already going to touch them.
Everything G2 needs to do that is here.

## `VmDriver::id_budget(&IsolationSpec) -> Option<usize>`

Default `None` — "this driver imposes no limit of its own", not
"unsupported". Firecracker answers from its jailer layout: its sockets
sit under the chroot and AF_UNIX leaves 107 bytes, so a long chroot base
makes them unaddressable — which surfaces as a boot that timed out, never
as a name error. The measurement is against the *longest* of them, which
is the guest dial-out listener (`run/firecracker.vsock_{port}`), not the
API socket; room is reserved for a five-digit port rather than the full
`u32` a `listen` takes, because ten digits would cost ten bytes of id and
refuse the 36-byte UUIDs an orchestrator mints. `Some(0)` is a real answer and is tested: a base under a
deep temp dir spends the budget whole (it has produced a false-green test
in this tree), and the subtraction saturates rather than wrapping into a
budget that mints ids which never connect.

## The FC side

`Staging` goes through `VmLayout::place`, so every path decision stays in
`render` and the two properties above come for free. `KERNEL_FILE`,
`disk_file` and `checkpoint_dir` are named once, shared by staging and
rendering: a pre-staged file has to land where rendering the boot would
have put it, or the render stages a second copy beside it and the warm
slot's whole point is lost. `StageKind::Move` is new and only staging
asks for it — only a caller knows it is handing a file over, and a
multi-gigabyte rootfs coming back must not be duplicated on the way.

## Contract

Three checks, all run against the fake and listed for the hardware
harness. A spec naming what was staged has to boot; a staged checkpoint
has to restore (the warm-slot path, and the only coverage
`stage_checkpoint` has); and a staged disk has
to come back out intact — with the self-copy hazard pinned (staging a
file already in the area names it where it is, rather than copying it
onto itself), a traversing disk id refused by both `stage_disk` and
`unstage_disk`, and an identity driver required to leave the caller's own
file alone. `capabilities_agree_with_accessors` gains the coherence half:
claiming `staging` without `Prepare` leaves no way to reach it.

## Scope

Nothing under `computer/arcbox-computer-runtime` changes: the additions
are additive, and `cargo check -p arcbox-computer-runtime --all-targets`
passing untouched is the check that says so.

R3, PR-G1 of the VM stack redesign.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches jail path resolution, disk move/staging, and id-length limits on the Firecracker boot path; changes are additive at the port layer but incorrect budgets or path handling would surface as silent connect failures or lost disks on pause/unstage.
> 
> **Overview**
> Adds **`Staging`** on prepared VMs and **`VmDriver::id_budget`**, so orchestrators can pre-stage boot files into a jail and mint VM ids that fit AF_UNIX socket paths—without the computer runtime continuing to own those Firecracker-specific details.
> 
> **`Staging`** (`stage_kernel`, `stage_disk` with `DiskSource::{Device,Image,Handover}`, `unstage_disk`, `stage_checkpoint`) returns the paths specs must name; without a jail each verb is identity. **`FcPrepared`** implements it via `VmLayout::place` and shared names (`KERNEL_FILE`, `disk_file`, `checkpoint_dir`) so warm-pool staging matches render and does not double-copy. New **`StageKind::Move`** and **`move_into_jail`** move handed-over disks; **`Jail::view`** uses lexical path resolution so `..` paths are not treated as inside the jail.
> 
> **`id_budget`** on **`FcDriver`** (jailer only) derives max id length from the longest socket path (vsock dial-out listener at port 65535), with saturating math so deep chroot bases yield **`Some(0)`** instead of wrapping.
> 
> Contract: three new checks (staged boot, unstage/handover, staged checkpoint restore), fake driver staging, and a **`wait_until_executable`** helper in snapshot tests for **`ETXTBSY`**. **`discard`** still does not remove the jail (planned for PR-G2 with runtime call-site reorder).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3204e467be0a197a6e659978d335b4b047bd6f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->