### PR TITLE
fix: a startup read that cannot parse one record skips it instead of bricking the host

### DIFF
--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -697,13 +697,16 @@ pub(crate) fn catalogued_checkpoint(meta: &SnapshotMeta) -> Result<CheckpointIma
 /// [`validate_new_sandbox_id`] where an id becomes a VM identity.
 ///
 /// Deliberately NO length cap here: this also runs against persisted
-/// records (reconcile, record loads) — where rejecting one legacy
-/// over-long id costs that record its reconciliation, so it is skipped
-/// rather than acted on and every resource it names is held (see
-/// `reconcile::sweep_orphans`) — and against snapshot / execution ids
-/// that never become a VM identity at all. Both limits the driver imposes
-/// are enforced only where a sandbox id enters the system:
-/// [`validate_new_sandbox_id`].
+/// records, and what one legacy over-long id would cost differs by call
+/// site. On the sweep path it costs that record its reconciliation — the
+/// journal is skipped rather than acted on, and every resource it names
+/// is held (`reconcile::sweep_orphans`). On a record *load* it costs
+/// every record theirs: [`SandboxRecordStore::load_all`] validates each
+/// id and propagates, so one rejection aborts the whole startup read,
+/// which is the stronger reason the cap is absent. It also runs against
+/// snapshot / execution ids that never become a VM identity at all. Both
+/// limits the driver imposes are enforced only where a sandbox id enters
+/// the system: [`validate_new_sandbox_id`].
 ///
 /// The gap between this alphabet and [`VmId`]'s is not academic: `_` is
 /// legal here and is not a `VmId`, so every record a pre-#680 process

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -698,10 +698,17 @@ pub(crate) fn catalogued_checkpoint(meta: &SnapshotMeta) -> Result<CheckpointIma
 ///
 /// Deliberately NO length cap here: this also runs against persisted
 /// records (reconcile, record loads) — where rejecting one legacy
-/// over-long id would abort a whole sweep — and against snapshot /
-/// execution ids that never become a VM identity at all. Both limits the
-/// driver imposes are enforced only where a sandbox id enters the system:
+/// over-long id costs that record its reconciliation, so it is skipped
+/// rather than acted on and every resource it names is held (see
+/// `reconcile::sweep_orphans`) — and against snapshot / execution ids
+/// that never become a VM identity at all. Both limits the driver imposes
+/// are enforced only where a sandbox id enters the system:
 /// [`validate_new_sandbox_id`].
+///
+/// The gap between this alphabet and [`VmId`]'s is not academic: `_` is
+/// legal here and is not a `VmId`, so every record a pre-#680 process
+/// wrote for an `inst_…` sandbox is one this process cannot name — which
+/// is exactly what the sweep and the quarantine ledger read back.
 pub(super) fn validate_id(kind: &str, id: &str) -> Result<()> {
     if id.is_empty() {
         return Err(VmmError::Config(format!("{kind} must not be empty")));

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -402,12 +402,6 @@ pub(super) struct AdoptedSandbox {
     net_invariant: bool,
 }
 
-/// What one sweep did, in the two pieces its caller needs at different
-/// moments: [`OrphanSweep::take_runtime`] first, for normalization, and the
-/// runtime directories afterwards, for [`finalize_sweep`].
-///
-/// Both halves are private so neither can be read after the first has been
-/// taken out.
 /// The journals one sweep could not read, in the two vocabularies it has
 /// to answer in afterwards.
 ///
@@ -446,6 +440,12 @@ impl SkippedJournals {
     }
 }
 
+/// What one sweep did, in the two pieces its caller needs at different
+/// moments: [`OrphanSweep::take_runtime`] first, for normalization, and the
+/// runtime directories afterwards, for [`finalize_sweep`].
+///
+/// Both halves are private so neither can be read after the first has been
+/// taken out.
 pub(super) struct OrphanSweep {
     /// Ids whose journaled resources were torn down.
     ids: HashSet<String>,

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -414,8 +414,8 @@ pub(super) struct OrphanSweep {
     /// Sandboxes reclaimed alive, by id. Their journals stay on disk — they
     /// are live state again, not debris — and so do their runtime dirs.
     adopted: HashMap<String, AdoptedSandbox>,
-    /// Ids whose journal this process could not make sense of, so it acted
-    /// on neither the record nor the resources it names.
+    /// Sandboxes whose journal this process could not read: the name of
+    /// the directory each was found in, never the id it claimed.
     skipped: HashSet<String>,
     runtime_dirs: Vec<PathBuf>,
 }
@@ -520,15 +520,21 @@ pub(super) async fn sweep_orphans(
                 %error,
                 "skipping an unusable crash journal; the resources it names are left in place"
             );
-            // Both spellings, because one reason a journal is unusable is
-            // that they disagree: the durable record is keyed by the
-            // directory the journal was found in, and by the id the journal
-            // claims, and an unreadable one is exactly the case where those
-            // are not the same sandbox.
+            // The directory name, and never the id the journal claims.
+            // The directory is how this journal was found and the key its
+            // durable record shares; the claimed id is the untrusted half
+            // of a record this process has just refused to read, and one
+            // reason to refuse is that the two disagree. Letting directory
+            // `foo`'s broken journal insert `bar` would let it answer for a
+            // durable `bar` it has nothing to do with: a genuinely
+            // unjournaled `bar` in a live phase would read `Unchecked`
+            // instead of `Unjournaled`, so `recovery::plan` would return
+            // `Fail` where it must return `RefuseUnjournaled` — declaring a
+            // sandbox failed while its VMM may still be running, which is
+            // the one thing that refusal exists to prevent.
             if let Some(dir_name) = dir.file_name().and_then(|name| name.to_str()) {
                 skipped.insert(dir_name.to_owned());
             }
-            skipped.insert(record.id);
             continue;
         }
         records.push((dir, record));
@@ -729,11 +735,13 @@ pub(super) fn normalize_durable_records(
             None => JournalEvidence::Unchecked,
             Some(_) if adopted.contains_key(&record.id) => JournalEvidence::Adopted,
             Some(ids) if ids.contains(&record.id) => JournalEvidence::Swept,
-            // The sweep found this one's journal and could not read it, so
-            // it knows no more about the resources than if it had never
-            // run — which is what `Unchecked` means. Reading it as
-            // `Unjournaled` instead would refuse a live phase and abort
-            // startup, undoing the skip that kept the sweep going.
+            // The sweep found a journal in this id's directory and could
+            // not read it, so it knows no more about the resources than if
+            // it had never run — which is what `Unchecked` means. Reading
+            // it as `Unjournaled` instead would refuse a live phase and
+            // abort startup, undoing the skip that kept the sweep going.
+            // Keyed by directory name alone: see where `skipped` is filled
+            // for why a journal never answers for the id it claims.
             Some(_) if skipped.contains(&record.id) => JournalEvidence::Unchecked,
             Some(_) => JournalEvidence::Unjournaled,
         };
@@ -2093,6 +2101,52 @@ mod tests {
         assert!(
             broken_dir.join(STATE_FILE).exists(),
             "its journal stays on disk for a version that can read it"
+        );
+    }
+
+    /// A journal this process cannot read answers for the directory it
+    /// sits in and for nothing else. Recording the id it *claims* would let
+    /// it answer for a durable record it has nothing to do with, and the
+    /// answer it gives — `Unchecked` — is exactly the one that turns
+    /// `RefuseUnjournaled` into `Fail`: a sandbox declared failed while its
+    /// VMM may still be running.
+    #[tokio::test]
+    async fn a_skipped_journal_does_not_answer_for_the_id_it_claims() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let mut config = VmmConfig::default();
+        config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
+
+        // Directory `broken`, journal claiming `ghost` — the disagreement
+        // that makes a journal unreadable in the first place.
+        let broken_dir = data_dir.path().join("sandboxes").join("broken");
+        std::fs::create_dir_all(&broken_dir).unwrap();
+        let stray = SandboxStateRecord::new("ghost", None, None, None, &config, None).unwrap();
+        write_state_record(&broken_dir, &stray).unwrap();
+
+        // A real `ghost`: durably `Ready`, with no journal of its own. Its
+        // VMM may still be running, so recovery must refuse rather than
+        // declare it failed.
+        let (vm, _manager, network, reconciled) = sweep_one(
+            data_dir.path(),
+            &AdoptionCase::live(),
+            &[("ghost", PersistPhase::Ready)],
+        )
+        .await;
+
+        let error = reconciled.expect_err("an unjournaled live record still refuses normalization");
+        assert!(
+            error.to_string().contains("has no cleanup journal"),
+            "the broken journal spoke for ghost: {error}"
+        );
+        assert_eq!(
+            vm.state(),
+            VmState::Exited(arcbox_vm_driver::ExitStatus::signaled(9)),
+            "the reclaimed vm is handed back, not dropped"
+        );
+        assert_eq!(
+            network.adopted_mode(&VmId::new("keeper").unwrap()),
+            None,
+            "and so is its lease"
         );
     }
 

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -414,6 +414,9 @@ pub(super) struct OrphanSweep {
     /// Sandboxes reclaimed alive, by id. Their journals stay on disk — they
     /// are live state again, not debris — and so do their runtime dirs.
     adopted: HashMap<String, AdoptedSandbox>,
+    /// Ids whose journal this process could not make sense of, so it acted
+    /// on neither the record nor the resources it names.
+    skipped: HashSet<String>,
     runtime_dirs: Vec<PathBuf>,
 }
 
@@ -424,6 +427,7 @@ impl SweptRuntime {
         Self {
             swept: HashSet::new(),
             adopted: HashMap::new(),
+            skipped: HashSet::new(),
         }
     }
 }
@@ -433,6 +437,7 @@ impl OrphanSweep {
         Self {
             ids: HashSet::new(),
             adopted: HashMap::new(),
+            skipped: HashSet::new(),
             runtime_dirs: Vec::new(),
         }
     }
@@ -444,6 +449,7 @@ impl OrphanSweep {
         SweptRuntime {
             swept: std::mem::take(&mut self.ids),
             adopted: std::mem::take(&mut self.adopted),
+            skipped: std::mem::take(&mut self.skipped),
         }
     }
 }
