### PR TITLE
refactor(computer): the runtime stages through the port, and discard takes its jail (R3, PR-G2)

### DIFF
--- a/computer/arcbox-computer-runtime/src/lifecycle/effect.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/effect.rs
@@ -53,7 +53,8 @@ pub(super) enum Unconfirmed {
 /// Which resources a release drops.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReleaseScope {
-    /// VMM, CoW, TAP + IP and chroot; the record stays inspectable.
+    /// VMM (and the area its files were staged into, which the driver
+    /// takes with it), CoW, TAP + IP; the record stays inspectable.
     Runtime,
     /// The pause release: the same, but the disk overlay is retained.
     KeepDisk,

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/boot.rs
@@ -110,7 +110,6 @@ impl ComputerFlows {
                 &self.id,
                 &ticket,
                 &self.computer,
-                &services.config,
                 &services.cow_manager,
                 // The gate holds `Starting` for its whole duration — the
                 // reservation the boot's own `cmd` is owed — so the

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/restore.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/restore.rs
@@ -57,12 +57,7 @@ impl ComputerFlows {
             )));
         };
 
-        let claimed = pool::claim_restore_slot(
-            &services.pool,
-            &services.config,
-            &services.cow_manager,
-            &snapshot_id,
-        );
+        let claimed = pool::claim_restore_slot(&services.pool, &services.cow_manager, &snapshot_id);
         let restored = restore_vm(RestoreVm {
             new_id: &self.id,
             snap_meta: &snap_meta,

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
@@ -95,9 +95,9 @@ impl ComputerFlows {
                 })?;
         }
 
-        // Release the VMM (already exited, or never booted), TAP/IP, CoW
-        // device, and chroot; the record itself stays inspectable until
-        // Remove.
+        // Release the VMM (already exited, or never booted) and with it the
+        // area its files were staged into, then TAP/IP and the CoW device;
+        // the record itself stays inspectable until Remove.
         self.release_scope(ReleaseScope::Runtime).await?;
         info!(sandbox_id = %self.id, "computer stopped");
         Ok(())
@@ -111,7 +111,6 @@ impl ComputerFlows {
                     &self.id,
                     &self.computer,
                     &services.network,
-                    &services.config,
                     &services.cow_manager,
                 )
                 .await

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
@@ -116,25 +116,24 @@ impl ComputerFlows {
                 )
                 .await
             }
