### PR TITLE
feat(tap-net): add an nftables PacketFilter backend

### DIFF
--- a/.github/workflows/test-vm-linux.yml
+++ b/.github/workflows/test-vm-linux.yml
@@ -119,20 +119,26 @@ jobs:
       # as the System VM's, so it exercises the same path
       # (block_tools::busybox_attach_report_and_detach). Its util-linux
       # sibling needs no install: that is what ubuntu's own /usr/sbin is.
-      - name: Install busybox
+      #
+      # nftables is the compute node's netfilter userland (PLAT-191) and is
+      # not in the runner image. ubuntu-22.04 ships nft 1.0.2, an older
+      # floor than Debian 12's 1.0.6, so the JSON listing the teardown reads
+      # is proven below the version the target platform has.
+      - name: Install busybox and nftables
         run: |
           sudo apt-get update
-          sudo apt-get install -y busybox-static
+          sudo apt-get install -y busybox-static nftables
 
       - name: Build test binary
         run: cargo test --test integration -p arcbox-computer-runtime -p arcbox-tap-net --no-run
 
-      # ARCBOX_REQUIRE_BLOCK_TOOLS: this runner has busybox (installed
-      # above) and util-linux (stock ubuntu), so the block-tools tests must
-      # run rather than skip — otherwise a regression in the discovery probe
-      # silently takes its own coverage with it.
+      # ARCBOX_REQUIRE_BLOCK_TOOLS / ARCBOX_REQUIRE_NFT: this runner has
+      # busybox and nftables (installed above) and util-linux (stock
+      # ubuntu), so those tests must run rather than skip — otherwise a
+      # regression in a discovery probe silently takes its own coverage
+      # with it.
       - name: Run integration tests (as root for TAP creation and loop devices)
-        run: sudo env PATH="$PATH" HOME="$HOME" ARCBOX_REQUIRE_BLOCK_TOOLS=1 cargo test --test integration -p arcbox-computer-runtime -p arcbox-tap-net
+        run: sudo env PATH="$PATH" HOME="$HOME" ARCBOX_REQUIRE_BLOCK_TOOLS=1 ARCBOX_REQUIRE_NFT=1 cargo test --test integration -p arcbox-computer-runtime -p arcbox-tap-net
 
   # ---------------------------------------------------------------------------
   # Job 3: E2E tests — requires KVM + root + Firecracker assets

--- a/computer/arcbox-computer-runtime/README.md
+++ b/computer/arcbox-computer-runtime/README.md
@@ -77,13 +77,12 @@ the driver), the loop-device tooling behind
 stock-distro one; an ioctl implementation is a consumer's few dozen
 lines) and the netfilter
 rendering of the identity-invariant translation behind
-`arcbox_tap_net::PacketFilter` (`IptablesLegacy` is the reference;
-a stock distro on the nft backend supplies an nftables one — legacy and
-nft rulesets are mutually invisible, so this is a seam, not a path); the
-path seams follow.
+`arcbox_tap_net::PacketFilter` (`IptablesLegacy` is the reference,
+`Nftables` the stock-distro one — legacy and nft rulesets are mutually
+invisible, so this is a seam, not a path); the path seams follow.
 
 The sandbox network itself — the IPv4 pool, the per-sandbox TAP, the
-invariant NAT (eBPF TCX or iptables), and the quarantine ledger — is
+invariant NAT (eBPF TCX or netfilter), and the quarantine ledger — is
 [`arcbox-tap-net`](../../virt/arcbox-tap-net), the Linux adapter of the
 `arcbox-vm-driver` `GuestNetwork` port; `arcbox_computer_runtime::network`
 re-exports it and `NetworkManager` is an alias of its `TapNetwork` until