@@ -476,6 +482,7 @@ pub(super) async fn sweep_orphans(
         Err(error) => return Err(error.into()),
     };
     let mut records = Vec::new();
+    let mut skipped = HashSet::new();
     for entry in entries {
         let entry = entry?;
         let dir = entry.path();
@@ -489,7 +496,41 @@ pub(super) async fn sweep_orphans(
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
             Err(error) => return Err(error.into()),
         };
-        validate_state_record(config, &sandboxes_dir, &dir, &record)?;
+        // A journal this process cannot make sense of is skipped, not
+        // propagated. Aborting here costs far more than the record itself:
+        // the sweep gates every create, so one unreadable journal would
+        // strand every *other* sandbox's resources and leave the manager
+        // unusable, where skipping leaks only what this one record names.
+        // It stays on disk, so a later version can still reclaim it, and
+        // the warning says which one to look at.
+        //
+        // This is also the single place the question is asked. `VmId` is
+        // narrower than [`super::validate_id`] — the latter runs over
+        // snapshot and execution ids that never become a VM identity, and
+        // is deliberately permissive for exactly this reason — so the id a
+        // driver will be handed is parsed here, letting `adopt_or_kill` and
+        // [`SandboxStateRecord::lease`] rely on it downstream.
+        let usable = validate_state_record(config, &sandboxes_dir, &dir, &record)
+            .and_then(|()| VmId::new(record.id.as_str()).map_err(VmmError::from))
+            .and_then(|_| VmId::new(record.resource_owner()).map_err(VmmError::from));
+        if let Err(error) = usable {
+            warn!(
+                sandbox_id = %record.id,
+                path = %dir.display(),
+                %error,
+                "skipping an unusable crash journal; the resources it names are left in place"
+            );
+            // Both spellings, because one reason a journal is unusable is
+            // that they disagree: the durable record is keyed by the
+            // directory the journal was found in, and by the id the journal
+            // claims, and an unreadable one is exactly the case where those
+            // are not the same sandbox.
+            if let Some(dir_name) = dir.file_name().and_then(|name| name.to_str()) {
+                skipped.insert(dir_name.to_owned());
+            }
+            skipped.insert(record.id);
+            continue;
+        }
         records.push((dir, record));
     }
     // `read_dir` order is arbitrary; a stable one makes a sweep that fails
@@ -536,6 +577,7 @@ pub(super) async fn sweep_orphans(
     Ok(OrphanSweep {
         ids: swept,
         adopted,
+        skipped,
         runtime_dirs,
     })
 }