-            ReleaseScope::KeepDisk => match services.config.firecracker.jailer.as_ref() {
-                Some(jailer) => {
-                    release_for_pause(
-                        &self.id,
-                        &self.computer,
-                        jailer,
-                        &services.config,
-                        &services.cow_manager,
-                        &*services.network,
-                    )
-                    .await
-                }
-                // Unreachable: `pause_sandbox` refuses direct mode before it
-                // claims anything, because a direct-mode vmstate pins origin
-                // paths and could never resume.
-                None => Err(VmmError::Config(
+            // Unreachable: `pause_sandbox` refuses direct mode before it
+            // claims anything, because a direct-mode vmstate pins origin
+            // paths and could never resume.
+            ReleaseScope::KeepDisk if services.config.firecracker.jailer.is_none() => {
+                Err(VmmError::Config(
                     "computer pause requires jailer isolation; direct mode cannot resume".into(),
-                )),
-            },
+                ))
+            }
+            ReleaseScope::KeepDisk => {
+                release_for_pause(
+                    &self.id,
+                    &self.computer,
+                    &services.config,
+                    &services.cow_manager,
+                    &*services.network,
+                )
+                .await
+            }
             ReleaseScope::Full => {
                 release_everything(
                     &self.id,

--- a/computer/arcbox-computer-runtime/src/lifecycle/runtime.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/runtime.rs
@@ -80,13 +80,14 @@ pub struct ComputerRuntime {
     /// dm-snapshot CoW handle (present when snapshot-based rootfs is active).
     pub cow_handle: Option<CowHandle>,
     /// When this sandbox adopted a pre-warmed restore slot's resources
-    /// (CORE-78), the slot id (`pool-<uuid>`) its jailer chroot and dm/CoW
-    /// names are keyed by. `None` for resources created under the
-    /// sandbox's own id.
+    /// (CORE-78), the slot id (`pool-<uuid>`) its VM and its dm/CoW names
+    /// are keyed by. `None` for resources created under the sandbox's own
+    /// id.
     ///
-    /// Cleared by pause: releasing a paused sandbox renames its retained
-    /// overlay to the sandbox-id path and destroys the slot chroot, so a
-    /// resumed sandbox owns everything under its own id again.
+    /// Cleared by pause: releasing a paused sandbox discards the slot's VM
+    /// (which takes the area its files were staged into) and renames its
+    /// retained overlay to the sandbox-id path, so a resumed sandbox owns
+    /// everything under its own id again.
     pub(crate) pool_slot_id: Option<String>,
     /// Whether this guest runs the fixed invariant network identity
     /// (CORE-81). Set by the create path when the boot bakes the invariant

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
@@ -11,10 +11,6 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use arcbox_fc_driver::jail::{
-    chroot_root, stage_kernel_for_jailer, stage_rootfs_copy_for_jailer,
-    stage_rootfs_device_for_jailer,
-};
 use arcbox_snapshot::SnapshotError;
 use arcbox_vm_driver::{IsolationSpec, PreparedVm, VmDriver, VmHandle, VmId};
 use tracing::{debug, warn};
@@ -23,7 +19,7 @@ use crate::agent::{ClockSync, GuestAgent, GuestAgentFactory, ReadyGate};
 use crate::config::VmmConfig;
 use crate::error::{Result, VmmError};
 use crate::lifecycle::runtime::ComputerRuntime;
-use crate::sandbox::boot::create_rootfs_symlink;
+use crate::sandbox::boot::{StageError, create_rootfs_symlink, stage_rootfs_cow_or_copy};
 use crate::sandbox::spec::build_vm_spec;
 use crate::sandbox::{self, NetworkAttachment, SandboxSpec, SandboxState};
 use crate::snapshot_cow::{CowHandle, CowManager};
@@ -228,79 +224,56 @@ pub async fn do_boot(
 
     // Determine the kernel and rootfs paths.
     //
-    // In jailer mode the files must exist inside the chroot: they are staged
-    // there and named to the driver by their in-jail host path, which it
-    // passes to the VMM chroot-relative. In direct mode the host-absolute
-    // paths from the spec are used as-is.
+    // The kernel is not brought anywhere here: rendering the boot stages
+    // whatever the spec names, wherever the VMM has to be able to open it
+    // from, so a pre-staged copy beside the one the render makes is pure
+    // cost. The disk is the one file this layer does stage itself, because
+    // only it can decide between a copy-on-write device and the copy that
+    // falls back from one — see `stage_rootfs_cow_or_copy`.
+    //
+    // Direct mode keeps its own arrangement: without a confinement staging
+    // is the identity, so the VM would be told the ephemeral dm device
+    // name and record *that* in its vmstate. `rootfs.link` is the stable
+    // name a later restore can retarget, and it is worth the branch.
     let mut cow_handle = None;
     let paths: Result<(PathBuf, PathBuf)> = async {
-        if let Some(ref jc) = fc_cfg.jailer {
-            // Jailer mode: stage kernel + rootfs into chroot.
-            let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-            let cr = chroot_root(&fc_cfg.binary, base, id);
-
-            // Kernel is always copied (small, ~16MB).
-            let k = stage_kernel_for_jailer(&cr, &spec.kernel, jc.uid, jc.gid).await?;
-
-            // Rootfs: try dm-snapshot + mknod, fall back to full copy.
-            let r = match cow_manager.setup(id, &spec.rootfs).await {
-                Ok(handle) => {
-                    cow_handle = Some(handle);
-                    let record = sandbox::reconcile::SandboxStateRecord::new(
-                        id,
-                        process_pid,
-                        net.map(NetworkAttachment::journaled),
-                        cow_handle.as_ref(),
-                        config,
-                        None,
-                    )?;
-                    sandbox::reconcile::write_state_record(vm_dir, &record)?;
-                    match stage_rootfs_device_for_jailer(
-                        &cr,
-                        &cow_handle.as_ref().unwrap().dm_device,
-                        jc.uid,
-                        jc.gid,
-                    )
-                    .await
-                    {
-                        Ok(path) => path,
-                        Err(e) => {
-                            debug!(
-                                sandbox_id = %id,
-                                error = %e,
-                                "mknod failed, falling back to rootfs copy"
-                            );
-                            cow_manager
-                                .teardown_checked(cow_handle.as_ref().unwrap())
-                                .await?;
-                            cow_handle = None;
-                            let record = sandbox::reconcile::SandboxStateRecord::new(
-                                id,
-                                process_pid,
-                                net.map(NetworkAttachment::journaled),
-                                None,
-                                config,
-                                None,
-                            )?;
-                            sandbox::reconcile::write_state_record(vm_dir, &record)?;
-                            stage_rootfs_copy_for_jailer(&cr, &spec.rootfs, jc.uid, jc.gid).await?
-                        }
-                    }
+        if fc_cfg.jailer.is_some() {
+            let journal = |cow: Option<&CowHandle>| {
+                sandbox::reconcile::SandboxStateRecord::new(
+                    id,
+                    process_pid,
+                    net.map(NetworkAttachment::journaled),
+                    cow,
+                    config,
+                    None,
+                )
+                .and_then(|record| sandbox::reconcile::write_state_record(vm_dir, &record))
+            };
+            let staged = stage_rootfs_cow_or_copy(
+                cow_manager,
+                sandbox::staging_capability(&*prepared),
+                id,
+                &spec.rootfs,
+                &journal,
+            )
+            .await;
+            let rootfs = match staged {
+                Ok(staged) => {
+                    cow_handle = staged.cow_handle;
+                    staged.path
                 }
-                Err(e) => {
-                    if matches!(e, SnapshotError::Unavailable(_)) {
-                        return Err(e.into());
-                    }
-                    debug!(
-                        sandbox_id = %id,
-                        error = %e,
-                        "dm-snapshot unavailable, copying rootfs into chroot"
-                    );
-                    stage_rootfs_copy_for_jailer(&cr, &spec.rootfs, jc.uid, jc.gid).await?
+                Err(StageError {
+                    error,
+                    cow_handle: acquired,
+                }) => {
+                    // Whatever the failed staging left is handed to the
+                    // computer with everything else below, so cleanup finds
+                    // it: the error is reported, not the resources dropped.
+                    cow_handle = acquired;
+                    return Err(error);
                 }
             };
-
-            Ok((in_jail(&cr, &k), in_jail(&cr, &r)))
+            Ok((PathBuf::from(&spec.kernel), rootfs))
         } else {
             // Direct mode: try dm-snapshot CoW, fall back to using rootfs directly.
             // When CoW is active, create a stable `{vm_dir}/rootfs.link` symlink
@@ -391,12 +364,6 @@ pub async fn do_boot(
         .await
         .map_err(|error| failed(error.into()))?;
     Ok((Arc::from(handle), ready_gate))
-}
-
-/// A staged file's host path inside the jail, from the chroot-relative name
-/// the staging helpers return (`/vmlinux` → `{chroot}/vmlinux`).
-fn in_jail(chroot: &Path, name: &str) -> PathBuf {
-    chroot.join(name.trim_start_matches('/'))
 }
 
 fn complete_resource_handoff(signal: &mut Option<tokio::sync::oneshot::Sender<()>>) {

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
@@ -12,57 +12,82 @@
 //! before the chroot is removed — and the renaming that leaves every
 //! retained resource keyed by the computer's own id.
 //!
-//! **The copy-mode move must precede the chroot removal, and the kill must
-//! not take the jail with it.** In copy mode the staged rootfs *is* the
-//! paused computer's disk, and it lives inside the jail: the move is guarded
-//! on `staged.exists()`, so a chroot removed any earlier turns that guard
-//! false, the move is silently skipped, pause reports success, and the
-//! resume that follows has no disk to resume from. This is why
-//! `PreparedVm::discard` kills the process without removing the jail the
-//! adapter created — the two only come apart in one order.
+//! **The copy-mode disk comes out of the VM's area before the VMM is
+//! killed.** In copy mode the staged rootfs *is* the paused computer's
+//! disk, and it lives wherever the driver put it — an area a kill is
+//! entitled to take with it, and one nothing here can name. So the disk is
+//! taken back out through the port first, while the grip that staged it is
+//! still held; only then is the VMM discarded. The other order reports a
+//! successful pause and leaves the resume that follows with no disk, which
+//! is why it is stated here rather than left to the reader of two
+//! statements twenty lines apart.
+//!
+//! The guest is quiesced by the checkpoint that precedes this, which is
+//! what makes taking its disk out safe while its VMM is still up.
 
 use std::sync::{Arc, Mutex};
 
-use arcbox_fc_driver::jail::{chroot_root, move_file};
 use arcbox_vm_driver::net::GuestNetwork;
 
-use crate::config::{JailerConfig, VmmConfig};
+use crate::config::VmmConfig;
 use crate::error::{Result, VmmError};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox::pause::PAUSED_ROOTFS_FILE;
-use crate::sandbox::{self, SandboxId};
+use crate::sandbox::{self, ROOTFS_DISK_ID, SandboxId};
 use crate::snapshot_cow::CowManager;
 
-/// Free the VM, network, and chroot of a checkpointed sandbox while
-/// keeping its disk.
+/// Free the VM and the network of a checkpointed sandbox while keeping its
+/// disk.
 ///
 /// Ordering is load-bearing, mirroring full release: the VMM must be
-/// dead before the dm detach (EBUSY) and TAP destruction. The network
-/// allocation is quarantined — the daemon completes host-side forwarding
-/// cleanup through the same durable ticket flow Stop uses.
+/// dead before the dm detach (EBUSY) and TAP destruction — and, ahead of
+/// both, a copy-mode disk must leave the VM's area before the kill that
+/// may take that area with it. The network allocation is quarantined —
+/// the daemon completes host-side forwarding cleanup through the same
+/// durable ticket flow Stop uses.
 ///
-/// A sandbox that adopted a pre-warmed slot (CORE-78) is released out of
-/// the *slot's* chroot and its slot-keyed overlay is renamed onto the
-/// sandbox-id path, so `Paused` is always reached with every retained
-/// resource keyed by the sandbox id.
-#[allow(
-    clippy::too_many_arguments,
-    reason = "the pause release spans the resource set its computer owns"
-)]
+/// A sandbox that adopted a pre-warmed slot (CORE-78) has its slot-keyed
+/// overlay renamed onto the sandbox-id path, so `Paused` is always reached
+/// with every retained resource keyed by the sandbox id.
 pub async fn release_for_pause(
     id: &SandboxId,
     arc: &Arc<Mutex<ComputerRuntime>>,
-    jailer: &JailerConfig,
     config: &VmmConfig,
     cow_manager: &CowManager,
     network: &dyn GuestNetwork,
 ) -> Result<()> {
+    // Copy mode: the staged rootfs IS this computer's disk. Take it out of
+    // the VM's area first — the guest is quiesced, the grip that staged it
+    // is still held, and after the kill neither is true.
+    let (prepared, in_copy_mode, vm_dir) = {
+        let computer = arc.lock().unwrap();
+        (
+            computer.prepared.clone(),
+            computer.cow_handle.is_none(),
+            computer.vm_dir.clone(),
+        )
+    };
+    if in_copy_mode {
+        let prepared = prepared.ok_or_else(|| {
+            // A computer this process adopted rather than booted (CORE-135)
+            // holds no prepared VM, so nothing here can reach into the area
+            // its disk sits in. Refusing before the checkpoint's guest is
+            // killed leaves the disk where it is and the pause retryable;
+            // the routes an adopted computer is missing arrive with R3
+            // PR-G3.
+            VmmError::Unavailable(format!(
+                "computer {id} runs on a copied rootfs and was adopted after an agent restart,                  so its disk cannot be taken out of the vm it was staged into; it can be                  stopped or removed, but not paused"
+            ))
+        })?;
+        sandbox::staging_capability(&*prepared)
+            .unstage_disk(ROOTFS_DISK_ID, &vm_dir.join(PAUSED_ROOTFS_FILE))
+            .await?;
+    }
+
     super::release::kill_sandbox_process(id, arc).await?;
     let owner = super::release::chroot_owner(id, arc);
 
-    // Disk: detach the overlay but keep its COW file; the copy-mode
-    // fallback parks the staged rootfs (the sandbox's actual disk) in
-    // vm_dir before the chroot is removed.
+    // Disk: detach the overlay but keep its COW file.
     let cow_handle = arc.lock().unwrap().cow_handle.take();
     if let Some(handle) = cow_handle {
         if let Err(error) = cow_manager.detach_keep_cow(&handle).await {
@@ -76,15 +101,6 @@ pub async fn release_for_pause(
         let detached = sandbox::preserved_cow_file(config, &owner);
         if detached != retained && detached.exists() {
             tokio::fs::rename(&detached, &retained)
-                .await
-                .map_err(VmmError::Io)?;
-        }
-    } else {
-        let base = jailer.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-        let staged = chroot_root(&config.firecracker.binary, base, &owner).join("rootfs.ext4");
-        if staged.exists() {
-            let vm_dir = arc.lock().unwrap().vm_dir.clone();
-            move_file(&staged, &vm_dir.join(PAUSED_ROOTFS_FILE))
                 .await
                 .map_err(VmmError::Io)?;
         }

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
@@ -135,3 +135,125 @@ pub async fn release_for_pause(
     arc.lock().unwrap().pool_slot_id = None;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use arcbox_vm_driver::testkit::{FakeDriver, FakeNetwork};
+    use arcbox_vm_driver::{DiskSource, IsolationSpec, PreparedVm, VmDriver as _, VmId};
+
+    use super::*;
+    use crate::sandbox::SandboxSpec;
+    use crate::snapshot_cow::CowOptions;
+
+    /// A copy-mode computer — no overlay, its disk staged into its VM's
+    /// area — with `staged` written there under the root disk's id when
+    /// asked for.
+    async fn copy_mode_computer(
+        data_dir: &std::path::Path,
+        driver: &FakeDriver,
+        staged: Option<&[u8]>,
+    ) -> (Arc<Mutex<ComputerRuntime>>, Arc<dyn PreparedVm>, PathBuf) {
+        let vm_dir = data_dir.join("sandboxes/job");
+        std::fs::create_dir_all(&vm_dir).unwrap();
+        let prepared: Arc<dyn PreparedVm> = Arc::from(
+            driver
+                .prepare()
+                .unwrap()
+                .prepare(&VmId::new("job").unwrap(), &IsolationSpec::None, &vm_dir)
+                .await
+                .unwrap(),
+        );
+        if let Some(bytes) = staged {
+            let source = data_dir.join("template.ext4");
+            std::fs::write(&source, bytes).unwrap();
+            prepared
+                .staging()
+                .unwrap()
+                .stage_disk(ROOTFS_DISK_ID, DiskSource::Image(&source))
+                .await
+                .unwrap();
+        }
+        let mut computer = ComputerRuntime::new(
+            "job".to_owned(),
+            SandboxSpec::default(),
+            None,
+            vm_dir.clone(),
+        );
+        computer.prepared = Some(Arc::clone(&prepared));
+        (Arc::new(Mutex::new(computer)), prepared, vm_dir)
+    }
+
+    fn config(data_dir: &std::path::Path) -> VmmConfig {
+        let mut config = VmmConfig::default();
+        config.firecracker.data_dir = data_dir.to_string_lossy().into_owned();
+        config
+    }
+
+    /// A copy-mode computer's disk comes out of the VM's area and lands
+    /// where resume looks for it, and the VM is released.
+    ///
+    /// That the take-out *precedes* the discard is not observable through
+    /// the fake, whose staging area survives one; the ordering is held by
+    /// the comment at the site and proven by the `sandbox` e2e, where the
+    /// area really does go with the kill.
+    #[tokio::test]
+    async fn the_copy_mode_disk_is_parked_before_the_vm_is_discarded() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let driver = FakeDriver::new();
+        let (computer, prepared, vm_dir) =
+            copy_mode_computer(data_dir.path(), &driver, Some(b"the guest's disk")).await;
+        let config = config(data_dir.path());
+        let cow = CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap();
+
+        release_for_pause(
+            &"job".to_owned(),
+            &computer,
+            &config,
+            &cow,
+            &FakeNetwork::new(),
+        )
+        .await
+        .expect("a copy-mode pause parks the disk and releases the vm");
+
+        assert_eq!(
+            std::fs::read(vm_dir.join(PAUSED_ROOTFS_FILE)).unwrap(),
+            b"the guest's disk"
+        );
+        assert!(
+            !prepared.alive(),
+            "the vm is discarded after the disk is out"
+        );
+    }
+
+    /// Nothing to take out is a refusal, not a skip: continuing would
+    /// discard the VM, take its area with it, and record `Paused` for a
+    /// computer with no disk to resume from.
+    #[tokio::test]
+    async fn a_copy_mode_pause_with_no_staged_disk_is_refused_before_the_kill() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let driver = FakeDriver::new();
+        let (computer, prepared, vm_dir) = copy_mode_computer(data_dir.path(), &driver, None).await;
+        let config = config(data_dir.path());
+        let cow = CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap();
+
+        let refused = release_for_pause(
+            &"job".to_owned(),
+            &computer,
+            &config,
+            &cow,
+            &FakeNetwork::new(),
+        )
+        .await;
+
+        match refused {
+            Err(VmmError::Snapshot(message)) => {
+                assert!(message.contains("nothing to resume from"), "{message}");
+            }
+            other => panic!("expected a refusal, got {other:?}"),
+        }
+        assert!(prepared.alive(), "the vm is left running for a retry");
+        assert!(!vm_dir.join(PAUSED_ROOTFS_FILE).exists());
+    }
+}

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
@@ -81,9 +81,21 @@ pub async fn release_for_pause(
                  it can be stopped or removed, but not paused"
             ))
         })?;
-        sandbox::staging_capability(&*prepared)
+        // Nothing taken out is a refusal, not a skip: in copy mode the
+        // VM's area is where this computer's only writable disk lives, so
+        // `false` means there is no disk to pause. Discarding anyway would
+        // commit `Paused` with neither a preserved overlay nor a parked
+        // rootfs — the exact state resume refuses to start from, reached
+        // after the disk is already unrecoverable.
+        if !sandbox::staging_capability(&*prepared)
             .unstage_disk(ROOTFS_DISK_ID, &vm_dir.join(PAUSED_ROOTFS_FILE))
-            .await?;
+            .await?
+        {
+            return Err(VmmError::Snapshot(format!(
+                "computer {id} runs on a copied rootfs but its vm has no disk staged to take \
+                 out; pausing it would leave nothing to resume from"
+            )));
+        }
     }
 
     super::release::kill_sandbox_process(id, arc).await?;

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
@@ -8,8 +8,8 @@
 //! The ordering mirrors a full release and is load-bearing for the same
 //! reasons: the VMM must be dead before the dm detach (EBUSY) and before the
 //! TAP goes. What differs is the disk — the overlay is detached with its COW
-//! file kept, or, in copy mode, the staged rootfs is parked in `vm_dir`
-//! before the chroot is removed — and the renaming that leaves every
+//! file kept, or, in copy mode, the staged rootfs is taken back out of the
+//! VM's area and parked in `vm_dir` — and the renaming that leaves every
 //! retained resource keyed by the computer's own id.
 //!
 //! **The copy-mode disk comes out of the VM's area before the VMM is
@@ -76,7 +76,9 @@ pub async fn release_for_pause(
             // the routes an adopted computer is missing arrive with R3
             // PR-G3.
             VmmError::Unavailable(format!(
-                "computer {id} runs on a copied rootfs and was adopted after an agent restart,                  so its disk cannot be taken out of the vm it was staged into; it can be                  stopped or removed, but not paused"
+                "computer {id} runs on a copied rootfs and was adopted after an agent \
+                 restart, so its disk cannot be taken out of the vm it was staged into; \
+                 it can be stopped or removed, but not paused"
             ))
         })?;
         sandbox::staging_capability(&*prepared)
@@ -85,7 +87,7 @@ pub async fn release_for_pause(
     }
 
     super::release::kill_sandbox_process(id, arc).await?;
-    let owner = super::release::chroot_owner(id, arc);
+    let owner = super::release::resource_owner(id, arc);
 
     // Disk: detach the overlay but keep its COW file.
     let cow_handle = arc.lock().unwrap().cow_handle.take();
@@ -116,8 +118,8 @@ pub async fn release_for_pause(
         }
     }
 
-    super::release::remove_jailer_chroot(id, arc, config).await?;
-    // Nothing slot-keyed survives this point.
+    // Nothing slot-keyed survives this point: the slot's VM is gone with
+    // the area it ran in, and its overlay was renamed above.
     arc.lock().unwrap().pool_slot_id = None;
     Ok(())
 }

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/release.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/release.rs
@@ -19,7 +19,6 @@
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-use arcbox_fc_driver::jail::chroot_root;
 use arcbox_vm_driver::ShutdownMode;
 use arcbox_vm_driver::net::GuestNetwork;
 
@@ -30,9 +29,10 @@ use crate::sandbox;
 use crate::snapshot_cow::CowManager;
 
 /// Free every runtime resource a sandbox holds: the VMM process (SIGKILL +
-/// bounded reap through the driver), the dm-snapshot CoW device, the TAP +
-/// IP allocation, and the jailer chroot. Idempotent — every resource is
-/// `take()`n, so calling this from both Stop and Remove is safe.
+/// bounded reap through the driver, which takes the area the VM's files
+/// were staged into with it), the dm-snapshot CoW device, and the TAP + IP
+/// allocation. Idempotent — every resource is `take()`n, so calling this
+/// from both Stop and Remove is safe.
 ///
 /// The ordering is load-bearing: the VMM must be dead before the CoW
 /// teardown (`dmsetup remove` returns EBUSY while the block device is open)
@@ -41,7 +41,6 @@ pub async fn release_runtime_resources(
     id: &str,
     arc: &Arc<Mutex<ComputerRuntime>>,
     network: &Arc<dyn GuestNetwork>,
-    config: &Arc<VmmConfig>,
     cow_manager: &Arc<CowManager>,
 ) -> Result<()> {
     kill_sandbox_process(id, arc).await?;
@@ -60,50 +59,21 @@ pub async fn release_runtime_resources(
     cow_manager.cleanup_setup_orphan(id).await?;
 
     // Release network resources (destroys TAP via ioctl).
+    let lease = arc.lock().unwrap().network.take();
+    if let Some(lease) = lease
+        && let Err(error) = network.quarantine(lease.clone()).await
     {
-        let lease = arc.lock().unwrap().network.take();
-        if let Some(lease) = lease
-            && let Err(error) = network.quarantine(lease.clone()).await
-        {
-            arc.lock().unwrap().network = Some(lease);
-            return Err(error.into());
-        }
-    }
-
-    // Clean up the jailer chroot directory if applicable. A sandbox that
-    // adopted a pre-warmed pool slot lives in the slot's chroot, so the
-    // removal is keyed by the owning id, not the sandbox id.
-    remove_jailer_chroot(id, arc, config).await
-}
-
-/// Remove the jailer chroot a sandbox actually lives in.
-///
-/// Keyed by the adopted pool slot id when the sandbox claimed a pre-warmed
-/// slot (CORE-78), by the sandbox id otherwise. Shared with the pause path,
-/// which releases the same chroot while keeping the disk.
-pub async fn remove_jailer_chroot(
-    id: &str,
-    arc: &Arc<Mutex<ComputerRuntime>>,
-    config: &VmmConfig,
-) -> Result<()> {
-    let Some(ref jc) = config.firecracker.jailer else {
-        return Ok(());
-    };
-    let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-    let chroot_owner = chroot_owner(id, arc);
-    let chroot_dir = chroot_root(&config.firecracker.binary, base, &chroot_owner);
-    // Remove {base}/{exec_name}/{id}/ (parent of "root/").
-    if let Some(parent) = chroot_dir.parent()
-        && let Err(e) = tokio::fs::remove_dir_all(parent).await
-        && e.kind() != std::io::ErrorKind::NotFound
-    {
-        return Err(VmmError::Io(e));
+        arc.lock().unwrap().network = Some(lease);
+        return Err(error.into());
     }
     Ok(())
 }
 
-/// Id the sandbox's jailer chroot and dm/CoW resources are named after.
-pub fn chroot_owner(id: &str, arc: &Arc<Mutex<ComputerRuntime>>) -> String {
+/// Id this computer's dm/CoW resources are named after.
+///
+/// A computer that adopted a pre-warmed pool slot (CORE-78) runs on the
+/// slot's resources, so they are named after the slot and not after it.
+pub fn resource_owner(id: &str, arc: &Arc<Mutex<ComputerRuntime>>) -> String {
     arc.lock()
         .unwrap()
         .pool_slot_id
@@ -116,6 +86,11 @@ pub fn chroot_owner(id: &str, arc: &Arc<Mutex<ComputerRuntime>>) -> String {
 /// VM's handle only names a corpse — nothing dials, checkpoints or stops a
 /// stopped, paused or failed sandbox — so it is dropped here too, the one
 /// place both are let go.
+///
+/// **The driver takes the VM's staging area with the kill**, so anything
+/// that has to outlive the VM leaves through `Staging::unstage_disk`
+/// before this is called — which is what the pause release does with a
+/// copy-mode rootfs.
 ///
 /// A sandbox this process adopted rather than booted has no `PreparedVm` —
 /// nothing hands the driver's grip on a *process* back across a restart — so
@@ -178,7 +153,7 @@ pub async fn release_everything(
     cow_manager: &Arc<CowManager>,
     snapshots: &Arc<crate::snapshot::SnapshotCatalog>,
 ) -> Result<()> {
-    release_runtime_resources(id, arc, network, config, cow_manager).await?;
+    release_runtime_resources(id, arc, network, cow_manager).await?;
 
     // Pause artifacts survive Stop-style release by design (CORE-21); Remove
     // is where they die: the retained disk overlay and the internal pause

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
@@ -15,13 +15,10 @@
 //! crash window with no journal at all, and the slot-keyed VMM, chroot and
 //! CoW invisible to reconciliation.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use arcbox_fc_driver::jail::{
-    SnapshotFiles, chroot_root, stage_kernel_for_jailer, stage_snapshot_files,
-};
 use arcbox_vm_driver::net::{GuestNetwork, NetworkIdentity, NetworkLease};
 use arcbox_vm_driver::{
     CheckpointImage, IsolationSpec, NicSpec, PreparedVm, VmDriver, VmHandle, VmId,
@@ -36,6 +33,7 @@ use crate::sandbox;
 use crate::sandbox::boot::{StageError, stage_rootfs_cow_or_copy};
 use crate::sandbox::pool::PreparedSlot;
 use crate::sandbox::reconcile::JournaledLease;
+use crate::sandbox::spec::restore_spec;
 use crate::snapshot::SnapshotMeta;
 use crate::snapshot_cow::{CowHandle, CowManager};
 
@@ -124,8 +122,6 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
         agents,
     } = inputs;
 
-    let fc_cfg = &config.firecracker;
-
     // Track resources that need cleanup if anything between this point
     // and the final instance registration fails:
     //
@@ -139,11 +135,10 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
     // reconfiguration as the only restore work. From the claim on, the
     // slot's resources are owned by this restore and unwind through
     // rollback_restore like freshly created ones.
-    let base = jailer.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
     let pool_hit = claimed.is_some();
-    // The id the jail is keyed by (the slot's for a pool hit), which is
-    // also the id the driver prepared the VMM under.
-    let (prepared, resource_owner, chroot, staged_checkpoint, t_prepared, t_staged) =
+    // The id this restore's resources are keyed by (the slot's for a pool
+    // hit), which is also the id the driver prepared the VMM under.
+    let (prepared, resource_owner, rootfs, staged_checkpoint, t_prepared, t_staged) =
         if let Some(slot) = claimed {
             // Record the adopting sandbox's slot id first: failure cleanup
             // and crash reconciliation key the chroot and dm/CoW teardown
@@ -165,6 +160,7 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
                 slot_id,
                 prepared: slot_prepared,
                 cow_handle,
+                rootfs,
                 image,
                 vm_dir: slot_vm_dir,
             } = slot;
@@ -211,12 +207,11 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
             // Both phases were pre-executed by the slot; the timestamps
             // collapse so the completion log reports them honestly as ~0.
             let t_claimed = std::time::Instant::now();
-            let chroot = chroot_root(&fc_cfg.binary, base, &slot_id);
-            (slot_prepared, slot_id, chroot, image, t_claimed, t_claimed)
+            (slot_prepared, slot_id, rootfs, image, t_claimed, t_claimed)
         } else {
-            // Each jailer restore owns a distinct chroot; the driver's
-            // prepared VMM spawns into it.
-            let cr = chroot_root(&fc_cfg.binary, base, new_id);
+            // Each jailer restore owns a VMM of its own; the driver spawns
+            // it and stages this restore's files into the area it reads
+            // from.
             let spawned: Result<Arc<dyn PreparedVm>> = async {
                 let prepared = sandbox::prepare_capability(driver)
                     .prepare(
@@ -263,60 +258,58 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
 
             let t_prepared = std::time::Instant::now();
 
-            // In jailer mode the restored FC process also runs inside a
-            // chroot and cannot access the catalog's host-absolute paths.
-            // Stage the snapshot files into the new sandbox's chroot and use
-            // chroot-relative paths.
-            let setup_result: Result<CheckpointImage> = async {
-                let jc = jailer;
+            // The restored VMM reads none of the catalog's host-absolute
+            // paths: everything it loads is brought into the area it can
+            // reach first, and named by where staging put it.
+            let setup_result: Result<(PathBuf, CheckpointImage)> = async {
+                let staging = sandbox::staging_capability(&*spawned_prepared);
 
-                // Stage kernel (always hard-linked or copied, ~16MB).
+                // The kernel. A snapshot load names only the vmstate and
+                // the mem file, so this stage may well be vestigial — but
+                // nothing on the restore path proves that, so it is
+                // brought in exactly as before rather than dropped on a
+                // guess. (The *boot* path's kernel stage did go: rendering
+                // a boot stages the kernel its spec names.)
                 if let Some(k) = snap_meta.kernel_path.as_deref() {
-                    stage_kernel_for_jailer(&cr, k, jc.uid, jc.gid).await?;
+                    staging.stage_kernel(Path::new(k)).await?;
                 }
 
-                // Stage rootfs: dm-snapshot + mknod with full-copy fallback,
-                // mirroring the boot path so restored sandboxes get the same
-                // CoW semantics (block-level template sharing, sparse COW).
-                if let Some(r) = snap_meta.rootfs_path.as_deref() {
-                    match stage_rootfs_cow_or_copy(
-                        cow_manager,
-                        &cr,
-                        new_id,
-                        r,
-                        jc.uid,
-                        jc.gid,
-                        &journal,
-                    )
-                    .await
+                // The disk: a copy-on-write device with a full-copy
+                // fallback, mirroring the boot path so a restored computer
+                // gets the same CoW semantics (block-level template
+                // sharing, sparse COW).
+                let rootfs = snap_meta.rootfs_path.as_deref().ok_or_else(|| {
+                    VmmError::Snapshot(format!(
+                        "checkpoint {} records no rootfs template; there is no disk to restore \
+                         it onto",
+                        snap_meta.id
+                    ))
+                })?;
+                let staged =
+                    match stage_rootfs_cow_or_copy(cow_manager, staging, new_id, rootfs, &journal)
+                        .await
                     {
-                        Ok(cow) => pending_cow = cow,
+                        Ok(staged) => staged,
                         Err(StageError { error, cow_handle }) => {
                             pending_cow = cow_handle;
                             return Err(error);
                         }
-                    }
-                }
+                    };
+                pending_cow = staged.cow_handle;
 
-                // Stage vmstate + mem into the chroot. Both are read-only to
-                // FC (mem is mapped MAP_PRIVATE on load), so the root jailer
-                // hard-links them instead of copying — the mem file is the
-                // sandbox's full memory size (CORE-75).
-                let files = SnapshotFiles {
-                    id: &snap_meta.id,
-                    vmstate: &snap_meta.vmstate_path,
-                    mem: snap_meta.mem_path.as_deref(),
-                };
-                stage_snapshot_files(&cr, &files, jc.uid, jc.gid).await?;
-                Ok(sandbox::checkpoint_image(
-                    cr.join("snapshots").join(&snap_meta.id),
-                    &snap_meta.format,
-                ))
+                // The checkpoint itself. Its mem file is the guest's whole
+                // memory (CORE-75), which is why bringing it in is the
+                // expensive half of a restore and why a pre-warmed slot
+                // that already paid for it restores in milliseconds.
+                let image = staging
+                    .stage_checkpoint(&sandbox::catalogued_checkpoint(snap_meta)?)
+                    .await?;
+                Ok((staged.path, image))
             }
             .await;
 
-            let image = match setup_result {
-                Ok(image) => image,
+            let (rootfs, image) = match setup_result {
+                Ok(staged) => staged,
                 Err(error) => {
                     return Err(RestoreFailure {
                         error,
@@ -328,7 +321,7 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
             (
                 spawned_prepared,
                 new_id.to_owned(),
-                cr,
+                rootfs,
                 image,
                 t_prepared,
                 std::time::Instant::now(),
@@ -347,12 +340,12 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
     // nothing is told how to reach it by address in the meantime.
     let settled_on_load = snap_meta.net_invariant.then(|| identity.clone()).flatten();
 
-    // Load the image on the prepared VMM: the disk is the rootfs staged
-    // into the owner's jail, eth0 lands on the fresh TAP.
+    // Load the image on the prepared VMM: the disk is the rootfs staging
+    // put in the VMM's reach, eth0 lands on the fresh TAP.
     let loaded: Result<(Arc<dyn VmHandle>, Arc<dyn GuestAgent>)> = async {
-        let restore = sandbox::spec::restore_spec(
+        let restore = restore_spec(
             &resource_owner,
-            &chroot,
+            rootfs,
             nic.clone(),
             IsolationSpec::try_from(jailer)?,
         )?;

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
@@ -14,7 +14,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use arcbox_fc_driver::jail::{chroot_root, move_file};
+use arcbox_fc_driver::jail::chroot_root;
 use arcbox_vm_driver::net::{GuestNetwork, NetworkLease};
 use arcbox_vm_driver::{DiskSource, IsolationSpec, NicSpec, PreparedVm, VmDriver, VmHandle, VmId};
 use tracing::warn;
@@ -31,10 +31,10 @@ use crate::snapshot_cow::{CowHandle, CowManager};
 
 /// Re-create the runtime of a paused sandbox from its checkpoint.
 ///
-/// On failure every re-created resource is unwound (the VMM killed,
-/// overlay detached with its COW kept, copy-mode rootfs parked again,
-/// fresh network quarantined, chroot and journal removed) so the caller
-/// can park the sandbox back at `Paused`.
+/// On failure every re-created resource is unwound (a copy-mode rootfs
+/// parked again, the VMM killed, the overlay detached with its COW kept,
+/// the fresh network quarantined, chroot and journal removed) so the
+/// caller can park the sandbox back at `Paused`.
 #[allow(
     clippy::too_many_arguments,
     reason = "the resume spans the resource set its computer owns"
@@ -244,6 +244,42 @@ pub async fn restore_paused(
     }
 }
 
+/// Take a copy-mode rootfs back out of the VM's area and park it in
+/// `vm_dir`, restoring what a clean pause leaves behind.
+///
+/// This runs before the discard, for the same reason the pause release's
+/// does: the staged rootfs *is* the paused computer's disk, it sits in an
+/// area the discard is entitled to take with it, and only the grip being
+/// discarded can reach in there. Nothing is writing it — a resume that got
+/// as far as a running guest dropped that handle on its way out, and a
+/// dropped handle SIGKILLs.
+///
+/// `false` when the disk could not be parked, which is what stops the
+/// computer being recorded as cleanly `Paused`.
+async fn park_copy_mode_rootfs(
+    id: &SandboxId,
+    vm_dir: &Path,
+    config: &VmmConfig,
+    prepared: Option<&Arc<dyn PreparedVm>>,
+) -> bool {
+    let Some(prepared) = prepared else {
+        return true;
+    };
+    if sandbox::preserved_cow_file(config, id).exists() {
+        return true;
+    }
+    match sandbox::staging_capability(&**prepared)
+        .unstage_disk(ROOTFS_DISK_ID, &vm_dir.join(PAUSED_ROOTFS_FILE))
+        .await
+    {
+        Ok(_) => true,
+        Err(error) => {
+            warn!(sandbox_id = %id, error = %error, "resume unwind: parking rootfs failed");
+            false
+        }
+    }
+}
+
 /// Best-effort release of everything a failed resume re-created,
 /// restoring the on-disk shape of a cleanly paused sandbox.
 ///
@@ -263,7 +299,7 @@ async fn unwind_resume(
     cow_handle: Option<CowHandle>,
     net_lease: Option<NetworkLease>,
 ) -> bool {
-    let mut clean = true;
+    let mut clean = park_copy_mode_rootfs(id, vm_dir, config, prepared.as_ref()).await;
 
     if let Some(prepared) = prepared {
         // SIGKILL plus the driver's bounded wait for the reaper.
@@ -280,21 +316,8 @@ async fn unwind_resume(
         clean = false;
     }
 
-    // Copy-mode fallback: park the staged rootfs back in vm_dir so the
-    // retained disk state survives the chroot removal below. The order is
-    // load-bearing in the same way the pause release's is — the staged
-    // rootfs *is* the paused computer's disk and it lives inside the jail,
-    // so a chroot removed before this point turns the `exists()` guard
-    // false, the move is skipped, and the computer is left unresumable.
     let base = jailer.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
     let cr = chroot_root(&config.firecracker.binary, base, id);
-    let staged = cr.join("rootfs.ext4");
-    if !sandbox::preserved_cow_file(config, id).exists() && staged.exists() {
-        if let Err(error) = move_file(&staged, &vm_dir.join(PAUSED_ROOTFS_FILE)).await {
-            warn!(sandbox_id = %id, error = %error, "resume unwind: parking rootfs failed");
-            clean = false;
-        }
-    }
 
     if let Some(lease) = net_lease
         && let Err(error) = network.quarantine(lease).await

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
@@ -14,12 +14,9 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use arcbox_fc_driver::jail::{
-    chroot_root, link_or_copy_for_jailer, move_file, stage_kernel_for_jailer,
-    stage_rootfs_device_for_jailer,
-};
+use arcbox_fc_driver::jail::{chroot_root, move_file};
 use arcbox_vm_driver::net::{GuestNetwork, NetworkLease};
-use arcbox_vm_driver::{IsolationSpec, NicSpec, PreparedVm, VmDriver, VmHandle, VmId};
+use arcbox_vm_driver::{DiskSource, IsolationSpec, NicSpec, PreparedVm, VmDriver, VmHandle, VmId};
 use tracing::warn;
 
 use crate::agent::{ClockSync, GuestAgentFactory};
@@ -28,7 +25,7 @@ use crate::error::{Result, VmmError};
 use crate::sandbox::pause::{PAUSED_ROOTFS_FILE, ResumeFailure, ResumedRuntime};
 use crate::sandbox::reconcile::JournaledLease;
 use crate::sandbox::spec::restore_spec;
-use crate::sandbox::{self, SandboxId};
+use crate::sandbox::{self, ROOTFS_DISK_ID, SandboxId};
 use crate::snapshot::SnapshotMeta;
 use crate::snapshot_cow::{CowHandle, CowManager};
 
@@ -54,12 +51,6 @@ pub async fn restore_paused(
     network: &dyn GuestNetwork,
     agents: &dyn GuestAgentFactory,
 ) -> std::result::Result<ResumedRuntime, ResumeFailure> {
-    let fc_cfg = &config.firecracker;
-    let base = jailer.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-    let cr = chroot_root(&fc_cfg.binary, base, id);
-    let uid = jailer.uid;
-    let gid = jailer.gid;
-
     // Incrementally-owned resources for the unwind. The lease is held
     // apart from the NIC because it is owed to the pool from `reserve`
     // on, and the journal write between the two can fail — an unwind
@@ -103,73 +94,60 @@ pub async fn restore_paused(
             );
         }
 
-        // Fresh chroot + VMM process, prepared through the driver.
+        // A fresh VMM, prepared through the driver.
         let spawned: Arc<dyn PreparedVm> = Arc::from(
             sandbox::prepare_capability(driver)
                 .prepare(&VmId::new(id)?, &IsolationSpec::try_from(jailer)?, vm_dir)
                 .await?,
         );
         let pid = sandbox::journaled_pid(&*spawned);
-        prepared = Some(spawned);
+        let staging = sandbox::staging_capability(&*spawned);
+        prepared = Some(Arc::clone(&spawned));
         journal(pid, None, lease.as_ref())?;
 
-        // Stage kernel + the retained disk + snapshot files.
+        // Bring the kernel, the retained disk and the checkpoint into the
+        // area the fresh VMM reads from.
         if let Some(kernel) = snap_meta.kernel_path.as_deref() {
-            stage_kernel_for_jailer(&cr, kernel, uid, gid).await?;
+            staging.stage_kernel(Path::new(kernel)).await?;
         }
         let preserved_cow = sandbox::preserved_cow_file(config, id);
-        if preserved_cow.exists() {
-            let rootfs = snap_meta.rootfs_path.as_deref().ok_or_else(|| {
+        let rootfs = if preserved_cow.exists() {
+            let template = snap_meta.rootfs_path.as_deref().ok_or_else(|| {
                 VmmError::Snapshot(format!(
                     "pause checkpoint for {id} records no rootfs template"
                 ))
             })?;
-            let handle = cow_manager.reattach(id, rootfs).await?;
+            let handle = cow_manager.reattach(id, template).await?;
             journal(pid, Some(&handle), lease.as_ref())?;
-            stage_rootfs_device_for_jailer(&cr, &handle.dm_device, uid, gid).await?;
+            let staged = staging
+                .stage_disk(
+                    ROOTFS_DISK_ID,
+                    DiskSource::Device(Path::new(&handle.dm_device)),
+                )
+                .await?;
             cow_handle = Some(handle);
+            staged
         } else {
+            // The copy-mode disk the pause parked outside: handed over, so
+            // it is moved back in rather than duplicated — it is the size
+            // of a guest rootfs, and nothing else holds a copy of it.
             let parked = vm_dir.join(PAUSED_ROOTFS_FILE);
             if !parked.exists() {
                 return Err(VmmError::Snapshot(format!(
                     "paused sandbox {id} has neither a preserved overlay nor a parked rootfs"
                 )));
             }
-            let staged = cr.join("rootfs.ext4");
-            move_file(&parked, &staged).await.map_err(VmmError::Io)?;
-            nix::unistd::chown(
-                &staged,
-                Some(nix::unistd::Uid::from_raw(uid)),
-                Some(nix::unistd::Gid::from_raw(gid)),
-            )
-            .map_err(|e| VmmError::Process(format!("chown parked rootfs: {e}")))?;
-        }
+            staging
+                .stage_disk(ROOTFS_DISK_ID, DiskSource::Handover(&parked))
+                .await?
+        };
+        let image = staging
+            .stage_checkpoint(&sandbox::catalogued_checkpoint(snap_meta)?)
+            .await?;
 
-        let snap_in_chroot = cr.join("snapshots").join(&snap_meta.id);
-        std::fs::create_dir_all(&snap_in_chroot).map_err(VmmError::Io)?;
-        nix::unistd::chown(
-            &snap_in_chroot,
-            Some(nix::unistd::Uid::from_raw(uid)),
-            Some(nix::unistd::Gid::from_raw(gid)),
-        )
-        .map_err(|e| VmmError::Process(format!("chown snap dir: {e}")))?;
-        link_or_copy_for_jailer(
-            &snap_meta.vmstate_path,
-            &snap_in_chroot.join("vmstate"),
-            uid,
-            gid,
-        )
-        .await?;
-        if let Some(ref mem) = snap_meta.mem_path
-            && mem.exists()
-        {
-            link_or_copy_for_jailer(mem, &snap_in_chroot.join("mem"), uid, gid).await?;
-        }
-
-        // Load the snapshot on the prepared VMM: the retained disk in
-        // this jail, eth0 retargeted onto the fresh TAP.
-        let image = sandbox::checkpoint_image(snap_in_chroot, &snap_meta.format);
-        let restore = restore_spec(id, &cr, nic.clone(), IsolationSpec::try_from(jailer)?)?;
+        // Load the snapshot on the prepared VMM: the retained disk where
+        // staging put it, eth0 retargeted onto the fresh TAP.
+        let restore = restore_spec(id, rootfs, nic.clone(), IsolationSpec::try_from(jailer)?)?;
         let handle: Arc<dyn VmHandle> = Arc::from(
             prepared
                 .as_ref()

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
@@ -14,7 +14,6 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use arcbox_fc_driver::jail::chroot_root;
 use arcbox_vm_driver::net::{GuestNetwork, NetworkLease};
 use arcbox_vm_driver::{DiskSource, IsolationSpec, NicSpec, PreparedVm, VmDriver, VmHandle, VmId};
 use tracing::warn;
@@ -32,9 +31,9 @@ use crate::snapshot_cow::{CowHandle, CowManager};
 /// Re-create the runtime of a paused sandbox from its checkpoint.
 ///
 /// On failure every re-created resource is unwound (a copy-mode rootfs
-/// parked again, the VMM killed, the overlay detached with its COW kept,
-/// the fresh network quarantined, chroot and journal removed) so the
-/// caller can park the sandbox back at `Paused`.
+/// parked again, the VMM killed — which takes the area it ran in — the
+/// overlay detached with its COW kept, the fresh network quarantined, the
+/// journal removed) so the caller can park the sandbox back at `Paused`.
 #[allow(
     clippy::too_many_arguments,
     reason = "the resume spans the resource set its computer owns"
@@ -230,7 +229,6 @@ pub async fn restore_paused(
             let unwound = unwind_resume(
                 id,
                 vm_dir,
-                jailer,
                 config,
                 cow_manager,
                 network,
@@ -291,7 +289,6 @@ async fn park_copy_mode_rootfs(
 async fn unwind_resume(
     id: &SandboxId,
     vm_dir: &Path,
-    jailer: &JailerConfig,
     config: &VmmConfig,
     cow_manager: &CowManager,
     network: &dyn GuestNetwork,
@@ -316,21 +313,10 @@ async fn unwind_resume(
         clean = false;
     }
 
-    let base = jailer.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-    let cr = chroot_root(&config.firecracker.binary, base, id);
-
     if let Some(lease) = net_lease
         && let Err(error) = network.quarantine(lease).await
     {
         warn!(sandbox_id = %id, error = %error, "resume unwind: network quarantine failed");
-        clean = false;
-    }
-
-    if let Some(parent) = cr.parent()
-        && let Err(error) = tokio::fs::remove_dir_all(parent).await
-        && error.kind() != std::io::ErrorKind::NotFound
-    {
-        warn!(sandbox_id = %id, error = %error, "resume unwind: chroot removal failed");
         clean = false;
     }
 

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
@@ -253,7 +253,10 @@ pub async fn restore_paused(
 /// dropped handle SIGKILLs.
 ///
 /// `false` when the disk could not be parked, which is what stops the
-/// computer being recorded as cleanly `Paused`.
+/// computer being recorded as cleanly `Paused`. Unlike the pause release,
+/// *nothing staged* is a normal outcome here and not a refusal: a resume
+/// that failed before it handed the parked disk over never moved it, so
+/// the file is still sitting in `vm_dir` where a clean pause left it.
 async fn park_copy_mode_rootfs(
     id: &SandboxId,
     vm_dir: &Path,

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -13,18 +13,15 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
-use arcbox_fc_driver::jail::{
-    SnapshotFiles, api_socket_path, chroot_root, stage_kernel_for_jailer,
-    stage_rootfs_copy_for_jailer, stage_rootfs_device_for_jailer, stage_snapshot_files,
-};
+use arcbox_fc_driver::jail::{api_socket_path, chroot_root};
 use arcbox_fc_driver::{FcDriver, FcDriverConfig};
 use arcbox_vm_driver::net::{
     AttachMode, GuestNetwork, NetworkIdentity, NetworkLease, NetworkMode, NetworkPolicy,
     NetworkReconcile,
 };
 use arcbox_vm_driver::{
-    CheckpointFormat, CheckpointImage, CheckpointKind, IsolationSpec, NicSpec, Prepare, PreparedVm,
-    VmDriver, VmHandle, VmId,
+    CheckpointFormat, CheckpointImage, CheckpointKind, DiskSource, IsolationSpec, NicSpec, Prepare,
+    PreparedVm, Staging, VmDriver, VmHandle, VmId,
 };
 use chrono::{DateTime, Utc};
 use tokio::sync::broadcast;
@@ -43,7 +40,7 @@ use crate::lifecycle::event::{Provision, RestoreOrigin};
 use crate::lifecycle::flows::{BootLaunch, ComputerFlows, ComputerServices, Launch, RestoreLaunch};
 use crate::lifecycle::runtime::{ComputerRuntime, Runtime};
 use crate::network::NetworkManager;
-use crate::snapshot::SnapshotCatalog;
+use crate::snapshot::{SnapshotCatalog, SnapshotMeta};
 use crate::snapshot_cow::{CowHandle, CowManager, CowOptions};
 use crate::template_catalog::TemplateCatalog;
 
@@ -71,6 +68,7 @@ pub use execution::{
     ExecutionChannel, ExecutionOutput, ExecutionSnapshot, ExecutionSpec, StdinState,
 };
 pub use pause::reason as pause_reason;
+pub(crate) use spec::ROOTFS_DISK_ID;
 pub(crate) use types::NetworkAttachment;
 pub use types::{
     CheckpointInfo, CheckpointSummary, IdleAction, LifecycleUpdate, RestoreSandboxSpec,
@@ -161,6 +159,12 @@ impl SandboxManager {
                 driver.prepare().is_none(),
                 "prepare",
                 "the boot and pool flows spawn the VMM ahead of the guest",
+            ),
+            (
+                !capabilities.staging,
+                "staging",
+                "every flow brings the files its computer boots from into the area the VMM \
+                 can reach, and pause takes the disk back out of it",
             ),
             // The last hard-wired transport assumption in this layer: every
             // agent implementation the crate ships reaches its guest through
@@ -624,6 +628,16 @@ pub(crate) fn prepare_capability(driver: &dyn VmDriver) -> &dyn Prepare {
         .expect("SandboxManager::with_environment requires the driver's Prepare capability")
 }
 
+/// The prepared VM's `Staging` capability, which
+/// [`SandboxManager::with_environment`] requires — every flow that puts a
+/// guest on a VMM first brings that guest's files into the area the VMM can
+/// reach, and pause takes its disk back out of it.
+pub(crate) fn staging_capability(prepared: &dyn PreparedVm) -> &dyn Staging {
+    prepared
+        .staging()
+        .expect("SandboxManager::with_environment requires the driver's Staging capability")
+}
+
 /// The VMM's pid as the crash journal records it: what a restart sweep
 /// kills before tearing the sandbox's other resources down.
 pub(crate) fn journaled_pid(prepared: &dyn PreparedVm) -> Option<i32> {
@@ -652,15 +666,29 @@ pub(crate) fn preserved_cow_file(config: &VmmConfig, id: &str) -> PathBuf {
         .join(format!("arcbox-cow-{id}.img"))
 }
 
-/// A catalogued checkpoint as the driver reads it back: the directory the
-/// files were staged into (`vmstate` + `mem`) and the format the catalog
-/// recorded at capture — legacy entries default to the Firecracker format.
-pub(super) fn checkpoint_image(dir: PathBuf, format: &str) -> CheckpointImage {
-    CheckpointImage {
-        dir,
-        format: CheckpointFormat::new(format),
+/// A checkpoint as the catalog holds it, which is what
+/// [`Staging::stage_checkpoint`] takes and what the driver reads back.
+///
+/// The catalog writes one directory per checkpoint and puts `vmstate` and
+/// `mem` in it, so the image is that directory — read off the meta's own
+/// `vmstate_path` rather than recomputed from the catalog's layout, which
+/// this layer does not own. Its name is what the driver stages the
+/// checkpoint under, and a restore reproduces that name from the same
+/// image, so the two cannot drift. The format is the one the catalog
+/// recorded at capture; legacy entries default to the Firecracker format.
+pub(crate) fn catalogued_checkpoint(meta: &SnapshotMeta) -> Result<CheckpointImage> {
+    let dir = meta.vmstate_path.parent().ok_or_else(|| {
+        VmmError::Snapshot(format!(
+            "checkpoint {} records a vmstate at {}, which is in no directory",
+            meta.id,
+            meta.vmstate_path.display()
+        ))
+    })?;
+    Ok(CheckpointImage {
+        dir: dir.to_path_buf(),
+        format: CheckpointFormat::new(&meta.format),
         kind: CheckpointKind::Full,
-    }
+    })
 }
 
 /// Stock sandbox id budget: what [`max_sandbox_id_len`] computes for the

--- a/computer/arcbox-computer-runtime/src/sandbox/boot.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/boot.rs
@@ -127,45 +127,74 @@ pub struct StageError {
     pub cow_handle: Option<CowHandle>,
 }
 
-/// Stage a snapshot's rootfs into a jailer chroot: dm-snapshot + mknod
-/// when device-mapper is available, full copy otherwise.
+/// The root disk as the VM will see it, and the overlay behind it.
+pub struct StagedRootfs {
+    /// Where the disk is now — the path the spec must name for it.
+    pub path: PathBuf,
+    /// The copy-on-write overlay the disk is a view of, when that path was
+    /// taken; `None` after the full-copy fallback.
+    pub cow_handle: Option<CowHandle>,
+}
+
+/// Stage `rootfs` as the computer's root disk: a copy-on-write device when
+/// device-mapper gives one, a private copy of the template otherwise.
 ///
-/// `owner_id` keys the dm/CoW resource names (the sandbox id, or a pool
+/// The decision is the runtime's and cannot be left to the driver: it is
+/// made from whether `setup` produced a device *and* whether the driver
+/// could bring that device into the VM's area, and the fallback has to
+/// tear the overlay down and re-journal before it copies. Everything else
+/// about where the disk goes — the name it lands under, whether a
+/// confinement exists at all — belongs to [`Staging`] and is not decided
+/// here.
+///
+/// `owner_id` keys the dm/CoW resource names (the computer id, or a pool
 /// slot id for pre-warmed slots). `journal` persists the caller's crash
 /// record whenever CoW resources appear or disappear, so reconciliation
-/// can always identify them. Returns the CoW handle when the dm path was
-/// taken; the staged rootfs is `/rootfs.ext4` inside the chroot either way.
+/// can always identify them.
 pub async fn stage_rootfs_cow_or_copy(
     cow_manager: &CowManager,
-    chroot: &Path,
+    staging: &dyn Staging,
     owner_id: &str,
     rootfs: &str,
-    uid: u32,
-    gid: u32,
     journal: &(dyn Fn(Option<&CowHandle>) -> Result<()> + Sync),
-) -> std::result::Result<Option<CowHandle>, StageError> {
+) -> std::result::Result<StagedRootfs, StageError> {
     let fail = |error: VmmError, cow_handle: Option<CowHandle>| StageError { error, cow_handle };
+    let copy = async || {
+        staging
+            .stage_disk(ROOTFS_DISK_ID, DiskSource::Image(Path::new(rootfs)))
+            .await
+            .map_err(VmmError::from)
+    };
     match cow_manager.setup(owner_id, rootfs).await {
         Ok(handle) => {
             if let Err(error) = journal(Some(&handle)) {
                 return Err(fail(error, Some(handle)));
             }
-            match stage_rootfs_device_for_jailer(chroot, &handle.dm_device, uid, gid).await {
-                Ok(_) => Ok(Some(handle)),
+            match staging
+                .stage_disk(
+                    ROOTFS_DISK_ID,
+                    DiskSource::Device(Path::new(&handle.dm_device)),
+                )
+                .await
+            {
+                Ok(path) => Ok(StagedRootfs {
+                    path,
+                    cow_handle: Some(handle),
+                }),
                 Err(e) => {
                     debug!(
                         owner_id,
                         error = %e,
-                        "mknod failed, falling back to rootfs copy"
+                        "the overlay could not be brought into the vm's area, falling back to a rootfs copy"
                     );
                     if let Err(error) = cow_manager.teardown_checked(&handle).await {
                         return Err(fail(error.into(), Some(handle)));
                     }
                     journal(None).map_err(|error| fail(error, None))?;
-                    stage_rootfs_copy_for_jailer(chroot, rootfs, uid, gid)
-                        .await
-                        .map_err(|error| fail(error.into(), None))?;
-                    Ok(None)
+                    Ok(StagedRootfs {
+                        path: copy().await.map_err(|error| fail(error, None))?,
+                        cow_handle: None,
+                    })
                 }
             }
         }
@@ -174,12 +203,12 @@ pub async fn stage_rootfs_cow_or_copy(
             debug!(
                 owner_id,
                 error = %e,
-                "dm-snapshot unavailable, copying rootfs into chroot"
+                "dm-snapshot unavailable, staging a copy of the rootfs"
             );
-            stage_rootfs_copy_for_jailer(chroot, rootfs, uid, gid)
-                .await
-                .map_err(|error| fail(error.into(), None))?;
-            Ok(None)
+            Ok(StagedRootfs {
+                path: copy().await.map_err(|error| fail(error, None))?,
+                cow_handle: None,
+            })
         }
     }
 }

--- a/computer/arcbox-computer-runtime/src/sandbox/cleanup.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/cleanup.rs
@@ -13,21 +13,9 @@ use super::*;
 mod tests {
     use arcbox_vm_driver::ShutdownMode;
 
-    use crate::lifecycle::tasks::release::release_runtime_resources;
-
     use super::*;
     use crate::snapshot_cow::{CowOptions, CowTestProbe};
-    use arcbox_vm_driver::testkit::FakeNetwork;
     use std::os::unix::fs::PermissionsExt;
-
-    fn instance(id: &str) -> Arc<Mutex<ComputerRuntime>> {
-        Arc::new(Mutex::new(ComputerRuntime::new(
-            id.to_owned(),
-            SandboxSpec::default(),
-            None,
-            PathBuf::from("/tmp/x"),
-        )))
-    }
 
     /// A sandbox this process adopted rather than booted holds a handle and
     /// no `PreparedVm`, and Remove must still reach its VMM: the old code
@@ -220,45 +208,5 @@ mod tests {
         assert!(!vm_dir.exists());
 
         server.abort();
-    }
-
-    #[tokio::test]
-    async fn release_removes_the_chroot_of_an_adopted_pool_slot() {
-        let data_dir = tempfile::tempdir().unwrap();
-        let chroot_base = data_dir.path().join("jailer");
-        let mut config = VmmConfig::default();
-        config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
-        config.firecracker.jailer = Some(crate::config::JailerConfig {
-            binary: "/usr/bin/jailer".into(),
-            uid: 0,
-            gid: 0,
-            chroot_base_dir: Some(chroot_base.to_string_lossy().into_owned()),
-            netns: None,
-            new_pid_ns: false,
-            cgroup_version: None,
-            parent_cgroup: None,
-            resource_limits: vec![],
-        });
-        let slot_chroot = chroot_root(&config.firecracker.binary, &chroot_base, "pool-slot");
-        let sandbox_chroot = chroot_root(&config.firecracker.binary, &chroot_base, "job");
-        std::fs::create_dir_all(&slot_chroot).unwrap();
-        std::fs::create_dir_all(&sandbox_chroot).unwrap();
-
-        let arc = instance("job");
-        arc.lock().unwrap().pool_slot_id = Some("pool-slot".into());
-        let config = Arc::new(config);
-        let network: Arc<dyn GuestNetwork> = Arc::new(FakeNetwork::new());
-        let cow_manager =
-            Arc::new(CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap());
-
-        release_runtime_resources("job", &arc, &network, &config, &cow_manager)
-            .await
-            .unwrap();
-
-        assert!(!slot_chroot.parent().unwrap().exists());
-        assert!(
-            sandbox_chroot.exists(),
-            "the sandbox-id chroot belongs to nobody here and must not be touched"
-        );
     }
 }

--- a/computer/arcbox-computer-runtime/src/sandbox/pool.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/pool.rs
@@ -24,20 +24,22 @@ use crate::snapshot::SnapshotMeta;
 /// `pool::SlotPool`.
 pub use super::policy::pool::SlotPool;
 
-/// A fully staged restore slot: jailer chroot prepared, the VMM spawned
-/// (API socket up, nothing loaded yet), kernel + vmstate + mem staged,
+/// A fully staged restore slot: the VMM spawned (API socket up, nothing
+/// loaded yet), kernel + vmstate + mem staged into the area it reads from,
 /// dm-snapshot of the rootfs created.
 pub struct PreparedSlot {
-    /// Slot id (`pool-<uuid>`): the chroot, dm/CoW names, and crash
+    /// Slot id (`pool-<uuid>`): the VM, its dm/CoW names, and its crash
     /// journal are keyed by it.
     pub slot_id: String,
-    /// The VMM the driver prepared, chrooted into the slot's jail and
-    /// waiting for the snapshot load.
+    /// The VMM the driver prepared, waiting for the snapshot load.
     pub prepared: Arc<dyn PreparedVm>,
     /// dm-snapshot of the snapshot's rootfs (`None` = copy fallback).
     pub cow_handle: Option<CowHandle>,
-    /// The checkpoint as staged into the slot's chroot, ready for the
-    /// driver to load.
+    /// The root disk as staging left it — the path the restore's spec must
+    /// name, which is not the caller's to recompute.
+    pub rootfs: PathBuf,
+    /// The checkpoint as staged for this slot, ready for the driver to
+    /// load.
     pub image: CheckpointImage,
     /// Slot runtime dir (`sandboxes/pool-<uuid>`) holding its crash journal.
     pub vm_dir: PathBuf,
@@ -81,11 +83,12 @@ pub(super) async fn prepare_slot(
     )?;
 
     match stage_slot(driver, config, jc, cow_manager, snapshot, &slot_id, &vm_dir).await {
-        Ok((prepared, cow_handle, image)) => Ok(PreparedSlot {
+        Ok(staged) => Ok(PreparedSlot {
             slot_id,
-            prepared,
-            cow_handle,
-            image,
+            prepared: staged.prepared,
+            cow_handle: staged.cow_handle,
+            rootfs: staged.rootfs,
+            image: staged.image,
             vm_dir,
         }),
         Err(mut failure) => {
@@ -144,7 +147,13 @@ impl From<VmmError> for SlotFailure {
     }
 }
 
-type StagedSlot = (Arc<dyn PreparedVm>, Option<CowHandle>, CheckpointImage);
+/// What [`stage_slot`] pre-executes, and [`PreparedSlot`] then carries.
+struct StagedSlot {
+    prepared: Arc<dyn PreparedVm>,
+    cow_handle: Option<CowHandle>,
+    rootfs: PathBuf,
+    image: CheckpointImage,
+}
 
 async fn stage_slot(
     driver: &dyn VmDriver,
@@ -155,10 +164,6 @@ async fn stage_slot(
     slot_id: &str,
     vm_dir: &Path,
 ) -> std::result::Result<StagedSlot, SlotFailure> {
-    let fc_cfg = &config.firecracker;
-    let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-    let cr = chroot_root(&fc_cfg.binary, base, slot_id);
-
     let prepared: Arc<dyn PreparedVm> = Arc::from(
         super::prepare_capability(driver)
             .prepare(
@@ -185,37 +190,51 @@ async fn stage_slot(
         return Err(carry(error, Some(prepared), None));
     }
 
+    // Everything the restore would otherwise pay for on its critical path,
+    // brought into the area this slot's VMM reads from — under the same
+    // names a restore renders, so claiming the slot stages nothing twice.
+    let staging = super::staging_capability(&*prepared);
     if let Some(kernel) = snapshot.kernel_path.as_deref() {
-        if let Err(error) = stage_kernel_for_jailer(&cr, kernel, jc.uid, jc.gid).await {
+        if let Err(error) = staging.stage_kernel(Path::new(kernel)).await {
             return Err(carry(error.into(), Some(prepared), None));
         }
     }
 
-    let mut cow_handle = None;
-    if let Some(rootfs) = snapshot.rootfs_path.as_deref() {
-        match stage_rootfs_cow_or_copy(cow_manager, &cr, slot_id, rootfs, jc.uid, jc.gid, &journal)
-            .await
-        {
-            Ok(handle) => cow_handle = handle,
+    let Some(rootfs) = snapshot.rootfs_path.as_deref() else {
+        return Err(carry(
+            VmmError::Snapshot(format!(
+                "checkpoint {} records no rootfs template; there is no disk to pre-warm a slot \
+                 with",
+                snapshot.id
+            )),
+            Some(prepared),
+            None,
+        ));
+    };
+    let staged =
+        match stage_rootfs_cow_or_copy(cow_manager, staging, slot_id, rootfs, &journal).await {
+            Ok(staged) => staged,
             Err(StageError {
                 error,
                 cow_handle: leaked,
             }) => return Err(carry(error, Some(prepared), leaked)),
-        }
-    }
+        };
 
-    let files = SnapshotFiles {
-        id: &snapshot.id,
-        vmstate: &snapshot.vmstate_path,
-        mem: snapshot.mem_path.as_deref(),
+    let image = match super::catalogued_checkpoint(snapshot) {
+        Ok(catalogued) => staging
+            .stage_checkpoint(&catalogued)
+            .await
+            .map_err(Into::into),
+        Err(error) => Err(error),
     };
-    match stage_snapshot_files(&cr, &files, jc.uid, jc.gid).await {
-        Ok(_) => {
-            let image =
-                super::checkpoint_image(cr.join("snapshots").join(&snapshot.id), &snapshot.format);
-            Ok((prepared, cow_handle, image))
-        }
-        Err(error) => Err(carry(error.into(), Some(prepared), cow_handle)),
+    match image {
+        Ok(image) => Ok(StagedSlot {
+            prepared,
+            cow_handle: staged.cow_handle,
+            rootfs: staged.path,
+            image,
+        }),
+        Err(error) => Err(carry(error, Some(prepared), staged.cow_handle)),
     }
 }
 

--- a/computer/arcbox-computer-runtime/src/sandbox/pool.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/pool.rs
@@ -114,12 +114,9 @@ pub(super) async fn prepare_slot(
                 },
                 None => true,
             };
+            // The discard above took the area the slot's files were staged
+            // into with it, so what is left to unwind is the journal.
             if fc_unwound && cow_unwound {
-                let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-                let chroot = chroot_root(&fc_cfg.binary, base, &slot_id);
-                if let Some(parent) = chroot.parent() {
-                    let _ = tokio::fs::remove_dir_all(parent).await;
-                }
                 if let Err(error) = reconcile::clear_state_record(&vm_dir) {
                     warn!(slot_id, error = %error, "failed slot prepare kept its journal");
                 } else {
@@ -243,13 +240,12 @@ async fn stage_slot(
 /// sweep — the slots' crash journals keep them reclaimable.
 pub(super) async fn drain_pool_slots(
     pool: &SlotPool,
-    config: &VmmConfig,
     cow_manager: &CowManager,
     snapshot_id: Option<&str>,
 ) {
     for slot in pool.drain(snapshot_id) {
         let slot_id = slot.slot_id.clone();
-        if let Err(error) = destroy_slot(config, cow_manager, slot).await {
+        if let Err(error) = destroy_slot(cow_manager, slot).await {
             warn!(
                 slot_id,
                 error = %error,
@@ -259,30 +255,17 @@ pub(super) async fn drain_pool_slots(
     }
 }
 
-/// Tear down a slot completely: process, CoW resources, chroot, journal.
+/// Tear down a slot completely: process (and the area its files were
+/// staged into, which the discard takes), CoW resources, journal.
 ///
 /// On error the slot's crash journal is left in place so the startup
 /// sweep retries; callers log and move on.
-pub(super) async fn destroy_slot(
-    config: &VmmConfig,
-    cow_manager: &CowManager,
-    mut slot: PreparedSlot,
-) -> Result<()> {
+pub(super) async fn destroy_slot(cow_manager: &CowManager, mut slot: PreparedSlot) -> Result<()> {
     // The VMM must be dead before the dm teardown (`dmsetup remove` returns
     // EBUSY while the block device is open).
     slot.prepared.discard().await?;
     if let Some(handle) = slot.cow_handle.take() {
         cow_manager.teardown_checked(&handle).await?;
-    }
-    if let Some(ref jc) = config.firecracker.jailer {
-        let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-        let chroot = chroot_root(&config.firecracker.binary, base, &slot.slot_id);
-        if let Some(parent) = chroot.parent()
-            && let Err(error) = tokio::fs::remove_dir_all(parent).await
-            && error.kind() != std::io::ErrorKind::NotFound
-        {
-            return Err(VmmError::Io(error));
-        }
     }
     reconcile::clear_state_record(&slot.vm_dir)?;
     match tokio::fs::remove_dir_all(&slot.vm_dir).await {
@@ -301,7 +284,6 @@ pub(super) async fn destroy_slot(
 /// be per-computer.
 pub fn claim_restore_slot(
     pool: &SlotPool,
-    config: &Arc<VmmConfig>,
     cow_manager: &Arc<CowManager>,
     snapshot_id: &str,
 ) -> Option<PreparedSlot> {
@@ -315,17 +297,16 @@ pub fn claim_restore_slot(
             slot_id = %slot.slot_id,
             "discarding pre-warmed slot whose vmm died"
         );
-        spawn_slot_teardown(config, cow_manager, slot);
+        spawn_slot_teardown(cow_manager, slot);
     }
 }
 
-fn spawn_slot_teardown(config: &Arc<VmmConfig>, cow_manager: &Arc<CowManager>, slot: PreparedSlot) {
+fn spawn_slot_teardown(cow_manager: &Arc<CowManager>, slot: PreparedSlot) {
     {
-        let config = Arc::clone(config);
         let cow_manager = Arc::clone(cow_manager);
         tokio::spawn(async move {
             let slot_id = slot.slot_id.clone();
-            if let Err(error) = destroy_slot(&config, &cow_manager, slot).await {
+            if let Err(error) = destroy_slot(&cow_manager, slot).await {
                 warn!(
                     slot_id,
                     error = %error,
@@ -351,7 +332,7 @@ pub fn spawn_pool_refill(
     {
         let plan = pool.begin_fill(snapshot_id, config.firecracker.pool_size);
         for slot in plan.evicted {
-            spawn_slot_teardown(config, cow_manager, slot);
+            spawn_slot_teardown(cow_manager, slot);
         }
         for _ in 0..plan.spawn {
             let pool = Arc::clone(pool);
@@ -372,8 +353,7 @@ pub fn spawn_pool_refill(
                         Some(rejected) => {
                             // Evicted or drained while the fill was in flight.
                             let slot_id = rejected.slot_id.clone();
-                            if let Err(error) = destroy_slot(&config, &cow_manager, rejected).await
-                            {
+                            if let Err(error) = destroy_slot(&cow_manager, rejected).await {
                                 warn!(
                                     slot_id,
                                     error = %error,
@@ -396,7 +376,7 @@ impl SandboxManager {
     /// Tear down pooled slots: all of them, or those staged from one
     /// snapshot.
     pub(super) async fn drain_pool(&self, snapshot_id: Option<&str>) {
-        drain_pool_slots(&self.pool, &self.config, &self.cow_manager, snapshot_id).await;
+        drain_pool_slots(&self.pool, &self.cow_manager, snapshot_id).await;
     }
 
     /// Release manager-held background resources: tears down every

--- a/computer/arcbox-computer-runtime/src/sandbox/spec.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/spec.rs
@@ -5,7 +5,7 @@
 //! single NIC, vsock, the kernel cmdline — so a boot and a restore of the
 //! same sandbox cannot drift apart in what they hand the driver.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use arcbox_vm_driver::{
     BootSpec, CacheMode, ConsoleSpec, DiskSpec, IsolationSpec, NicSpec, RestoreSpec, VmId, VmSpec,
@@ -81,11 +81,24 @@ pub fn build_vm_spec(
     })
 }
 
-/// The root disk: writable, `Unsafe` host caching, id `rootfs` — the name a
-/// checkpoint of this driver records for it, which a restore must reuse.
+/// The id the root disk carries, everywhere it is named.
+///
+/// One constant because two things must agree on it: the spec a boot or a
+/// restore hands the driver, and the [`Staging::stage_disk`] call that put
+/// the disk where that spec points. A driver stages a disk under a name it
+/// makes from this id and records that name in its checkpoints, so a disk
+/// staged under one id and specced under another is a checkpoint that will
+/// not restore.
+///
+/// [`Staging::stage_disk`]: arcbox_vm_driver::Staging::stage_disk
+pub const ROOTFS_DISK_ID: &str = "rootfs";
+
+/// The root disk: writable, `Unsafe` host caching, id [`ROOTFS_DISK_ID`] —
+/// the name a checkpoint of this driver records for it, which a restore
+/// must reuse.
 pub(super) fn rootfs_disk(path: PathBuf) -> DiskSpec {
     DiskSpec {
-        id: "rootfs".into(),
+        id: ROOTFS_DISK_ID.into(),
         path,
         read_only: false,
         root: true,
@@ -94,25 +107,27 @@ pub(super) fn rootfs_disk(path: PathBuf) -> DiskSpec {
 }
 
 /// What a restore may change about the checkpointed VM: its identity
-/// (`owner`, the id the jail is keyed by), the fresh NIC the guest network
-/// activated, and the disk it runs on — the rootfs staged into the owner's
-/// jail.
+/// (`owner`, the id its resources are keyed by), the fresh NIC the guest
+/// network activated, and the disk it runs on — wherever staging said that
+/// disk now is.
 pub fn restore_spec(
     owner: &str,
-    chroot: &Path,
+    rootfs: PathBuf,
     nic: Option<NicSpec>,
     isolation: IsolationSpec,
 ) -> Result<RestoreSpec> {
     Ok(RestoreSpec {
         id: VmId::new(owner)?,
         nics: nic.into_iter().collect(),
-        disks: vec![rootfs_disk(chroot.join("rootfs.ext4"))],
+        disks: vec![rootfs_disk(rootfs)],
         isolation,
     })
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use arcbox_vm_driver::NicAttachment;
     use arcbox_vm_driver::net::{NetworkIdentity, NetworkLease};
 

--- a/computer/arcbox-computer-runtime/src/sandbox/warm.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/warm.rs
@@ -111,7 +111,6 @@ pub async fn publish_after_boot(
     sandbox_id: &SandboxId,
     ticket: &WarmPublishTicket,
     computer: &Arc<Mutex<ComputerRuntime>>,
-    config: &VmmConfig,
     cow_manager: &CowManager,
     expected_state: SandboxState,
 ) -> Result<()> {
@@ -123,15 +122,8 @@ pub async fn publish_after_boot(
         return Ok(());
     }
     let started = std::time::Instant::now();
-    let published = publish_warm_snapshot(
-        sandbox_id,
-        ticket,
-        computer,
-        config,
-        cow_manager,
-        expected_state,
-    )
-    .await;
+    let published =
+        publish_warm_snapshot(sandbox_id, ticket, computer, cow_manager, expected_state).await;
     ticket.cache.end_publish(&ticket.key);
     match published {
         Ok(Some(snapshot_id)) => {
@@ -187,7 +179,6 @@ async fn publish_warm_snapshot(
     sandbox_id: &SandboxId,
     ticket: &WarmPublishTicket,
     computer: &Arc<Mutex<ComputerRuntime>>,
-    config: &VmmConfig,
     cow_manager: &CowManager,
     expected_state: SandboxState,
 ) -> std::result::Result<Option<String>, PublishFailure> {
@@ -231,13 +222,8 @@ async fn publish_warm_snapshot(
     for entry in entries {
         let replaced = entry.key == ticket.key.hex() && entry.snapshot_id != info.snapshot_id;
         if replaced || evicted.contains(&entry.key) {
-            super::pool::drain_pool_slots(
-                &ticket.pool,
-                config,
-                cow_manager,
-                Some(&entry.snapshot_id),
-            )
-            .await;
+            super::pool::drain_pool_slots(&ticket.pool, cow_manager, Some(&entry.snapshot_id))
+                .await;
             if let Err(error) = ticket.snapshots.delete_by_id(&entry.snapshot_id) {
                 warn!(
                     snapshot_id = %entry.snapshot_id,
@@ -297,7 +283,6 @@ mod tests {
             &"warm-ok".to_owned(),
             &ticket("a"),
             &instance,
-            &manager.config,
             &manager.cow_manager,
             SandboxState::Ready,
         )
@@ -312,7 +297,6 @@ mod tests {
             &"warm-frozen".to_owned(),
             &ticket("b"),
             &instance,
-            &manager.config,
             &manager.cow_manager,
             SandboxState::Ready,
         )

--- a/virt/arcbox-fc-driver/src/adopt.rs
+++ b/virt/arcbox-fc-driver/src/adopt.rs
@@ -60,11 +60,19 @@ pub(crate) async fn rebuild(
     let client = fc_sdk::connection::connect(&found.api_socket);
     let (info, devices) = match tokio::time::timeout(api_timeout, describe(&client)).await {
         Ok(Ok(answered)) => answered,
-        Ok(Err(error)) => return Ok(process_only(process, record, &error.to_string())),
+        Ok(Err(error)) => {
+            return Ok(process_only(
+                process,
+                record,
+                layout.jail().cloned(),
+                &error.to_string(),
+            ));
+        }
         Err(_) => {
             return Ok(process_only(
                 process,
                 record,
+                layout.jail().cloned(),
                 &format!("no answer within {api_timeout:?}"),
             ));
         }
@@ -87,10 +95,19 @@ async fn describe(client: &Client) -> crate::error::Result<(InstanceInfo, FullVm
 
 /// The fallback, and the warning that says why: the VM stays a process
 /// this driver can kill, and nothing more.
-fn process_only(process: Arc<FcProcess>, record: VmRecord, why: &str) -> Box<dyn VmHandle> {
+///
+/// The jail still comes along. Where the VM runs is read off the process,
+/// not asked of the API, so an unreachable API costs the handle its
+/// devices — never its ability to take the area down with the VM.
+fn process_only(
+    process: Arc<FcProcess>,
+    record: VmRecord,
+    jail: Option<crate::jail::Jail>,
+    why: &str,
+) -> Box<dyn VmHandle> {
     tracing::warn!(vm = %record.id, pid = process.pid(), socket = %process.api_socket().display(),
         "the adopted vmm's api did not answer ({why}); adopting the process alone: kill-able, nothing else");
-    Box::new(FcProcessHandle::new(process, record))
+    Box::new(FcProcessHandle::new(process, record, jail))
 }
 
 #[cfg(test)]

--- a/virt/arcbox-fc-driver/src/handle.rs
+++ b/virt/arcbox-fc-driver/src/handle.rs
@@ -148,6 +148,17 @@ impl VmHandle for FcHandle {
         self.process.events()
     }
 
+    /// Stops the VM — and, for one this driver adopted rather than
+    /// spawned, takes its jail with it.
+    ///
+    /// A VM's area belongs to the grip that owns its process. A spawned
+    /// VM has a [`FcPrepared`](crate::FcPrepared) for that, and
+    /// [`PreparedVm::discard`](arcbox_vm_driver::PreparedVm::discard)
+    /// removes the jail there; an adopted VM's jail outlived the process
+    /// that made it, and this handle is the only grip on it, so the jail
+    /// would otherwise be left behind by every teardown. A handle that
+    /// was handed on ([`Detach`]) keeps its hands off: the next owner
+    /// gets the VM and the area it runs in.
     async fn shutdown(&self, mode: ShutdownMode) -> Result<ExitStatus> {
         let status = match mode {
             ShutdownMode::Kill => self.process.kill().await?,
@@ -174,6 +185,12 @@ impl VmHandle for FcHandle {
             },
         };
         self.unlink_vsock();
+        if let Some(jail) = self.layout.jail()
+            && self.process.is_adopted()
+            && !self.process.is_detached()
+        {
+            jail.remove().await?;
+        }
         Ok(status)
     }
 

--- a/virt/arcbox-fc-driver/src/handle/process_only.rs
+++ b/virt/arcbox-fc-driver/src/handle/process_only.rs
@@ -18,6 +18,7 @@ use arcbox_vm_driver::{
 use async_trait::async_trait;
 use tokio::sync::broadcast;
 
+use crate::jail::Jail;
 use crate::process::FcProcess;
 
 /// A VMM process this driver verified but cannot talk to.
@@ -27,12 +28,20 @@ use crate::process::FcProcess;
 pub struct FcProcessHandle {
     process: Arc<FcProcess>,
     record: VmRecord,
+    /// The area this VM runs in, when it has one. Reachable without the
+    /// API: it is a property of how the VMM was launched, which the adopt
+    /// read off the process itself.
+    jail: Option<Jail>,
 }
 
 impl FcProcessHandle {
-    /// A handle over `process`, reporting `record`.
-    pub fn new(process: Arc<FcProcess>, record: VmRecord) -> Self {
-        Self { process, record }
+    /// A handle over `process`, reporting `record` and running in `jail`.
+    pub fn new(process: Arc<FcProcess>, record: VmRecord, jail: Option<Jail>) -> Self {
+        Self {
+            process,
+            record,
+            jail,
+        }
     }
 }
 
@@ -70,12 +79,23 @@ impl VmHandle for FcProcessHandle {
     /// `Kill` as for any VM. `Graceful` degrades to it — asking the guest
     /// (`SendCtrlAltDel`) needs the API this handle does not have, and
     /// waiting out the deadline without having asked would gain nothing.
+    ///
+    /// The jail goes with the kill, on the same rule as
+    /// [`FcHandle::shutdown`](crate::FcHandle): every VM reaching this
+    /// handle was adopted, so nothing else is left to remove the area it
+    /// ran in — unless the VM was handed on instead.
     async fn shutdown(&self, mode: ShutdownMode) -> Result<ExitStatus> {
         if matches!(mode, ShutdownMode::Graceful { .. }) && self.process.alive() {
             tracing::warn!(vm = %self.record.id, pid = self.process.pid(),
                 "the vmm's api is unreachable: a graceful shutdown cannot ask the guest and kills it");
         }
-        Ok(self.process.kill().await?)
+        let status = self.process.kill().await?;
+        if let Some(jail) = &self.jail
+            && !self.process.is_detached()
+        {
+            jail.remove().await?;
+        }
+        Ok(status)
     }
 
     /// Present as on every handle of this driver: releasing the process
@@ -106,6 +126,11 @@ mod tests {
 
     /// A `sleep` child adopted as a VMM, and the child to reap it with.
     fn adopted() -> (FcProcessHandle, tokio::process::Child) {
+        adopted_in(None)
+    }
+
+    /// [`adopted`], running in `jail`.
+    fn adopted_in(jail: Option<Jail>) -> (FcProcessHandle, tokio::process::Child) {
         let child = tokio::process::Command::new("sleep")
             .arg("30")
             .spawn()
@@ -122,7 +147,26 @@ mod tests {
             }),
         };
         let process = Arc::new(FcProcess::adopt(pid, socket));
-        (FcProcessHandle::new(process, record), child)
+        (FcProcessHandle::new(process, record, jail), child)
+    }
+
+    /// An API this handle cannot reach costs it the VM's devices, never
+    /// the area the VM runs in: every VM that reaches this handle was
+    /// adopted, so nothing else is left to take the jail down with it.
+    #[tokio::test]
+    async fn the_jail_goes_with_the_kill_even_without_an_api() {
+        let dir = tempfile::tempdir().unwrap();
+        let area = dir.path().join("jail/firecracker/box");
+        std::fs::create_dir_all(area.join("root")).unwrap();
+        let (vm, mut child) = adopted_in(Some(Jail {
+            root: area.join("root"),
+            uid: 0,
+            gid: 0,
+        }));
+        let reaper = tokio::spawn(async move { child.wait().await.unwrap() });
+        vm.shutdown(ShutdownMode::Kill).await.unwrap();
+        assert!(!area.exists(), "the adopted vm's jail goes with the kill");
+        reaper.await.unwrap();
     }
 
     fn signal_of(status: std::process::ExitStatus) -> Option<i32> {

--- a/virt/arcbox-fc-driver/src/handle/tests.rs
+++ b/virt/arcbox-fc-driver/src/handle/tests.rs
@@ -5,7 +5,7 @@ use arcbox_vm_driver::{IsolationSpec, ProcessRecord};
 use super::*;
 use crate::api::fake_fc::FakeFc;
 use crate::config::FcDriverConfig;
-use crate::process::testing::{pid_exists, spawn};
+use crate::process::testing::{adopt, pid_exists, spawn};
 
 /// A handle over a `sleep` child and an API socket nobody answers on.
 fn handle(dir: &Path, isolation: IsolationSpec, vsock: bool) -> FcHandle {
@@ -117,6 +117,40 @@ async fn state_follows_the_process_and_kill_reports_the_signal() {
             .await,
         Err(Error::WrongState { .. })
     ));
+}
+
+/// The jail belongs to whichever grip owns the VMM. A spawned VM's grip
+/// is its `FcPrepared`, which takes the jail on `discard`, so a kill
+/// through the handle must leave it standing — the pause path kills a
+/// spawned VM and then still reads out of its area. An *adopted* VM has
+/// no such grip: its jail outlived the process that made it, and this
+/// handle is the last thing that can take it away.
+#[tokio::test]
+async fn only_an_adopted_vm_takes_its_jail_with_the_kill() {
+    let dir = tempfile::tempdir().unwrap();
+    let isolation = jail(dir.path());
+
+    let spawned = handle(dir.path(), isolation.clone(), false);
+    let area = spawned
+        .layout
+        .jail()
+        .unwrap()
+        .root
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    std::fs::create_dir_all(&area).unwrap();
+    spawned.shutdown(ShutdownMode::Kill).await.unwrap();
+    assert!(area.exists(), "a spawned vm's jail waits for its discard");
+
+    let (process, mut child) = adopt("sleep", &["30"]);
+    // Nothing in this process reaps an adopted VMM; the child's real
+    // parent — this test — does, and the handle's kill observes it.
+    let reaper = tokio::spawn(async move { child.wait().await.unwrap() });
+    let adopted = handle_over(Arc::new(process), dir.path(), isolation, false);
+    adopted.shutdown(ShutdownMode::Kill).await.unwrap();
+    assert!(!area.exists(), "an adopted vm's jail goes with the kill");
+    reaper.await.unwrap();
 }
 
 #[tokio::test]

--- a/virt/arcbox-fc-driver/src/jail.rs
+++ b/virt/arcbox-fc-driver/src/jail.rs
@@ -51,6 +51,26 @@ impl Jail {
             .ok()
             .map(|rel| format!("/{}", rel.display()))
     }
+
+    /// Remove the jail and everything staged into it.
+    ///
+    /// The jailer's per-VM directory is `{base}/{exec}/{id}`, of which
+    /// [`root`](Self::root) is the `root/` inside it — the whole thing
+    /// goes, because the copy of the Firecracker binary and the cgroup
+    /// bookkeeping beside it belong to this VM too.
+    ///
+    /// Already gone is not a failure: this is called wherever a VM ends,
+    /// and a VM can end more than once.
+    pub async fn remove(&self) -> Result<()> {
+        let Some(dir) = self.root.parent() else {
+            return Ok(());
+        };
+        match tokio::fs::remove_dir_all(dir).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(Error::Io(e)),
+        }
+    }
 }
 
 /// `path` with its `.` and `..` components resolved as far as they can be
@@ -510,6 +530,27 @@ mod tests {
         // which is how a test suite meets this before production does.
         let deep = PathBuf::from("/").join("d".repeat(200));
         assert_eq!(id_budget("/opt/fc/firecracker", deep), 0);
+    }
+
+    #[tokio::test]
+    async fn removing_a_jail_takes_the_whole_per_vm_directory_and_tolerates_its_absence() {
+        let dir = tempfile::tempdir().unwrap();
+        let per_vm = dir.path().join("jail/firecracker/box");
+        let root = per_vm.join("root");
+        std::fs::create_dir_all(root.join("run")).unwrap();
+        std::fs::write(root.join("rootfs.ext4"), b"disk").unwrap();
+        // The jailer's copy of the binary sits beside `root/`, not in it.
+        std::fs::write(per_vm.join("firecracker"), b"vmm").unwrap();
+        let jail = Jail {
+            root,
+            uid: 0,
+            gid: 0,
+        };
+
+        jail.remove().await.unwrap();
+        assert!(!per_vm.exists(), "the whole per-vm directory goes");
+        assert!(dir.path().join("jail/firecracker").exists(), "and no more");
+        jail.remove().await.expect("a vm can end more than once");
     }
 
     #[tokio::test]

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -52,32 +52,49 @@ impl FcPrepared {
         let layout = VmLayout::new(id, isolation, &config, runtime_dir)?;
         tokio::fs::create_dir_all(runtime_dir).await?;
         let plan = layout.spawn_plan();
-        let child = spawn::spawn(&plan, &config).await?;
-        debug_assert_eq!(
-            child.socket_path(),
-            plan.api_socket,
-            "the layout and fc-sdk agree on the API socket"
-        );
-        let process = Arc::new(FcProcess::spawn(child, plan.api_socket.clone())?);
-        let record = VmRecord {
-            id: id.clone(),
-            driver: NAME.to_owned(),
-            runtime_dir: runtime_dir.to_path_buf(),
-            process: Some(ProcessRecord {
-                pid: process.pid(),
-                api_socket: Some(plan.api_socket),
-            }),
-        };
-        let vsock = VsockEndpoint::new(layout.vsock_host_uds());
-        Ok(Self {
-            config,
-            layout,
-            process,
-            record,
-            vsock,
-            consumed: AtomicBool::new(false),
-            launch: tokio::sync::Mutex::new(()),
-        })
+        let spawned = async {
+            let child = spawn::spawn(&plan, &config).await?;
+            debug_assert_eq!(
+                child.socket_path(),
+                plan.api_socket,
+                "the layout and fc-sdk agree on the API socket"
+            );
+            let process = Arc::new(FcProcess::spawn(child, plan.api_socket.clone())?);
+            let record = VmRecord {
+                id: id.clone(),
+                driver: NAME.to_owned(),
+                runtime_dir: runtime_dir.to_path_buf(),
+                process: Some(ProcessRecord {
+                    pid: process.pid(),
+                    api_socket: Some(plan.api_socket.clone()),
+                }),
+            };
+            let vsock = VsockEndpoint::new(layout.vsock_host_uds());
+            Ok(Self {
+                config: Arc::clone(&config),
+                layout: layout.clone(),
+                process,
+                record,
+                vsock,
+                consumed: AtomicBool::new(false),
+                launch: tokio::sync::Mutex::new(()),
+            })
+        }
+        .await;
+        if spawned.is_err()
+            && let Some(jail) = layout.jail()
+        {
+            // The jailer makes the chroot before it execs, so a spawn that
+            // failed after that point leaves one standing with no grip to
+            // discard it. The area goes with the failure exactly as it goes
+            // with a discard — best-effort, because the spawn's own error
+            // is the one worth reporting.
+            if let Err(error) = jail.remove().await {
+                tracing::warn!(vm = %id, error = %error,
+                    "the jail of a vmm that failed to spawn could not be removed");
+            }
+        }
+        spawned
     }
 
     fn require_unused(&self) -> Result<()> {
@@ -247,16 +264,22 @@ impl PreparedVm for FcPrepared {
         Ok(Box::new(self.handle(client, has_vsock)))
     }
 
-    /// Kills the VMM. The jail it was spawned into outlives it: the one
-    /// caller still removes the chroot itself, and its copy-mode pause
-    /// path takes the sandbox's only writable disk out of that chroot
-    /// *after* discarding, so a `discard` that removed the jail here would
-    /// destroy the disk it is about to park — silently, since the move is
-    /// guarded by an existence check. Removing the jail moves onto this
-    /// verb in the same change that reorders those call sites onto
-    /// [`Staging::unstage_disk`] (vm-stack-redesign R3, PR-G2).
+    /// Kills the VMM, and the jail goes with it.
+    ///
+    /// This grip made the area — the jailer built the chroot for the
+    /// process this discards — so it is the grip that takes it away, and
+    /// with it every file staged in. A caller that wants something out of
+    /// there takes it out first, through
+    /// [`Staging::unstage_disk`]; that is what the paused computer's
+    /// copy-mode rootfs does. Reporting a removal failure rather than
+    /// swallowing it is deliberate: the caller keeps its grip and can
+    /// retry, and both halves are idempotent.
     async fn discard(&self) -> Result<ExitStatus> {
-        Ok(self.process.kill().await?)
+        let status = self.process.kill().await?;
+        if let Some(jail) = self.layout.jail() {
+            jail.remove().await?;
+        }
+        Ok(status)
     }
 }
 

--- a/virt/arcbox-fc-driver/src/process.rs
+++ b/virt/arcbox-fc-driver/src/process.rs
@@ -237,6 +237,16 @@ impl FcProcess {
         self.detached.load(Ordering::Acquire)
     }
 
+    /// `true` for a process this driver found running rather than spawned.
+    ///
+    /// The distinction is which grip owns the VM's on-disk area: a spawned
+    /// process has a [`FcPrepared`](crate::FcPrepared) that made the jail
+    /// and takes it away on `discard`, an adopted one has none — its jail
+    /// outlived the process that made it, and the handle is all there is.
+    pub fn is_adopted(&self) -> bool {
+        self.ownership == Ownership::Adopted
+    }
+
     fn signal(&self, signal: Signal) -> Result<()> {
         #[allow(
             clippy::cast_possible_wrap,
@@ -410,6 +420,18 @@ pub(crate) mod testing {
             .spawn()
             .expect("spawn test child");
         FcProcess::spawn(Child(child), PathBuf::from("/tmp/api.sock")).unwrap()
+    }
+
+    /// An [`FcProcess`] adopted over a `program args` child, plus the
+    /// child itself — nothing here reaps an adopted process, so the test
+    /// that owns it must.
+    pub fn adopt(program: &str, args: &[&str]) -> (FcProcess, tokio::process::Child) {
+        let child = tokio::process::Command::new(program)
+            .args(args)
+            .spawn()
+            .expect("spawn test child");
+        let pid = child.id().expect("a spawned child has a pid");
+        (FcProcess::adopt(pid, PathBuf::from("/tmp/api.sock")), child)
     }
 
     /// `true` while `pid` can be signalled.


### PR DESCRIPTION
The computer runtime asked the Firecracker adapter where a chroot is and
put files in it. It now asks the port's `Staging` capability (#676),
which answers with the path a spec must name and never says whether a
confinement exists — and `PreparedVm::discard` takes the jail away, which
is the half #676 had to leave behind.

## Converted, or deleted

PR-G1's finding was that `render` + `jail::apply` already stage what a
spec names, so a converted call the driver was going to make anyway is
pure cost. Per site:

| site | what happened | why |
|---|---|---|
| boot's kernel | **deleted** | rendering a boot stages the kernel its `BootSpec` names, into the same file |
| boot / restore / pool root disk | **converted** | only this layer can choose between a CoW device and the copy that falls back from one, and the fallback tears the overlay down and re-journals first |
| restore's + the pool's kernel | **converted** | a snapshot load names only vmstate and mem, so these may be vestigial — nothing on the restore path proves it, so they are kept as they were rather than dropped on a guess |
| restore / resume / pool checkpoint | **converted** to `stage_checkpoint` | subsumes the hand-rolled mkdir + chown + link of `vmstate`/`mem` |
| resume's parked disk | **converted** to `DiskSource::Handover` | moved in and chowned, not duplicated — it is a guest rootfs |
| `remove_jailer_chroot`, `destroy_slot`'s + `prepare_slot`'s + `unwind_resume`'s chroot removals | **deleted** | the discard takes the area now |

Two consequences: `PreparedSlot` carries the staged disk's path (after
staging nobody else can recompute it) and `restore_spec` takes that path
instead of a chroot to join a name onto; and a checkpoint recording no
rootfs template is refused where it is read, as the resume path already
did, instead of pointing a restore at a file that was never staged.

## The ordering, which is why this is one PR

`release_for_pause` killed the VMM and *then* moved a copy-mode rootfs
out of the chroot, guarded on the file existing; `unwind_resume` had the
same shape. Both now take the disk out through `unstage_disk` **before**
the discard. Removing the jail first turns that guard false, the move is
silently skipped, pause reports success, and the resume that follows has
no disk. So the reorder lands first (2nd commit), the jail moves onto
`discard` after (3rd), and the module docs PR-F1 wrote on
`tasks/pause.rs` say the new invariant in the same words.

Taking a disk out from under a live VMM is what `unstage_disk` is
specified for: pause runs it on a guest the checkpoint has quiesced, the
resume unwind after the handle that could have been running a guest was
dropped — and a dropped handle SIGKILLs.

## The adapter's rule, and the adopted computer

`discard` removing the jail is one half of a rule the adapter now states
once: **a jail goes with the grip that owns its VMM.** The other halves
follow from #674, which was not in the plan's field of view:

- A VM this process *adopted* has no `PreparedVm` — its jail outlived the
  process that made it — so its handle's completed kill takes the jail.
  Without this, every adopted computer removed would leak a chroot, and
  in copy mode that chroot holds a whole guest rootfs. `FcProcessHandle`
  does it too: an unreachable API costs a handle its devices, never its
  ability to take the area down. Handing the VM on (`Detach`) leaves the
  area to the next owner.
- A spawn that fails after the jailer has made the chroot removes it on
  the way out, since no grip is returned to discard it. That is what the
  runtime's deleted unwinds used to do.

One case is left refused rather than solved: an adopted computer whose
disk is a **copy** (the dm-snapshot fallback) has no route into the area
its disk sits in, so its pause now fails — before the kill, so the disk
stays and the pause is retryable — instead of succeeding and losing it.
Stop and Remove are unaffected. Giving an adopted computer the same
reach the sweep gets belongs with **PR-G3**, which is already the step
that puts the sweep's chroot path behind `Adopt`.

## Scope

- Left for PR-G3, as the plan has it: the startup sweep's `chroot_root`
  and `max_sandbox_id_len`. Those are the only two `jail::` uses left
  under `computer/arcbox-computer-runtime/src`.
- **Not covered by any G step**: `sandbox/checkpoint.rs` re-exports
  `arcbox_fc_driver::CHECKPOINT_FORMAT`. It is a non-jail edge, so
  `rg arcbox_fc_driver computer/` will not be empty even after G5 —
  worth planning for in G4/G5.
- `check-layers` still passes with the two grandfathered exceptions;
  G5 deletes them.

## Checks

`cargo clippy -p arcbox-computer-runtime -p arcbox-fc-driver -p
arcbox-vm-driver --all-targets --all-features -- -D warnings`, the three
crates' tests, `cargo check -p arcbox-agent --target
aarch64-unknown-linux-musl --all-targets`, and `cargo xtask
check-layers`, all green. The `sandbox` e2e suite is the oracle for the
pause/resume reorder — numbers in a comment below.

`release_removes_the_chroot_of_an_adopted_pool_slot` goes with the code
it covered. Its invariant — an adopted pool slot releases the *slot's*
chroot, not one named after the computer — is no longer derived from an
id and so can no longer pick the wrong one: the grip being discarded is
the slot's own prepared VM, whose layout is the slot's jail.

R3, PR-G2 of the VM stack redesign.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes load-bearing teardown ordering on pause/resume/stop/remove and moves jail ownership into discard/kill; regressions would leak chroots or lose paused disks without obvious API errors.
> 
> **Overview**
> Moves **file staging off direct Firecracker jail helpers** onto the VM driver’s **`Staging`** capability: boot/restore/pool/resume use `stage_disk`, `stage_kernel`, and `stage_checkpoint`; copy-mode pause and failed-resume unwind **`unstage_disk`** the rootfs before killing the VMM. Boot drops redundant kernel staging (the boot render already places the kernel); rootfs still goes through `stage_rootfs_cow_or_copy`, which chooses CoW vs full copy and journals overlay changes.
> 
> **Jail lifecycle is tied to whoever owns the VMM:** `PreparedVm::discard` (and adopted-handle kill) now **`Jail::remove()`** the per-VM area, so runtime **`remove_jailer_chroot`** and pool slot chroot teardown are deleted. That makes **ordering critical**: taking the disk out of the VM area must happen **before** discard, or pause “succeeds” with nothing to resume from.
> 
> Restore/pool paths carry the **staged rootfs path** (`PreparedSlot.rootfs`, `restore_spec` takes a path not a chroot). Warm publish and `claim_restore_slot` shed config args that only served chroot cleanup.
> 
> **Pause edge cases:** copy-mode pause refuses if there is no staged disk to unstage; **adopted** computers on a copied rootfs (no `PreparedVm`) are refused before kill so the disk isn’t lost—Stop/Remove still work; full adopt reach is deferred to PR-G3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 425aaf31e7b15dc68a947b595b16eb43a7774c0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->