--- a/computer/arcbox-computer-runtime/src/config/vmm.rs
+++ b/computer/arcbox-computer-runtime/src/config/vmm.rs
@@ -281,10 +281,17 @@ mod tests {
         assert_eq!(cfg.sandbox_datapath, SandboxDatapath::Ebpf);
         // The fallback is reachable by config alone.
         let cfg: FirecrackerConfig = toml::from_str(
+            "binary = \"/usr/bin/firecracker\"\ndata_dir = \"/var/lib/vmm\"\nsandbox_datapath = \"filter\"\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.sandbox_datapath, SandboxDatapath::Filter);
+        // And under the name it had while iptables was the only rendering —
+        // a node's config file predates the nftables backend.
+        let cfg: FirecrackerConfig = toml::from_str(
             "binary = \"/usr/bin/firecracker\"\ndata_dir = \"/var/lib/vmm\"\nsandbox_datapath = \"iptables\"\n",
         )
         .unwrap();
-        assert_eq!(cfg.sandbox_datapath, SandboxDatapath::Iptables);
+        assert_eq!(cfg.sandbox_datapath, SandboxDatapath::Filter);
     }
 
     #[test]

--- a/computer/arcbox-computer-runtime/src/environment.rs
+++ b/computer/arcbox-computer-runtime/src/environment.rs
@@ -65,7 +65,11 @@ pub struct SandboxEnvironment {
     pub cow_manager: Option<Arc<CowManager>>,
     /// How the identity-invariant translation is expressed in the host's
     /// netfilter framework ([`crate::network::packet_filter`]) — used by
-    /// the iptables datapath and as the eBPF datapath's fallback.
+    /// the filter datapath and as the eBPF datapath's fallback. The
+    /// reference is iptables-legacy; a composer on a stock distro supplies
+    /// `Nftables::discover()?`, because legacy and nft rulesets are mutually
+    /// invisible and pointing this at another `iptables` binary would install
+    /// rules that never take effect.
     pub packet_filter: Arc<dyn PacketFilter>,
 }
 

--- a/virt/arcbox-tap-net/README.md
+++ b/virt/arcbox-tap-net/README.md
@@ -12,9 +12,10 @@ owns:
 - the identity-invariant translation (CORE-81): every guest boots on the
   fixed `169.254.100.2/30` behind `169.254.100.1` (`invariant`), and the
   pool address is applied host-side per TAP — as two eBPF TCX programs
-  (`bpf/sandbox_nat.bpf.o`, the default) or as the iptables rule set
-  behind the `PacketFilter` seam (`IptablesLegacy` is the reference; a
-  stock distro on the nft backend supplies its own);
+  (`bpf/sandbox_nat.bpf.o`, the default) or as the netfilter rule set
+  behind the `PacketFilter` seam (`IptablesLegacy` for the System VM's
+  userland, `Nftables` for a stock distro; legacy and nft rulesets are
+  mutually invisible, so that is a seam rather than a binary path);
 - the hand-encoded rtnetlink requests the invariant scheme needs (fwmark
   fib rule, per-sandbox table route, onlink gateway route) — pure
   encoders, unit-tested;
@@ -63,8 +64,8 @@ use arcbox_tap_net::{AttachMode, Datapath, IptablesLegacy, TapNetwork};
 let network = TapNetwork::with_quarantine_dir(
     "172.20.0.0/16", "172.20.0.1", vec![],
     data_dir.join("sandbox-network-quarantine"),
-    Datapath::default(),                 // eBPF, iptables fallback
-    Arc::new(IptablesLegacy::default()),
+    Datapath::default(),                 // eBPF, packet-filter fallback
+    Arc::new(IptablesLegacy::default()), // or `Nftables::discover()?`
 )?;
 let allocation = network.reserve("box-1")?;          // journal it, then:
 network.activate(&allocation, AttachMode::Invariant)?;
@@ -79,16 +80,30 @@ is `network.reconcile()`.
 ## Requirements and tests
 
 Everything that touches the kernel is Linux-only and needs `CAP_NET_ADMIN`
-(root in practice): TAP creation, netlink, `/sbin/iptables`, and the TCX
-attach (`BPF_SYSCALL`, `BPF_JIT_ALWAYS_ON`, `NET_XGRESS`; the loader
-attaches only through TCX links and never falls back to netlink tc). The
-pool, the encoders, the ledger, and the port mapping compile and are
-unit-tested on every host.
+(root in practice): TAP creation, netlink, `/sbin/iptables` or
+`/usr/sbin/nft`, and the TCX attach (`BPF_SYSCALL`, `BPF_JIT_ALWAYS_ON`,
+`NET_XGRESS`; the loader attaches only through TCX links and never falls
+back to netlink tc). The pool, the encoders, the ledger, the rule
+renderings, and the port mapping compile and are unit-tested on every
+host.
 
 ```bash
 cargo test -p arcbox-tap-net                     # unit + bpf-object guards, no root
 sudo -E cargo test -p arcbox-tap-net --test integration   # real TAPs (skips unless root)
 ```
+
+The nftables tests move their own thread into a private network namespace
+before touching a ruleset, so they never mutate the host's. That also
+makes them runnable without a root shell:
+
+```bash
+cargo test -p arcbox-tap-net --test integration --no-run   # then, on the built binary:
+ARCBOX_REQUIRE_NFT=1 unshare -rn ./target/debug/deps/integration-* nftables
+```
+
+`ARCBOX_REQUIRE_NFT=1` turns "nft is missing, skipping" into a failure —
+set it wherever nft is known to be installed, so the coverage cannot
+evaporate silently.
 
 `.github/workflows/test-vm-linux.yml` runs both.
 

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -513,7 +513,7 @@ mod tests {
             v4("169.254.100.2")
         );
 
-        record(crate::AppliedDatapath::Iptables);
+        record(crate::AppliedDatapath::Filter);
         assert_eq!(
             network.host_ingress(&lease).unwrap(),
             HostIngress::GuestAddress {
@@ -540,7 +540,7 @@ mod tests {
             (crate::AppliedDatapath::Ebpf, ExposeTarget::PoolIp),
             (crate::AppliedDatapath::Untranslated, ExposeTarget::PoolIp),
             (
-                crate::AppliedDatapath::Iptables,
+                crate::AppliedDatapath::Filter,
                 ExposeTarget::GuestIpWithFwmark,
             ),
         ] {

--- a/virt/arcbox-tap-net/src/invariant.rs
+++ b/virt/arcbox-tap-net/src/invariant.rs
@@ -27,8 +27,8 @@
 //!   destination through a per-sandbox table holding `GUEST_IP dev <tap>`.
 //!
 //! The rule set above is the contract; how it is expressed in the host's
-//! netfilter framework is the [`PacketFilter`](super::packet_filter::PacketFilter)
-//! seam. The reference implementation is iptables-legacy, because that is
+//! netfilter framework is the [`PacketFilter`] seam. The reference
+//! implementation is iptables-legacy, because that is
 //! what the System VM ships (2026-08, boot-assets rootfs + arcbox kernel
 //! config): no nftables userland, no `tc`, and a kernel without
 //! `NET_ACT_NAT` / `NETMAP` / `CONNMARK` — what it does enable (`IP_NF_NAT`,
@@ -52,7 +52,7 @@
 //! activations, and crash-recovery replays; rule specs derive entirely from
 //! the allocation, so cleanup needs no extra state.
 //!
-//! Since CORE-83 this rule set is the `SandboxDatapath::Iptables` mechanism
+//! Since CORE-83 this rule set is the `SandboxDatapath::Filter` mechanism
 //! and the automatic fallback; the default datapath applies the same
 //! translation with two TCX programs per TAP instead (`super::ebpf`),
 //! needing none of the mark/fwmark machinery.

--- a/virt/arcbox-tap-net/src/invariant.rs
+++ b/virt/arcbox-tap-net/src/invariant.rs
@@ -27,16 +27,16 @@
 //!   destination through a per-sandbox table holding `GUEST_IP dev <tap>`.
 //!
 //! The rule set above is the contract; how it is expressed in the host's
-//! netfilter framework is the [`PacketFilter`] seam. The reference implementation is iptables-legacy, because that is
-//! what the System VM ships (2026-08, boot-assets rootfs + arcbox kernel
-//! config): no nftables userland, no `tc`, and a kernel without
-//! `NET_ACT_NAT` / `NETMAP` / `CONNMARK` — what it does enable (`IP_NF_NAT`,
-//! `IP_NF_MANGLE`, `NETFILTER_XT_MARK`, `IP_MULTIPLE_TABLES`) is exactly
-//! that rule set. A stock distro is the other way round — nft is the live
-//! ruleset and a legacy rule would be installed into one nothing consults —
-//! so it composes [`Nftables`](super::packet_filter::Nftables) instead. The
-//! sysctls, the fwmark fib rule, and the per-sandbox table route are
-//! framework-independent and installed here.
+//! netfilter framework is the [`PacketFilter`] seam. The reference
+//! implementation is iptables-legacy, because that is what the System VM
+//! ships (2026-08, boot-assets rootfs + arcbox kernel config): no nftables
+//! userland, no `tc`, and a kernel without `NET_ACT_NAT` / `NETMAP` /
+//! `CONNMARK` — what it does enable (`IP_NF_NAT`, `IP_NF_MANGLE`,
+//! `NETFILTER_XT_MARK`, `IP_MULTIPLE_TABLES`) is exactly that rule set. A
+//! stock distro is the other way round — nft is the live ruleset and a
+//! legacy rule would be installed into one nothing consults — so it
+//! composes [`Nftables`] instead. The sysctls, the fwmark fib rule, and the
+//! per-sandbox table route are framework-independent and installed here.
 //!
 //! The TAP itself keeps today's point-to-point shape with one change: its
 //! local address is the fixed [`GUEST_GATEWAY`] instead of the pool gateway.
@@ -58,6 +58,13 @@
 //! and the automatic fallback; the default datapath applies the same
 //! translation with two TCX programs per TAP instead (`super::ebpf`),
 //! needing none of the mark/fwmark machinery.
+//!
+//! Both links are resolved here rather than left bare, because the `use`
+//! that would bring them into scope is `#[cfg(target_os = "linux")]` — a
+//! bare link would break rustdoc on macOS, the P0 platform.
+//!
+//! [`PacketFilter`]: super::packet_filter::PacketFilter
+//! [`Nftables`]: super::packet_filter::Nftables
 
 use std::net::Ipv4Addr;
 

--- a/virt/arcbox-tap-net/src/invariant.rs
+++ b/virt/arcbox-tap-net/src/invariant.rs
@@ -27,14 +27,16 @@
 //!   destination through a per-sandbox table holding `GUEST_IP dev <tap>`.
 //!
 //! The rule set above is the contract; how it is expressed in the host's
-//! netfilter framework is the [`PacketFilter`] seam. The reference
-//! implementation is iptables-legacy, because that is
+//! netfilter framework is the [`PacketFilter`] seam. The reference implementation is iptables-legacy, because that is
 //! what the System VM ships (2026-08, boot-assets rootfs + arcbox kernel
 //! config): no nftables userland, no `tc`, and a kernel without
 //! `NET_ACT_NAT` / `NETMAP` / `CONNMARK` — what it does enable (`IP_NF_NAT`,
 //! `IP_NF_MANGLE`, `NETFILTER_XT_MARK`, `IP_MULTIPLE_TABLES`) is exactly
-//! that rule set. The sysctls, the fwmark fib rule, and the per-sandbox
-//! table route are framework-independent and installed here.
+//! that rule set. A stock distro is the other way round — nft is the live
+//! ruleset and a legacy rule would be installed into one nothing consults —
+//! so it composes [`Nftables`](super::packet_filter::Nftables) instead. The
+//! sysctls, the fwmark fib rule, and the per-sandbox table route are
+//! framework-independent and installed here.
 //!
 //! The TAP itself keeps today's point-to-point shape with one change: its
 //! local address is the fixed [`GUEST_GATEWAY`] instead of the pool gateway.

--- a/virt/arcbox-tap-net/src/lib.rs
+++ b/virt/arcbox-tap-net/src/lib.rs
@@ -3,7 +3,7 @@
 //! One [`TapNetwork`] owns an IPv4 pool and, per VM, a persistent TAP
 //! device on an isolated point-to-point link, the identity-invariant NAT
 //! that gives every guest the same address ([`invariant`]) — applied per
-//! TAP either as two eBPF TCX programs or as the iptables rule set behind
+//! TAP either as two eBPF TCX programs or as the netfilter rule set behind
 //! the [`PacketFilter`] seam — and the durable quarantine ledger that keeps
 //! a released address out of the pool until host-side forwarding state is
 //! confirmed gone. It moved here from `arcbox-vm/src/network` as the Linux
@@ -82,14 +82,20 @@ mod tap;
 pub enum Datapath {
     /// Per-TAP TCX eBPF programs: two attach syscalls and one map update per
     /// activation, stateless, O(1) per packet (CORE-83). Falls back to
-    /// [`Self::Iptables`] automatically when the BPF object cannot be loaded
+    /// [`Self::Filter`] automatically when the BPF object cannot be loaded
     /// or attached.
     #[default]
     Ebpf,
-    /// The CORE-81 iptables rule set (mark + DNAT/SNAT + fwmark fib rules);
-    /// conntrack-stateful and O(active sandboxes) per packet. Also the only
-    /// mechanism ever applied to legacy (non-invariant) TAPs.
-    Iptables,
+    /// The CORE-81 netfilter rule set (mark + DNAT/SNAT + fwmark fib rules)
+    /// as rendered by the composed [`PacketFilter`] — iptables in the System
+    /// VM, nftables on a stock distro. Conntrack-stateful and O(active
+    /// sandboxes) per packet. Also the only mechanism ever applied to legacy
+    /// (non-invariant) TAPs.
+    ///
+    /// The alias is the name this value had while iptables was the only
+    /// rendering; configs written then keep loading.
+    #[serde(alias = "iptables")]
+    Filter,
 }
 
 /// The name this type had inside `arcbox-vm`, kept so the System VM's
@@ -99,7 +105,7 @@ pub type NetworkManager = TapNetwork;
 /// The translation mechanism actually applied to an active TAP.
 ///
 /// Distinct from the configured [`Datapath`]: a TAP configured for
-/// eBPF lands on `Iptables` when the object cannot be loaded or this TAP's
+/// eBPF lands on `Filter` when the object cannot be loaded or this TAP's
 /// attach fails. Teardown and expose targeting must follow what was applied,
 /// not what was asked for — which is why a [`AttachMode::LegacySnapshot`]
 /// TAP records [`Self::Untranslated`] rather than nothing at all: absent and
@@ -116,8 +122,8 @@ pub type NetworkManager = TapNetwork;
 enum AppliedDatapath {
     /// TCX programs + map entry + onlink gateway route.
     Ebpf,
-    /// The CORE-81 iptables/fwmark rule set.
-    Iptables,
+    /// The CORE-81 netfilter/fwmark rule set, through the [`PacketFilter`].
+    Filter,
     /// None: the guest owns the pool address itself, so nothing is
     /// rewritten per TAP ([`AttachMode::LegacySnapshot`]).
     Untranslated,
@@ -139,7 +145,7 @@ pub enum ExposeTarget {
     PoolIp,
     /// DNAT to the fixed invariant guest IP with a companion fwmark `MARK`
     /// rule on the same match, so the rewritten destination routes out the
-    /// right TAP through the CORE-81 fwmark table (iptables datapath only).
+    /// right TAP through the CORE-81 fwmark table (filter datapath only).
     GuestIpWithFwmark,
 }
 
@@ -192,9 +198,9 @@ pub struct TapNetwork {
     /// TAP (activation inserts, teardown removes). A TAP absent here was
     /// either activated by a previous agent process (its eBPF links died
     /// with that process) or is legacy — both tear down via the tolerant
-    /// iptables removal and expose via the fwmark form.
+    /// packet-filter removal and expose via the fwmark form.
     applied: Mutex<HashMap<String, AppliedDatapath>>,
-    /// How the iptables-datapath translation (and the eBPF fallback) is
+    /// How the filter-datapath translation (and the eBPF fallback) is
     /// expressed on this host; see [`packet_filter`].
     #[cfg_attr(
         not(target_os = "linux"),
@@ -484,7 +490,7 @@ impl TapNetwork {
                 // process that opened them (see the `ebpf` module docs), so
                 // an adopted invariant TAP has its onlink route and no
                 // programs: the guest is alive and unreachable until they
-                // are re-attached. Iptables rules survive instead and their
+                // are re-attached. Filter rules survive instead and their
                 // install appends rather than replaces, so remove first —
                 // through the tolerant removal (no `applied` record yet is
                 // exactly its "activated by a previous agent process"
@@ -516,18 +522,18 @@ impl TapNetwork {
     }
 
     /// Apply the invariant pool-IP translation to an existing TAP, honoring
-    /// the configured [`Datapath`] and falling back to iptables when
-    /// the eBPF path is unavailable, then record what was applied.
+    /// the configured [`Datapath`] and falling back to the packet filter
+    /// when the eBPF path is unavailable, then record what was applied.
     #[cfg(target_os = "linux")]
     fn install_translation(&self, allocation: &NetworkAllocation) -> Result<()> {
         let applied = match self.datapath {
-            Datapath::Iptables => {
+            Datapath::Filter => {
                 invariant::install(
                     &*self.packet_filter,
                     &allocation.tap_name,
                     allocation.ip_address,
                 )?;
-                AppliedDatapath::Iptables
+                AppliedDatapath::Filter
             }
             Datapath::Ebpf => match self.attach_ebpf(allocation) {
                 Ok(ebpf::Attach::Done) => AppliedDatapath::Ebpf,
@@ -538,20 +544,20 @@ impl TapNetwork {
                         &allocation.tap_name,
                         allocation.ip_address,
                     )?;
-                    AppliedDatapath::Iptables
+                    AppliedDatapath::Filter
                 }
                 Err(error) => {
                     tracing::warn!(
                         tap = %allocation.tap_name,
                         %error,
-                        "eBPF TAP attach failed; using iptables NAT for this TAP"
+                        "eBPF TAP attach failed; using packet-filter NAT for this TAP"
                     );
                     invariant::install(
                         &*self.packet_filter,
                         &allocation.tap_name,
                         allocation.ip_address,
                     )?;
-                    AppliedDatapath::Iptables
+                    AppliedDatapath::Filter
                 }
             },
         };
@@ -592,9 +598,9 @@ impl TapNetwork {
     /// Remove whatever translation this process applied to the TAP.
     ///
     /// eBPF TAPs detach their links and drop their map entry (the gateway
-    /// route dies with the TAP). Everything else — iptables TAPs, legacy
+    /// route dies with the TAP). Everything else — filter TAPs, legacy
     /// TAPs, and TAPs activated by a previous agent process (whose eBPF
-    /// links died with it) — takes the tolerant iptables removal, exactly
+    /// links died with it) — takes the tolerant packet-filter removal, exactly
     /// as before CORE-83.
     #[cfg(target_os = "linux")]
     fn deactivate_translation(&self, alloc: &NetworkAllocation) -> Result<()> {
@@ -613,13 +619,13 @@ impl TapNetwork {
     /// Follows the *applied* datapath, not the configured one: an eBPF TAP's
     /// egress program translates pool-IP packets on the TAP itself and a
     /// legacy TAP never translated anything, so the plain pool-IP form
-    /// suffices for both; everything else — iptables TAPs, and TAPs whose
+    /// suffices for both; everything else — filter TAPs, and TAPs whose
     /// activation record died with a previous agent process — needs the
     /// CORE-81 guest-IP + fwmark form.
     pub(crate) fn expose_target(&self, tap_name: &str) -> ExposeTarget {
         match self.applied.lock().unwrap().get(tap_name) {
             Some(AppliedDatapath::Ebpf | AppliedDatapath::Untranslated) => ExposeTarget::PoolIp,
-            Some(AppliedDatapath::Iptables) | None => ExposeTarget::GuestIpWithFwmark,
+            Some(AppliedDatapath::Filter) | None => ExposeTarget::GuestIpWithFwmark,
         }
     }
 

--- a/virt/arcbox-tap-net/src/lib.rs
+++ b/virt/arcbox-tap-net/src/lib.rs
@@ -40,7 +40,7 @@ use uuid::Uuid;
 
 pub use crate::allocation::NetworkAllocation;
 pub use crate::error::{Result, TapNetError};
-pub use packet_filter::{IptablesLegacy, PacketFilter};
+pub use packet_filter::{IptablesLegacy, Nftables, PacketFilter};
 
 pub mod allocation;
 pub mod error;

--- a/virt/arcbox-tap-net/src/packet_filter/iptables_legacy.rs
+++ b/virt/arcbox-tap-net/src/packet_filter/iptables_legacy.rs
@@ -1,67 +1,12 @@
-//! The packet-filter seam: how the identity-invariant translation is
-//! expressed in the host's netfilter framework.
-//!
-//! The *contract* is fixed by [`super::invariant`] and does not vary with
-//! the framework: for a sandbox behind `tap` whose external identity is
-//! `pool_ip`, with `mark = fwmark(pool_ip)`,
-//!
-//! 1. every packet entering from `tap` is marked `mark` (so post-routing
-//!    NAT, which cannot match the input interface, can pick the source
-//!    identity);
-//! 2. every packet whose *pre-NAT* destination is `pool_ip` is marked
-//!    `mark`, both forwarded (prerouting) and locally originated (output),
-//!    so the fwmark fib rule routes the rewritten destination out `tap`;
-//! 3. `pool_ip` is DNAT'd to [`GUEST_IP`] in prerouting and output;
-//! 4. traffic from `tap` to local services is SNAT'd to `pool_ip` in the
-//!    input hook, so DNS and relays keep seeing the pool identity;
-//! 5. forwarded traffic with source [`GUEST_IP`] *and* mark `mark` is SNAT'd
-//!    to `pool_ip` in postrouting — the source match keeps to-sandbox packets
-//!    (same mark, client source) out of the rewrite.
-//!
-//! How that is spelled is the environment's business. The System VM ships
-//! iptables-legacy and nothing else, so [`IptablesLegacy`] is the reference
-//! implementation. A stock distro is usually on the nft backend, and legacy
-//! and nft rulesets are mutually invisible — rules that exist but do not
-//! take effect — so a composer there supplies an nftables implementation
-//! rather than a path to a different `iptables` binary. Removal must
-//! tolerate absence: teardown runs for partially activated and crash-
-//! recovered TAPs alike.
-//!
-//! [`GUEST_IP`]: super::invariant::GUEST_IP
+//! [`PacketFilter`] over iptables-legacy — the System VM's userland, and the
+//! reference rendering of the seam's contract (see [`super`]).
 
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
 
-use super::invariant::{GUEST_IP, fwmark};
+use super::{PacketFilter, RULE_COMMENT};
 use crate::error::{Result, TapNetError};
-
-/// Installs and removes the per-TAP translation rules of one sandbox.
-///
-/// Methods are synchronous; the network manager calls them on the
-/// activation and teardown paths, which already run blocking netlink work.
-///
-/// Two obligations every implementation carries, because callers were
-/// built against them:
-///
-/// - **Pipeline placement.** The rules are *appended* to their chains, so
-///   they sit below whatever the composer installed at boot (the reference
-///   guest agent's isolation DROPs) and above nothing; per-sandbox expose
-///   companions are prepended above them by their own code. Rendering the
-///   same rules at another position changes the pipeline even when each
-///   rule is faithful.
-/// - **Failure shape.** `install_translation` fails fast on the first rule
-///   that does not apply, leaving the earlier ones in place — the caller
-///   then calls `remove_translation`, which must attempt every rule,
-///   tolerate ones that are already absent (partial installs, crash
-///   replays, legacy TAPs), and report the failures it could not clear
-///   together rather than stopping at the first.
-pub trait PacketFilter: Send + Sync {
-    /// Install the translation for `tap` ↔ `pool_ip`.
-    fn install_translation(&self, tap: &str, pool_ip: Ipv4Addr) -> Result<()>;
-
-    /// Remove the translation, tolerating rules that are already gone.
-    fn remove_translation(&self, tap: &str, pool_ip: Ipv4Addr) -> Result<()>;
-}
+use crate::invariant::{GUEST_IP, fwmark};
 
 /// [`PacketFilter`] over iptables-legacy — the System VM's userland.
 ///
@@ -142,13 +87,9 @@ impl PacketFilter for IptablesLegacy {
     }
 }
 
-/// Comment tag on every translation rule, marking them as arcbox-owned for
-/// forensics (`iptables -S`). Deletion goes by exact rule spec, not the tag.
-const RULE_COMMENT: &str = "arcbox-nat";
-
 /// One iptables rule of the per-TAP translation set.
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) struct XtRule {
+pub struct XtRule {
     pub table: &'static str,
     pub chain: &'static str,
     pub spec: Vec<String>,
@@ -156,7 +97,7 @@ pub(crate) struct XtRule {
 
 /// The complete per-TAP translation rule set, in install order — the
 /// iptables rendering of the module-level contract.
-pub(crate) fn translation_rules(tap: &str, pool_ip: Ipv4Addr) -> Vec<XtRule> {
+pub fn translation_rules(tap: &str, pool_ip: Ipv4Addr) -> Vec<XtRule> {
     let mark = format!("{:#x}", fwmark(pool_ip));
     let pool = format!("{pool_ip}/32");
     let comment = |spec: &mut Vec<String>| {

--- a/virt/arcbox-tap-net/src/packet_filter/mod.rs
+++ b/virt/arcbox-tap-net/src/packet_filter/mod.rs
@@ -1,0 +1,74 @@
+//! The packet-filter seam: how the identity-invariant translation is
+//! expressed in the host's netfilter framework.
+//!
+//! The *contract* is fixed by [`super::invariant`] and does not vary with
+//! the framework: for a sandbox behind `tap` whose external identity is
+//! `pool_ip`, with `mark = fwmark(pool_ip)`,
+//!
+//! 1. every packet entering from `tap` is marked `mark` (so post-routing
+//!    NAT, which cannot match the input interface, can pick the source
+//!    identity);
+//! 2. every packet whose *pre-NAT* destination is `pool_ip` is marked
+//!    `mark`, both forwarded (prerouting) and locally originated (output),
+//!    so the fwmark fib rule routes the rewritten destination out `tap`;
+//! 3. `pool_ip` is DNAT'd to [`GUEST_IP`] in prerouting and output;
+//! 4. traffic from `tap` to local services is SNAT'd to `pool_ip` in the
+//!    input hook, so DNS and relays keep seeing the pool identity;
+//! 5. forwarded traffic with source [`GUEST_IP`] *and* mark `mark` is SNAT'd
+//!    to `pool_ip` in postrouting — the source match keeps to-sandbox packets
+//!    (same mark, client source) out of the rewrite.
+//!
+//! How that is spelled is the environment's business. The System VM ships
+//! iptables-legacy and nothing else, so [`IptablesLegacy`] is the reference
+//! implementation. A stock distro is usually on the nft backend, and legacy
+//! and nft rulesets are mutually invisible — rules that exist but do not
+//! take effect — so a composer there supplies an nftables implementation
+//! rather than a path to a different `iptables` binary. Removal must
+//! tolerate absence: teardown runs for partially activated and crash-
+//! recovered TAPs alike.
+//!
+//! [`GUEST_IP`]: super::invariant::GUEST_IP
+
+mod iptables_legacy;
+
+use std::net::Ipv4Addr;
+
+pub use iptables_legacy::IptablesLegacy;
+
+use crate::error::Result;
+
+/// Installs and removes the per-TAP translation rules of one sandbox.
+///
+/// Methods are synchronous; the network manager calls them on the
+/// activation and teardown paths, which already run blocking netlink work.
+///
+/// Two obligations every implementation carries, because callers were
+/// built against them:
+///
+/// - **Pipeline placement.** The rules are *appended* to their chains, so
+///   they sit below whatever the composer installed at boot (the reference
+///   guest agent's isolation DROPs) and above nothing; per-sandbox expose
+///   companions are prepended above them by their own code. Rendering the
+///   same rules at another position changes the pipeline even when each
+///   rule is faithful.
+/// - **Failure shape.** `install_translation` may fail after applying some
+///   of the rules — the caller then calls `remove_translation`, which must
+///   attempt every rule, tolerate ones that are already absent (partial
+///   installs, crash replays, legacy TAPs), and report the failures it could
+///   not clear together rather than stopping at the first. An implementation
+///   whose install is atomic satisfies this trivially; one that applies
+///   rules one at a time ([`IptablesLegacy`]) leaves the earlier ones in
+///   place and relies on that tolerance.
+pub trait PacketFilter: Send + Sync {
+    /// Install the translation for `tap` ↔ `pool_ip`.
+    fn install_translation(&self, tap: &str, pool_ip: Ipv4Addr) -> Result<()>;
+
+    /// Remove the translation, tolerating rules that are already gone.
+    fn remove_translation(&self, tap: &str, pool_ip: Ipv4Addr) -> Result<()>;
+}
+
+/// Tag stamped on every translation rule, marking them as arcbox-owned for
+/// forensics (`iptables -S`, `nft list ruleset`).
+///
+/// [`IptablesLegacy`] uses it bare and deletes by exact rule spec.
+const RULE_COMMENT: &str = "arcbox-nat";

--- a/virt/arcbox-tap-net/src/packet_filter/mod.rs
+++ b/virt/arcbox-tap-net/src/packet_filter/mod.rs
@@ -22,18 +22,23 @@
 //! iptables-legacy and nothing else, so [`IptablesLegacy`] is the reference
 //! implementation. A stock distro is usually on the nft backend, and legacy
 //! and nft rulesets are mutually invisible — rules that exist but do not
-//! take effect — so a composer there supplies an nftables implementation
-//! rather than a path to a different `iptables` binary. Removal must
-//! tolerate absence: teardown runs for partially activated and crash-
-//! recovered TAPs alike.
+//! take effect — so a composer there supplies [`Nftables`] rather than a path
+//! to a different `iptables` binary. Removal must tolerate absence: teardown
+//! runs for partially activated and crash-recovered TAPs alike.
+//!
+//! The two backends render the same five points as the same seven rules, in
+//! the same order; the `renderings_agree_on_the_contract` test is what keeps
+//! them a pair rather than two drifting dialects.
 //!
 //! [`GUEST_IP`]: super::invariant::GUEST_IP
 
 mod iptables_legacy;
+mod nftables;
 
 use std::net::Ipv4Addr;
 
 pub use iptables_legacy::IptablesLegacy;
+pub use nftables::Nftables;
 
 use crate::error::Result;
 
@@ -56,9 +61,9 @@ use crate::error::Result;
 ///   attempt every rule, tolerate ones that are already absent (partial
 ///   installs, crash replays, legacy TAPs), and report the failures it could
 ///   not clear together rather than stopping at the first. An implementation
-///   whose install is atomic satisfies this trivially; one that applies
-///   rules one at a time ([`IptablesLegacy`]) leaves the earlier ones in
-///   place and relies on that tolerance.
+///   whose install is atomic ([`Nftables`]) satisfies this trivially; one
+///   that applies rules one at a time ([`IptablesLegacy`]) leaves the earlier
+///   ones in place and relies on that tolerance.
 pub trait PacketFilter: Send + Sync {
     /// Install the translation for `tap` ↔ `pool_ip`.
     fn install_translation(&self, tap: &str, pool_ip: Ipv4Addr) -> Result<()>;
@@ -70,5 +75,7 @@ pub trait PacketFilter: Send + Sync {
 /// Tag stamped on every translation rule, marking them as arcbox-owned for
 /// forensics (`iptables -S`, `nft list ruleset`).
 ///
-/// [`IptablesLegacy`] uses it bare and deletes by exact rule spec.
+/// [`IptablesLegacy`] uses it bare and deletes by exact rule spec;
+/// [`Nftables`] qualifies it per TAP (`arcbox-nat:<tap>`) and deletes by it,
+/// because nft can only delete a rule by handle.
 const RULE_COMMENT: &str = "arcbox-nat";

--- a/virt/arcbox-tap-net/src/packet_filter/nftables.rs
+++ b/virt/arcbox-tap-net/src/packet_filter/nftables.rs
@@ -1,0 +1,382 @@
+//! [`PacketFilter`] over nftables — a stock distro's netfilter userland.
+//!
+//! Renders the seam's contract (see [`super`]) as the same seven rules
+//! [`IptablesLegacy`](super::IptablesLegacy) renders, in the same order, in a
+//! dedicated `table ip arcbox` whose base chains sit at the hook priorities
+//! the iptables tables occupy. Two shape differences follow from nftables
+//! itself rather than from taste:
+//!
+//! - **Install is one atomic batch.** `nft -f -` commits a transaction, so a
+//!   rejected rule leaves nothing behind instead of a partial rule set. The
+//!   batch also `add`s the table and chains, which is idempotent, so a
+//!   ruleset an operator flushed is rebuilt by the next activation.
+//! - **Removal is by comment, not by spec.** nftables can only delete a rule
+//!   by handle, and handles are assigned by the kernel. Every rule therefore
+//!   carries `comment "arcbox-nat:<tap>"`, and teardown lists the table, keeps
+//!   the handles whose comment matches, and deletes those. That tag is the
+//!   only key, which makes teardown strictly more thorough than the iptables
+//!   path's delete-by-spec: it also collects a rule whose spec has drifted,
+//!   and it collects *every* copy when a crash replay appended a second set
+//!   (`iptables -D` removes only the first match).
+
+use std::io::Write as _;
+use std::net::Ipv4Addr;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use serde::Deserialize;
+
+use super::{PacketFilter, RULE_COMMENT};
+use crate::error::{Result, TapNetError};
+use crate::invariant::{GUEST_IP, fwmark};
+
+/// Family and name of the table every arcbox rule lives in.
+const TABLE: &str = "ip arcbox";
+
+/// Reference search list for `nft`. The first entry that exists and answers
+/// `--version` as nftables wins; `/usr/sbin` covers usrmerged distros,
+/// `/sbin` the rest.
+const NFT_CANDIDATES: &[&str] = &["/usr/sbin/nft", "/sbin/nft"];
+
+/// The base chains, in table order, each at the hook priority of the
+/// iptables table it stands in for: `NF_IP_PRI_MANGLE` (-150),
+/// `NF_IP_PRI_NAT_DST` (-100), `NF_IP_PRI_NAT_SRC` (100).
+///
+/// The priorities are numeric rather than the readable `mangle` / `dstnat` /
+/// `srcnat` keywords because those keywords are **hook-scoped** on older
+/// nftables: nft 1.0.2 (Ubuntu 22.04, and the floor below Debian 12's 1.0.6)
+/// rejects `dstnat` in the output hook and `srcnat` in the input hook with
+/// "invalid priority expression value in this context", while nft 1.1.6
+/// accepts both. The numbers mean the same thing on every version.
+///
+/// `mangle_output` is `type route`, not `type filter`: that is what makes a
+/// mark set there trigger a re-route, which is the whole point of rule 3 and
+/// what iptables' mangle OUTPUT does.
+const BASE_CHAINS: &[(&str, &str)] = &[
+    (
+        "mangle_prerouting",
+        "type filter hook prerouting priority -150 ; policy accept ;",
+    ),
+    (
+        "mangle_output",
+        "type route hook output priority -150 ; policy accept ;",
+    ),
+    (
+        "nat_prerouting",
+        "type nat hook prerouting priority -100 ; policy accept ;",
+    ),
+    (
+        "nat_output",
+        "type nat hook output priority -100 ; policy accept ;",
+    ),
+    (
+        "nat_input",
+        "type nat hook input priority 100 ; policy accept ;",
+    ),
+    (
+        "nat_postrouting",
+        "type nat hook postrouting priority 100 ; policy accept ;",
+    ),
+];
+
+/// [`PacketFilter`] over the `nft` binary.
+///
+/// Every rule carries the `arcbox-nat:<tap>` comment, which is both the
+/// forensic tag (`nft list ruleset`) and the teardown key.
+#[derive(Debug, Clone)]
+pub struct Nftables {
+    nft: PathBuf,
+}
+
+impl Nftables {
+    /// Where a stock distro installs `nft`.
+    pub const DEFAULT_PATH: &'static str = "/usr/sbin/nft";
+
+    /// Use the binary at `nft` as given. Nothing is probed: a composer that
+    /// knows where its userland lives (a bundled copy, a non-standard
+    /// prefix) says so and is believed.
+    pub fn new(nft: impl Into<PathBuf>) -> Self {
+        Self { nft: nft.into() }
+    }
+
+    /// Find `nft` in the reference search list, failing when it is absent or
+    /// is not nftables.
+    ///
+    /// `PATH` is deliberately not searched: a node agent's `PATH` is whatever
+    /// its unit file happened to inherit.
+    pub fn discover() -> Result<Self> {
+        Self::discover_in(NFT_CANDIDATES)
+    }
+
+    fn discover_in(candidates: &[&str]) -> Result<Self> {
+        candidates
+            .iter()
+            .map(PathBuf::from)
+            .find(|bin| is_nftables(bin))
+            .map(|nft| Self { nft })
+            .ok_or_else(|| TapNetError::Network(format!("no nft among {}", candidates.join(", "))))
+    }
+
+    /// Run one `nft` invocation, optionally feeding `script` to its stdin.
+    ///
+    /// `LC_ALL=C` is forced so [`is_missing`]'s match on strerror text holds
+    /// whatever locale the node agent inherited. The failure is the bare
+    /// diagnostic: callers wrap it into [`TapNetError::Network`] once, so a
+    /// collected teardown report carries one prefix, not one per rule.
+    fn run(&self, args: &[&str], script: Option<&str>) -> std::result::Result<Output, String> {
+        let spawn_failed = |e| format!("run {}: {e}", self.nft.display());
+        let mut child = Command::new(&self.nft)
+            .args(args)
+            .env("LC_ALL", "C")
+            .stdin(if script.is_some() {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            })
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(spawn_failed)?;
+        if let Some(script) = script {
+            // Taking the handle closes the pipe at the end of this block,
+            // which is what lets nft reach EOF and exit.
+            let mut stdin = child
+                .stdin
+                .take()
+                .expect("stdin is piped when a script is given");
+            stdin
+                .write_all(script.as_bytes())
+                .map_err(|e| format!("write batch to {}: {e}", self.nft.display()))?;
+        }
+        child.wait_with_output().map_err(spawn_failed)
+    }
+
+    /// Chain and handle of every rule in the table tagged for this TAP.
+    ///
+    /// An absent table is an empty list, not an error: teardown runs for TAPs
+    /// that never had rules (legacy, partially activated) and on hosts where
+    /// a previous sweep already removed the last one.
+    fn tagged_rules(&self, tag: &str) -> std::result::Result<Vec<RuleHandle>, String> {
+        let output = self.run(&["-j", "-a", "list", "table", TABLE], None)?;
+        if !output.status.success() {
+            let stderr = stderr_of(&output);
+            if is_missing(&stderr) {
+                return Ok(Vec::new());
+            }
+            return Err(format!("nft list table {TABLE}: {stderr}"));
+        }
+        rule_handles(&output.stdout, tag)
+    }
+}
+
+impl Default for Nftables {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_PATH)
+    }
+}
+
+impl PacketFilter for Nftables {
+    fn install_translation(&self, tap: &str, pool_ip: Ipv4Addr) -> Result<()> {
+        let output = self
+            .run(&["-f", "-"], Some(&install_batch(tap, pool_ip)))
+            .map_err(TapNetError::Network)?;
+        if output.status.success() {
+            return Ok(());
+        }
+        Err(TapNetError::Network(format!(
+            "nft -f - (install {tap}): {}",
+            stderr_of(&output)
+        )))
+    }
+
+    /// `pool_ip` is not read: the TAP name derives from the pool address
+    /// (`vmtap<c>-<d>`), so the tag alone names the sandbox, and matching on
+    /// the tag rather than on a rendered spec is what lets teardown collect
+    /// drifted and duplicated rules too.
+    fn remove_translation(&self, tap: &str, _pool_ip: Ipv4Addr) -> Result<()> {
+        let tag = rule_tag(tap);
+        let rules = self.tagged_rules(&tag).map_err(TapNetError::Network)?;
+        // One delete per rule rather than one batch: a batch is a
+        // transaction, so a single handle a concurrent teardown already freed
+        // would roll back the deletion of every other rule and report the
+        // whole thing as "already gone".
+        let mut failures = Vec::new();
+        for rule in rules {
+            let delete = format!("delete rule {TABLE} {} handle {}", rule.chain, rule.handle);
+            match self.run(&["-f", "-"], Some(&format!("{delete}\n"))) {
+                Ok(output) if output.status.success() => {}
+                Ok(output) => {
+                    let stderr = stderr_of(&output);
+                    if !is_missing(&stderr) {
+                        failures.push(format!("nft {delete}: {stderr}"));
+                    }
+                }
+                Err(failure) => failures.push(failure),
+            }
+        }
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(TapNetError::Network(failures.join("; ")))
+        }
+    }
+}
+
+/// The tag every rule of one TAP's translation carries.
+fn rule_tag(tap: &str) -> String {
+    format!("{RULE_COMMENT}:{tap}")
+}
+
+/// One nft rule of the per-TAP translation set: the chain it is appended to
+/// and the expression that goes in it (the comment is added on rendering).
+#[derive(Debug, PartialEq, Eq)]
+pub struct NftRule {
+    pub chain: &'static str,
+    pub expr: String,
+}
+
+/// The complete per-TAP translation rule set, in install order — the nft
+/// rendering of the module-level contract, point for point with
+/// [`iptables_legacy::translation_rules`](super::iptables_legacy::translation_rules).
+pub fn translation_rules(tap: &str, pool_ip: Ipv4Addr) -> Vec<NftRule> {
+    let mark = format!("{:#x}", fwmark(pool_ip));
+    let mut rules = Vec::new();
+    let mut rule = |chain, expr: String| rules.push(NftRule { chain, expr });
+
+    // 1. Mark sandbox-originated packets so postrouting NAT (which cannot
+    //    match the input interface) can select the right source identity.
+    rule(
+        "mangle_prerouting",
+        format!("iifname \"{tap}\" meta mark set {mark}"),
+    );
+    // 2. Mark to-sandbox packets from their pre-NAT destination; the fwmark
+    //    fib rule then routes the DNAT'd destination out this TAP.
+    rule(
+        "mangle_prerouting",
+        format!("ip daddr {pool_ip} meta mark set {mark}"),
+    );
+    rule(
+        "mangle_output",
+        format!("ip daddr {pool_ip} meta mark set {mark}"),
+    );
+    // 3. External identity → fixed guest identity, both directions.
+    rule(
+        "nat_prerouting",
+        format!("ip daddr {pool_ip} dnat to {GUEST_IP}"),
+    );
+    rule(
+        "nat_output",
+        format!("ip daddr {pool_ip} dnat to {GUEST_IP}"),
+    );
+    // 4. Local services (DNS, relays) see the pool identity, and their
+    //    replies are addressed to it — which is what makes them routable
+    //    back out the right TAP (dst-based mark + fwmark table).
+    rule("nat_input", format!("iifname \"{tap}\" snat to {pool_ip}"));
+    // 5. Forwarded sandbox-originated traffic. The source match is the
+    //    definitive sandbox-origin signature at postrouting (only pre-SNAT
+    //    sandbox packets carry the fixed guest source); the mark picks which
+    //    sandbox, keeping to-sandbox packets (marked with the same value but
+    //    carrying a client source) out of this rewrite.
+    rule(
+        "nat_postrouting",
+        format!("ip saddr {GUEST_IP} meta mark {mark} snat to {pool_ip}"),
+    );
+    rules
+}
+
+/// The batch that installs one TAP's translation: the table and chains
+/// (`add` is idempotent, so this is also the repair path) followed by the
+/// seven rules, each appended and tagged.
+pub fn install_batch(tap: &str, pool_ip: Ipv4Addr) -> String {
+    let tag = rule_tag(tap);
+    std::iter::once(format!("add table {TABLE}\n"))
+        .chain(
+            BASE_CHAINS
+                .iter()
+                .map(|(chain, spec)| format!("add chain {TABLE} {chain} {{ {spec} }}\n")),
+        )
+        .chain(
+            translation_rules(tap, pool_ip)
+                .into_iter()
+                .map(|NftRule { chain, expr }| {
+                    format!("add rule {TABLE} {chain} {expr} comment \"{tag}\"\n")
+                }),
+        )
+        .collect()
+}
+
+/// Chain and handle of one rule the kernel reports.
+#[derive(Debug, PartialEq, Eq)]
+pub struct RuleHandle {
+    chain: String,
+    handle: u64,
+}
+
+/// `nft -j` output, narrowed to the rules it lists. Every other item of the
+/// array (metainfo, table, chain) deserializes with `rule: None`.
+#[derive(Deserialize)]
+struct Listing {
+    nftables: Vec<ListingItem>,
+}
+
+#[derive(Deserialize)]
+struct ListingItem {
+    rule: Option<ListedRule>,
+}
+
+#[derive(Deserialize)]
+struct ListedRule {
+    chain: String,
+    handle: u64,
+    comment: Option<String>,
+}
+
+/// Every rule in an `nft -j -a list table` document carrying `tag`.
+///
+/// `comment`, `chain` and `handle` are top-level fields on the rule object
+/// under nft's declared-stable `json_schema_version: 1`, so this stays a flat
+/// filter rather than a walk of the expression tree — the rendering can
+/// change without touching the reader.
+pub fn rule_handles(listing: &[u8], tag: &str) -> std::result::Result<Vec<RuleHandle>, String> {
+    let listing: Listing =
+        serde_json::from_slice(listing).map_err(|e| format!("parse nft listing: {e}"))?;
+    Ok(listing
+        .nftables
+        .into_iter()
+        .filter_map(|item| item.rule)
+        .filter(|rule| rule.comment.as_deref() == Some(tag))
+        .map(|rule| RuleHandle {
+            chain: rule.chain,
+            handle: rule.handle,
+        })
+        .collect())
+}
+
+/// Whether `bin` answers `--version` as nftables.
+fn is_nftables(bin: &Path) -> bool {
+    Command::new(bin)
+        .arg("--version")
+        .output()
+        .is_ok_and(|out| {
+            out.status.success() && String::from_utf8_lossy(&out.stdout).contains("nftables")
+        })
+}
+
+/// Whether a failed invocation failed because the object was not there.
+///
+/// nft reports a missing table, chain, or handle as exit 1 with
+/// `strerror(ENOENT)`; [`Nftables::run`] forces `LC_ALL=C` so that text is
+/// stable. This is what makes removal idempotent — a table that was never
+/// created and a handle a concurrent teardown just freed both read as
+/// "already gone" — and it is deliberately narrower than the whole of exit 1,
+/// which also covers syntax errors and permission failures.
+fn is_missing(stderr: &str) -> bool {
+    stderr.contains("No such file or directory")
+}
+
+fn stderr_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).trim().to_owned()
+}
+
+#[cfg(test)]
+mod tests;

--- a/virt/arcbox-tap-net/src/packet_filter/nftables/tests.rs
+++ b/virt/arcbox-tap-net/src/packet_filter/nftables/tests.rs
@@ -1,0 +1,351 @@
+//! Unit tests for the nftables rendering, its teardown reader, and the
+//! tolerance the seam demands of removal. Nothing here needs a kernel; the
+//! real-ruleset half lives in `tests/integration.rs`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use super::*;
+use crate::packet_filter::iptables_legacy::translation_rules as xt_rules;
+
+fn pool() -> Ipv4Addr {
+    "172.20.0.2".parse().unwrap()
+}
+
+/// The batch is the NAT contract as this backend states it; pin it exactly
+/// so drift is loud, the way `translation_rules_pin_the_nat_contract` pins
+/// the iptables specs. Every line here was applied to a live kernel on both
+/// nft 1.0.2 (CI's floor) and 1.1.6 — which is what the numeric priorities
+/// buy: the readable `dstnat` / `srcnat` keywords are hook-scoped on 1.0.2
+/// and it rejects them on the output and input hooks (see `BASE_CHAINS`).
+#[test]
+fn install_batch_pins_the_nat_contract() {
+    assert_eq!(
+        install_batch("vmtap0-2", pool()),
+        "\
+add table ip arcbox
+add chain ip arcbox mangle_prerouting { type filter hook prerouting priority -150 ; policy accept ; }
+add chain ip arcbox mangle_output { type route hook output priority -150 ; policy accept ; }
+add chain ip arcbox nat_prerouting { type nat hook prerouting priority -100 ; policy accept ; }
+add chain ip arcbox nat_output { type nat hook output priority -100 ; policy accept ; }
+add chain ip arcbox nat_input { type nat hook input priority 100 ; policy accept ; }
+add chain ip arcbox nat_postrouting { type nat hook postrouting priority 100 ; policy accept ; }
+add rule ip arcbox mangle_prerouting iifname \"vmtap0-2\" meta mark set 0xac140002 comment \"arcbox-nat:vmtap0-2\"
+add rule ip arcbox mangle_prerouting ip daddr 172.20.0.2 meta mark set 0xac140002 comment \"arcbox-nat:vmtap0-2\"
+add rule ip arcbox mangle_output ip daddr 172.20.0.2 meta mark set 0xac140002 comment \"arcbox-nat:vmtap0-2\"
+add rule ip arcbox nat_prerouting ip daddr 172.20.0.2 dnat to 169.254.100.2 comment \"arcbox-nat:vmtap0-2\"
+add rule ip arcbox nat_output ip daddr 172.20.0.2 dnat to 169.254.100.2 comment \"arcbox-nat:vmtap0-2\"
+add rule ip arcbox nat_input iifname \"vmtap0-2\" snat to 172.20.0.2 comment \"arcbox-nat:vmtap0-2\"
+add rule ip arcbox nat_postrouting ip saddr 169.254.100.2 meta mark 0xac140002 snat to 172.20.0.2 comment \"arcbox-nat:vmtap0-2\"
+"
+    );
+}
+
+/// The two backends are a pair, not two dialects: same rules, same order,
+/// each in the chain that corresponds to its iptables table+hook, each
+/// carrying the same identity values. A rule added to one and not the other
+/// — or reordered, or built on a different selector — fails here.
+#[test]
+fn renderings_agree_on_the_contract() {
+    let (tap, pool) = ("vmtap0-2", pool());
+    let mark = format!("{:#x}", fwmark(pool));
+    let xt = xt_rules(tap, pool);
+    let nft = translation_rules(tap, pool);
+
+    assert_eq!(xt.len(), nft.len(), "the contract is seven rules on both");
+
+    for (xt, nft) in xt.iter().zip(&nft) {
+        let hook = format!("{}_{}", xt.table, xt.chain.to_lowercase());
+        assert_eq!(
+            nft.chain, hook,
+            "{} {} landed elsewhere",
+            xt.table, xt.chain
+        );
+
+        let xt_spec = xt.spec.join(" ");
+        for value in [tap, &pool.to_string(), &mark, &GUEST_IP.to_string()] {
+            assert_eq!(
+                xt_spec.contains(value),
+                nft.expr.contains(value),
+                "{hook}: {value} appears in only one rendering\n  iptables: {xt_spec}\n  nft:      {}",
+                nft.expr
+            );
+        }
+    }
+}
+
+/// The postrouting SNAT must be gated on the fixed guest source, not the
+/// mark alone: to-sandbox packets carry the same mark but a client source,
+/// and rewriting those would hide real client IPs from guests.
+#[test]
+fn snat_selection_never_rewrites_client_sources() {
+    let rules = translation_rules("vmtap0-2", pool());
+    let postrouting = rules
+        .iter()
+        .find(|r| r.chain == "nat_postrouting")
+        .expect("postrouting SNAT rule");
+    assert!(
+        postrouting
+            .expr
+            .starts_with(&format!("ip saddr {GUEST_IP} ")),
+        "{}",
+        postrouting.expr
+    );
+}
+
+/// A real `nft -j -a list table` document, trimmed to two taps' rules.
+const LISTING: &[u8] = br#"{"nftables": [
+  {"metainfo": {"version": "1.0.6", "json_schema_version": 1}},
+  {"table": {"family": "ip", "name": "arcbox", "handle": 1}},
+  {"chain": {"family": "ip", "table": "arcbox", "name": "nat_prerouting",
+             "handle": 1, "type": "nat", "hook": "prerouting", "prio": -100,
+             "policy": "accept"}},
+  {"rule": {"family": "ip", "table": "arcbox", "chain": "nat_prerouting",
+            "handle": 2, "comment": "arcbox-nat:vmtap0-2",
+            "expr": [{"match": {"op": "==", "left": {"payload":
+                     {"protocol": "ip", "field": "daddr"}},
+                     "right": "172.20.0.2"}},
+                     {"dnat": {"addr": "169.254.100.2"}}]}},
+  {"rule": {"family": "ip", "table": "arcbox", "chain": "nat_prerouting",
+            "handle": 3, "comment": "arcbox-nat:vmtap0-3",
+            "expr": [{"dnat": {"addr": "169.254.100.2"}}]}},
+  {"rule": {"family": "ip", "table": "arcbox", "chain": "nat_postrouting",
+            "handle": 9, "comment": "arcbox-nat:vmtap0-2",
+            "expr": [{"snat": {"addr": "172.20.0.2"}}]}},
+  {"rule": {"family": "ip", "table": "arcbox", "chain": "nat_postrouting",
+            "handle": 11, "expr": [{"masquerade": null}]}}
+]}"#;
+
+/// Teardown must collect this TAP's rules across every chain and leave
+/// another sandbox's — and an untagged rule the node installed itself —
+/// alone.
+#[test]
+fn rule_handles_picks_only_this_taps_tagged_rules() {
+    let handles = rule_handles(LISTING, "arcbox-nat:vmtap0-2").unwrap();
+    assert_eq!(
+        handles,
+        [
+            RuleHandle {
+                chain: "nat_prerouting".into(),
+                handle: 2
+            },
+            RuleHandle {
+                chain: "nat_postrouting".into(),
+                handle: 9
+            },
+        ]
+    );
+}
+
+/// A listing that is not the document we asked for is a parse error, not an
+/// empty rule set — "nothing to remove" and "could not read the ruleset" are
+/// opposite answers, and only the first may report a clean teardown.
+#[test]
+fn a_listing_that_will_not_parse_is_an_error_not_an_empty_set() {
+    let err = rule_handles(b"not json", "arcbox-nat:vmtap0-2").unwrap_err();
+    assert!(err.contains("parse nft listing"), "{err}");
+}
+
+// ---- stand-in `nft` -------------------------------------------------------
+
+/// An `nft` stand-in driving `body` as a `case "$*"` body. Returns the
+/// binary, the log of argv lines, and the log of whatever was fed to stdin.
+fn fake_nft(dir: &Path, body: &str) -> (Nftables, PathBuf, PathBuf) {
+    let calls = dir.join("nft.calls");
+    let stdin = dir.join("nft.stdin");
+    let script = dir.join("nft");
+    write_script(
+        &script,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> {}\n\
+             if [ \"$1\" = \"-f\" ]; then cat >> {}; fi\n\
+             case \"$*\" in\n{body}\nesac\n",
+            calls.display(),
+            stdin.display()
+        ),
+    );
+    // The probe in `write_script` ran it, so every test starts from an empty
+    // record.
+    std::fs::remove_file(&calls).ok();
+    std::fs::remove_file(&stdin).ok();
+    (Nftables::new(script), calls, stdin)
+}
+
+/// Write `body` to `path`, make it executable, and do not return until the
+/// kernel agrees to exec it: a sibling test thread that forks between this
+/// thread's `create` and `close` holds a write fd to the script, and Linux
+/// will not exec a file open for writing (`ETXTBSY`).
+fn write_script(path: &Path, body: &str) {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    std::fs::write(path, body).unwrap();
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        match Command::new(path).output() {
+            Err(error) if error.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "{} stayed busy for 5s",
+                    path.display()
+                );
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            other => {
+                other.unwrap();
+                return;
+            }
+        }
+    }
+}
+
+fn lines(log: &Path) -> Vec<String> {
+    std::fs::read_to_string(log)
+        .unwrap_or_default()
+        .lines()
+        .map(str::to_owned)
+        .collect()
+}
+
+const LIST_ONE_RULE: &str = "\"-j -a list table ip arcbox\") echo '{\"nftables\": [{\"rule\": \
+     {\"chain\": \"nat_prerouting\", \"handle\": 2, \"comment\": \"arcbox-nat:vmtap0-2\"}}]}' ;;";
+
+#[test]
+fn install_feeds_the_rendered_batch_on_stdin() {
+    let dir = tempfile::tempdir().unwrap();
+    let (nft, calls, stdin) = fake_nft(dir.path(), "*) exit 0 ;;");
+
+    nft.install_translation("vmtap0-2", pool()).unwrap();
+
+    assert_eq!(lines(&calls), ["-f -"]);
+    assert_eq!(
+        std::fs::read_to_string(&stdin).unwrap(),
+        install_batch("vmtap0-2", pool()),
+        "the kernel must receive exactly what the renderer produced"
+    );
+}
+
+#[test]
+fn a_failed_install_carries_nfts_own_reason() {
+    let dir = tempfile::tempdir().unwrap();
+    let (nft, _, _) = fake_nft(
+        dir.path(),
+        "*) echo \"Error: Could not process rule: Operation not permitted\" >&2; exit 1 ;;",
+    );
+
+    let err = nft.install_translation("vmtap0-2", pool()).unwrap_err();
+
+    assert!(err.to_string().contains("install vmtap0-2"), "{err}");
+    assert!(err.to_string().contains("Operation not permitted"), "{err}");
+}
+
+#[test]
+fn a_missing_table_reads_clean_and_deletes_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    let (nft, calls, _) = fake_nft(
+        dir.path(),
+        "\"-j -a list table ip arcbox\") echo \"Error: No such file or directory\" >&2; exit 1 ;;\n\
+         *) echo \"unexpected: $*\" >&2; exit 2 ;;",
+    );
+
+    nft.remove_translation("vmtap0-2", pool()).unwrap();
+
+    assert_eq!(
+        lines(&calls),
+        ["-j -a list table ip arcbox"],
+        "an absent table leaves nothing to delete"
+    );
+}
+
+#[test]
+fn a_handle_a_concurrent_teardown_freed_reads_clean() {
+    let dir = tempfile::tempdir().unwrap();
+    let (nft, _, stdin) = fake_nft(
+        dir.path(),
+        &format!(
+            "{LIST_ONE_RULE}\n\
+             \"-f -\") echo \"Error: Could not process rule: No such file or directory\" >&2; \
+             exit 1 ;;"
+        ),
+    );
+
+    nft.remove_translation("vmtap0-2", pool()).unwrap();
+
+    assert_eq!(
+        lines(&stdin),
+        ["delete rule ip arcbox nat_prerouting handle 2"]
+    );
+}
+
+#[test]
+fn a_removal_failure_that_is_not_absence_is_reported() {
+    let dir = tempfile::tempdir().unwrap();
+    let (nft, _, _) = fake_nft(
+        dir.path(),
+        &format!(
+            "{LIST_ONE_RULE}\n\
+             \"-f -\") echo \"Error: Operation not permitted\" >&2; exit 1 ;;"
+        ),
+    );
+
+    let err = nft.remove_translation("vmtap0-2", pool()).unwrap_err();
+
+    assert!(err.to_string().contains("handle 2"), "{err}");
+    assert!(err.to_string().contains("Operation not permitted"), "{err}");
+}
+
+#[test]
+fn a_listing_failure_that_is_not_absence_is_reported() {
+    let dir = tempfile::tempdir().unwrap();
+    let (nft, _, _) = fake_nft(
+        dir.path(),
+        "*) echo \"Error: Operation not permitted\" >&2; exit 1 ;;",
+    );
+
+    let err = nft.remove_translation("vmtap0-2", pool()).unwrap_err();
+
+    assert!(err.to_string().contains("list table ip arcbox"), "{err}");
+}
+
+#[test]
+fn a_missing_binary_is_an_error_even_on_tolerant_removal() {
+    // Tolerance covers "the object is gone", never "could not run nft at
+    // all": a wrong path must surface, not read as clean.
+    let nft = Nftables::new("/nonexistent/arcbox-nft");
+    let err = nft.remove_translation("vmtap0-2", pool()).unwrap_err();
+    assert!(err.to_string().contains("run "), "{err}");
+}
+
+#[test]
+fn the_default_path_is_where_a_stock_distro_installs_nft() {
+    assert_eq!(
+        Nftables::default().nft,
+        PathBuf::from(Nftables::DEFAULT_PATH)
+    );
+}
+
+#[test]
+fn discovery_names_the_candidates_it_could_not_find() {
+    let err = Nftables::discover_in(&["/nonexistent/arcbox-nft"]).unwrap_err();
+    assert!(err.to_string().contains("no nft"), "{err}");
+    assert!(err.to_string().contains("/nonexistent/arcbox-nft"), "{err}");
+}
+
+#[test]
+fn discovery_skips_a_binary_that_does_not_answer_as_nftables() {
+    let dir = tempfile::tempdir().unwrap();
+    let impostor = dir.path().join("nft-impostor");
+    write_script(&impostor, "#!/bin/sh\necho 'iptables v1.8.7 (nf_tables)'\n");
+    let real = dir.path().join("nft-real");
+    write_script(
+        &real,
+        "#!/bin/sh\necho 'nftables v1.0.6 (Lester Gooch #5)'\n",
+    );
+
+    let found =
+        Nftables::discover_in(&[impostor.to_str().unwrap(), real.to_str().unwrap()]).unwrap();
+
+    assert_eq!(found.nft, real);
+}

--- a/virt/arcbox-tap-net/src/packet_filter/nftables/tests.rs
+++ b/virt/arcbox-tap-net/src/packet_filter/nftables/tests.rs
@@ -53,6 +53,7 @@ fn renderings_agree_on_the_contract() {
     let xt = xt_rules(tap, pool);
     let nft = translation_rules(tap, pool);
 
+    assert_eq!(xt.len(), 7, "the contract is seven rules");
     assert_eq!(xt.len(), nft.len(), "the contract is seven rules on both");
 
     for (xt, nft) in xt.iter().zip(&nft) {

--- a/virt/arcbox-tap-net/src/tests.rs
+++ b/virt/arcbox-tap-net/src/tests.rs
@@ -128,7 +128,7 @@ fn expose_target_follows_the_applied_datapath() {
     };
     record(AppliedDatapath::Ebpf);
     assert_eq!(manager.expose_target("vmtap0-2"), ExposeTarget::PoolIp);
-    record(AppliedDatapath::Iptables);
+    record(AppliedDatapath::Filter);
     assert_eq!(
         manager.expose_target("vmtap0-2"),
         ExposeTarget::GuestIpWithFwmark

--- a/virt/arcbox-tap-net/tests/common/mod.rs
+++ b/virt/arcbox-tap-net/tests/common/mod.rs
@@ -96,11 +96,30 @@ pub fn nft_in_private_netns(test: &str) -> Option<std::path::PathBuf> {
 
 /// How many rules in `table ip arcbox` carry `tag`. Every rule of one TAP's
 /// translation carries exactly one, so this is that TAP's rule count.
+///
+/// Matches the comment for equality, the way the production reader in
+/// `packet_filter::nftables` does: a substring count would fold
+/// `arcbox-nat:vmtap9-20` into a query for `arcbox-nat:vmtap9-2`. A failed
+/// listing panics rather than counting zero — "the table is gone" and "nft
+/// could not be asked" are opposite answers, and the assertions that expect
+/// `0` must not accept the second.
 #[cfg(target_os = "linux")]
 pub fn nft_rules_tagged(nft: &std::path::Path, tag: &str) -> usize {
     let output = std::process::Command::new(nft)
         .args(["-j", "-a", "list", "table", "ip", "arcbox"])
         .output()
         .expect("run nft");
-    String::from_utf8_lossy(&output.stdout).matches(tag).count()
+    assert!(
+        output.status.success(),
+        "nft list table ip arcbox: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    let listing: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse nft listing");
+    listing["nftables"]
+        .as_array()
+        .expect("nftables listing array")
+        .iter()
+        .filter(|item| item["rule"]["comment"] == serde_json::json!(tag))
+        .count()
 }

--- a/virt/arcbox-tap-net/tests/common/mod.rs
+++ b/virt/arcbox-tap-net/tests/common/mod.rs
@@ -45,3 +45,62 @@ pub fn get_peer_addr(iface: &str) -> Option<String> {
     }
     None
 }
+
+/// Where a stock distro installs `nft`, in the order [`Nftables::discover`]
+/// searches — kept here so a test can also *read* the ruleset it installed.
+#[cfg(target_os = "linux")]
+const NFT_CANDIDATES: &[&str] = &["/usr/sbin/nft", "/sbin/nft"];
+
+/// The `nft` binary to drive, having moved this thread into a private
+/// network namespace — or `None`, with the reason printed.
+///
+/// The namespace is what makes this test safe to run on a workstation:
+/// nftables rulesets are per-netns, so `table ip arcbox` is created,
+/// inspected, and discarded without the host's own ruleset ever seeing it.
+/// It is per-*thread*, so sibling tests keep the netns they started in.
+///
+/// `ARCBOX_REQUIRE_NFT=1` turns a skip into a failure, for hosts known to
+/// have nft (CI) — otherwise the coverage evaporates the day the package
+/// stops being installed.
+#[cfg(target_os = "linux")]
+pub fn nft_in_private_netns(test: &str) -> Option<std::path::PathBuf> {
+    let require = std::env::var("ARCBOX_REQUIRE_NFT").is_ok_and(|v| v == "1");
+    let skip = |reason: String| -> Option<std::path::PathBuf> {
+        assert!(
+            !require,
+            "ARCBOX_REQUIRE_NFT=1 but {test} would skip: {reason}"
+        );
+        eprintln!("SKIP {test} — {reason}");
+        None
+    };
+
+    if !is_root() {
+        return skip("requires root (netfilter, and unshare(CLONE_NEWNET))".into());
+    }
+    let Some(nft) = NFT_CANDIDATES
+        .iter()
+        .map(std::path::PathBuf::from)
+        .find(|bin| bin.exists())
+    else {
+        return skip(format!("no nft among {}", NFT_CANDIDATES.join(", ")));
+    };
+    // SAFETY: `unshare` is a plain syscall with no memory operands; it moves
+    // this thread into a fresh network namespace and reports failure through
+    // errno, which the caller turns into a skip.
+    if unsafe { libc::unshare(libc::CLONE_NEWNET) } != 0 {
+        let errno = std::io::Error::last_os_error();
+        return skip(format!("unshare(CLONE_NEWNET): {errno}"));
+    }
+    Some(nft)
+}
+
+/// How many rules in `table ip arcbox` carry `tag`. Every rule of one TAP's
+/// translation carries exactly one, so this is that TAP's rule count.
+#[cfg(target_os = "linux")]
+pub fn nft_rules_tagged(nft: &std::path::Path, tag: &str) -> usize {
+    let output = std::process::Command::new(nft)
+        .args(["-j", "-a", "list", "table", "ip", "arcbox"])
+        .output()
+        .expect("run nft");
+    String::from_utf8_lossy(&output.stdout).matches(tag).count()
+}

--- a/virt/arcbox-tap-net/tests/integration.rs
+++ b/virt/arcbox-tap-net/tests/integration.rs
@@ -1,11 +1,16 @@
-//! Root-only TAP integration tests: the network manager against a real
-//! kernel — device creation, point-to-point addressing, host routes, and
-//! pool recycling. Every test skips unless it runs as root on Linux.
+//! Root-only integration tests against a real kernel: the network manager's
+//! device creation, point-to-point addressing, host routes and pool
+//! recycling, and the nftables [`PacketFilter`] rendering the kernel has to
+//! accept. Every test skips unless it runs as root on Linux; the nftables
+//! ones also move their thread into a private network namespace, so they
+//! never touch the host's own ruleset.
+//!
+//! [`PacketFilter`]: arcbox_tap_net::PacketFilter
 
 mod common;
 
 #[cfg(target_os = "linux")]
-use arcbox_tap_net::{NetworkAllocation, NetworkManager};
+use arcbox_tap_net::{NetworkAllocation, NetworkManager, Nftables, PacketFilter};
 
 // ---------------------------------------------------------------------------
 // TAP lifecycle (Linux, root only)
@@ -186,4 +191,80 @@ fn multiple_taps_are_isolated() {
         "TAP {} should not be attached to any bridge",
         a1.tap_name
     );
+}
+
+/// The nftables backend against a real kernel: two sandboxes' rule sets
+/// coexist in one table, teardown removes exactly the one it was asked for,
+/// and a repeat teardown of the same TAP is a no-op rather than an error.
+///
+/// This is the half the unit tests cannot reach — that the rendered batch is
+/// syntax the kernel accepts, and that removal really finds its handles.
+#[test]
+#[cfg(target_os = "linux")]
+fn nftables_translation_installs_and_removes_per_tap() {
+    let Some(nft) =
+        common::nft_in_private_netns("nftables_translation_installs_and_removes_per_tap")
+    else {
+        return;
+    };
+    // Discovery must agree with the binary this host actually has; the rest
+    // of the test drives the found path so a non-standard prefix still works.
+    Nftables::discover().expect("a host with nft must discover it");
+    let filter = Nftables::new(&nft);
+
+    let (tap_a, pool_a) = ("vmtap9-2", "172.31.9.2".parse().unwrap());
+    let (tap_b, pool_b) = ("vmtap9-3", "172.31.9.3".parse().unwrap());
+
+    filter.install_translation(tap_a, pool_a).unwrap();
+    filter.install_translation(tap_b, pool_b).unwrap();
+
+    assert_eq!(
+        common::nft_rules_tagged(&nft, "arcbox-nat:vmtap9-2"),
+        7,
+        "the contract is seven rules"
+    );
+    assert_eq!(common::nft_rules_tagged(&nft, "arcbox-nat:vmtap9-3"), 7);
+
+    filter.remove_translation(tap_a, pool_a).unwrap();
+
+    assert_eq!(
+        common::nft_rules_tagged(&nft, "arcbox-nat:vmtap9-2"),
+        0,
+        "teardown must leave no residue for its own TAP"
+    );
+    assert_eq!(
+        common::nft_rules_tagged(&nft, "arcbox-nat:vmtap9-3"),
+        7,
+        "and must not touch another sandbox's rules"
+    );
+
+    // Tolerating absence is the seam's contract: teardown runs again for
+    // crash replays and partially activated TAPs.
+    filter.remove_translation(tap_a, pool_a).unwrap();
+    filter.remove_translation(tap_b, pool_b).unwrap();
+    assert_eq!(common::nft_rules_tagged(&nft, "arcbox-nat:vmtap9-3"), 0);
+}
+
+/// A crash replay re-installs over rules that survived the process (unlike
+/// eBPF links, netfilter rules do not die with it), so a TAP can end up with
+/// two copies of its set. One teardown must collect both — `iptables -D`
+/// deletes only the first match, which is the residue this backend avoids by
+/// deleting on the tag.
+#[test]
+#[cfg(target_os = "linux")]
+fn a_double_installed_tap_is_fully_torn_down() {
+    let Some(nft) = common::nft_in_private_netns("a_double_installed_tap_is_fully_torn_down")
+    else {
+        return;
+    };
+    let filter = Nftables::new(&nft);
+    let (tap, pool) = ("vmtap9-4", "172.31.9.4".parse().unwrap());
+
+    filter.install_translation(tap, pool).unwrap();
+    filter.install_translation(tap, pool).unwrap();
+    assert_eq!(common::nft_rules_tagged(&nft, "arcbox-nat:vmtap9-4"), 14);
+
+    filter.remove_translation(tap, pool).unwrap();
+
+    assert_eq!(common::nft_rules_tagged(&nft, "arcbox-nat:vmtap9-4"), 0);
 }


### PR DESCRIPTION
A compute node is a stock distro, where nft is the live ruleset and an<br>iptables-legacy rule lands in one nothing consults — visible in `iptables -S`,<br>never matched. [CORE-127](https://linear.app/arcbox/issue/CORE-127/make-the-sandbox-stack-composable-seams-for-environment-specific)'s `PacketFilter` seam exists for exactly this, so<br>[PLAT-191](https://linear.app/arcbox/issue/PLAT-191/实现-nftables-packetfilter-backend) gets a real nftables implementation rather than a path to another<br>`iptables` binary. It lands here, next to the seam and its reference<br>implementation, the way [PLAT-192](https://linear.app/arcbox/issue/PLAT-192/实现-util-linux-blocktools-backend)'s `UtilLinuxBlockTools` did in arcboxlabs/arcbox#679.

Scope is the per-TAP seam. Node-level egress NAT and host DNS stay with<br>[PLAT-152](https://linear.app/arcbox/issue/PLAT-152/配置节点级-egress-nat-与-anti-spoof).

## The rendering

`Nftables` renders the same seven rules `IptablesLegacy` does, in the same<br>order, in a dedicated `table ip arcbox` whose base chains sit at the hook<br>priorities the iptables tables occupy:

<!-- linear:table-colwidths:200,200,200,200 -->
| \# | `IptablesLegacy` | nft chain | nft rule |
| -- | -- | -- | -- |
| 1 | mangle PREROUTING `-i tap` | `mangle_prerouting` | `iifname "vmtap0-2" meta mark set 0xac140002` |
| 2 | mangle PREROUTING `-d pool` | `mangle_prerouting` | `ip daddr 172.20.0.2 meta mark set 0xac140002` |
| 3 | mangle OUTPUT `-d pool` | `mangle_output` (**type route**) | `ip daddr 172.20.0.2 meta mark set 0xac140002` |
| 4 | nat PREROUTING `-d pool` | `nat_prerouting` | `ip daddr 172.20.0.2 dnat to 169.254.100.2` |
| 5 | nat OUTPUT `-d pool` | `nat_output` | `ip daddr 172.20.0.2 dnat to 169.254.100.2` |
| 6 | nat INPUT `-i tap` | `nat_input` | `iifname "vmtap0-2" snat to 172.20.0.2` |
| 7 | nat POSTROUTING `-s GUEST -m mark` | `nat_postrouting` | `ip saddr 169.254.100.2 meta mark 0xac140002 snat to 172.20.0.2` |

A 1:1 mirror rather than a map/set-driven ruleset, deliberately: the contract<br>stays mirrored statement-for-statement against `translation_rules`, so a future<br>change to the 5-point contract in the module doc is a diff you can read side by<br>side in both backends. `renderings_agree_on_the_contract` enforces it — same<br>count, same order, each rule in the corresponding hook and carrying the same<br>identity values, so a rule added to one backend and not the other fails there.

## Two shapes nftables forces

**Install is one** `nft -f -` **batch.** A transaction, so a rejected rule leaves<br>nothing behind, and the batch re-`add`s the table and chains, which is<br>idempotent — a ruleset an operator flushed is repaired by the next activation.

**Removal is by comment, not by spec**, because nft only deletes by<br>kernel-assigned handle. Every rule carries `comment "arcbox-nat:<tap>"`;<br>teardown lists the table, keeps the handles whose comment matches, and deletes<br>them one at a time (a batch would roll back every deletion over a single handle<br>a concurrent teardown had already freed). Deleting on the tag also collects<br>what delete-by-spec misses: a drifted rule, and *every* copy when a crash<br>replay appended a second set — `iptables -D` removes only the first match.

Absence is tolerated narrowly: exit 1 **and** strerror ENOENT, with `LC_ALL=C`<br>forced so that text is stable. A missing table and a freed handle read as<br>clean; a syntax or permission failure still surfaces, and a failed spawn is<br>always an error.

## `Datapath::Iptables` → `Datapath::Filter`

The value never meant iptables — it means "the `PacketFilter` seam", whichever<br>framework the composer supplied — and a node on nftables selecting its datapath<br>by writing `sandbox_datapath = "iptables"` reads as a mistake.<br>`#[serde(alias = "iptables")]` keeps existing configs loading, pinned by test.

## The nft 1.0.2 trap

The named priorities are **hook-scoped** on older nftables. nft 1.0.2 rejects<br>`dstnat` on the output hook and `srcnat` on the input hook outright:

```
Error: invalid priority expression value in this context.
add chain ip arcbox nat_output { type nat hook output priority dstnat ; ...
```

nft 1.1.6 accepts them anywhere, which is how the first version of this passed<br>local validation and would still have failed on Debian 12's 1.0.6. The base<br>chains therefore carry numeric priorities (`-150` / `-100` / `100`, the<br>`NF_IP_PRI_*` values); 1.1.6 prints all six back as the names, so they are the<br>same hooks on every version.

## Verification

Unit (no kernel): the batch pinned exactly, the two renderings held together,<br>the postrouting SNAT still gated on the guest source, the JSON reader against a<br>real `nft -j -a` document, and a stand-in `nft` for the tolerance and<br>failed-spawn paths.

Integration (root, in a private netns): two sandboxes' rule sets coexist,<br>removing one leaves the other's seven rules untouched and no residue of its<br>own, a repeat removal is a no-op, and a double install — what a crash replay<br>produces — is fully collected by one teardown. Each test moves its own thread<br>into a fresh netns first, so the host's ruleset is never touched and the tests<br>run under `unshare -rn` without a root shell.

CI installs `nftables` and sets `ARCBOX_REQUIRE_NFT=1` so a missing package<br>fails rather than skips. ubuntu-22.04's nft 1.0.2 is an older floor than Debian<br>12's 1.0.6, so the JSON listing teardown depends on is proven *below* the<br>target platform's version. Locally both were exercised: the batch, the schema<br>version, the `comment`/`chain`/`handle` fields, the 14-rule replay teardown and<br>the ENOENT strings all check out on 1.0.2 and 1.1.6.

Note on coverage: the e2e job does **not** exercise this backend. It uses<br>`SandboxDatapath::default()` (eBPF) and the default `SandboxEnvironment`, so<br>`IptablesLegacy` is the only filter it constructs. The integration job is the<br>real gate here; end-to-end coverage arrives when a node agent composes<br>`Nftables::discover()?` ([PLAT-195](https://linear.app/arcbox/issue/PLAT-195/在开发机端到端验收新-engine)).

## Flagged, not done

* **Expose/port-forward is still iptables-only** (`port_forward.rs`, and<br>`ExposeTarget::GuestIpWithFwmark` assumes it). A node gets a working per-TAP<br>translation from this PR but no nft expose path — the next thing that breaks<br>on real hardware, and its own issue.
* **Anti-spoof**: rule 7 only rewrites `saddr == 169.254.100.2`, so a guest<br>sourcing a spoofed address is not rewritten — the same hole the iptables<br>reference has. [PLAT-152](https://linear.app/arcbox/issue/PLAT-152/配置节点级-egress-nat-与-anti-spoof) owns node-level anti-spoof; a drop rule in this seam<br>would misplace the policy.

Closes [PLAT-191](https://linear.app/arcbox/issue/PLAT-191/实现-nftables-packetfilter-backend).