@@ -651,6 +693,7 @@ pub(super) async fn finalize_sweep(sweep: OrphanSweep) -> Result<()> {
 pub(super) struct SweptRuntime {
     swept: HashSet<String>,
     adopted: HashMap<String, AdoptedSandbox>,
+    skipped: HashSet<String>,
 }
 
 /// Normalizes durable records after the orphan sweep decided each sandbox's
@@ -675,9 +718,10 @@ pub(super) fn normalize_durable_records(
 ) -> Result<()> {
     let inactive = built;
     let mut nothing_adopted = HashMap::new();
-    let (swept, adopted) = match sweep {
-        Some(sweep) => (Some(&sweep.swept), &mut sweep.adopted),
-        None => (None, &mut nothing_adopted),
+    let nothing_skipped = HashSet::new();
+    let (swept, adopted, skipped) = match sweep {
+        Some(sweep) => (Some(&sweep.swept), &mut sweep.adopted, &sweep.skipped),
+        None => (None, &mut nothing_adopted, &nothing_skipped),
     };
 
     for record in store.load_all()? {
@@ -685,6 +729,12 @@ pub(super) fn normalize_durable_records(
             None => JournalEvidence::Unchecked,
             Some(_) if adopted.contains_key(&record.id) => JournalEvidence::Adopted,
             Some(ids) if ids.contains(&record.id) => JournalEvidence::Swept,
+            // The sweep found this one's journal and could not read it, so
+            // it knows no more about the resources than if it had never
+            // run — which is what `Unchecked` means. Reading it as
+            // `Unjournaled` instead would refuse a live phase and abort
+            // startup, undoing the skip that kept the sweep going.
+            Some(_) if skipped.contains(&record.id) => JournalEvidence::Unchecked,
             Some(_) => JournalEvidence::Unjournaled,
         };
         match recovery::plan(record.phase, evidence) {
@@ -1994,6 +2044,55 @@ mod tests {
                 .join(STATE_FILE)
                 .exists(),
             "an adopted journal is live state, not debris"
+        );
+    }
+
+    /// A journal this process cannot make sense of costs only itself. The
+    /// sweep gates every create, so propagating would strand every *other*
+    /// sandbox's resources and leave the manager unusable — a far larger
+    /// leak than the one record names.
+    #[tokio::test]
+    async fn an_unusable_journal_is_skipped_and_the_sweep_goes_on() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let mut config = VmmConfig::default();
+        config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
+
+        // A journal whose id disagrees with the directory holding it, which
+        // is the shape `validate_state_record` refuses — and the one where
+        // the two spellings name different sandboxes. Written by hand:
+        // nothing this crate does produces one.
+        let broken_dir = data_dir.path().join("sandboxes").join("broken");
+        std::fs::create_dir_all(&broken_dir).unwrap();
+        let stray = SandboxStateRecord::new("not-broken", None, None, None, &config, None).unwrap();
+        write_state_record(&broken_dir, &stray).unwrap();
+
+        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        record_in_phase(&store, "broken", PersistPhase::Ready);
+        drop(store);
+
+        let (vm, manager, _network, reconciled) =
+            sweep_one(data_dir.path(), &AdoptionCase::live(), &[]).await;
+
+        reconciled.expect("one unreadable journal does not fail the reconciliation");
+        assert_eq!(
+            vm.state(),
+            VmState::Running,
+            "the sandbox the sweep could read was still reclaimed"
+        );
+        assert_eq!(
+            manager.snapshot(&"keeper".to_owned()).unwrap().state,
+            SandboxState::Ready
+        );
+        // Inspectable rather than fatal. `Unjournaled` would have refused a
+        // live phase here, which is the abort the skip exists to avoid.
+        assert_eq!(
+            manager.snapshot(&"broken".to_owned()).unwrap().state,
+            SandboxState::Failed,
+            "the unreadable one is reported, not reconciled"
+        );
+        assert!(
+            broken_dir.join(STATE_FILE).exists(),
+            "its journal stays on disk for a version that can read it"
         );
     }
 

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -2164,6 +2164,52 @@ mod tests {
         );
     }
 
+    /// The motivating shape, end to end: a journal `validate_state_record`
+    /// accepts and the *port* cannot name. `_` is legal to
+    /// [`super::validate_id`] and is not a [`VmId`] (#680), so every record
+    /// a previous process wrote for an `inst_…` sandbox arrives here.
+    ///
+    /// The parse belongs at this boundary rather than downstream: without
+    /// it the record reaches `adopt_or_kill`, whose `VmId::new` propagates
+    /// and fails the whole sweep — which is what this PR removes.
+    #[tokio::test]
+    async fn a_journal_the_port_cannot_name_is_skipped_at_the_boundary() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let mut config = VmmConfig::default();
+        config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
+
+        // Directory and id agree, and both are what a pre-#680 process
+        // could legitimately have created.
+        let legacy = "inst_7f3a";
+        let legacy_dir = data_dir.path().join("sandboxes").join(legacy);
+        std::fs::create_dir_all(&legacy_dir).unwrap();
+        let record = SandboxStateRecord::new(legacy, None, None, None, &config, None).unwrap();
+        write_state_record(&legacy_dir, &record).unwrap();
+
+        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        record_in_phase(&store, legacy, PersistPhase::Ready);
+        drop(store);
+
+        let (vm, manager, _network, reconciled) =
+            sweep_one(data_dir.path(), &AdoptionCase::live(), &[]).await;
+
+        reconciled.expect("a journal the port cannot name does not fail the reconciliation");
+        assert_eq!(
+            vm.state(),
+            VmState::Running,
+            "the sandbox the sweep could name was still reclaimed"
+        );
+        assert_eq!(
+            manager.snapshot(&legacy.to_owned()).unwrap().state,
+            SandboxState::Failed,
+            "the one it could not is reported, not reconciled"
+        );
+        assert!(
+            legacy_dir.join(STATE_FILE).exists(),
+            "its journal stays on disk for a version that can name it"
+        );
+    }
+
     /// Skipping means acting on nothing the record names, which is more
     /// than leaving it out of the sweep's records. Left out alone, its
     /// overlay falls out of the global keep sets and the CoW pass deletes

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -59,7 +59,9 @@ use crate::error::{Result, VmmError};
 use crate::lifecycle::actor::{Deadlines, Seeded};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::network::NetworkAllocation;
-use crate::snapshot_cow::{CowHandle, CowManager};
+use crate::snapshot_cow::{
+    COW_FILE_PREFIX, COW_FILE_SUFFIX, CowHandle, CowManager, DM_NAME_PREFIX,
+};
 
 /// How long the sweep gives the driver to find and reconnect to one
 /// orphaned VMM. Finding one is a `/proc` walk and reconnecting a couple of
@@ -424,12 +426,13 @@ impl SkippedJournals {
     ///
     /// The durable key is the directory alone. The resource names are
     /// every spelling the record offers — the directory it sat in, the id
-    /// it claims, and the pool slot it says its dm/CoW resources are keyed
-    /// by ([`SandboxStateRecord::resource_owner`]) — because one reason a
-    /// journal is unreadable is that those disagree, and holding a name
-    /// that turns out to be nobody's costs a leaked device this sweep
-    /// would have reaped, while missing the real one aborts the whole
-    /// reconciliation on a device a live VMM still pins.
+    /// it claims, the pool slot it says its dm/CoW resources are keyed by
+    /// ([`SandboxStateRecord::resource_owner`]), and the owners its
+    /// journaled CoW names spell out. One reason a journal is unreadable
+    /// is that those disagree, so holding a name that turns out to be
+    /// nobody's costs a leaked device this sweep would have reaped, while
+    /// missing the real one aborts the whole reconciliation on a device a
+    /// live VMM still pins.
     fn hold(&mut self, dir: &Path, record: &SandboxStateRecord) {
         if let Some(name) = dir.file_name().and_then(|name| name.to_str()) {
             self.ids.insert(name.to_owned());
@@ -437,6 +440,29 @@ impl SkippedJournals {
         }
         self.owners.insert(record.id.clone());
         self.owners.insert(record.resource_owner().to_owned());
+        // A record names its dm device and its overlay outright, and those
+        // names need not agree with `resource_owner()` on a record this
+        // process refused to read — `validate_state_record`'s check that
+        // they do is one of the checks that can have failed. The reap keys
+        // on owners, so take the owner back out of each name exactly the
+        // way `CowManager::reconcile_stale` derives it.
+        if let Some(cow) = &record.cow {
+            if let Some(owner) = cow.dm_name.strip_prefix(DM_NAME_PREFIX) {
+                self.owners.insert(owner.to_owned());
+            }
+            if let Some(rest) = cow
+                .cow_file
+                .file_name()
+                .and_then(|name| name.to_str())
+                .and_then(|name| name.strip_prefix(COW_FILE_PREFIX))
+            {
+                self.owners.insert(
+                    rest.strip_suffix(COW_FILE_SUFFIX)
+                        .unwrap_or(rest)
+                        .to_owned(),
+                );
+            }
+        }
     }
 }
 
@@ -1329,10 +1355,10 @@ fn validate_state_record(
     }
     if let Some(cow) = &record.cow {
         let owner = record.resource_owner();
-        let expected_name = format!("arcbox-snap-{owner}");
+        let expected_name = format!("{DM_NAME_PREFIX}{owner}");
         let expected_file = Path::new(&config.firecracker.data_dir)
             .join("cow")
-            .join(format!("arcbox-cow-{owner}.img"));
+            .join(format!("{COW_FILE_PREFIX}{owner}{COW_FILE_SUFFIX}"));
         if cow.dm_name != expected_name
             || cow.dm_device != format!("/dev/mapper/{expected_name}")
             || cow.cow_file != expected_file
@@ -2236,7 +2262,7 @@ mod tests {
         };
         let broken_dir = data_dir.path().join("sandboxes").join("broken");
         std::fs::create_dir_all(&broken_dir).unwrap();
-        let stray = SandboxStateRecord::new(
+        let mut stray = SandboxStateRecord::new(
             "not-broken",
             None,
             Some(JournaledLease::cold_boot(&lease, true)),
@@ -2245,24 +2271,41 @@ mod tests {
             None,
         )
         .unwrap();
+        // A third owner, named by the journal's own CoW record: the check
+        // that it agrees with `resource_owner()` is one of the ones an
+        // unreadable record can have failed, so it cannot be derived.
+        let cow_dir = data_dir.path().join("cow");
+        stray.cow = Some(CowRecord {
+            dm_name: format!("{DM_NAME_PREFIX}journaled"),
+            dm_device: format!("/dev/mapper/{DM_NAME_PREFIX}journaled"),
+            cow_loop: "/dev/loop9".into(),
+            cow_file: cow_dir.join(format!("{COW_FILE_PREFIX}journaled{COW_FILE_SUFFIX}")),
+            template_path: "/templates/rootfs.img".into(),
+        });
         write_state_record(&broken_dir, &stray).unwrap();
 
-        // Both spellings: an unreadable record is exactly the case where
-        // the directory it sits in and the id it claims are not the same
-        // sandbox, so neither can be ruled out as the overlay's owner.
-        let cow_dir = data_dir.path().join("cow");
+        // Every spelling: an unreadable record is exactly the case where
+        // the directory it sits in, the id it claims and the resources it
+        // names need not be the same sandbox, so none can be ruled out as
+        // the overlay's owner.
         std::fs::create_dir_all(&cow_dir).unwrap();
-        for owner in ["broken", "not-broken"] {
-            std::fs::write(cow_dir.join(format!("arcbox-cow-{owner}.img")), b"overlay").unwrap();
+        for owner in ["broken", "not-broken", "journaled"] {
+            std::fs::write(
+                cow_dir.join(format!("{COW_FILE_PREFIX}{owner}{COW_FILE_SUFFIX}")),
+                b"overlay",
+            )
+            .unwrap();
         }
 
         let (_vm, _manager, network, reconciled) =
             sweep_one(data_dir.path(), &AdoptionCase::live(), &[]).await;
         reconciled.expect("one unreadable journal does not fail the reconciliation");
 
-        for owner in ["broken", "not-broken"] {
+        for owner in ["broken", "not-broken", "journaled"] {
             assert!(
-                cow_dir.join(format!("arcbox-cow-{owner}.img")).exists(),
+                cow_dir
+                    .join(format!("{COW_FILE_PREFIX}{owner}{COW_FILE_SUFFIX}"))
+                    .exists(),
                 "the global reap deleted the overlay of a sandbox it could not identify: {owner}"
             );
         }

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -408,6 +408,44 @@ pub(super) struct AdoptedSandbox {
 ///
 /// Both halves are private so neither can be read after the first has been
 /// taken out.
+/// The journals one sweep could not read, in the two vocabularies it has
+/// to answer in afterwards.
+///
+/// Two sets rather than one on purpose: `ids` are durable-record keys and
+/// `owners` are host-resource names. Conflating them is how a journal ends
+/// up speaking for a durable record it does not own — see [`Self::hold`].
+#[derive(Default)]
+struct SkippedJournals {
+    /// The name of the directory each unreadable journal sat in: the key
+    /// its durable record shares, and never the id the journal claims.
+    ids: HashSet<String>,
+    /// Every name such a record could have given a host resource. Nothing
+    /// in a record this process refused to read can be trusted to be the
+    /// real one, so the reap holds all of them rather than guessing.
+    owners: HashSet<String>,
+}
+
+impl SkippedJournals {
+    /// Record that nothing `dir`'s journal names may be acted on.
+    ///
+    /// The durable key is the directory alone. The resource names are
+    /// every spelling the record offers — the directory it sat in, the id
+    /// it claims, and the pool slot it says its dm/CoW resources are keyed
+    /// by ([`SandboxStateRecord::resource_owner`]) — because one reason a
+    /// journal is unreadable is that those disagree, and holding a name
+    /// that turns out to be nobody's costs a leaked device this sweep
+    /// would have reaped, while missing the real one aborts the whole
+    /// reconciliation on a device a live VMM still pins.
+    fn hold(&mut self, dir: &Path, record: &SandboxStateRecord) {
+        if let Some(name) = dir.file_name().and_then(|name| name.to_str()) {
+            self.ids.insert(name.to_owned());
+            self.owners.insert(name.to_owned());
+        }
+        self.owners.insert(record.id.clone());
+        self.owners.insert(record.resource_owner().to_owned());
+    }
+}
+
 pub(super) struct OrphanSweep {
     /// Ids whose journaled resources were torn down.
     ids: HashSet<String>,
@@ -482,7 +520,7 @@ pub(super) async fn sweep_orphans(
         Err(error) => return Err(error.into()),
     };
     let mut records = Vec::new();
-    let mut skipped = HashSet::new();
+    let mut skipped = SkippedJournals::default();
     for entry in entries {
         let entry = entry?;
         let dir = entry.path();
@@ -500,9 +538,27 @@ pub(super) async fn sweep_orphans(
         // propagated. Aborting here costs far more than the record itself:
         // the sweep gates every create, so one unreadable journal would
         // strand every *other* sandbox's resources and leave the manager
-        // unusable, where skipping leaks only what this one record names.
-        // It stays on disk, so a later version can still reclaim it, and
-        // the warning says which one to look at.
+        // unusable.
+        //
+        // Skipping means acting on *nothing* the record names, which is
+        // more than leaving it out of `records`. That alone would leave
+        // its VM neither adopted nor killed — `adopt_or_kill` iterates
+        // `records` — while its dm device and overlay fell out of the keep
+        // sets `reap_orphans` builds, so the global CoW pass would walk
+        // into a device a live VMM still pins and fail the whole
+        // reconciliation on it: the exact abort this skip exists to
+        // remove, in the exact case it was written for. So the sweep holds
+        // instead. Every name the record could have given a host resource
+        // goes into those keep sets, and the address it names goes out of
+        // the pool ([`GuestNetwork::hold_address`]) so a later create
+        // cannot take the interface out from under a guest that may still
+        // be running on it.
+        //
+        // The trade, stated plainly: one sandbox leaks visibly — its VM,
+        // its TAP, its device, its overlay and its address, all held for
+        // this process's lifetime, with the journal still on disk for a
+        // version that can read it — instead of every sandbox on the node
+        // leaking silently behind a manager that never starts.
         //
         // This is also the single place the question is asked. `VmId` is
         // narrower than [`super::validate_id`] — the latter runs over
@@ -518,22 +574,16 @@ pub(super) async fn sweep_orphans(
                 sandbox_id = %record.id,
                 path = %dir.display(),
                 %error,
-                "skipping an unusable crash journal; the resources it names are left in place"
+                "skipping an unusable crash journal: its VM is left alone and every \
+                 resource it names is held out of this sweep's reap"
             );
-            // The directory name, and never the id the journal claims.
-            // The directory is how this journal was found and the key its
-            // durable record shares; the claimed id is the untrusted half
-            // of a record this process has just refused to read, and one
-            // reason to refuse is that the two disagree. Letting directory
-            // `foo`'s broken journal insert `bar` would let it answer for a
-            // durable `bar` it has nothing to do with: a genuinely
-            // unjournaled `bar` in a live phase would read `Unchecked`
-            // instead of `Unjournaled`, so `recovery::plan` would return
-            // `Fail` where it must return `RefuseUnjournaled` — declaring a
-            // sandbox failed while its VMM may still be running, which is
-            // the one thing that refusal exists to prevent.
-            if let Some(dir_name) = dir.file_name().and_then(|name| name.to_str()) {
-                skipped.insert(dir_name.to_owned());
+            skipped.hold(&dir, &record);
+            // Held rather than quarantined: quarantining needs a `VmId` to
+            // name the lease through the port, which is exactly what may
+            // have failed above, and it would tear down the TAP of a guest
+            // this sweep has decided not to touch.
+            if let Some(allocation) = &record.network {
+                network.hold_address(allocation.ip_address.into());
             }
             continue;
         }
@@ -565,6 +615,7 @@ pub(super) async fn sweep_orphans(
         &records,
         &mut adopted,
         &retained,
+        &skipped.owners,
         &phases,
         config,
         driver,
@@ -583,7 +634,7 @@ pub(super) async fn sweep_orphans(
     Ok(OrphanSweep {
         ids: swept,
         adopted,
-        skipped,
+        skipped: skipped.ids,
         runtime_dirs,
     })
 }
@@ -600,6 +651,7 @@ async fn reap_orphans(
     records: &[(PathBuf, SandboxStateRecord)],
     adopted: &mut HashMap<String, AdoptedSandbox>,
     retained: &HashSet<String>,
+    held: &HashSet<String>,
     phases: &HashMap<&str, super::record::PersistPhase>,
     config: &VmmConfig,
     driver: &dyn VmDriver,
@@ -629,11 +681,19 @@ async fn reap_orphans(
     // are distinct because a paused sandbox has a retained file and no
     // device, so folding them together would leave the device of a sandbox
     // that crashed mid-pause unreaped.
-    let live_devices: HashSet<String> = records
+    //
+    // Every name a skipped journal offered counts as live here: `records`
+    // does not carry those journals, so nothing above killed their VMs,
+    // and a device a live VMM pins turns this pass into the error that
+    // fails the whole reconciliation. Not provably dead is treated as
+    // alive, which is a held device at worst and a completed sweep at
+    // best.
+    let mut live_devices: HashSet<String> = records
         .iter()
         .filter(|(_, record)| adopted.contains_key(&record.id))
         .map(|(_, record)| record.resource_owner().to_owned())
         .collect();
+    live_devices.extend(held.iter().cloned());
     let mut keep_cow_files = retained.clone();
     keep_cow_files.extend(live_devices.iter().cloned());
     cow_manager.reconcile_stale(&keep_cow_files, &live_devices)?;
@@ -2101,6 +2161,77 @@ mod tests {
         assert!(
             broken_dir.join(STATE_FILE).exists(),
             "its journal stays on disk for a version that can read it"
+        );
+    }
+
+    /// Skipping means acting on nothing the record names, which is more
+    /// than leaving it out of the sweep's records. Left out alone, its
+    /// overlay falls out of the global keep sets and the CoW pass deletes
+    /// it — or, while the VMM it named is still alive, aborts the whole
+    /// reconciliation on the device that VMM pins — and its address goes
+    /// back into the pool, where the next create takes the interface out
+    /// from under that guest.
+    #[tokio::test]
+    async fn a_skipped_journal_holds_its_disk_and_its_address() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let mut config = VmmConfig::default();
+        config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
+
+        // The address is the pool's next free one, so a create after the
+        // sweep takes it back the moment the sweep lets it go.
+        let held = "10.200.0.2".parse::<std::net::IpAddr>().unwrap();
+        let lease = NetworkLease {
+            vm: VmId::new("not-broken").unwrap(),
+            ip: held,
+            prefix_len: 16,
+            gateway: "10.200.0.1".parse().unwrap(),
+            mac: "02:fc:00:00:00:02".parse().unwrap(),
+            cleanup_token: "gen-broken".into(),
+        };
+        let broken_dir = data_dir.path().join("sandboxes").join("broken");
+        std::fs::create_dir_all(&broken_dir).unwrap();
+        let stray = SandboxStateRecord::new(
+            "not-broken",
+            None,
+            Some(JournaledLease::cold_boot(&lease, true)),
+            None,
+            &config,
+            None,
+        )
+        .unwrap();
+        write_state_record(&broken_dir, &stray).unwrap();
+
+        // Both spellings: an unreadable record is exactly the case where
+        // the directory it sits in and the id it claims are not the same
+        // sandbox, so neither can be ruled out as the overlay's owner.
+        let cow_dir = data_dir.path().join("cow");
+        std::fs::create_dir_all(&cow_dir).unwrap();
+        for owner in ["broken", "not-broken"] {
+            std::fs::write(cow_dir.join(format!("arcbox-cow-{owner}.img")), b"overlay").unwrap();
+        }
+
+        let (_vm, _manager, network, reconciled) =
+            sweep_one(data_dir.path(), &AdoptionCase::live(), &[]).await;
+        reconciled.expect("one unreadable journal does not fail the reconciliation");
+
+        for owner in ["broken", "not-broken"] {
+            assert!(
+                cow_dir.join(format!("arcbox-cow-{owner}.img")).exists(),
+                "the global reap deleted the overlay of a sandbox it could not identify: {owner}"
+            );
+        }
+        let fresh = GuestNetwork::reserve(
+            &*network,
+            &VmId::new("fresh").unwrap(),
+            arcbox_vm_driver::net::NetworkPolicy {
+                mode: arcbox_vm_driver::net::NetworkMode::Nat,
+            },
+        )
+        .await
+        .unwrap();
+        assert_ne!(
+            fresh.ip, held,
+            "the address of a guest nobody could identify was handed out again"
         );
     }
 

--- a/engine/arcbox-snapshot/src/snapshot_cow.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow.rs
@@ -52,7 +52,20 @@ const DMSETUP_CANDIDATES: &[&str] = &["/usr/sbin/dmsetup", "/sbin/dmsetup"];
 const SNAPSHOT_CHUNK_SECTORS: u64 = 8;
 
 /// Device-mapper name prefix for sandbox snapshots.
-const DM_NAME_PREFIX: &str = "arcbox-snap-";
+///
+/// Public with [`COW_FILE_PREFIX`] and [`COW_FILE_SUFFIX`] because the
+/// convention has an inverse: [`CowManager::reconcile_stale`] reads an
+/// owner back out of a name on the host, and a composer holding a durable
+/// record it cannot otherwise interpret does the same to decide what that
+/// record still names. One definition, so the two directions cannot drift.
+pub const DM_NAME_PREFIX: &str = "arcbox-snap-";
+
+/// File-name prefix of a sandbox's copy-on-write overlay, under `cow_dir`.
+pub const COW_FILE_PREFIX: &str = "arcbox-cow-";
+
+/// File-name suffix of a sandbox's copy-on-write overlay. Optional when
+/// reading one back: `reconcile_stale` accepts a name without it.
+pub const COW_FILE_SUFFIX: &str = ".img";
 
 /// Maximum length of a device-mapper name (DM_NAME_LEN - 1, from linux/dm-ioctl.h).
 const DM_NAME_MAX_LEN: usize = 127;
@@ -140,7 +153,7 @@ impl CowTestProbe {
         CowHandle {
             dm_device: format!("/dev/mapper/{dm_name}"),
             cow_loop: format!("/dev/loop-test-{sandbox_id}"),
-            cow_file: cow_dir.join(format!("arcbox-cow-{sandbox_id}.img")),
+            cow_file: cow_dir.join(format!("{COW_FILE_PREFIX}{sandbox_id}{COW_FILE_SUFFIX}")),
             template_path: PathBuf::from(rootfs_path),
             dm_name,
         }
@@ -467,7 +480,9 @@ impl CowManager {
         // On reattach the overlay is the sandbox's retained disk, so every
         // rollback below passes `cow_file: None` — a failed re-assembly must
         // never delete it.
-        let cow_file = self.cow_dir.join(format!("arcbox-cow-{sandbox_id}.img"));
+        let cow_file = self
+            .cow_dir
+            .join(format!("{COW_FILE_PREFIX}{sandbox_id}{COW_FILE_SUFFIX}"));
         let cow_size = sectors * 512;
         if reuse_existing_cow {
             let verified = std::fs::metadata(&cow_file)
@@ -692,7 +707,9 @@ impl CowManager {
     /// Idempotent: a missing file is success. Any loop still backing the
     /// file is detached first so the unlink actually frees the space.
     pub async fn remove_preserved_cow(&self, sandbox_id: &str) -> Result<()> {
-        let cow_file = self.cow_dir.join(format!("arcbox-cow-{sandbox_id}.img"));
+        let cow_file = self
+            .cow_dir
+            .join(format!("{COW_FILE_PREFIX}{sandbox_id}{COW_FILE_SUFFIX}"));
         if !cow_file.exists() {
             return Ok(());
         }

--- a/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
@@ -9,8 +9,8 @@ use tracing::{debug, info, warn};
 
 use super::block_tools::loop_backing_file;
 use super::{
-    CowHandle, CowManager, DM_NAME_PREFIX, TEMPLATE_LOOP_DIR, TEMPLATE_MARKER_TEMP_PREFIX,
-    TEMPLATE_PENDING_PREFIX, TemplateEntry, dmsetup_remove,
+    COW_FILE_PREFIX, COW_FILE_SUFFIX, CowHandle, CowManager, DM_NAME_PREFIX, TEMPLATE_LOOP_DIR,
+    TEMPLATE_MARKER_TEMP_PREFIX, TEMPLATE_PENDING_PREFIX, TemplateEntry, dmsetup_remove,
 };
 use crate::error::{Result, SnapshotError};
 
@@ -208,8 +208,8 @@ impl CowManager {
             let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                 continue;
             };
-            if let Some(rest) = name.strip_prefix("arcbox-cow-") {
-                let id = rest.strip_suffix(".img").unwrap_or(rest);
+            if let Some(rest) = name.strip_prefix(COW_FILE_PREFIX) {
+                let id = rest.strip_suffix(COW_FILE_SUFFIX).unwrap_or(rest);
                 if keep_cow_files.contains(id) || live_devices.contains(id) {
                     debug!(file = %path.display(), "keeping retained sandbox cow file");
                     continue;

--- a/virt/arcbox-tap-net/README.md
+++ b/virt/arcbox-tap-net/README.md
@@ -25,7 +25,11 @@ owns:
   (`[A-Za-z0-9._-]`, at most 64 bytes, not `.`/`..`), checked at `reserve`
   and on every ledger write and load, so whatever is reserved can be
   quarantined and every entry is one `NetworkReconcile` can list and
-  finalize.
+  finalize. A marker that fails those checks is skipped rather than
+  fatal — the load runs inside the constructor, and a host that cannot
+  build its network reaps nothing — but its address is still withheld
+  from the pool for the manager's lifetime, because a guest this build
+  cannot name may still be on it.
 
 It moved here from `arcbox-vm/src/network` (vm-stack-redesign R2a,
 D-VM6). `arcbox_computer_runtime::network` re-exports the crate and

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -746,12 +746,20 @@ mod tests {
             serde_json::to_vec(&marker).unwrap(),
         )
         .unwrap();
-        let Err(error) = network() else {
-            panic!("a ledger holding an id the port cannot name must fail to load");
-        };
+        // This used to be fatal, and being fatal was the opposite of
+        // useful: the load runs inside the constructor, so one marker this
+        // build cannot name meant no network at all — and the ledger holds
+        // host resources that still need reaping, which a host that cannot
+        // construct its network never reaps. The marker is skipped, and it
+        // stays on disk for a version that can name it.
+        let reloaded = network().expect("an unnameable marker is skipped, not fatal");
         assert!(
-            error.to_string().contains(&long_id) && error.to_string().contains("exceeds 64"),
-            "{error}"
+            !reloaded.quarantine_pending(&long_id),
+            "a skipped marker is not registered as a pending cleanup"
+        );
+        assert!(
+            ledger.join(format!("{long_id}.json")).exists(),
+            "its entry is left where a later version can read it"
         );
     }
 }

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -155,7 +155,7 @@ impl GuestNetwork for TapNetwork {
     }
 
     /// An IPv6 address cannot have come from this pool, so there is
-    /// nothing to withhold — the same reasoning [`TapNetwork::allocation`]
+    /// nothing to withhold — the same reasoning `TapNetwork::allocation`
     /// refuses one on, without an error to report to a caller that has no
     /// answer for it.
     fn hold_address(&self, address: IpAddr) {

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -195,14 +195,16 @@ impl NetworkReconcile for TapNetwork {
     /// Every quarantined VM with its token.
     ///
     /// The error is a broken invariant rather than an expected on-disk
-    /// case: every id this crate reserves, writes, or loads passes the
-    /// `VmId` rules (`quarantine::validate_id`), and a marker file
-    /// carrying anything else fails construction outright. Should one
-    /// reach here, the whole list fails rather than losing that one entry
-    /// from it — nothing can name the entry, so nothing can finalize it,
-    /// so `finalize_startup_cleanup` refuses while it sits in the ledger
-    /// and the startup gate never opens. Dropping it would trade one loud
-    /// failure for that permanent, unexplained stall.
+    /// case: every id this crate reserves or writes passes the `VmId`
+    /// rules (`quarantine::validate_id`), and a marker file carrying
+    /// anything else never enters the map — the load skips it, holding its
+    /// address out of the pool without registering a cleanup nothing could
+    /// finalize. Should one reach here anyway, the whole list fails rather
+    /// than losing that one entry from it: nothing can name the entry, so
+    /// nothing can finalize it, so `finalize_startup_cleanup` refuses while
+    /// it sits in the map and the startup gate never opens. Dropping it
+    /// would trade one loud failure for that permanent, unexplained
+    /// stall.
     async fn pending_cleanups(&self) -> Result<Vec<(VmId, String)>> {
         self.pending_quarantines()
             .into_iter()
@@ -708,10 +710,12 @@ mod tests {
 
     /// The network only ever carries ids the port can name: an id past
     /// `VmId::MAX_LEN` is refused at `reserve` (before any TAP exists) with
-    /// the port's own message, and
-    /// a ledger file that carries one (written outside this contract) fails
-    /// at load naming it, instead of surviving as a quarantine
-    /// `NetworkReconcile` could never list or finalize.
+    /// the port's own message, and a ledger file that carries one (written
+    /// outside this contract, or by a build whose rules were wider) is
+    /// skipped at load rather than admitted as a quarantine
+    /// `NetworkReconcile` could never list or finalize. Skipped is not
+    /// forgotten: the entry stays on disk and its address stays out of the
+    /// pool, because a guest this process cannot name may still be on it.
     #[cfg(not(target_os = "linux"))]
     #[test]
     fn ids_the_port_cannot_name_are_refused_not_stranded() {
@@ -763,6 +767,10 @@ mod tests {
         // construct its network never reaps. The marker is skipped, and it
         // stays on disk for a version that can name it.
         let reloaded = network().expect("an unnameable marker is skipped, not fatal");
+        reloaded.mark_reconciled();
+        let startup = TapNetwork::startup_cleanup_token(&reloaded).unwrap();
+        TapNetwork::finalize_startup_cleanup(&reloaded, &startup)
+            .expect("a skipped marker is no pending cleanup, so the gate opens");
         assert!(
             !reloaded.quarantine_pending(&long_id),
             "a skipped marker is not registered as a pending cleanup"
@@ -770,6 +778,20 @@ mod tests {
         assert!(
             ledger.join(format!("{long_id}.json")).exists(),
             "its entry is left where a later version can read it"
+        );
+        // And the gate opening is exactly why the address must be withheld
+        // by something else: nothing can finalize a cleanup for an id
+        // nothing can name, so nothing would ever hand this address back.
+        // A guest may still be on it, and `activate` would destroy the TAP
+        // that address names.
+        assert_eq!(
+            TapNetwork::reserve(&reloaded, "box").unwrap().ip_address,
+            "10.0.0.2".parse::<Ipv4Addr>().unwrap()
+        );
+        assert_eq!(
+            TapNetwork::reserve(&reloaded, "next").unwrap().ip_address,
+            "10.0.0.4".parse::<Ipv4Addr>().unwrap(),
+            "10.0.0.3 is the skipped marker's address and must not be reissued"
         );
     }
 }

--- a/virt/arcbox-tap-net/src/guest_network.rs
+++ b/virt/arcbox-tap-net/src/guest_network.rs
@@ -154,6 +154,16 @@ impl GuestNetwork for TapNetwork {
         Ok(self.release_checked(&allocation)?)
     }
 
+    /// An IPv6 address cannot have come from this pool, so there is
+    /// nothing to withhold — the same reasoning [`TapNetwork::allocation`]
+    /// refuses one on, without an error to report to a caller that has no
+    /// answer for it.
+    fn hold_address(&self, address: IpAddr) {
+        if let IpAddr::V4(ip) = address {
+            Self::hold_address(self, ip);
+        }
+    }
+
     fn identity(&self, lease: &NetworkLease, mode: AttachMode) -> NetworkIdentity {
         Self::identity_for(lease, mode)
     }

--- a/virt/arcbox-tap-net/src/lib.rs
+++ b/virt/arcbox-tap-net/src/lib.rs
@@ -165,7 +165,9 @@ pub struct TapNetwork {
     gateway: Ipv4Addr,
     /// DNS servers.
     dns: Vec<String>,
-    /// Set of already-allocated guest IPs.
+    /// Set of already-allocated guest IPs: live leases, quarantined ones,
+    /// and addresses held by [`TapNetwork::hold_address`] for durable state
+    /// this build cannot read.
     allocated: Mutex<HashSet<u32>>,
     /// Allocations whose TAP is inactive but whose IP cannot be recycled until
     /// the host confirms its listeners are gone.
@@ -268,7 +270,10 @@ impl TapNetwork {
         let gateway = gateway
             .parse::<Ipv4Addr>()
             .map_err(|e| TapNetError::Network(format!("invalid gateway: {e}")))?;
-        let quarantined = quarantine_dir
+        let quarantine::LoadedQuarantines {
+            pending: quarantined,
+            held,
+        } = quarantine_dir
             .as_deref()
             .map(|dir| quarantine::load_quarantines(dir, base, prefix_len, gateway))
             .transpose()?
@@ -282,6 +287,14 @@ impl TapNetwork {
                 )));
             }
         }
+        // A marker this build could not act on still names an address, and
+        // a guest may still be on it. Held, not quarantined: `next_ip`
+        // skips it, while `pending_quarantines` never lists it and
+        // `finalize_startup_cleanup` never waits on a cleanup nothing could
+        // perform. A collision with a readable marker's address is a set
+        // union, not a duplicate — the readable one is the actionable
+        // record of the two, and both want the same address kept.
+        allocated.extend(held.into_iter().map(u32::from));
 
         let startup_barrier = quarantine_dir.is_some();
         let startup_token = if startup_barrier {

--- a/virt/arcbox-tap-net/src/lib.rs
+++ b/virt/arcbox-tap-net/src/lib.rs
@@ -629,6 +629,23 @@ impl TapNetwork {
         }
     }
 
+    /// Withhold `ip` from the pool for this manager's lifetime, without
+    /// touching any host state.
+    ///
+    /// For an address named by durable state this build cannot read: the
+    /// entry cannot be quarantined (nothing can name its VM) and cannot be
+    /// released (nothing can prove its guest is gone), but a guest may
+    /// still be on it. `next_ip` skips whatever `allocated` holds, so this
+    /// is what keeps the address from being handed to a fresh sandbox
+    /// whose [`TapNetwork::activate`] would then destroy the live TAP that
+    /// address names. There is no matching un-hold: the whole reason to
+    /// hold it is that nothing here can tell when it would be safe.
+    pub fn hold_address(&self, ip: Ipv4Addr) {
+        if self.allocated.lock().unwrap().insert(u32::from(ip)) {
+            debug!(%ip, "holding an address named by durable state this build cannot read");
+        }
+    }
+
     /// Release the TAP interface and guest IP associated with `vm_id`.
     pub fn release(&self, alloc: &NetworkAllocation) {
         if let Err(error) = self.release_checked(alloc) {

--- a/virt/arcbox-tap-net/src/quarantine.rs
+++ b/virt/arcbox-tap-net/src/quarantine.rs
@@ -213,12 +213,30 @@ struct NetworkQuarantine {
     allocation: NetworkAllocation,
 }
 
+/// What one ledger load found.
+///
+/// Two collections rather than one because a marker this process cannot
+/// read is not a lesser quarantine — it is not a quarantine at all.
+/// Nothing can name it, so nothing can list or finalize it, and folding it
+/// into [`Self::pending`] would leave a gate waiting on a cleanup no caller
+/// could ever perform ([`TapNetwork::finalize_startup_cleanup`]). Its
+/// address is still real, so it is held instead.
+#[derive(Default)]
+pub struct LoadedQuarantines {
+    /// The per-VM cleanups this process can name, list and finalize.
+    pub pending: HashMap<String, NetworkAllocation>,
+    /// Addresses named by markers this process could not act on: withheld
+    /// from the pool for this manager's lifetime, listed nowhere, and
+    /// releasable by nothing.
+    pub held: HashSet<Ipv4Addr>,
+}
+
 pub fn load_quarantines(
     dir: &Path,
     base: Ipv4Addr,
     prefix_len: u8,
     gateway: Ipv4Addr,
-) -> Result<HashMap<String, NetworkAllocation>> {
+) -> Result<LoadedQuarantines> {
     let existed = dir.try_exists()?;
     std::fs::create_dir_all(dir)?;
     std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
@@ -234,6 +252,7 @@ pub fn load_quarantines(
         std::fs::File::open(parent)?.sync_all()?;
     }
     let mut quarantined = HashMap::new();
+    let mut held = HashSet::new();
     let mut tokens = HashSet::new();
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
@@ -255,28 +274,47 @@ pub fn load_quarantines(
         }
         // A marker this process cannot read is skipped, not propagated.
         // This load runs inside `TapNetwork`'s constructor, so an error
-        // here fails the network subsystem outright — every address stays
-        // out of the pool and nothing can be created, with no self-heal
-        // short of deleting the file by hand. Skipping leaks the one
-        // address the marker names, visibly, and the ledger entry stays on
-        // disk for a version that can read it.
+        // here fails the network subsystem outright — no pool, no creates,
+        // and no self-heal short of deleting the file by hand, while the
+        // ledger exists precisely to name host resources that still need
+        // reaping. The entry stays on disk for a version that can read it.
         //
         // The rule this pays for: an id a *previous* process could write is
         // not necessarily one this process can parse. `VmId` is narrower
         // than it was, and a marker is written before the VMM that would
         // have rejected the id ever starts, so the hosts that most need
         // reconciling are exactly the ones holding unparseable markers.
-        let marker = match read_marker(&path, base, prefix_len, gateway) {
+        //
+        // The two skips differ in what is left behind, and the warnings say
+        // which is which. A marker that decodes names an address, and that
+        // address is held: a guest may still be on it, and handing it out
+        // again would give `tap::create` a live device of the same name to
+        // destroy and leave the new occupant inheriting filter rules the
+        // previous one's activation appended. A marker that does not decode
+        // names nothing, so there is nothing to hold.
+        let marker = match decode_marker(&path) {
             Ok(marker) => marker,
             Err(error) => {
                 warn!(
                     path = %path.display(),
                     %error,
-                    "skipping an unreadable network quarantine marker; its address stays out of the pool"
+                    "skipping a network quarantine marker this process cannot decode; \
+                     it names no address, so none is held for it"
                 );
                 continue;
             }
         };
+        if let Err(error) = check_marker(&path, &marker, base, prefix_len, gateway) {
+            warn!(
+                path = %path.display(),
+                ip = %marker.allocation.ip_address,
+                %error,
+                "skipping a network quarantine marker this process cannot act on; its \
+                 address is held out of the pool, and no cleanup can finalize it"
+            );
+            held.insert(marker.allocation.ip_address);
+            continue;
+        }
         if !tokens.insert(marker.allocation.cleanup_token.clone()) {
             return Err(TapNetError::Network(format!(
                 "duplicate sandbox network quarantine token for {}",
@@ -294,25 +332,35 @@ pub fn load_quarantines(
         }
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
     }
-    Ok(quarantined)
+    Ok(LoadedQuarantines {
+        pending: quarantined,
+        held,
+    })
 }
 
-/// One marker, and every check that decides whether *this* process can act
-/// on it.
+/// The bytes on disk as a marker. Separate from [`check_marker`] because
+/// the split is what the two skips in [`load_quarantines`] turn on: a
+/// marker that decodes names an address to hold even when every check on
+/// it fails, and one that does not decode names nothing at all.
+fn decode_marker(path: &Path) -> Result<NetworkQuarantine> {
+    Ok(serde_json::from_slice(&std::fs::read(path)?)?)
+}
+
+/// Every check that decides whether *this* process can act on `marker`.
 ///
-/// Split out so [`load_quarantines`] has one place to skip: everything here
-/// is about the marker alone, and a failure means the ledger holds an entry
-/// this build cannot name. The duplicate-token and duplicate-id checks stay
-/// in the loop deliberately — they are properties of the set, not of a
+/// One place for [`load_quarantines`] to skip on: everything here is about
+/// the marker alone, and a failure means the ledger holds an entry this
+/// build cannot name. The duplicate-token and duplicate-id checks stay in
+/// the loop deliberately — they are properties of the set, not of a
 /// marker, and skipping one of a colliding pair would silently pick a
 /// winner and lose the other's address.
-fn read_marker(
+fn check_marker(
     path: &Path,
+    marker: &NetworkQuarantine,
     base: Ipv4Addr,
     prefix_len: u8,
     gateway: Ipv4Addr,
-) -> Result<NetworkQuarantine> {
-    let marker: NetworkQuarantine = serde_json::from_slice(&std::fs::read(path)?)?;
+) -> Result<()> {
     validate_id(&marker.id)?;
     if Uuid::parse_str(&marker.allocation.cleanup_token).is_err() {
         return Err(TapNetError::Network(format!(
@@ -327,7 +375,7 @@ fn read_marker(
             marker.id
         )));
     }
-    Ok(marker)
+    Ok(())
 }
 
 /// Whether `allocation` is one this network could have written for `id`:
@@ -417,10 +465,11 @@ fn quarantine_path(dir: &Path, sandbox_id: &str) -> PathBuf {
 /// of its own, so the only dot in a marker's name is the extension).
 /// Checked where an id enters the network (`reserve`), on
 /// every ledger write, and on every ledger load, so a reserved address can
-/// always be quarantined, every entry the ledger holds is one the port can
-/// name, and a file from outside the contract fails at load with its id in
-/// the message rather than lingering as a quarantine `NetworkReconcile`
-/// could never list or finalize.
+/// always be quarantined and every entry the ledger *holds* is one the port
+/// can name. A file from outside the contract never becomes one: the load
+/// skips it, names it in a warning and withholds its address, rather than
+/// admitting it as a quarantine `NetworkReconcile` could never list or
+/// finalize.
 pub fn validate_id(id: &str) -> Result<()> {
     VmId::new(id)
         .map(drop)

--- a/virt/arcbox-tap-net/src/quarantine.rs
+++ b/virt/arcbox-tap-net/src/quarantine.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::Ordering;
 
 use arcbox_vm_driver::VmId;
 use serde::{Deserialize, Serialize};
-use tracing::debug;
+use tracing::{debug, warn};
 use uuid::Uuid;
 
 #[cfg(target_os = "linux")]
@@ -249,30 +249,37 @@ pub fn load_quarantines(
             Some("tmp") => continue,
             Some("json") => {}
             _ => {
-                return Err(TapNetError::Network(format!(
-                    "unexpected sandbox network quarantine file {}",
-                    path.display()
-                )));
+                warn!(path = %path.display(), "ignoring an unexpected file in the quarantine ledger");
+                continue;
             }
         }
-        let marker: NetworkQuarantine = serde_json::from_slice(&std::fs::read(&path)?)?;
-        validate_id(&marker.id)?;
-        if Uuid::parse_str(&marker.allocation.cleanup_token).is_err() {
-            return Err(TapNetError::Network(format!(
-                "sandbox network quarantine {} has an invalid cleanup token",
-                marker.id
-            )));
-        }
-        validate_allocation(&marker.id, &marker.allocation, base, prefix_len, gateway)?;
+        // A marker this process cannot read is skipped, not propagated.
+        // This load runs inside `TapNetwork`'s constructor, so an error
+        // here fails the network subsystem outright — every address stays
+        // out of the pool and nothing can be created, with no self-heal
+        // short of deleting the file by hand. Skipping leaks the one
+        // address the marker names, visibly, and the ledger entry stays on
+        // disk for a version that can read it.
+        //
+        // The rule this pays for: an id a *previous* process could write is
+        // not necessarily one this process can parse. `VmId` is narrower
+        // than it was, and a marker is written before the VMM that would
+        // have rejected the id ever starts, so the hosts that most need
+        // reconciling are exactly the ones holding unparseable markers.
+        let marker = match read_marker(&path, base, prefix_len, gateway) {
+            Ok(marker) => marker,
+            Err(error) => {
+                warn!(
+                    path = %path.display(),
+                    %error,
+                    "skipping an unreadable network quarantine marker; its address stays out of the pool"
+                );
+                continue;
+            }
+        };
         if !tokens.insert(marker.allocation.cleanup_token.clone()) {
             return Err(TapNetError::Network(format!(
                 "duplicate sandbox network quarantine token for {}",
-                marker.id
-            )));
-        }
-        if path.file_stem().and_then(|value| value.to_str()) != Some(marker.id.as_str()) {
-            return Err(TapNetError::Network(format!(
-                "sandbox network quarantine filename does not match {}",
                 marker.id
             )));
         }
@@ -288,6 +295,39 @@ pub fn load_quarantines(
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
     }
     Ok(quarantined)
+}
+
+/// One marker, and every check that decides whether *this* process can act
+/// on it.
+///
+/// Split out so [`load_quarantines`] has one place to skip: everything here
+/// is about the marker alone, and a failure means the ledger holds an entry
+/// this build cannot name. The duplicate-token and duplicate-id checks stay
+/// in the loop deliberately — they are properties of the set, not of a
+/// marker, and skipping one of a colliding pair would silently pick a
+/// winner and lose the other's address.
+fn read_marker(
+    path: &Path,
+    base: Ipv4Addr,
+    prefix_len: u8,
+    gateway: Ipv4Addr,
+) -> Result<NetworkQuarantine> {
+    let marker: NetworkQuarantine = serde_json::from_slice(&std::fs::read(path)?)?;
+    validate_id(&marker.id)?;
+    if Uuid::parse_str(&marker.allocation.cleanup_token).is_err() {
+        return Err(TapNetError::Network(format!(
+            "sandbox network quarantine {} has an invalid cleanup token",
+            marker.id
+        )));
+    }
+    validate_allocation(&marker.id, &marker.allocation, base, prefix_len, gateway)?;
+    if path.file_stem().and_then(|value| value.to_str()) != Some(marker.id.as_str()) {
+        return Err(TapNetError::Network(format!(
+            "sandbox network quarantine filename does not match {}",
+            marker.id
+        )));
+    }
+    Ok(marker)
 }
 
 /// Whether `allocation` is one this network could have written for `id`:

--- a/virt/arcbox-tap-net/src/tests.rs
+++ b/virt/arcbox-tap-net/src/tests.rs
@@ -341,23 +341,49 @@ fn quarantine_survives_reload_past_a_staging_leftover() {
     );
 }
 
+/// A marker whose allocation this pool did not write is skipped, not
+/// fatal: the load runs inside the constructor, so failing takes the whole
+/// network subsystem down over one file — and with it every address that
+/// file was protecting.
+///
+/// Skipped is not forgotten. The entry is not trusted as a pending
+/// cleanup, because nothing here can name the VM a cleanup would finalize;
+/// but an address of *this* pool that it names is withheld anyway, since a
+/// guest may still be on it and `activate` would destroy the TAP that
+/// address names. An address from another network was never in this pool
+/// to withhold, which is what the last column below distinguishes.
 #[test]
-fn quarantine_loader_rejects_foreign_or_inconsistent_allocations() {
-    let mutations: [fn(&mut NetworkAllocation); 4] = [
-        |allocation: &mut NetworkAllocation| {
-            allocation.ip_address = "192.0.2.2".parse().unwrap();
-        },
-        |allocation: &mut NetworkAllocation| {
-            allocation.tap_name = "vmtap-wrong".into();
-        },
-        |allocation: &mut NetworkAllocation| {
-            allocation.mac_address = "02:00:00:00:00:00".into();
-        },
-        |allocation: &mut NetworkAllocation| {
-            allocation.gateway = "10.0.0.9".parse().unwrap();
-        },
+fn quarantine_loader_skips_foreign_or_inconsistent_allocations() {
+    // What the marker gets wrong, and whether this pool's one allocatable
+    // address (`10.0.0.2` in a /30) is still free afterwards.
+    type SkipCase = (fn(&mut NetworkAllocation), bool);
+    let mutations: [SkipCase; 4] = [
+        (
+            |allocation: &mut NetworkAllocation| {
+                allocation.ip_address = "192.0.2.2".parse().unwrap();
+            },
+            true,
+        ),
+        (
+            |allocation: &mut NetworkAllocation| {
+                allocation.tap_name = "vmtap-wrong".into();
+            },
+            false,
+        ),
+        (
+            |allocation: &mut NetworkAllocation| {
+                allocation.mac_address = "02:00:00:00:00:00".into();
+            },
+            false,
+        ),
+        (
+            |allocation: &mut NetworkAllocation| {
+                allocation.gateway = "10.0.0.9".parse().unwrap();
+            },
+            false,
+        ),
     ];
-    for mutate in mutations {
+    for (mutate, address_still_free) in mutations {
         let root = tempfile::tempdir().unwrap();
         let quarantine = root.path().join("network-quarantine");
         std::fs::create_dir(&quarantine).unwrap();
@@ -376,15 +402,30 @@ fn quarantine_loader_rejects_foreign_or_inconsistent_allocations() {
             "10.0.0.0/30",
             "10.0.0.1",
             vec![],
-            quarantine,
+            quarantine.clone(),
             Datapath::default(),
             Arc::new(IptablesLegacy::default()),
         )
         .expect("a marker this pool did not write is skipped, not fatal");
-        // Skipped means *not adopted*: the entry is neither trusted as a
-        // pending cleanup nor allowed to hold an address out of the pool.
-        // Failing the whole load instead would take the network subsystem
-        // down over one file, and with it every address it was protecting.
         assert!(!network.quarantine_pending("box"));
+        assert!(
+            quarantine.join("box.json").exists(),
+            "the entry stays on disk for a version that can read it"
+        );
+
+        // Nothing pending means the startup gate opens as soon as the host
+        // finalizes the sweep — so the withheld address is the only thing
+        // standing between a live guest and the next `reserve`.
+        network.mark_reconciled();
+        let startup = network.startup_cleanup_token().unwrap();
+        network
+            .finalize_startup_cleanup(&startup)
+            .expect("a skipped marker is no pending cleanup, so the gate opens");
+        assert_eq!(
+            network.reserve("fresh").is_ok(),
+            address_still_free,
+            "a skipped marker's own address must not be reissued, and a foreign \
+             one must not take this pool's address with it"
+        );
     }
 }

--- a/virt/arcbox-tap-net/src/tests.rs
+++ b/virt/arcbox-tap-net/src/tests.rs
@@ -372,16 +372,19 @@ fn quarantine_loader_rejects_foreign_or_inconsistent_allocations() {
         };
         mutate(&mut allocation);
         quarantine::write_quarantine(&quarantine, "box", &allocation).unwrap();
-        assert!(
-            TapNetwork::with_quarantine_dir(
-                "10.0.0.0/30",
-                "10.0.0.1",
-                vec![],
-                quarantine,
-                Datapath::default(),
-                Arc::new(IptablesLegacy::default()),
-            )
-            .is_err()
-        );
+        let network = TapNetwork::with_quarantine_dir(
+            "10.0.0.0/30",
+            "10.0.0.1",
+            vec![],
+            quarantine,
+            Datapath::default(),
+            Arc::new(IptablesLegacy::default()),
+        )
+        .expect("a marker this pool did not write is skipped, not fatal");
+        // Skipped means *not adopted*: the entry is neither trusted as a
+        // pending cleanup nor allowed to hold an address out of the pool.
+        // Failing the whole load instead would take the network subsystem
+        // down over one file, and with it every address it was protecting.
+        assert!(!network.quarantine_pending("box"));
     }
 }

--- a/virt/arcbox-vm-driver/src/net.rs
+++ b/virt/arcbox-vm-driver/src/net.rs
@@ -60,6 +60,29 @@ pub trait GuestNetwork: Send + Sync {
     /// Returns the address to the pool outright, skipping quarantine.
     async fn release(&self, lease: NetworkLease) -> Result<()>;
 
+    /// Withholds `address` from this process's pool without creating,
+    /// claiming or touching any host state.
+    ///
+    /// For durable state a restart could not read: nothing can name that
+    /// record's lease through this port, so nothing can adopt, quarantine
+    /// or release it — yet its guest may still be running on that address
+    /// with its interface up. Handing the address to the next VM would
+    /// take that interface out from under the guest, since
+    /// [`GuestNetwork::activate`] replaces a device of the same name, and
+    /// forwarding rules installed for the previous occupant outlive the
+    /// process that installed them. So the address is held for this
+    /// process's lifetime instead.
+    ///
+    /// Deliberately neither a lease nor a quarantine: it cannot be listed
+    /// by [`NetworkReconcile::pending_cleanups`], finalized, or released,
+    /// because nothing can prove whose it is. An adapter whose pool does
+    /// not contain `address` has nothing to withhold and does nothing.
+    ///
+    /// Infallible and idempotent, unlike everything above it: this is what
+    /// a caller reaches for once every richer answer has already failed,
+    /// and "could not hold it" would leave that caller nothing to do.
+    fn hold_address(&self, address: IpAddr);
+
     /// The network as the guest sees it under `mode`: what goes on the
     /// kernel command line or into a net-reconfigure command.
     ///

--- a/virt/arcbox-vm-driver/src/testkit/fake_network.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_network.rs
@@ -320,6 +320,17 @@ impl GuestNetwork for FakeNetwork {
         Ok(())
     }
 
+    /// Takes the host number out of the pool and records nothing else:
+    /// a held address is not a lease, so `stale` never reports it as
+    /// another VM's, and no protocol call can give it back.
+    fn hold_address(&self, address: IpAddr) {
+        // An address this fake could never have handed out is already
+        // unreachable through `reserve`; there is nothing to withhold.
+        if let Ok(host) = host_number(address) {
+            lock(&self.ledger).used.insert(host);
+        }
+    }
+
     async fn release(&self, lease: NetworkLease) -> Result<()> {
         let mut ledger = lock(&self.ledger);
         let host = host_number(lease.ip)?;


### PR DESCRIPTION
Raised from the review threads on #680.

Two startup reads propagated a per-record validation failure, so **one unparseable record took the whole host down** rather than costing itself:

- `sweep_orphans` propagated `validate_state_record`. The sweep gates every create, so a single bad journal left every *other* sandbox holding its orphaned VMM, TAP and dm device, and the manager never became usable.
- `load_quarantines` propagated every per-marker check, and it runs inside `TapNetwork`s constructor — so one bad marker meant no network subsystem at all, with no self-heal short of deleting the file by hand.

Both are one-way doors, and both are pointed the wrong way: the journal and the ledger exist precisely to name host resources that still need reaping, and a host that refuses to start reaps nothing.

## Why this is reachable, not theoretical

#680 is merged (`b5bac730`), and it narrowed `VmId` to `[A-Za-z0-9-]` because Firecracker validates its `--id` that way and **panics** on anything else. `_` is still legal to `validate_id`, which is what these two reads run: so every record a pre-#680 process wrote for an `inst_…` sandbox is now one this process cannot name. Both paths here are live, not hypothetical.

#680's review note argued no unparseable record can exist because firecracker rejects the id first — **that ordering runs the other way**, and pullfrog is right about it. `create` reserves the lease and journals inside its setup block, before any VMM exists (`sandbox/lifecycle.rs`); the boot task spawns later. So on exactly the hosts #680 describes — where every Computer create failed on `inst_…` — a lease was reserved and a journal persisted *before* firecracker ever saw the id, and the sweep that follows the crash writes that id into the quarantine ledger too.

I checked the boot task first and drew the opposite conclusion from `prepare` preceding `write_state_record` there. That is true of the boot path and irrelevant: the create path got there first.

The shape outlives this particular narrowing: `validate_id` and `VmId` are deliberately different vocabularies — the former also runs over persisted records and over snapshot and execution ids that never become a VM identity, and carries no length cap for that reason — so a record written under the wider one is exactly what the sweep and the ledger read back. `validate_id`'s own doc said an over-long id there "would abort a whole sweep"; that is corrected here, in the change that makes it false.

## What "skip" means here

**Skipping means acting on nothing the record names** — including not reaping the resources it names. That is more than dropping it from the sweep's `records`, and the first revision of this PR got exactly that wrong: `records` is what every downstream consumer iterates, so a skipped sandbox's VM was neither adopted nor killed *and* its resource owner was absent from `live_devices` / `keep_cow_files`, which sent the global CoW pass into a dm device the live VMM still pins — the abort this PR exists to remove, in the case it was written for. If the VMM was already dead, the overlay was deleted instead, so the surviving journal named a disk that no longer existed.

So the sweep now **holds**:

- **Every spelling the record offers goes into the keep sets** — the directory it sat in, the id it claims, the pool slot its dm/CoW resources may be keyed by (`resource_owner()`), and the owners its journaled `CowRecord` names outright. That last one is not derivable from the others: the check that `dm_name`/`cow_file` agree with `resource_owner()` is one of the checks a skipped record can have failed, so on exactly these records they can differ. Nothing in a record this process refused to read can be trusted to be the real one, so not-provably-dead is treated as alive: a held device at worst, a completed sweep at best.

  Reading an owner back out of a name is only sound if there is one convention, so `arcbox-snapshot` now exports the three pieces of it (`DM_NAME_PREFIX`, `COW_FILE_PREFIX`, `COW_FILE_SUFFIX`) and the sites that build or parse a name use them, replacing literals `reconcile.rs` and `persistence.rs` each carried separately.
- **The address it names goes out of the pool** (`GuestNetwork::hold_address`, new). A guest may still be on it with its TAP up, and the next create would hand `tap::create` a live device of the same name to destroy. Quarantining it instead is not available and would not be right: quarantine needs a `VmId` to name the lease — the thing that just failed — and it tears the TAP down.
- **Nothing else changes for it.** Its VM is left alone, its runtime dir and journal stay on disk, its lease is not released.

The trade, stated plainly and identically in the code: one sandbox leaks visibly — VM, TAP, device, overlay, address, all held for this process's lifetime — instead of every sandbox on the node leaking silently behind a manager that never starts.

**A skipped journal is `Unchecked` to recovery, not `Unjournaled`.** The sweep knows no more about those resources than if it had never run, which is what `Unchecked` means; `Unjournaled` refuses a live phase and aborts startup, undoing the skip.

**Only the directory name is authoritative.** The first revision inserted the id the journal *claims* as well, which let directory `foo`'s broken journal answer for a durable `bar` it has nothing to do with: a legitimate, genuinely unjournaled `bar` in a live phase read `Unchecked` instead of `Unjournaled`, so `plan` returned `Fail` rather than `RefuseUnjournaled` — declaring a sandbox failed while its VMM may still be running, which is the one thing that refusal exists to prevent. The directory is how the journal was found and the key its durable record shares; where the two agree there is one id anyway. The claimed id survives only as a *resource* name, where over-holding costs a leak and under-holding costs the abort.

**Duplicate-token and duplicate-id checks stay fatal.** Those are properties of the set, not of a marker; skipping half of a colliding pair would silently pick a winner and lose the other address.

## The ledger: held, not freed

The first revision's warning said a skipped marker's address "stays out of the pool". It did the opposite. `new_inner` builds the in-use set from nothing but the load's return value, so a skipped marker's IP was absent from `allocated` and `next_ip` handed it out again — and `finalize_startup_cleanup`, whose gate exists for exactly this, does not cover it either: it refuses only while `quarantined` is non-empty, and a skipped marker is not in that map, so if the skipped ones are the only entries the gate opens immediately.

Given the choice between holding the address and documenting that it is freed, this holds it. The whole argument for skipping is that it is safer than failing, and handing out an address a live guest may hold is not safer — the next occupant tears the NIC out from under that guest (`tap::create` destroys a same-named device) and inherits filter rules the previous occupant's activation appended, which `activate` (unlike `readopt_host_state`) does not remove first. On a multi-tenant host that is cross-tenant exposure, not one leaked address.

So the load now distinguishes a marker it can **decode** from one it can **act on**:

- decodes but fails a check → skipped, and its address is held out of the pool. Held, not quarantined: nothing lists it (`pending_cleanups`), nothing can finalize it, and no gate waits on a cleanup no caller could perform.
- does not decode → skipped, and it names no address, so nothing is held. The warning says that rather than implying a hold that did not happen.

`GuestNetwork::hold_address` is the same primitive on both paths, and it is infallible on purpose: it is what a caller reaches for once every richer answer has already failed, and "could not hold it" would leave that caller nothing to do.

## Text that contradicted behaviour

Three of the six review findings were exactly that, so every remaining claim was re-checked against the code. Also corrected: `quarantine::validate_id`'s "fails at load with its id in the message", `NetworkReconcile::pending_cleanups`' "a marker file carrying anything else fails construction outright", the `ids_the_port_cannot_name_are_refused_not_stranded` doc comment, and the tap-net README's ledger bullet — all written when the propagation they describe still existed.

## Tests

All mutation-checked in both directions.

- `an_unusable_journal_is_skipped_and_the_sweep_goes_on` — a journal whose id disagrees with its directory, alongside a live sandbox the sweep can read: the reconciliation completes, the readable one is still reclaimed, the unreadable one is `Failed` rather than fatal, and its journal is still on disk. Drop the `Unchecked` arm → `sandbox broken is ready but has no cleanup journal`; restore the propagation → fails.
- `a_skipped_journal_holds_its_disk_and_its_address` — plants an overlay under all three spellings (directory, claimed id, and a third owner named only by the journal's `CowRecord`) and a journaled lease on the pool's next free address. Drop the keep-set hold → the overlay is deleted (or, off Linux, the CoW pass errors out of the whole sweep). Drop the CoW-name arm → the third overlay is deleted. Drop the address hold → the next `reserve` hands out the address of the guest nobody could identify.
- `a_journal_the_port_cannot_name_is_skipped_at_the_boundary` — the motivating shape end to end: directory and id agree and are `inst_7f3a`, which `validate_state_record` accepts and `VmId` refuses. Drop the boundary parse → the record reaches `adopt_or_kill`, whose own `VmId::new` propagates and fails the whole sweep, which is what this PR removes.
- `a_skipped_journal_does_not_answer_for_the_id_it_claims` — directory `broken` claiming `ghost`, with a real durably-`Ready` `ghost` that has no journal: recovery still refuses. Restore the claimed-id insert → it silently fails `ghost` instead.
- `quarantine_loader_skips_foreign_or_inconsistent_allocations` — four ways a marker can be wrong over a /30 pool, and whether the pool's one address survives free: an address from another network is not held (there is nothing of this pool to withhold), an in-pool one is.
- `ids_the_port_cannot_name_are_refused_not_stranded` — opens the startup gate (which a skipped marker does not hold shut) and pins that `reserve` skips `10.0.0.3` while handing out `.2` and `.4`.

Rebased onto `b5bac730`. `cargo test -p arcbox-computer-runtime --all-features` (204 + 32 + 1), `-p arcbox-tap-net` (64 + 3), `-p arcbox-vm-driver` (43 + 34), `-p arcbox-snapshot` (76), clippy `-D warnings` on all four, `cargo fmt --all --check`, `cargo check --workspace --all-targets`, the musl cross-checks for `arcbox-tap-net` and `arcbox-agent`, `cargo xtask check-layers` — all green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes orphan sweep, CoW reconciliation, and IP pool behavior on agent restart—incorrect hold/skip logic could leak resources or tear down live guests, though the intent is to avoid bricking the node when one legacy record is unreadable.
> 
> **Overview**
> Startup reconciliation no longer **fails the whole manager** when one crash journal or quarantine marker cannot be validated or parsed as a `VmId` (e.g. legacy `inst_…` ids after #680). Those records are **skipped with a warning** instead of aborting the orphan sweep or `TapNetwork` construction.
> 
> For skipped journals, the sweep **does not adopt or kill** the VM, but **withholds every host resource the record might name** from global cleanup: CoW/dm owners (directory name, claimed id, `resource_owner()`, and owners parsed from journaled dm/cow filenames via newly exported `DM_NAME_PREFIX` / `COW_FILE_PREFIX` / `COW_FILE_SUFFIX`) stay in the reap keep-sets, and the journaled IP is **`hold_address`**’d on the guest network. Durable normalization treats skipped journals as **`JournalEvidence::Unchecked`** keyed by **directory name only**, so a broken journal cannot mis-classify another sandbox’s durable record.
> 
> The tap-net quarantine loader splits **actionable pending** quarantines from **held** addresses for markers that decode but fail checks; unnameable markers are skipped while still keeping their pool IP out of allocation. **`GuestNetwork::hold_address`** is added on the driver port (with a fake-network implementation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 145ed3abc1989ba65acfb388528d902363517e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->