### PR TITLE
refactor(computer): the sweep and pause reach a VM's area through the port

### DIFF
--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
@@ -251,7 +251,7 @@ pub async fn do_boot(
             };
             let staged = stage_rootfs_cow_or_copy(
                 cow_manager,
-                sandbox::staging_capability(&*prepared),
+                sandbox::staging_capability(prepared.staging()),
                 id,
                 &spec.rootfs,
                 &journal,

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
@@ -16,7 +16,7 @@
 //! killed.** In copy mode the staged rootfs *is* the paused computer's
 //! disk, and it lives wherever the driver put it — an area a kill is
 //! entitled to take with it, and one nothing here can name. So the disk is
-//! taken back out through the port first, while the grip that staged it is
+//! taken back out through the port first, while a grip on that area is
 //! still held; only then is the VMM discarded. The other order reports a
 //! successful pause and leaves the resume that follows with no disk, which
 //! is why it is stated here rather than left to the reader of two
@@ -57,43 +57,49 @@ pub async fn release_for_pause(
     network: &dyn GuestNetwork,
 ) -> Result<()> {
     // Copy mode: the staged rootfs IS this computer's disk. Take it out of
-    // the VM's area first — the guest is quiesced, the grip that staged it
-    // is still held, and after the kill neither is true.
-    let (prepared, in_copy_mode, vm_dir) = {
+    // the VM's area first — the guest is quiesced, a grip on the VM is
+    // still held, and after the kill neither is true.
+    let (prepared, handle, in_copy_mode, vm_dir) = {
         let computer = arc.lock().unwrap();
         (
             computer.prepared.clone(),
+            computer.handle.clone(),
             computer.cow_handle.is_none(),
             computer.vm_dir.clone(),
         )
     };
     if in_copy_mode {
-        let prepared = prepared.ok_or_else(|| {
-            // A computer this process adopted rather than booted (CORE-135)
-            // holds no prepared VM, so nothing here can reach into the area
-            // its disk sits in. Refusing before the checkpoint's guest is
-            // killed leaves the disk where it is and the pause retryable;
-            // the routes an adopted computer is missing arrive with R3
-            // PR-G3.
-            VmmError::Unavailable(format!(
-                "computer {id} runs on a copied rootfs and was adopted after an agent \
-                 restart, so its disk cannot be taken out of the vm it was staged into; \
-                 it can be stopped or removed, but not paused"
-            ))
-        })?;
+        // Either grip reaches the area, and both name the same one: a
+        // computer booted here holds the prepared VM, one this process
+        // adopted after an agent restart (CORE-135) holds only the handle.
+        let staging = prepared
+            .as_deref()
+            .map(|prepared| sandbox::staging_capability(prepared.staging()))
+            .or_else(|| {
+                handle
+                    .as_deref()
+                    .map(|handle| sandbox::staging_capability(handle.staging()))
+            });
         // Nothing taken out is a refusal, not a skip: in copy mode the
         // VM's area is where this computer's only writable disk lives, so
-        // `false` means there is no disk to pause. Discarding anyway would
-        // commit `Paused` with neither a preserved overlay nor a parked
-        // rootfs — the exact state resume refuses to start from, reached
-        // after the disk is already unrecoverable.
-        if !sandbox::staging_capability(&*prepared)
-            .unstage_disk(ROOTFS_DISK_ID, &vm_dir.join(PAUSED_ROOTFS_FILE))
-            .await?
-        {
+        // `false` means there is no disk to pause — as does holding no grip
+        // on the VM to ask through, which the checkpoint this follows would
+        // already have refused. Discarding anyway would commit `Paused`
+        // with neither a preserved overlay nor a parked rootfs — the exact
+        // state resume refuses to start from, reached after the disk is
+        // already unrecoverable.
+        let parked = match staging {
+            Some(staging) => {
+                staging
+                    .unstage_disk(ROOTFS_DISK_ID, &vm_dir.join(PAUSED_ROOTFS_FILE))
+                    .await?
+            }
+            None => false,
+        };
+        if !parked {
             return Err(VmmError::Snapshot(format!(
-                "computer {id} runs on a copied rootfs but its vm has no disk staged to take \
-                 out; pausing it would leave nothing to resume from"
+                "computer {id} runs on a copied rootfs but nothing could be taken out of its \
+                 vm's area; pausing it would leave nothing to resume from"
             )));
         }
     }
@@ -141,27 +147,46 @@ mod tests {
     use std::path::PathBuf;
 
     use arcbox_vm_driver::testkit::{FakeDriver, FakeNetwork};
-    use arcbox_vm_driver::{DiskSource, IsolationSpec, PreparedVm, VmDriver as _, VmId};
+    use arcbox_vm_driver::{
+        BootSpec, ConsoleSpec, DiskSource, IsolationSpec, PreparedVm, ShutdownMode, VmDriver as _,
+        VmId, VmSpec,
+    };
 
     use super::*;
     use crate::sandbox::SandboxSpec;
     use crate::snapshot_cow::CowOptions;
 
+    /// Which grip on its VM a computer holds.
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Grip {
+        /// Booted by this process, so the prepared VM is still around.
+        Prepared,
+        /// Adopted after an agent restart (CORE-135): the prepared VM died
+        /// with the process that made it, and only the handle is left.
+        AdoptedHandle,
+    }
+
     /// A copy-mode computer — no overlay, its disk staged into its VM's
     /// area — with `staged` written there under the root disk's id when
     /// asked for.
+    ///
+    /// Answers with the prepared VM whichever grip the computer ends up
+    /// holding, because the staging area is the same one either way and the
+    /// caller needs a way to look into it.
     async fn copy_mode_computer(
         data_dir: &std::path::Path,
         driver: &FakeDriver,
         staged: Option<&[u8]>,
+        grip: Grip,
     ) -> (Arc<Mutex<ComputerRuntime>>, Arc<dyn PreparedVm>, PathBuf) {
         let vm_dir = data_dir.join("sandboxes/job");
         std::fs::create_dir_all(&vm_dir).unwrap();
+        let id = VmId::new("job").unwrap();
         let prepared: Arc<dyn PreparedVm> = Arc::from(
             driver
                 .prepare()
                 .unwrap()
-                .prepare(&VmId::new("job").unwrap(), &IsolationSpec::None, &vm_dir)
+                .prepare(&id, &IsolationSpec::None, &vm_dir)
                 .await
                 .unwrap(),
         );
@@ -181,8 +206,38 @@ mod tests {
             None,
             vm_dir.clone(),
         );
-        computer.prepared = Some(Arc::clone(&prepared));
+        match grip {
+            Grip::Prepared => computer.prepared = Some(Arc::clone(&prepared)),
+            // The guest is running and nothing holds the process that
+            // spawned it, exactly as a sweep hands a computer back.
+            Grip::AdoptedHandle => {
+                computer.handle = Some(Arc::from(prepared.boot(vm_spec(&id)).await.unwrap()));
+            }
+        }
         (Arc::new(Mutex::new(computer)), prepared, vm_dir)
+    }
+
+    /// The least a fake VM needs to boot.
+    fn vm_spec(id: &VmId) -> VmSpec {
+        VmSpec {
+            id: id.clone(),
+            cpus: 1,
+            memory_mib: 128,
+            boot: BootSpec::Kernel {
+                image: "/vmlinux".into(),
+                cmdline: String::new(),
+                initrd: None,
+            },
+            disks: vec![],
+            nics: vec![],
+            vsock: None,
+            shares: vec![],
+            console: ConsoleSpec::Off,
+            balloon: false,
+            entropy: false,
+            dirty_tracking: false,
+            isolation: IsolationSpec::None,
+        }
     }
 
     fn config(data_dir: &std::path::Path) -> VmmConfig {
@@ -202,8 +257,13 @@ mod tests {
     async fn the_copy_mode_disk_is_parked_before_the_vm_is_discarded() {
         let data_dir = tempfile::tempdir().unwrap();
         let driver = FakeDriver::new();
-        let (computer, prepared, vm_dir) =
-            copy_mode_computer(data_dir.path(), &driver, Some(b"the guest's disk")).await;
+        let (computer, prepared, vm_dir) = copy_mode_computer(
+            data_dir.path(),
+            &driver,
+            Some(b"the guest's disk"),
+            Grip::Prepared,
+        )
+        .await;
         let config = config(data_dir.path());
         let cow = CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap();
 
@@ -234,7 +294,8 @@ mod tests {
     async fn a_copy_mode_pause_with_no_staged_disk_is_refused_before_the_kill() {
         let data_dir = tempfile::tempdir().unwrap();
         let driver = FakeDriver::new();
-        let (computer, prepared, vm_dir) = copy_mode_computer(data_dir.path(), &driver, None).await;
+        let (computer, prepared, vm_dir) =
+            copy_mode_computer(data_dir.path(), &driver, None, Grip::Prepared).await;
         let config = config(data_dir.path());
         let cow = CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap();
 
@@ -255,5 +316,50 @@ mod tests {
         }
         assert!(prepared.alive(), "the vm is left running for a retry");
         assert!(!vm_dir.join(PAUSED_ROOTFS_FILE).exists());
+    }
+
+    /// The regression CORE-135 left open: a copy-mode computer this process
+    /// adopted rather than booted holds no prepared VM, and pausing it used
+    /// to be refused outright — it could be stopped or removed, never
+    /// paused. Its disk is reachable through the handle, so it pauses like
+    /// any other, landing where resume looks for it.
+    #[tokio::test]
+    async fn an_adopted_copy_mode_computer_pauses_through_its_handle() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let driver = FakeDriver::new();
+        let (computer, _prepared, vm_dir) = copy_mode_computer(
+            data_dir.path(),
+            &driver,
+            Some(b"the guest's disk"),
+            Grip::AdoptedHandle,
+        )
+        .await;
+        assert!(
+            computer.lock().unwrap().prepared.is_none(),
+            "an adopted computer has only its handle"
+        );
+        let config = config(data_dir.path());
+        let cow = CowManager::new(CowOptions::new(&config.firecracker.data_dir)).unwrap();
+
+        release_for_pause(
+            &"job".to_owned(),
+            &computer,
+            &config,
+            &cow,
+            &FakeNetwork::new(),
+        )
+        .await
+        .expect("an adopted copy-mode computer pauses");
+
+        assert_eq!(
+            std::fs::read(vm_dir.join(PAUSED_ROOTFS_FILE)).unwrap(),
+            b"the guest's disk"
+        );
+        // Through the handle, since there is no prepared VM to discard —
+        // and asked to die rather than merely dropped.
+        assert_eq!(
+            driver.shutdowns(&VmId::new("job").unwrap()),
+            [ShutdownMode::Kill]
+        );
     }
 }

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
@@ -262,7 +262,7 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
             // paths: everything it loads is brought into the area it can
             // reach first, and named by where staging put it.
             let setup_result: Result<(PathBuf, CheckpointImage)> = async {
-                let staging = sandbox::staging_capability(&*spawned_prepared);
+                let staging = sandbox::staging_capability(spawned_prepared.staging());
 
                 // The kernel. A snapshot load names only the vmstate and
                 // the mem file, so this stage may well be vestigial — but

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
@@ -100,7 +100,7 @@ pub async fn restore_paused(
                 .await?,
         );
         let pid = sandbox::journaled_pid(&*spawned);
-        let staging = sandbox::staging_capability(&*spawned);
+        let staging = sandbox::staging_capability(spawned.staging());
         prepared = Some(Arc::clone(&spawned));
         journal(pid, None, lease.as_ref())?;
 
@@ -269,7 +269,7 @@ async fn park_copy_mode_rootfs(
     if sandbox::preserved_cow_file(config, id).exists() {
         return true;
     }
-    match sandbox::staging_capability(&**prepared)
+    match sandbox::staging_capability(prepared.staging())
         .unstage_disk(ROOTFS_DISK_ID, &vm_dir.join(PAUSED_ROOTFS_FILE))
         .await
     {

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -589,14 +589,17 @@ pub(crate) fn prepare_capability(driver: &dyn VmDriver) -> &dyn Prepare {
         .expect("SandboxManager::new requires the driver's Prepare capability")
 }
 
-/// The prepared VM's `Staging` capability, which [`SandboxManager::new`]
-/// requires — every flow that puts a guest on a VMM first brings that
-/// guest's files into the area the VMM can reach, and pause takes its disk
-/// back out of it.
-pub(crate) fn staging_capability(prepared: &dyn PreparedVm) -> &dyn Staging {
-    prepared
-        .staging()
-        .expect("SandboxManager::new requires the driver's Staging capability")
+/// A grip's `Staging` capability, which [`SandboxManager::new`] requires —
+/// every flow that puts a guest on a VMM first brings that guest's files
+/// into the area the VMM can reach, and pause takes its disk back out of
+/// it.
+///
+/// Takes the accessor's answer rather than the grip it came from: both
+/// grips on a VM have one and they name the same area, so a computer
+/// booted here asks its [`PreparedVm`] and one this process adopted asks
+/// its [`VmHandle`](arcbox_vm_driver::VmHandle).
+pub(crate) fn staging_capability(staging: Option<&dyn Staging>) -> &dyn Staging {
+    staging.expect("SandboxManager::new requires the driver's Staging capability")
 }
 
 /// The VMM's pid as the crash journal records it: what a restart sweep

--- a/computer/arcbox-computer-runtime/src/sandbox/pool.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/pool.rs
@@ -190,7 +190,7 @@ async fn stage_slot(
     // Everything the restore would otherwise pay for on its critical path,
     // brought into the area this slot's VMM reads from — under the same
     // names a restore renders, so claiming the slot stages nothing twice.
-    let staging = super::staging_capability(&*prepared);
+    let staging = super::staging_capability(prepared.staging());
     if let Some(kernel) = snapshot.kernel_path.as_deref() {
         if let Err(error) = staging.stage_kernel(Path::new(kernel)).await {
             return Err(carry(error.into(), Some(prepared), None));

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -160,6 +160,15 @@ pub struct SandboxStateRecord {
     #[serde(default)]
     cow: Option<CowRecord>,
     /// Whether a jailer chroot was created for this sandbox.
+    ///
+    /// Written, never read. This sweep asks the driver to discard a dead
+    /// VM's area instead ([`arcbox_vm_driver::Adopt::discard_area`]): the
+    /// flag records what the *writing* process's config said, while the
+    /// only area this process can name is the one its own config
+    /// describes. It stays in the record because an agent that predates
+    /// that route still gates its chroot removal on it, and the field
+    /// defaults to `false` — so dropping it would make a downgrade skip
+    /// every removal.
     #[serde(default)]
     pub jailer: bool,
     /// For restored sandboxes: the recreated origin directory to remove.
@@ -524,7 +533,8 @@ impl OrphanSweep {
 ///
 /// Runs once per manager construction, in the background. Ordering per
 /// killed sandbox mirrors live teardown: kill the VMM → wait for exit → dm
-/// teardown → TAP release → chroot + directory removal.
+/// teardown → TAP release → the VM's own area, discarded through the
+/// driver → directory removal.
 pub(super) async fn sweep_orphans(
     config: &VmmConfig,
     driver: &dyn VmDriver,
@@ -684,6 +694,10 @@ async fn reap_orphans(
     network: &dyn GuestNetwork,
     cow_manager: &CowManager,
 ) -> Result<(HashSet<String>, Vec<PathBuf>)> {
+    // What every VMM on this node runs under, and so where the driver will
+    // look for the area of one that is gone: read from this process's own
+    // config, because nothing can be read back off a dead process.
+    let isolation = super::isolation_spec(config)?;
     // Every VM this sweep does not keep must be dead before the global CoW
     // sweep runs: a live VMM pins its dm device, and a pinned device turns
     // a reap into an error that fails the whole reconciliation.
@@ -748,18 +762,23 @@ async fn reap_orphans(
             network.quarantine(lease).await.map_err(VmmError::from)?;
         }
 
-        if record.jailer
-            && let Some(ref jc) = config.firecracker.jailer
-        {
-            let base = jc.chroot_base_dir.as_deref().unwrap_or("/srv/jailer");
-            let chroot = arcbox_fc_driver::jail::chroot_root(
-                &config.firecracker.binary,
-                base,
-                record.resource_owner(),
-            );
-            if let Some(parent) = chroot.parent() {
-                remove_dir_if_present(parent).await?;
-            }
+        // The VM's own area — under the jailer, a whole chroot holding the
+        // guest's rootfs. Only the driver knows where that is, and the VM
+        // is already dead: the loop above either adopted it (and `continue`d
+        // past here) or killed it.
+        //
+        // The journal's `jailer` flag is deliberately not consulted. It
+        // says what the config of the process that *wrote* it had, while
+        // the only area this process can name is the one described by
+        // `isolation` — its own config — and a driver that confines nothing
+        // answers that there is no area rather than failing. Gating on the
+        // flag would skip the removal for a record written by a
+        // differently-configured process, leaving an area nothing else will
+        // ever collect.
+        if let Some(adopt) = driver.adopt() {
+            adopt
+                .discard_area(&vm_record(driver, dir, record)?, &isolation)
+                .await?;
         }
 
         runtime_dirs.push(dir.clone());
@@ -1182,18 +1201,7 @@ async fn adopt_or_kill(
     let Some(adopt) = driver.adopt() else {
         return Ok(None);
     };
-    let vm_record = VmRecord {
-        id: VmId::new(record.resource_owner())?,
-        driver: driver.name().to_owned(),
-        runtime_dir: runtime_dir.to_path_buf(),
-        process: record
-            .pid
-            .and_then(|pid| u32::try_from(pid).ok())
-            .map(|pid| ProcessRecord {
-                pid,
-                api_socket: None,
-            }),
-    };
+    let vm_record = vm_record(driver, runtime_dir, record)?;
     let adopted = tokio::time::timeout(ADOPT_TIMEOUT, adopt.adopt(&vm_record))
         .await
         .map_err(|_| {
@@ -1229,6 +1237,33 @@ async fn adopt_or_kill(
             Ok(None)
         }
     }
+}
+
+/// The VM a crash journal names, in the port's own vocabulary — what
+/// [`arcbox_vm_driver::Adopt`] takes both to find that VM and to discard
+/// what it left.
+///
+/// Keyed by the id its resources are named after, which for a sandbox that
+/// claimed a pre-warmed slot is the slot's, not its own. The id is already
+/// known to parse: [`sweep_orphans`] refuses a journal whose ids do not,
+/// before any of them reaches this far.
+fn vm_record(
+    driver: &dyn VmDriver,
+    runtime_dir: &Path,
+    record: &SandboxStateRecord,
+) -> Result<VmRecord> {
+    Ok(VmRecord {
+        id: VmId::new(record.resource_owner())?,
+        driver: driver.name().to_owned(),
+        runtime_dir: runtime_dir.to_path_buf(),
+        process: record
+            .pid
+            .and_then(|pid| u32::try_from(pid).ok())
+            .map(|pid| ProcessRecord {
+                pid,
+                api_socket: None,
+            }),
+    })
 }
 
 /// Take this live VM and the host state it was running on back, or say why
@@ -2663,6 +2698,95 @@ mod tests {
             let keeper = manager.snapshot(&"keeper".to_owned()).unwrap();
             assert_eq!(keeper.state, SandboxState::Failed, "{what}");
             assert!(keeper.handle.is_none(), "{what}");
+        }
+    }
+
+    /// Every VM the sweep does not keep loses its host area through the
+    /// driver — once, and under this process's own isolation. The journal's
+    /// `jailer` flag decides nothing, which is the point: it records what
+    /// the config of the process that *wrote* it had, and a record written
+    /// by a differently-configured process would otherwise keep an area
+    /// nothing else will ever collect.
+    ///
+    /// What the sweep keeps, it does not touch: a reclaimed VM is still
+    /// running on its area (the fake refuses the call outright), and a
+    /// journal this process could not read names resources it must leave
+    /// entirely alone.
+    #[tokio::test]
+    async fn a_dead_vms_area_goes_whatever_its_journal_says_about_the_jailer() {
+        use arcbox_vm_driver::testkit::{FakeDriver, FakeNetwork};
+
+        for journaled_jailer in [false, true] {
+            let data_dir = tempfile::tempdir().unwrap();
+            let driver = FakeDriver::new();
+            let probe = driver.clone();
+            let network = FakeNetwork::new();
+
+            let mut config = VmmConfig::default();
+            config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
+            config.firecracker.jailer = Some(crate::config::JailerConfig {
+                binary: "/usr/bin/jailer".into(),
+                uid: 0,
+                gid: 0,
+                chroot_base_dir: Some(data_dir.path().join("jail").to_string_lossy().into_owned()),
+                netns: None,
+                new_pid_ns: false,
+                cgroup_version: None,
+                parent_cgroup: None,
+                resource_limits: vec![],
+            });
+            let isolation = super::super::isolation_spec(&config).unwrap();
+
+            // Unadoptable: no vsock means the driver could only ever kill
+            // it, which is every refusal's fallback.
+            let goner_dir = data_dir.path().join("sandboxes").join("goner");
+            let goner = boot_previous_vm(&driver, &goner_dir, "goner", false, true).await;
+            let mut journal =
+                SandboxStateRecord::new("goner", None, None, None, &config, None).unwrap();
+            journal.jailer = journaled_jailer;
+            write_state_record(&goner_dir, &journal).unwrap();
+
+            // Reclaimed, so its area is still in use.
+            let keeper_dir = data_dir.path().join("sandboxes").join("keeper");
+            let keeper = boot_previous_vm(&driver, &keeper_dir, "keeper", true, true).await;
+            write_state_record(
+                &keeper_dir,
+                &SandboxStateRecord::new("keeper", None, None, None, &config, None).unwrap(),
+            )
+            .unwrap();
+
+            // Unreadable — the id does not match the directory holding it —
+            // so nothing it names may be acted on, its area included.
+            let odd_dir = data_dir.path().join("sandboxes").join("zzz-odd");
+            let _odd = boot_previous_vm(&driver, &odd_dir, "zzz-odd", true, true).await;
+            write_state_record(
+                &odd_dir,
+                &SandboxStateRecord::new("someone-else", None, None, None, &config, None).unwrap(),
+            )
+            .unwrap();
+
+            let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+            record_in_phase(&store, "goner", PersistPhase::Ready);
+            record_in_phase(&store, "keeper", PersistPhase::Ready);
+            let cow_manager =
+                CowManager::new(crate::snapshot_cow::CowOptions::new(data_dir.path())).unwrap();
+            let snapshots = crate::snapshot::SnapshotCatalog::new(&config.firecracker.data_dir);
+
+            let sweep = sweep_orphans(&config, &driver, &network, &cow_manager, &snapshots, &store)
+                .await
+                .expect("the sweep");
+
+            assert_eq!(
+                probe.discarded_areas(),
+                [(VmId::new("goner").unwrap(), isolation)],
+                "journaled jailer flag {journaled_jailer}"
+            );
+            assert_eq!(
+                goner.state(),
+                VmState::Exited(arcbox_vm_driver::ExitStatus::signaled(9))
+            );
+            assert!(sweep.adopted.contains_key("keeper"));
+            assert_eq!(keeper.state(), VmState::Running);
         }
     }
 

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -161,7 +161,7 @@ pub struct SandboxStateRecord {
     cow: Option<CowRecord>,
     /// Whether a jailer chroot was created for this sandbox.
     ///
-    /// Written, never read. This sweep asks the driver to discard a dead
+    /// Nothing in this agent acts on it. The sweep asks the driver to discard a dead
     /// VM's area instead ([`arcbox_vm_driver::Adopt::discard_area`]): the
     /// flag records what the *writing* process's config said, while the
     /// only area this process can name is the one its own config
@@ -764,8 +764,9 @@ async fn reap_orphans(
 
         // The VM's own area — under the jailer, a whole chroot holding the
         // guest's rootfs. Only the driver knows where that is, and the VM
-        // is already dead: the loop above either adopted it (and `continue`d
-        // past here) or killed it.
+        // is gone: the loop above either adopted it, in which case this one
+        // has already `continue`d past here, or killed it, or never found
+        // it at all.
         //
         // The journal's `jailer` flag is deliberately not consulted. It
         // says what the config of the process that *wrote* it had, while
@@ -1245,7 +1246,7 @@ async fn adopt_or_kill(
 ///
 /// Keyed by the id its resources are named after, which for a sandbox that
 /// claimed a pre-warmed slot is the slot's, not its own. The id is already
-/// known to parse: [`sweep_orphans`] refuses a journal whose ids do not,
+/// known to parse: [`sweep_orphans`] skips a journal whose ids do not,
 /// before any of them reaches this far.
 fn vm_record(
     driver: &dyn VmDriver,

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -697,6 +697,12 @@ async fn reap_orphans(
     // What every VMM on this node runs under, and so where the driver will
     // look for the area of one that is gone: read from this process's own
     // config, because nothing can be read back off a dead process.
+    //
+    // Read once, up front, so it is read even when there is nothing to
+    // reap. That moves the one way it can fail — a `cgroup_version` that is
+    // neither "1" nor "2" — from the first create to startup, which is
+    // where a node that could not have booted a VMM anyway should hear
+    // about it.
     let isolation = super::isolation_spec(config)?;
     // Every VM this sweep does not keep must be dead before the global CoW
     // sweep runs: a live VMM pins its dm device, and a pinned device turns

--- a/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
+++ b/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
@@ -1150,7 +1150,10 @@ async fn an_adopted_computer_on_a_copied_rootfs_pauses_and_keeps_its_disk() {
         .resume_sandbox(&id, pause_reason::RESUME)
         .await
         .expect_err("an adopted computer's checkpoint records no kernel to stage");
-    assert!(matches!(error, VmmError::Io(_)), "{error}");
+    assert!(
+        matches!(&error, VmmError::Io(io) if io.kind() == std::io::ErrorKind::NotFound),
+        "the kernel path the checkpoint recorded is empty, so staging it is ENOENT: {error}"
+    );
     fixture.await_state(&id, SandboxState::Paused).await;
     assert!(parked.exists(), "a failed resume leaves the disk parked");
 }

--- a/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
+++ b/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
@@ -1103,23 +1103,31 @@ async fn a_detached_computer_is_adopted_by_the_next_process_and_serves_an_exec()
     );
 }
 
-/// An adopted computer running on a copied rootfs cannot be paused: its
-/// disk lives in the VM's area, and this process holds no grip on that VM
-/// to reach in with. The refusal is raised before the pause takes anything
-/// out — the boundary R3 PR-G3 moves.
+/// An adopted computer running on a copied rootfs pauses like any other.
 ///
-/// What the refusal costs is the part worth pinning. `release_for_pause`
-/// declines before its own kill, but a release that fails has no
-/// recoverable arm in `releasing` the way a failed *capture* does in
-/// `capturing`, so the computer takes the shared failure path: killed
-/// through its handle, released, durably `Failed`. A caller therefore
-/// loses the computer to a pause that was refused for its safety — and
-/// the kill it loses it to is the grip's completed kill, which on a real
-/// adapter takes the jail, and in copy mode the rootfs inside it. Asserted
-/// as it behaves, not as it should: the fix belongs with the routes G3
-/// adds, and this is the test that will say when they arrive.
+/// Its disk lives in the VM's area and this process holds no prepared VM to
+/// reach in with, so until the handle grew a staging accessor the pause was
+/// refused — and the refusal cost the computer. `release_for_pause`
+/// declines before its own kill, but a failed *release* has no recoverable
+/// arm in `releasing` the way a failed *capture* has in `capturing`, so a
+/// pause refused for a computer's safety killed it through its handle and
+/// left it durably `Failed`.
+///
+/// The area is reachable from the handle now: the disk comes out ahead of
+/// the kill and lands where a resume looks for it.
+///
+/// The resume itself does not yet complete, for a reason of its own that
+/// this pause used to hide: the durable record redacts a computer's boot
+/// inputs when it reaches `Ready` (`redact_runtime_inputs`), so an adopted
+/// computer's `spec.kernel` is empty, and every checkpoint it takes records
+/// no kernel path for the staging that follows to bring in. That is a gap
+/// in adoption, not in pause — a *Checkpoint* of an adopted computer is
+/// unrestorable for the same reason, with no pause involved — and it is
+/// asserted here as it behaves: the resume fails, the computer is left back
+/// at `Paused`, and its retained disk is where the pause put it, so nothing
+/// is lost and a retry has something to succeed with.
 #[tokio::test]
-async fn an_adopted_computer_on_a_copied_rootfs_refuses_to_pause() {
+async fn an_adopted_computer_on_a_copied_rootfs_pauses_and_keeps_its_disk() {
     let mut fixture = Fixture::jailed().await;
     let id = fixture.ready("handed-over").await;
 
@@ -1127,23 +1135,24 @@ async fn an_adopted_computer_on_a_copied_rootfs_refuses_to_pause() {
     fixture = fixture.restart().await;
     fixture.await_state(&id, SandboxState::Ready).await;
 
-    let error = fixture.manager.pause_sandbox(&id).await.unwrap_err();
-    assert!(matches!(error, VmmError::Unavailable(_)), "{error}");
+    fixture.manager.pause_sandbox(&id).await.unwrap();
+    fixture.await_state(&id, SandboxState::Paused).await;
+    // The frozen on-disk name a resume reattaches from.
+    let parked = fixture.vm_dir(&id).join("paused-rootfs.ext4");
     assert!(
-        error.to_string().contains("cannot be taken out"),
-        "the refusal names the route it does not have: {error}"
+        parked.exists(),
+        "the copy-mode disk came out of the adopted vm's area"
     );
 
-    // Refused, and then torn down anyway.
-    fixture.await_released(&id).await;
-    assert_eq!(
-        fixture
-            .driver()
-            .shutdowns(&arcbox_vm_driver::VmId::new(&id).unwrap()),
-        vec![arcbox_vm_driver::ShutdownMode::Kill],
-        "the guest the refusal was protecting is killed by the failure path"
-    );
-    assert_eq!(fixture.settle_network_cleanups().await, vec![id]);
+    fixture.settle_network_cleanups().await;
+    let error = fixture
+        .manager
+        .resume_sandbox(&id, pause_reason::RESUME)
+        .await
+        .expect_err("an adopted computer's checkpoint records no kernel to stage");
+    assert!(matches!(error, VmmError::Io(_)), "{error}");
+    fixture.await_state(&id, SandboxState::Paused).await;
+    assert!(parked.exists(), "a failed resume leaves the disk parked");
 }
 
 /// A computer whose VMM did not survive the gap comes back `Failed`, not

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -11,11 +11,11 @@ taking one back out afterwards, from the prepared VM or from a handle —
 `Adopt`/`Detach` for VMs that outlive the process that booted them, and
 `Adopt::discard_area` for the jail of one that did not.
 
-Nothing above this crate names Firecracker. The sandbox manager
-(`arcbox-computer-runtime`) reaches it through `dyn VmDriver` — during the
-R1 migration it also calls the moved staging helpers directly, an edge R3
-removes — and the only other things it depends on are the port and
-`fc-sdk`: no snapshot catalog, no engine, no orchestrator.
+Nothing above this crate names Firecracker except the composition root
+that picks it. The sandbox manager (`arcbox-computer-runtime`) reaches
+every VM through `dyn VmDriver`, jail layout included; the only other
+things this crate depends on are the port and `fc-sdk`: no snapshot
+catalog, no engine, no orchestrator.
 
 ## Layout
 

--- a/virt/arcbox-fc-driver/README.md
+++ b/virt/arcbox-fc-driver/README.md
@@ -6,8 +6,10 @@ jailer) chroot-relative paths, owns the `firecracker`/`jailer` process,
 and serves the port's capabilities over it: `Vsock` and `VsockListen`
 through the hybrid-vsock Unix socket, `Checkpoint` through
 pause → snapshot → resume, `Prepare` for warm pools that spawn ahead of a
-boot, `Staging` for bringing that boot's files into the jail before it,
-`Adopt`/`Detach` for VMs that outlive the process that booted them.
+boot, `Staging` for bringing that boot's files into the jail before it — and for
+taking one back out afterwards, from the prepared VM or from a handle —
+`Adopt`/`Detach` for VMs that outlive the process that booted them, and
+`Adopt::discard_area` for the jail of one that did not.
 
 Nothing above this crate names Firecracker. The sandbox manager
 (`arcbox-computer-runtime`) reaches it through `dyn VmDriver` — during the
@@ -30,8 +32,9 @@ removes — and the only other things it depends on are the port and
 | `listener` | the port's `VsockListener` over a `{uds}_{port}` socket |
 | `discover` | finding a Firecracker that outlived its booter: the recorded pid and any `/proc` candidate, held to the same `--id` / `--api-sock` / jail-root test |
 | `adopt` | rebuilding a handle over what `discover` found: a bounded API reconnect for the full `FcHandle`, else `FcProcessHandle` over the process alone |
-| `prepared` | `FcPrepared: PreparedVm + VsockListen + Staging` — a spawned VMM waiting for a spec, and the jail its files are staged into |
-| `handle` | `FcHandle: VmHandle + Vsock + VsockListen + Checkpoint + Detach`; `FcProcessHandle: VmHandle + Detach`, over a VMM whose API is unreachable |
+| `staging` | `JailStaging: Staging` — one VM's jail as its staging area, built from a `VmLayout` so both grips on the VM reach the same one |
+| `prepared` | `FcPrepared: PreparedVm + VsockListen` — a spawned VMM waiting for a spec, and the jail its files are staged into |
+| `handle` | `FcHandle: VmHandle + Vsock + VsockListen + Checkpoint + Detach`; `FcProcessHandle: VmHandle + Detach`, over a VMM whose API is unreachable. Both offer `Staging`: the area is named by the layout, and asks the VMM nothing |
 | `driver` | `FcDriver: VmDriver + Prepare + Adopt` |
 
 ## Usage
@@ -106,12 +109,16 @@ this.
   is `{jail}/run/firecracker.socket`, the vsock socket
   `/run/firecracker.vsock` inside and `{jail}/run/firecracker.vsock` outside.
 
-  `Staging` on a prepared VM stages the same files under the same names
-  ahead of the boot that renders them, which is how a warm pool pays for a
-  checkpoint's memory file before a restore asks for it; `unstage_disk`
-  takes a disk back out of the jail, so it survives the VM. Without a jail
-  every staging verb is the identity. Removing the jail itself is still
-  the caller's, not `discard`'s — see the note on `FcPrepared::discard`.
+  `Staging` stages the same files under the same names ahead of the boot
+  that renders them, which is how a warm pool pays for a checkpoint's
+  memory file before a restore asks for it; `unstage_disk` takes a disk
+  back out of the jail, so it survives the VM. It is reached from either
+  grip on a VM — the prepared VM, and the handle, which is all a VM this
+  driver adopted has. Without a jail every staging verb is the identity.
+
+  The jail itself goes with whichever grip owns the VMM: `FcPrepared::discard`
+  for a VM this process spawned, `shutdown` for one it adopted, and
+  `Adopt::discard_area` for one that is gone and left neither.
 
   Those sockets are also what bounds a VM id: each must fit AF_UNIX's 107
   bytes, so `id_budget` answers with what the chroot base and binary name

--- a/virt/arcbox-fc-driver/src/adopt.rs
+++ b/virt/arcbox-fc-driver/src/adopt.rs
@@ -61,18 +61,13 @@ pub(crate) async fn rebuild(
     let (info, devices) = match tokio::time::timeout(api_timeout, describe(&client)).await {
         Ok(Ok(answered)) => answered,
         Ok(Err(error)) => {
-            return Ok(process_only(
-                process,
-                record,
-                layout.jail().cloned(),
-                &error.to_string(),
-            ));
+            return Ok(process_only(process, record, layout, &error.to_string()));
         }
         Err(_) => {
             return Ok(process_only(
                 process,
                 record,
-                layout.jail().cloned(),
+                layout,
                 &format!("no answer within {api_timeout:?}"),
             ));
         }
@@ -96,18 +91,19 @@ async fn describe(client: &Client) -> crate::error::Result<(InstanceInfo, FullVm
 /// The fallback, and the warning that says why: the VM stays a process
 /// this driver can kill, and nothing more.
 ///
-/// The jail still comes along. Where the VM runs is read off the process,
-/// not asked of the API, so an unreachable API costs the handle its
-/// devices — never its ability to take the area down with the VM.
+/// The layout still comes along. Where the VM runs is read off the process,
+/// not asked of the API, so an unreachable API costs the handle its devices
+/// — never the disks staged into its area, nor its ability to take that
+/// area down with the VM.
 fn process_only(
     process: Arc<FcProcess>,
     record: VmRecord,
-    jail: Option<crate::jail::Jail>,
+    layout: VmLayout,
     why: &str,
 ) -> Box<dyn VmHandle> {
     tracing::warn!(vm = %record.id, pid = process.pid(), socket = %process.api_socket().display(),
         "the adopted vmm's api did not answer ({why}); adopting the process alone: kill-able, nothing else");
-    Box::new(FcProcessHandle::new(process, record, jail))
+    Box::new(FcProcessHandle::new(process, record, layout))
 }
 
 #[cfg(test)]

--- a/virt/arcbox-fc-driver/src/driver.rs
+++ b/virt/arcbox-fc-driver/src/driver.rs
@@ -165,6 +165,25 @@ impl Adopt for FcDriver {
             None => Ok(None),
         }
     }
+
+    /// Removes the jail the VM ran in, and with it everything staged into
+    /// it — the jailer's whole per-VM directory,
+    /// `{chroot base}/{firecracker binary name}/{id}`, exactly as
+    /// [`PreparedVm::discard`] and an adopted handle's `shutdown` remove
+    /// it. Where the jail is comes from `isolation` and this driver's own
+    /// binary path, the same two things a boot builds it from; nothing is
+    /// asked of the VMM, which is gone.
+    ///
+    /// Firecracker run without the jailer reads host paths as they are, has
+    /// no area of its own, and leaves nothing to remove.
+    async fn discard_area(&self, record: &VmRecord, isolation: &IsolationSpec) -> Result<()> {
+        let layout =
+            render::VmLayout::new(&record.id, isolation, &self.config, &record.runtime_dir)?;
+        match layout.jail() {
+            Some(jail) => jail.remove().await,
+            None => Ok(()),
+        }
+    }
 }
 
 /// Whether guests may run their own hypervisor: KVM's `nested` module
@@ -257,6 +276,54 @@ mod tests {
             driver.id_budget(&jailed(&format!("/{}", "d".repeat(200)))),
             Some(0)
         );
+    }
+
+    /// The startup-sweep route: a VM whose process died with the agent
+    /// leaves its jail, and the driver is the only thing that knows where
+    /// that is. A second sweep finding it already cleared is not an error,
+    /// and a driver in direct mode has no area at all.
+    #[tokio::test]
+    async fn a_gone_vms_jail_is_removed_and_direct_mode_has_no_area() {
+        let base = tempfile::tempdir().unwrap();
+        let driver = driver();
+        let per_vm = base.path().join("firecracker/box");
+        std::fs::create_dir_all(per_vm.join("root/run")).unwrap();
+        std::fs::write(per_vm.join("root/rootfs.ext4"), b"the guest's disk").unwrap();
+        let record = VmRecord {
+            id: VmId::new("box").unwrap(),
+            driver: NAME.to_owned(),
+            runtime_dir: base.path().join("run/box"),
+            process: None,
+        };
+        let jailed = IsolationSpec::Jailer {
+            uid: 0,
+            gid: 0,
+            chroot_base: base.path().to_path_buf(),
+            netns: None,
+            new_pid_ns: false,
+            cgroup: None,
+        };
+
+        Adopt::discard_area(&driver, &record, &jailed)
+            .await
+            .unwrap();
+        assert!(
+            !per_vm.exists(),
+            "the whole per-vm directory goes, not just the chroot inside it"
+        );
+        Adopt::discard_area(&driver, &record, &jailed)
+            .await
+            .expect("a sweep may find what an earlier one already cleared");
+
+        // Direct mode: nothing was ever brought anywhere, so there is
+        // nothing to take away — and saying so is a success, not an error.
+        let outside = base.path().join("run/box/rootfs.ext4");
+        std::fs::create_dir_all(outside.parent().unwrap()).unwrap();
+        std::fs::write(&outside, b"the caller's own file").unwrap();
+        Adopt::discard_area(&driver, &record, &IsolationSpec::None)
+            .await
+            .unwrap();
+        assert!(outside.exists(), "direct mode removed the caller's file");
     }
 
     #[tokio::test]

--- a/virt/arcbox-fc-driver/src/handle.rs
+++ b/virt/arcbox-fc-driver/src/handle.rs
@@ -2,7 +2,8 @@
 //! with the vsock, listen, checkpoint, and detach capabilities.
 //!
 //! [`FcProcessHandle`] is the same port over a VMM process whose API is out
-//! of reach: kill, observe, detach, and nothing the API would serve.
+//! of reach: kill, observe, detach, reach the area the VM's files were
+//! staged into, and nothing the API would serve.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -11,8 +12,8 @@ use std::time::Duration;
 
 use arcbox_vm_driver::{
     AfterCheckpoint, Checkpoint, CheckpointFormat, CheckpointImage, CheckpointKind,
-    CheckpointOptions, Detach, Error, ExitStatus, IoMode, Result, ShutdownMode, VmEvent, VmHandle,
-    VmId, VmRecord, VmState, Vsock, VsockConn, VsockListen, VsockListener,
+    CheckpointOptions, Detach, Error, ExitStatus, IoMode, Result, ShutdownMode, Staging, VmEvent,
+    VmHandle, VmId, VmRecord, VmState, Vsock, VsockConn, VsockListen, VsockListener,
 };
 use async_trait::async_trait;
 use fc_sdk::Client;
@@ -23,6 +24,7 @@ use crate::error::FcError;
 use crate::listener::VsockEndpoint;
 use crate::process::FcProcess;
 use crate::render::VmLayout;
+use crate::staging::JailStaging;
 use crate::{CHECKPOINT_FORMAT, NAME, api, jail, listener, vsock};
 
 pub mod process_only;
@@ -41,7 +43,10 @@ const CTRL_ALT_DEL_TIMEOUT: Duration = Duration::from_secs(5);
 pub struct FcHandle {
     process: Arc<FcProcess>,
     client: Client,
-    layout: VmLayout,
+    /// The area this VM's files were staged into, and the layout that names
+    /// every path in it — the same area the prepared VM staged them into,
+    /// and the only route to them for a VM this driver adopted.
+    staging: JailStaging,
     record: VmRecord,
     /// The vsock socket the host dials and listens next to, when the VM
     /// has a vsock device; shared with the prepared VM the handle came from.
@@ -66,11 +71,16 @@ impl FcHandle {
         Self {
             process,
             client,
-            layout,
+            staging: JailStaging::new(layout),
             record,
             vsock,
             quiesced: AtomicBool::new(quiesced),
         }
+    }
+
+    /// Where this VM's files live: the jail, the runtime dir, the sockets.
+    fn layout(&self) -> &VmLayout {
+        self.staging.layout()
     }
 
     fn vsock_endpoint(&self) -> Result<&VsockEndpoint> {
@@ -185,7 +195,7 @@ impl VmHandle for FcHandle {
             },
         };
         self.unlink_vsock();
-        if let Some(jail) = self.layout.jail()
+        if let Some(jail) = self.layout().jail()
             && self.process.is_adopted()
             && !self.process.is_detached()
         {
@@ -202,7 +212,7 @@ impl VmHandle for FcHandle {
     /// it can be restored, and that is inside a per-VM chroot
     /// ([`crate::render::require_jailed_restore`]).
     fn checkpoint(&self) -> Option<&dyn Checkpoint> {
-        self.layout.jail().is_some().then_some(self)
+        self.layout().jail().is_some().then_some(self)
     }
 
     fn vsock_listener(&self) -> Option<&dyn VsockListen> {
@@ -211,6 +221,13 @@ impl VmHandle for FcHandle {
 
     fn detach(&self) -> Option<&dyn Detach> {
         Some(self)
+    }
+
+    /// The area this VM's disks were staged into. Present whatever grip
+    /// made it: an adopted VM has no [`FcPrepared`](crate::FcPrepared), and
+    /// this is then the only route to a disk that has to outlive it.
+    fn staging(&self) -> Option<&dyn Staging> {
+        Some(&self.staging)
     }
 }
 
@@ -232,7 +249,7 @@ impl VsockListen for FcHandle {
     /// Bound next to the same socket [`Vsock::dial`] uses — after a restore
     /// the one the checkpoint recorded, which is where the guest dials out.
     async fn listen(&self, port: u32) -> Result<Box<dyn VsockListener>> {
-        listener::bind(&self.layout, self.vsock_endpoint()?, &self.process, port)
+        listener::bind(self.layout(), self.vsock_endpoint()?, &self.process, port)
     }
 }
 
@@ -353,7 +370,7 @@ impl FcHandle {
     /// or when `dst` is already inside it (chowned so the jailed VMM can
     /// write there), else a fresh `{jail}/snapshots/<n>` to move from.
     async fn snapshot_site(&self, dst: &Path) -> Result<SnapshotSite> {
-        let Some(jail) = self.layout.jail() else {
+        let Some(jail) = self.layout().jail() else {
             return Ok(SnapshotSite::Direct {
                 vmstate: utf8(&dst.join("vmstate"))?,
                 mem: utf8(&dst.join("mem"))?,

--- a/virt/arcbox-fc-driver/src/handle/process_only.rs
+++ b/virt/arcbox-fc-driver/src/handle/process_only.rs
@@ -9,17 +9,24 @@
 //! kill, and detach, all served by the process guard. Nothing that needs
 //! the API is offered — no vsock, no listener, no checkpoint — and a
 //! `Graceful` shutdown, whose ctrl-alt-del is an API call, kills at once.
+//!
+//! Staging is offered, though: where a VM's files live is a property of
+//! how its VMM was launched, which the adopt read off the process itself,
+//! so an unreachable API costs this handle the VM's devices and never the
+//! disks staged into its area.
 
 use std::sync::Arc;
 
 use arcbox_vm_driver::{
-    Detach, ExitStatus, Result, ShutdownMode, VmEvent, VmHandle, VmId, VmRecord, VmState,
+    Detach, ExitStatus, Result, ShutdownMode, Staging, VmEvent, VmHandle, VmId, VmRecord, VmState,
 };
 use async_trait::async_trait;
 use tokio::sync::broadcast;
 
 use crate::jail::Jail;
 use crate::process::FcProcess;
+use crate::render::VmLayout;
+use crate::staging::JailStaging;
 
 /// A VMM process this driver verified but cannot talk to.
 ///
@@ -28,20 +35,26 @@ use crate::process::FcProcess;
 pub struct FcProcessHandle {
     process: Arc<FcProcess>,
     record: VmRecord,
-    /// The area this VM runs in, when it has one. Reachable without the
-    /// API: it is a property of how the VMM was launched, which the adopt
-    /// read off the process itself.
-    jail: Option<Jail>,
+    /// The area this VM runs in, and the layout that names paths in it.
+    /// Reachable without the API: where the VMM was launched is a property
+    /// of the launch, which the adopt read off the process itself.
+    staging: JailStaging,
 }
 
 impl FcProcessHandle {
-    /// A handle over `process`, reporting `record` and running in `jail`.
-    pub fn new(process: Arc<FcProcess>, record: VmRecord, jail: Option<Jail>) -> Self {
+    /// A handle over `process`, reporting `record` and running in the area
+    /// `layout` describes.
+    pub fn new(process: Arc<FcProcess>, record: VmRecord, layout: VmLayout) -> Self {
         Self {
             process,
             record,
-            jail,
+            staging: JailStaging::new(layout),
         }
+    }
+
+    /// The jail this VM runs in, when it has one.
+    fn jail(&self) -> Option<&Jail> {
+        self.staging.layout().jail()
     }
 }
 
@@ -90,7 +103,7 @@ impl VmHandle for FcProcessHandle {
                 "the vmm's api is unreachable: a graceful shutdown cannot ask the guest and kills it");
         }
         let status = self.process.kill().await?;
-        if let Some(jail) = &self.jail
+        if let Some(jail) = self.jail()
             && !self.process.is_detached()
         {
             jail.remove().await?;
@@ -102,6 +115,13 @@ impl VmHandle for FcProcessHandle {
     /// needs only the guard.
     fn detach(&self) -> Option<&dyn Detach> {
         Some(self)
+    }
+
+    /// Present as on every handle of this driver: bringing a file into the
+    /// jail, or taking one back out, is a filesystem operation on a path
+    /// the layout names, and asks the VMM nothing.
+    fn staging(&self) -> Option<&dyn Staging> {
+        Some(&self.staging)
     }
 }
 
@@ -115,39 +135,66 @@ impl Detach for FcProcessHandle {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::time::Duration;
 
-    use arcbox_vm_driver::ProcessRecord;
+    use arcbox_vm_driver::{IsolationSpec, ProcessRecord};
 
     use super::*;
     use crate::NAME;
+    use crate::config::FcDriverConfig;
     use crate::process::UNKNOWN_EXIT;
+
+    /// The Firecracker binary the layouts below are built from; only its
+    /// file name matters, and it names the jail's middle component.
+    const FC_BINARY: &str = "/nonexistent/arcbox-fc-driver/firecracker";
 
     /// A `sleep` child adopted as a VMM, and the child to reap it with.
     fn adopted() -> (FcProcessHandle, tokio::process::Child) {
-        adopted_in(None)
+        adopted_in(
+            &IsolationSpec::None,
+            Path::new("/nonexistent/arcbox-fc-driver"),
+        )
     }
 
-    /// [`adopted`], running in `jail`.
-    fn adopted_in(jail: Option<Jail>) -> (FcProcessHandle, tokio::process::Child) {
+    /// [`adopted`], confined by `isolation` with `runtime_dir` as its
+    /// scratch space — the layout an adopt reads off the process.
+    fn adopted_in(
+        isolation: &IsolationSpec,
+        runtime_dir: &Path,
+    ) -> (FcProcessHandle, tokio::process::Child) {
         let child = tokio::process::Command::new("sleep")
             .arg("30")
             .spawn()
             .expect("spawn test child");
         let pid = child.id().unwrap();
         let socket = PathBuf::from("/nonexistent/arcbox-fc-driver/api.sock");
+        let id = VmId::new("box").unwrap();
         let record = VmRecord {
-            id: VmId::new("box").unwrap(),
+            id: id.clone(),
             driver: NAME.to_owned(),
-            runtime_dir: "/nonexistent/arcbox-fc-driver".into(),
+            runtime_dir: runtime_dir.to_path_buf(),
             process: Some(ProcessRecord {
                 pid,
                 api_socket: Some(socket.clone()),
             }),
         };
+        let layout = VmLayout::new(&id, isolation, &FcDriverConfig::new(FC_BINARY), runtime_dir)
+            .expect("a layout for the adopted vm");
         let process = Arc::new(FcProcess::adopt(pid, socket));
-        (FcProcessHandle::new(process, record, jail), child)
+        (FcProcessHandle::new(process, record, layout), child)
+    }
+
+    /// The jail of a VM adopted into `base`.
+    fn jailed(base: &Path) -> IsolationSpec {
+        IsolationSpec::Jailer {
+            uid: 0,
+            gid: 0,
+            chroot_base: base.to_path_buf(),
+            netns: None,
+            new_pid_ns: false,
+            cgroup: None,
+        }
     }
 
     /// An API this handle cannot reach costs it the VM's devices, never
@@ -158,15 +205,39 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let area = dir.path().join("jail/firecracker/box");
         std::fs::create_dir_all(area.join("root")).unwrap();
-        let (vm, mut child) = adopted_in(Some(Jail {
-            root: area.join("root"),
-            uid: 0,
-            gid: 0,
-        }));
+        let (vm, mut child) = adopted_in(&jailed(&dir.path().join("jail")), dir.path());
+        assert_eq!(
+            vm.jail().map(|jail| jail.root.clone()),
+            Some(area.join("root"))
+        );
         let reaper = tokio::spawn(async move { child.wait().await.unwrap() });
         vm.shutdown(ShutdownMode::Kill).await.unwrap();
         assert!(!area.exists(), "the adopted vm's jail goes with the kill");
         reaper.await.unwrap();
+    }
+
+    /// The disks in that area are reachable too, which is what lets a
+    /// computer running on a staged rootfs be paused after its agent
+    /// restarted: taking the disk out needs the area, not the API.
+    #[tokio::test]
+    async fn a_staged_disk_comes_back_out_without_an_api() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("jail/firecracker/box/root");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("rootfs.ext4"), b"the guest's disk").unwrap();
+        let (vm, mut child) = adopted_in(&jailed(&dir.path().join("jail")), dir.path());
+
+        let parked = dir.path().join("paused-rootfs.ext4");
+        let staging = vm.staging().expect("an adopted vm reaches its own area");
+        assert!(staging.unstage_disk("rootfs", &parked).await.unwrap());
+        assert_eq!(std::fs::read(&parked).unwrap(), b"the guest's disk");
+        assert!(
+            !staging.unstage_disk("rootfs", &parked).await.unwrap(),
+            "nothing is left to take out"
+        );
+
+        child.kill().await.unwrap();
+        child.wait().await.unwrap();
     }
 
     fn signal_of(status: std::process::ExitStatus) -> Option<i32> {
@@ -185,6 +256,7 @@ mod tests {
         assert!(VmHandle::checkpoint(&vm).is_none());
         assert!(vm.balloon().is_none() && vm.console().is_none() && vm.debug().is_none());
         assert!(VmHandle::detach(&vm).is_some());
+        assert!(vm.staging().is_some());
         let mut events = vm.events();
         // The real parent reaps once the signal lands.
         let reaper = tokio::spawn(async move { child.wait().await.unwrap() });

--- a/virt/arcbox-fc-driver/src/handle/tests.rs
+++ b/virt/arcbox-fc-driver/src/handle/tests.rs
@@ -53,7 +53,7 @@ fn with_client(
 /// written in place and nothing has to be moved out afterwards (the
 /// scripted Firecracker writes no files).
 fn in_jail(vm: &FcHandle) -> PathBuf {
-    vm.layout
+    vm.layout()
         .jail()
         .expect("checkpoints are taken on jailed vms")
         .root
@@ -132,7 +132,7 @@ async fn only_an_adopted_vm_takes_its_jail_with_the_kill() {
 
     let spawned = handle(dir.path(), isolation.clone(), false);
     let area = spawned
-        .layout
+        .layout()
         .jail()
         .unwrap()
         .root
@@ -252,7 +252,7 @@ async fn snapshots_are_written_in_place_or_staged_in_the_jail() {
     }
 
     let vm = handle(dir.path(), jail(dir.path()), false);
-    let root = vm.layout.jail().unwrap().root.clone();
+    let root = vm.layout().jail().unwrap().root.clone();
     let inside = root.join("snapshots/abc");
     tokio::fs::create_dir_all(&inside).await.unwrap();
     match vm.snapshot_site(&inside).await.unwrap() {

--- a/virt/arcbox-fc-driver/src/lib.rs
+++ b/virt/arcbox-fc-driver/src/lib.rs
@@ -80,6 +80,7 @@ pub mod prepared;
 pub mod process;
 pub mod render;
 pub mod spawn;
+pub mod staging;
 pub mod vsock;
 
 pub use config::FcDriverConfig;
@@ -87,6 +88,7 @@ pub use driver::FcDriver;
 pub use error::FcError;
 pub use handle::{FcHandle, FcProcessHandle};
 pub use prepared::FcPrepared;
+pub use staging::JailStaging;
 
 /// The driver's name.
 ///

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -1,14 +1,13 @@
 //! [`FcPrepared`]: a spawned Firecracker waiting for a spec — the port's
 //! [`PreparedVm`].
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use arcbox_vm_driver::{
-    CheckpointImage, DiskSource, Error, ExitStatus, IsolationSpec, PreparedVm, ProcessRecord,
-    RestoreSpec, Result, Staging, VmHandle, VmId, VmRecord, VmSpec, VmState, VsockListen,
-    VsockListener,
+    CheckpointImage, Error, ExitStatus, IsolationSpec, PreparedVm, ProcessRecord, RestoreSpec,
+    Result, Staging, VmHandle, VmId, VmRecord, VmSpec, VmState, VsockListen, VsockListener,
 };
 use async_trait::async_trait;
 use fc_sdk::VmBuilder;
@@ -18,7 +17,8 @@ use crate::error::FcError;
 use crate::handle::FcHandle;
 use crate::listener::VsockEndpoint;
 use crate::process::FcProcess;
-use crate::render::{self, StageKind, VmLayout};
+use crate::render::{self, VmLayout};
+use crate::staging::JailStaging;
 use crate::{NAME, api, jail, listener, spawn};
 
 /// A spawned VMM process with its API socket up and nothing loaded yet.
@@ -27,7 +27,10 @@ use crate::{NAME, api, jail, listener, spawn};
 /// after which the returned handle owns it (and shares the guard).
 pub struct FcPrepared {
     config: Arc<FcDriverConfig>,
-    layout: VmLayout,
+    /// The area this VM's files are brought into, and the layout that
+    /// names every path in it. Shared in shape — not in value — with the
+    /// handle a boot returns, which builds its own from the same layout.
+    staging: JailStaging,
     process: Arc<FcProcess>,
     record: VmRecord,
     /// Where guest dial-outs land: the layout's vsock socket, until a
@@ -80,7 +83,7 @@ impl FcPrepared {
             let vsock = VsockEndpoint::new(layout.vsock_host_uds());
             Ok(Self {
                 config: Arc::clone(&config),
-                layout: layout.clone(),
+                staging: JailStaging::new(layout.clone()),
                 process,
                 record,
                 vsock,
@@ -130,7 +133,7 @@ impl FcPrepared {
                 self.record.id
             )));
         }
-        if *isolation != *self.layout.isolation() {
+        if *isolation != *self.layout().isolation() {
             return Err(Error::InvalidSpec(format!(
                 "spec isolation does not match what vm {} was prepared with",
                 self.record.id
@@ -139,21 +142,9 @@ impl FcPrepared {
         Ok(())
     }
 
-    /// Brings `src` into the jail at `in_jail` and answers with the host
-    /// path it landed at — the path a spec must name for it, which
-    /// rendering then passes to Firecracker chroot-relative.
-    ///
-    /// Goes through [`VmLayout::place`] rather than staging directly, so
-    /// every path decision stays in `render`: without a jail this is the
-    /// identity, and a source already inside the jail is named where it is
-    /// instead of being copied onto itself.
-    async fn bring_in(&self, src: &Path, in_jail: &str, kind: StageKind) -> Result<PathBuf> {
-        let mut stage = Vec::new();
-        let named = self.layout.place(src, in_jail, kind, &mut stage)?;
-        if let Some(jail) = self.layout.jail() {
-            jail::apply(jail, &stage).await?;
-        }
-        Ok(self.layout.host_view(&named))
+    /// Where this VM's files live: the jail, the runtime dir, the sockets.
+    fn layout(&self) -> &VmLayout {
+        self.staging.layout()
     }
 
     fn handle(&self, client: fc_sdk::Client, has_vsock: bool) -> FcHandle {
@@ -161,7 +152,7 @@ impl FcPrepared {
         FcHandle::new(
             Arc::clone(&self.process),
             client,
-            self.layout.clone(),
+            self.layout().clone(),
             self.record.clone(),
             has_vsock.then(|| self.vsock.clone()),
             false,
@@ -196,15 +187,15 @@ impl PreparedVm for FcPrepared {
     }
 
     fn staging(&self) -> Option<&dyn Staging> {
-        Some(self)
+        Some(&self.staging)
     }
 
     async fn boot(&self, spec: VmSpec) -> Result<Box<dyn VmHandle>> {
         let _launch = self.launch.lock().await;
         self.require_unused()?;
         self.require_same_identity(&spec.id, &spec.isolation)?;
-        let plan = render::fc_config(&spec, &self.config, self.layout.runtime_dir())?;
-        if let Some(jail) = self.layout.jail() {
+        let plan = render::fc_config(&spec, &self.config, self.layout().runtime_dir())?;
+        if let Some(jail) = self.layout().jail() {
             jail::apply(jail, &plan.stage).await?;
         }
         let mut builder = VmBuilder::new(self.process.api_socket())
@@ -236,8 +227,8 @@ impl PreparedVm for FcPrepared {
         let _launch = self.launch.lock().await;
         self.require_unused()?;
         self.require_same_identity(&spec.id, &spec.isolation)?;
-        let plan = render::fc_restore(image, &spec, &self.config, self.layout.runtime_dir())?;
-        if let Some(jail) = self.layout.jail() {
+        let plan = render::fc_restore(image, &spec, &self.config, self.layout().runtime_dir())?;
+        if let Some(jail) = self.layout().jail() {
             jail::apply(jail, &plan.stage).await?;
         }
         let vm = fc_sdk::restore(self.process.api_socket(), plan.load)
@@ -264,7 +255,8 @@ impl PreparedVm for FcPrepared {
         // can dial out.
         let has_vsock = loaded.vsock.is_some();
         if let Some(vsock) = loaded.vsock {
-            self.vsock.relocate(self.layout.host_view(&vsock.uds_path));
+            self.vsock
+                .relocate(self.layout().host_view(&vsock.uds_path));
         }
         // The load left the guest frozen so it could not touch a stale disk;
         // it runs from here.
@@ -284,93 +276,10 @@ impl PreparedVm for FcPrepared {
     /// retry, and both halves are idempotent.
     async fn discard(&self) -> Result<ExitStatus> {
         let status = self.process.kill().await?;
-        if let Some(jail) = self.layout.jail() {
+        if let Some(jail) = self.layout().jail() {
             jail.remove().await?;
         }
         Ok(status)
-    }
-}
-
-/// The jail is the staging area: files land under its root, named as
-/// [`render`] would have named them for a boot, so a spec that carries
-/// what these hand back is rendered without staging anything twice.
-/// Without a jail every verb is the identity — the VMM reads host paths as
-/// they are, and there is nothing to bring anywhere.
-#[async_trait]
-impl Staging for FcPrepared {
-    async fn stage_kernel(&self, src: &Path) -> Result<PathBuf> {
-        self.bring_in(src, render::KERNEL_FILE, StageKind::LinkOrCopy)
-            .await
-    }
-
-    async fn stage_disk(&self, id: &str, source: DiskSource<'_>) -> Result<PathBuf> {
-        let kind = match source {
-            DiskSource::Device(_) => StageKind::BlockNode,
-            // Never a hard link: Firecracker writes guest blocks into a
-            // disk, and a link would write them into the caller's file.
-            DiskSource::Image(_) => StageKind::Copy,
-            DiskSource::Handover(_) => StageKind::Move,
-        };
-        self.bring_in(source.path(), &render::staged_disk_file(id)?, kind)
-            .await
-    }
-
-    async fn unstage_disk(&self, id: &str, dst: &Path) -> Result<bool> {
-        let Some(staged) = self.layout.jail_path(&render::staged_disk_file(id)?)? else {
-            return Ok(false);
-        };
-        if !tokio::fs::try_exists(&staged).await.unwrap_or(false) {
-            return Ok(false);
-        }
-        // The jail is its own vfsmount, so this crosses one even on the
-        // same filesystem; `move_file` handles the EXDEV that follows.
-        jail::move_file(&staged, dst).await.map_err(Error::Io)?;
-        Ok(true)
-    }
-
-    async fn stage_checkpoint(&self, image: &CheckpointImage) -> Result<CheckpointImage> {
-        let Some(jail) = self.layout.jail() else {
-            return Ok(image.clone());
-        };
-        // Through the jail's own question, which resolves: a dir spelled
-        // through the root but landing outside it has to be brought in,
-        // not loaded from where the VMM cannot reach. The answer is where
-        // the files are, which is what the image must name.
-        if let Some(view) = jail.view(&image.dir) {
-            return Ok(CheckpointImage {
-                dir: self.layout.host_view(&view),
-                ..image.clone()
-            });
-        }
-        let name = image
-            .dir
-            .file_name()
-            .and_then(|name| name.to_str())
-            .ok_or_else(|| {
-                Error::InvalidSpec(format!(
-                    "{NAME}: checkpoint dir {} has no usable name",
-                    image.dir.display()
-                ))
-            })?;
-        let in_jail = render::checkpoint_dir(name);
-        // Both files are read-only to Firecracker (mem is mapped
-        // MAP_PRIVATE on load), so a root jailer links instead of copying
-        // — the mem file is the guest's whole memory.
-        self.bring_in(
-            &image.dir.join("vmstate"),
-            &format!("{in_jail}/vmstate"),
-            StageKind::LinkOrCopy,
-        )
-        .await?;
-        let mem = image.dir.join("mem");
-        if tokio::fs::try_exists(&mem).await.unwrap_or(false) {
-            self.bring_in(&mem, &format!("{in_jail}/mem"), StageKind::LinkOrCopy)
-                .await?;
-        }
-        Ok(CheckpointImage {
-            dir: jail.root.join(&in_jail),
-            ..image.clone()
-        })
     }
 }
 
@@ -412,7 +321,7 @@ impl VsockListen for FcPrepared {
     /// device; a restore moves the endpoint to the recorded path before
     /// the guest resumes and the listener follows.
     async fn listen(&self, port: u32) -> Result<Box<dyn VsockListener>> {
-        listener::bind(&self.layout, &self.vsock, &self.process, port)
+        listener::bind(self.layout(), &self.vsock, &self.process, port)
     }
 }
 

--- a/virt/arcbox-fc-driver/src/staging.rs
+++ b/virt/arcbox-fc-driver/src/staging.rs
@@ -1,0 +1,134 @@
+//! [`JailStaging`]: the port's [`Staging`] over one VM's jail.
+//!
+//! The jail *is* the staging area: files land under its root, named as
+//! [`render`] would have named them for a boot, so a spec that carries what
+//! these hand back is rendered without staging anything twice. Without a
+//! jail every verb is the identity — the VMM reads host paths as they are,
+//! and there is nothing to bring anywhere.
+//!
+//! Built from a [`VmLayout`] and nothing else, so both grips on a VM reach
+//! it: the [`FcPrepared`](crate::FcPrepared) that spawned the VMM, and the
+//! handle of a VM this driver adopted, whose prepared half died with the
+//! process that made it.
+
+use std::path::{Path, PathBuf};
+
+use arcbox_vm_driver::{CheckpointImage, DiskSource, Error, Result, Staging};
+use async_trait::async_trait;
+
+use crate::render::{self, StageKind, VmLayout};
+use crate::{NAME, jail};
+
+/// One VM's staging area: its jail, and the layout that names paths in it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JailStaging {
+    layout: VmLayout,
+}
+
+impl JailStaging {
+    /// The staging area of the VM `layout` describes.
+    pub fn new(layout: VmLayout) -> Self {
+        Self { layout }
+    }
+
+    /// Where this VM's files live, from the host's and Firecracker's points
+    /// of view.
+    pub fn layout(&self) -> &VmLayout {
+        &self.layout
+    }
+
+    /// Brings `src` into the jail at `in_jail` and answers with the host
+    /// path it landed at — the path a spec must name for it, which
+    /// rendering then passes to Firecracker chroot-relative.
+    ///
+    /// Goes through [`VmLayout::place`] rather than staging directly, so
+    /// every path decision stays in `render`: without a jail this is the
+    /// identity, and a source already inside the jail is named where it is
+    /// instead of being copied onto itself.
+    async fn bring_in(&self, src: &Path, in_jail: &str, kind: StageKind) -> Result<PathBuf> {
+        let mut stage = Vec::new();
+        let named = self.layout.place(src, in_jail, kind, &mut stage)?;
+        if let Some(jail) = self.layout.jail() {
+            jail::apply(jail, &stage).await?;
+        }
+        Ok(self.layout.host_view(&named))
+    }
+}
+
+#[async_trait]
+impl Staging for JailStaging {
+    async fn stage_kernel(&self, src: &Path) -> Result<PathBuf> {
+        self.bring_in(src, render::KERNEL_FILE, StageKind::LinkOrCopy)
+            .await
+    }
+
+    async fn stage_disk(&self, id: &str, source: DiskSource<'_>) -> Result<PathBuf> {
+        let kind = match source {
+            DiskSource::Device(_) => StageKind::BlockNode,
+            // Never a hard link: Firecracker writes guest blocks into a
+            // disk, and a link would write them into the caller's file.
+            DiskSource::Image(_) => StageKind::Copy,
+            DiskSource::Handover(_) => StageKind::Move,
+        };
+        self.bring_in(source.path(), &render::staged_disk_file(id)?, kind)
+            .await
+    }
+
+    async fn unstage_disk(&self, id: &str, dst: &Path) -> Result<bool> {
+        let Some(staged) = self.layout.jail_path(&render::staged_disk_file(id)?)? else {
+            return Ok(false);
+        };
+        if !tokio::fs::try_exists(&staged).await.unwrap_or(false) {
+            return Ok(false);
+        }
+        // The jail is its own vfsmount, so this crosses one even on the
+        // same filesystem; `move_file` handles the EXDEV that follows.
+        jail::move_file(&staged, dst).await.map_err(Error::Io)?;
+        Ok(true)
+    }
+
+    async fn stage_checkpoint(&self, image: &CheckpointImage) -> Result<CheckpointImage> {
+        let Some(jail) = self.layout.jail() else {
+            return Ok(image.clone());
+        };
+        // Through the jail's own question, which resolves: a dir spelled
+        // through the root but landing outside it has to be brought in,
+        // not loaded from where the VMM cannot reach. The answer is where
+        // the files are, which is what the image must name.
+        if let Some(view) = jail.view(&image.dir) {
+            return Ok(CheckpointImage {
+                dir: self.layout.host_view(&view),
+                ..image.clone()
+            });
+        }
+        let name = image
+            .dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| {
+                Error::InvalidSpec(format!(
+                    "{NAME}: checkpoint dir {} has no usable name",
+                    image.dir.display()
+                ))
+            })?;
+        let in_jail = render::checkpoint_dir(name);
+        // Both files are read-only to Firecracker (mem is mapped
+        // MAP_PRIVATE on load), so a root jailer links instead of copying
+        // — the mem file is the guest's whole memory.
+        self.bring_in(
+            &image.dir.join("vmstate"),
+            &format!("{in_jail}/vmstate"),
+            StageKind::LinkOrCopy,
+        )
+        .await?;
+        let mem = image.dir.join("mem");
+        if tokio::fs::try_exists(&mem).await.unwrap_or(false) {
+            self.bring_in(&mem, &format!("{in_jail}/mem"), StageKind::LinkOrCopy)
+                .await?;
+        }
+        Ok(CheckpointImage {
+            dir: jail.root.join(&in_jail),
+            ..image.clone()
+        })
+    }
+}

--- a/virt/arcbox-fc-driver/tests/contract.rs
+++ b/virt/arcbox-fc-driver/tests/contract.rs
@@ -252,4 +252,5 @@ contract_modes! {
     a_staged_spec_boots,
     a_staged_disk_can_be_taken_back_out,
     a_staged_checkpoint_restores,
+    a_dead_vms_area_is_discarded,
 }

--- a/virt/arcbox-vm-driver/src/capability.rs
+++ b/virt/arcbox-vm-driver/src/capability.rs
@@ -316,7 +316,8 @@ impl AsRef<str> for CheckpointFormat {
     }
 }
 
-/// Find a VM that outlived the process which booted it.
+/// Find a VM that outlived the process which booted it — or clear away what
+/// it left when it did not.
 ///
 /// Present on external-process VMMs only: an in-process VM dies with its
 /// process, so "adopt" has no meaning there and the accessor is `None`.
@@ -327,6 +328,28 @@ pub trait Adopt: Send + Sync {
     /// `Ok(None)` means nothing survived — a stale record, a dead pid — which
     /// is an outcome, not an absence of the capability.
     async fn adopt(&self, record: &VmRecord) -> Result<Option<Box<dyn VmHandle>>>;
+
+    /// Removes the host area of the VM `record` names, which is gone.
+    ///
+    /// A VM's area belongs to whichever grip owns its VMM: the
+    /// [`PreparedVm`] that made it, or the handle of a VM this driver
+    /// adopted. A VM that died with the process which booted it leaves
+    /// neither, and leaves its area — which, where a driver confines its
+    /// VMMs, holds everything [`Staging`] brought in. This is the only
+    /// route left to it, and only the driver knows where "it" is.
+    ///
+    /// `isolation` is what the VM was configured to run under, because
+    /// nothing can be read back off a process that is gone. A driver that
+    /// confines nothing has no area to remove and succeeds.
+    ///
+    /// Already removed is success: a startup sweep runs this on every
+    /// journal it does not keep, and may find what an earlier sweep
+    /// cleared.
+    ///
+    /// Never called on a VM that is still running — [`adopt`](Self::adopt)
+    /// answers that case with a handle, and the handle's stop takes the
+    /// area.
+    async fn discard_area(&self, record: &VmRecord, isolation: &IsolationSpec) -> Result<()>;
 }
 
 /// Give up ownership of a running VM without stopping it.

--- a/virt/arcbox-vm-driver/src/capability.rs
+++ b/virt/arcbox-vm-driver/src/capability.rs
@@ -79,7 +79,7 @@ pub trait PreparedVm: Send + Sync {
     /// Bring the files this VM boots from into the area its VMM can reach.
     /// `Some` iff [`crate::DriverCapabilities::staging`]. The handle of the
     /// VM booted on this process reaches the same area through
-    /// [`VmHandle::staging`](crate::VmHandle::staging).
+    /// [`VmHandle::staging`].
     fn staging(&self) -> Option<&dyn Staging> {
         None
     }
@@ -117,14 +117,13 @@ pub trait PreparedVm: Send + Sync {
 /// Present iff [`crate::DriverCapabilities::staging`], and reachable from
 /// both grips on a VM — the prepared VM the driver spawned
 /// ([`PreparedVm::staging`]) and the handle to the VM running on it
-/// ([`VmHandle::staging`](crate::VmHandle::staging)) — naming the same area
-/// either way. That is what lets a VM this driver *adopted*, whose prepared
-/// half died with the process that made it, still take a disk back out. A
-/// driver whose VMs read host paths as they are still offers it, as the
-/// identity: staging such a file is a no-op that answers with the path it
-/// was given. That is what lets an orchestrator stage unconditionally
-/// instead of branching on a confinement it is not supposed to know
-/// about.
+/// ([`VmHandle::staging`]) — naming the same area either way. That is what
+/// lets a VM this driver *adopted*, whose prepared half died with the
+/// process that made it, still take a disk back out. A driver whose VMs
+/// read host paths as they are still offers it, as the identity: staging
+/// such a file is a no-op that answers with the path it was given. That is
+/// what lets an orchestrator stage unconditionally instead of branching on
+/// a confinement it is not supposed to know about.
 ///
 /// Staging a file that is already in the VM's area leaves it alone and
 /// names it where it is — so a caller may stage what an earlier stage, or

--- a/virt/arcbox-vm-driver/src/capability.rs
+++ b/virt/arcbox-vm-driver/src/capability.rs
@@ -77,7 +77,9 @@ pub trait PreparedVm: Send + Sync {
     }
 
     /// Bring the files this VM boots from into the area its VMM can reach.
-    /// `Some` iff [`crate::DriverCapabilities::staging`].
+    /// `Some` iff [`crate::DriverCapabilities::staging`]. The handle of the
+    /// VM booted on this process reaches the same area through
+    /// [`VmHandle::staging`](crate::VmHandle::staging).
     fn staging(&self) -> Option<&dyn Staging> {
         None
     }
@@ -112,11 +114,17 @@ pub trait PreparedVm: Send + Sync {
 /// the caller says what a file is, and gets back the path its spec must
 /// name for it. It never learns whether a confinement exists.
 ///
-/// Present iff [`crate::DriverCapabilities::staging`]. A driver whose VMs
-/// read host paths as they are still offers it, as the identity: staging
-/// such a file is a no-op that answers with the path it was given. That is
-/// what lets an orchestrator stage unconditionally instead of branching on
-/// a confinement it is not supposed to know about.
+/// Present iff [`crate::DriverCapabilities::staging`], and reachable from
+/// both grips on a VM — the prepared VM the driver spawned
+/// ([`PreparedVm::staging`]) and the handle to the VM running on it
+/// ([`VmHandle::staging`](crate::VmHandle::staging)) — naming the same area
+/// either way. That is what lets a VM this driver *adopted*, whose prepared
+/// half died with the process that made it, still take a disk back out. A
+/// driver whose VMs read host paths as they are still offers it, as the
+/// identity: staging such a file is a no-op that answers with the path it
+/// was given. That is what lets an orchestrator stage unconditionally
+/// instead of branching on a confinement it is not supposed to know
+/// about.
 ///
 /// Staging a file that is already in the VM's area leaves it alone and
 /// names it where it is — so a caller may stage what an earlier stage, or

--- a/virt/arcbox-vm-driver/src/driver.rs
+++ b/virt/arcbox-vm-driver/src/driver.rs
@@ -205,9 +205,9 @@ pub struct DriverCapabilities {
     pub adopt: bool,
     /// The VMM can be spawned ahead of a boot ([`Prepare`]).
     pub prepare: bool,
-    /// Prepared VMs and handles expose [`Staging`](crate::Staging): the
-    /// files a VM boots from are brought into an area of its own and named
-    /// by where they landed.
+    /// Prepared VMs and handles expose [`Staging`]: the files a VM boots
+    /// from are brought into an area of its own and named by where they
+    /// landed.
     pub staging: bool,
     /// Handles expose a memory balloon.
     pub balloon: bool,

--- a/virt/arcbox-vm-driver/src/driver.rs
+++ b/virt/arcbox-vm-driver/src/driver.rs
@@ -17,8 +17,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
 use crate::capability::{
-    Adopt, Balloon, Checkpoint, CheckpointImage, Console, DebugSnapshot, Detach, Prepare, Vsock,
-    VsockListen,
+    Adopt, Balloon, Checkpoint, CheckpointImage, Console, DebugSnapshot, Detach, Prepare, Staging,
+    Vsock, VsockListen,
 };
 use crate::error::Result;
 use crate::spec::{DiskSpec, IsolationSpec, NicSpec, VmId, VmSpec};
@@ -146,6 +146,22 @@ pub trait VmHandle: Send + Sync {
         None
     }
 
+    /// The area this VM's files live in — the same one
+    /// [`PreparedVm::staging`](crate::PreparedVm::staging) stages into,
+    /// reached from the other grip on the same VM. `Some` iff
+    /// [`DriverCapabilities::staging`].
+    ///
+    /// The prepared VM is not the only grip that reaches an area: one this
+    /// driver *adopted* has no [`PreparedVm`](crate::PreparedVm) — the VMM
+    /// outlived the process that prepared it — and would otherwise have no
+    /// route to what was staged into it. Taking a disk back out
+    /// ([`Staging::unstage_disk`]) is what an orchestrator whose VM runs on
+    /// a staged disk must do before it stops that VM, and the VM it has to
+    /// do it for may well be an adopted one.
+    fn staging(&self) -> Option<&dyn Staging> {
+        None
+    }
+
     /// The memory balloon. `Some` iff the driver has one and the spec set
     /// [`VmSpec::balloon`].
     fn balloon(&self) -> Option<&dyn Balloon> {
@@ -189,9 +205,9 @@ pub struct DriverCapabilities {
     pub adopt: bool,
     /// The VMM can be spawned ahead of a boot ([`Prepare`]).
     pub prepare: bool,
-    /// Prepared VMs expose [`Staging`](crate::Staging): the files a VM
-    /// boots from are brought into an area of its own and named by where
-    /// they landed.
+    /// Prepared VMs and handles expose [`Staging`](crate::Staging): the
+    /// files a VM boots from are brought into an area of its own and named
+    /// by where they landed.
     pub staging: bool,
     /// Handles expose a memory balloon.
     pub balloon: bool,

--- a/virt/arcbox-vm-driver/src/lib.rs
+++ b/virt/arcbox-vm-driver/src/lib.rs
@@ -19,10 +19,10 @@
 //! - [`capability`] — everything optional, one trait each: [`Vsock`],
 //!   [`VsockListen`], [`Checkpoint`], [`Adopt`]/[`Detach`], [`Prepare`],
 //!   [`Staging`], [`Balloon`], [`Console`], [`DebugSnapshot`]. A handle —
-//!   or the driver, for `Adopt` and `Prepare`; or the prepared VM, for
-//!   `Staging` — exposes each through an `Option<&dyn Cap>` accessor,
-//!   `Some` only when the driver can and the spec asked;
-//!   `capabilities()` must agree with the accessors.
+//!   or the driver, for `Adopt` and `Prepare`; or the prepared VM *and*
+//!   the handle, for `Staging` — exposes each through an
+//!   `Option<&dyn Cap>` accessor, `Some` only when the driver can and the
+//!   spec asked; `capabilities()` must agree with the accessors.
 //! - [`net`] — the second port: [`net::GuestNetwork`] plans and builds
 //!   what a NIC is attached to and hands the driver a [`NicSpec`];
 //!   [`net::NetworkReconcile`] is its token-guarded cleanup protocol.

--- a/virt/arcbox-vm-driver/src/testkit/contract.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract.rs
@@ -205,6 +205,7 @@ macro_rules! driver_contract {
                 a_staged_spec_boots,
                 a_staged_disk_can_be_taken_back_out,
                 a_staged_checkpoint_restores,
+                a_dead_vms_area_is_discarded,
             }
         }
     };

--- a/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
@@ -746,3 +746,78 @@ pub async fn a_staged_checkpoint_restores(h: &dyn ContractHarness) {
     h.ready(&*restored).await;
     restored.shutdown(ShutdownMode::Kill).await.expect("kill");
 }
+
+/// The area of a VM that died with the process which prepared it is
+/// removed by [`Adopt::discard_area`], and removed again without
+/// complaint.
+///
+/// The startup-sweep shape: a prepared VM is dropped without a discard, so
+/// its VMM dies and no grip is left to take the area with it. The check
+/// then asks the driver — the only thing that knows where the area is — to
+/// clear it, and reads the answer off the disk the staging returned rather
+/// than off any path of its own.
+///
+/// A driver that confines nothing stages in place, has no area, and must
+/// answer success rather than an error; the check tells the two apart the
+/// way `a_staged_disk_can_be_taken_back_out` does, by whether staging
+/// moved the file at all. Either way the VM's runtime directory is the
+/// caller's, and survives.
+///
+/// [`Adopt::discard_area`]: crate::Adopt::discard_area
+pub async fn a_dead_vms_area_is_discarded(h: &dyn ContractHarness) {
+    const CONTENT: &[u8] = b"a disk left behind by a dead vm";
+
+    let driver = h.driver();
+    let (Some(prepare), Some(adopt)) = (driver.prepare(), driver.adopt()) else {
+        assert!(!driver.capabilities().prepare || !driver.capabilities().adopt);
+        return;
+    };
+    let spec = h.spec(&id("dead-area"));
+    let dir = h.runtime_dir();
+    let prepared = prepare
+        .prepare(&spec.id, &spec.isolation, &dir)
+        .await
+        .expect("prepare");
+    let record = prepared.record();
+    let Some(staging) = prepared.staging() else {
+        assert!(!driver.capabilities().staging);
+        return;
+    };
+
+    let source = dir.join("left-behind.ext4");
+    tokio::fs::write(&source, CONTENT)
+        .await
+        .expect("a file to stage");
+    let staged = staging
+        .stage_disk("data", DiskSource::Image(&source))
+        .await
+        .expect("stage a disk");
+
+    // The VMM dies with the grip that made it, and nothing takes the area:
+    // `discard` is what would, and a process that crashed never ran one.
+    drop(prepared);
+
+    adopt
+        .discard_area(&record, &spec.isolation)
+        .await
+        .expect("discard the area of a vm that is gone");
+    if staged == source {
+        // Nothing was brought anywhere, so there is no area to remove and
+        // the caller's own file is untouched.
+        assert!(
+            tokio::fs::try_exists(&source).await.unwrap_or(false),
+            "a driver that stages in place removed the caller's file"
+        );
+    } else {
+        assert!(
+            !tokio::fs::try_exists(&staged).await.unwrap_or(true),
+            "the area of a vm that is gone was left standing"
+        );
+    }
+    assert!(dir.is_dir(), "the vm's runtime directory is the caller's");
+
+    adopt
+        .discard_area(&record, &spec.isolation)
+        .await
+        .expect("an area already gone is discarded again without complaint");
+}

--- a/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
@@ -81,9 +81,10 @@ pub async fn capabilities_agree_with_accessors(h: &dyn ContractHarness) {
     assert_eq!(caps.console, vm.console().is_some(), "console");
     assert_eq!(caps.debug, vm.debug().is_some(), "debug");
     assert_eq!(caps.prepare, driver.prepare().is_some(), "prepare");
-    // Staging is reached through a prepared VM, so its accessor is checked
-    // in `a_staged_spec_boots`; claiming it without `Prepare` leaves no way
-    // to reach it at all.
+    assert_eq!(caps.staging, vm.staging().is_some(), "staging");
+    // The prepared VM's accessor is checked in `a_staged_spec_boots`, which
+    // has one; claiming staging without `Prepare` leaves nothing to stage
+    // into before a boot.
     assert!(caps.prepare || !caps.staging, "staging without prepare");
     vm.shutdown(ShutdownMode::Kill).await.expect("kill");
 }

--- a/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_driver.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 
 use super::fake_prepared::Preparer;
+use super::fake_staging::StagingArea;
 use super::fake_vm::{FakeVm, VmInner};
 use super::fake_vsock::Inbound;
 use super::lock;
@@ -18,7 +19,7 @@ use crate::driver::{
     VmRecord, VmState,
 };
 use crate::error::{Error, Result};
-use crate::spec::{VmId, VmSpec};
+use crate::spec::{IsolationSpec, VmId, VmSpec};
 
 /// Scripted failures, armed once and consumed by the next matching call.
 #[derive(Debug, Default)]
@@ -70,6 +71,9 @@ pub(super) struct DriverInner {
     next_pid: AtomicU32,
     /// Every VM booted or restored and not yet seen exited.
     vms: Mutex<HashMap<VmId, Arc<VmInner>>>,
+    /// Every `Adopt::discard_area`, in order, with what it was told the VM
+    /// ran under.
+    discarded_areas: Mutex<Vec<(VmId, IsolationSpec)>>,
 }
 
 /// Configures a [`FakeDriver`].
@@ -93,6 +97,7 @@ impl FakeDriverBuilder {
             knobs: Arc::new(self.knobs),
             next_pid: AtomicU32::new(FIRST_PID),
             vms: Mutex::new(HashMap::new()),
+            discarded_areas: Mutex::new(Vec::new()),
         });
         FakeDriver {
             adopter: Adopter(Arc::clone(&inner)),
@@ -219,6 +224,18 @@ impl FakeDriver {
     /// adoption is only meaningful once it has.
     pub fn owned_vms(&self) -> Vec<VmId> {
         self.inner.owned_vms()
+    }
+
+    /// Every [`Adopt::discard_area`] this driver was asked for, in order,
+    /// paired with the isolation the caller said the VM had run under.
+    ///
+    /// A sweep is expected to discard each dead VM's area exactly once and
+    /// to leave alone the ones it must not touch, and neither is visible
+    /// from the filesystem afterwards: a second discard of an
+    /// already-cleared area looks like the first, and an area nobody ever
+    /// staged into looks like one correctly skipped.
+    pub fn discarded_areas(&self) -> Vec<(VmId, IsolationSpec)> {
+        lock(&self.inner.discarded_areas).clone()
     }
 
     /// Appends `bytes` to what `Console::read_output` returns for `vm`.
@@ -367,6 +384,27 @@ impl Adopt for Adopter {
             });
         }
         Ok(Some(Box::new(FakeVm::new(vm))))
+    }
+
+    /// Removes `{runtime_dir}/staged`, and records the call.
+    ///
+    /// A VM that has not been seen to exit is refused: the port says this
+    /// is never asked of a running VM, and the fake is where a caller that
+    /// asks anyway is caught — on disk, tearing a live VM's area down looks
+    /// exactly like tearing a dead one's down.
+    async fn discard_area(&self, record: &VmRecord, isolation: &IsolationSpec) -> Result<()> {
+        if let Some(vm) = self.0.registered(&record.id) {
+            let state = vm.state();
+            if !matches!(state, VmState::Exited(_)) {
+                return Err(Error::WrongState {
+                    id: record.id.clone(),
+                    state,
+                    expected: "a vm that is gone",
+                });
+            }
+        }
+        lock(&self.0.discarded_areas).push((record.id.clone(), isolation.clone()));
+        StagingArea::new(&record.runtime_dir).remove().await
     }
 }
 

--- a/virt/arcbox-vm-driver/src/testkit/fake_driver/tests.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_driver/tests.rs
@@ -513,3 +513,34 @@ async fn a_discarded_prepared_vm_refuses_listeners_before_and_after_its_boot() {
         Some(Error::WrongState { .. })
     ));
 }
+
+/// Discarding the area of a VM that is still running is a caller bug the
+/// port forbids, and the fake is where it is caught: on disk, tearing a
+/// live VM's area down looks exactly like tearing a dead one's down.
+#[tokio::test]
+async fn the_area_of_a_running_vm_is_refused_and_a_dead_ones_is_not() {
+    let dir = tempfile::tempdir().unwrap();
+    let driver = FakeDriver::new();
+    let vm = driver.boot(spec("vm-1"), dir.path()).await.unwrap();
+    let adopt = driver.adopt().unwrap();
+    let record = vm.record();
+
+    assert!(matches!(
+        adopt
+            .discard_area(&record, &IsolationSpec::None)
+            .await
+            .err(),
+        Some(Error::WrongState { .. })
+    ));
+    assert!(driver.discarded_areas().is_empty(), "nothing was recorded");
+
+    vm.shutdown(ShutdownMode::Kill).await.unwrap();
+    adopt
+        .discard_area(&record, &IsolationSpec::None)
+        .await
+        .unwrap();
+    assert_eq!(
+        driver.discarded_areas(),
+        [(record.id.clone(), IsolationSpec::None)]
+    );
+}

--- a/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
@@ -1,19 +1,19 @@
 //! The fake's `Prepare` capability: a "spawned" VMM waiting for a spec.
 
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
 use super::fake_driver::{DriverInner, NAME};
+use super::fake_staging::StagingArea;
 use super::fake_vm::{CHECKPOINT_FORMAT, CheckpointFile, FakeVm, MEM_FILE, VMSTATE_FILE, VmInner};
 use super::fake_vsock::{FakeListener, Inbound};
 use super::lock;
 use crate::capability::{
-    CheckpointImage, CheckpointKind, DiskSource, Prepare, PreparedVm, Staging, VsockListen,
-    VsockListener,
+    CheckpointImage, CheckpointKind, Prepare, PreparedVm, Staging, VsockListen, VsockListener,
 };
 use crate::driver::{ExitStatus, ProcessRecord, RestoreSpec, VmHandle, VmRecord, VmState};
 use crate::error::{Error, Result};
@@ -21,39 +21,6 @@ use crate::spec::{IsolationSpec, VmId, VmSpec};
 
 /// What `discard` reports for a process killed before or after its boot.
 const SIGKILL: i32 = 9;
-
-/// `path` with its `.` and `..` components resolved as far as they can be
-/// without touching the filesystem.
-///
-/// Enough for deciding whether a path lands inside a directory: a `..`
-/// that walks out of one is what the check exists to catch, and symlinks
-/// are beyond what a fake needs to model.
-fn lexically_resolved(path: &Path) -> PathBuf {
-    let mut out = PathBuf::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                if !out.pop() {
-                    out.push(component);
-                }
-            }
-            other => out.push(other),
-        }
-    }
-    out
-}
-
-/// How a staged file gets into the staging area.
-#[derive(Debug, Clone, Copy)]
-enum Bring {
-    /// A stand-in for a device node.
-    Device,
-    /// A private copy; the source stays.
-    Copy,
-    /// The source is consumed.
-    Move,
-}
 
 /// The `Prepare` capability, on its own type so its `prepare` method does
 /// not shadow the driver's accessor of the same name.
@@ -82,6 +49,7 @@ impl Preparer {
             driver: Arc::clone(&self.0),
             isolation: isolation.clone(),
             inbound: Inbound::new(id.clone()),
+            area: StagingArea::new(runtime_dir),
             record,
             phase: Mutex::new(Phase::Prepared),
         }
@@ -106,6 +74,8 @@ pub(super) struct PreparedFake {
     driver: Arc<DriverInner>,
     isolation: IsolationSpec,
     inbound: Arc<Inbound>,
+    /// Where this VM's files are staged; the same area its handle reaches.
+    area: StagingArea,
     record: VmRecord,
     /// One lock for the whole life of the process, so a `boot` racing a
     /// `discard` cannot both pass: whichever takes the lock first decides.
@@ -183,69 +153,6 @@ impl PreparedFake {
         Ok(Box::new(FakeVm::new(vm)))
     }
 
-    /// The VM's staging area: a directory of its own under the runtime
-    /// dir, standing in for a jail's chroot.
-    fn staging_root(&self) -> PathBuf {
-        self.record.runtime_dir.join("staged")
-    }
-
-    /// Where the disk `id` sits in the staging area.
-    ///
-    /// Refuses an id that is not a plain name, exactly as a real adapter
-    /// must: staging writes and replaces at this path and unstaging moves
-    /// what it finds there, so a `..` would reach a file outside the area.
-    /// The fake enforces it because it is the reference driver — a gap it
-    /// shares with the adapters is a gap no contract check can see.
-    fn staged_disk(&self, id: &str) -> Result<PathBuf> {
-        let mut components = Path::new(id).components();
-        if !matches!(components.next(), Some(std::path::Component::Normal(_)))
-            || components.next().is_some()
-        {
-            return Err(Error::InvalidSpec(format!(
-                "disk id `{id}` must be a plain name"
-            )));
-        }
-        Ok(self.staging_root().join(format!("{id}.ext4")))
-    }
-
-    /// Brings `src` into the staging area at `dst`, and answers with where
-    /// it landed. A source already inside the area is left where it is —
-    /// the same short-circuit a real confinement makes.
-    async fn bring_in(&self, src: &Path, dst: &Path, how: Bring) -> Result<PathBuf> {
-        // Against the resolved path, not the written one: `starts_with`
-        // compares components, so `{staged}/../elsewhere` would look like
-        // it is already inside the area and be left where it is — and a
-        // `Handover` would then report a move that never happened. The
-        // answer names where the file is, not how it was spelled.
-        let resolved = lexically_resolved(src);
-        if resolved.starts_with(self.staging_root()) {
-            return Ok(resolved);
-        }
-        if let Some(parent) = dst.parent() {
-            tokio::fs::create_dir_all(parent).await?;
-        }
-        match tokio::fs::remove_file(dst).await {
-            Err(e) if e.kind() != std::io::ErrorKind::NotFound => return Err(Error::Io(e)),
-            _ => {}
-        }
-        match how {
-            // A device node is not something a fake can make; a symlink is
-            // the stand-in, and it is visibly not a copy.
-            Bring::Device => tokio::fs::symlink(src, dst).await?,
-            Bring::Copy => {
-                tokio::fs::copy(src, dst).await?;
-            }
-            Bring::Move => match tokio::fs::rename(src, dst).await {
-                Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
-                    tokio::fs::copy(src, dst).await?;
-                    tokio::fs::remove_file(src).await?;
-                }
-                other => other?,
-            },
-        }
-        Ok(dst.to_path_buf())
-    }
-
     /// Kills whatever `phase` says is running: the booted VM, or the bare
     /// process itself.
     fn kill(&self, phase: &mut Phase) -> ExitStatus {
@@ -295,7 +202,7 @@ impl PreparedVm for PreparedFake {
     }
 
     fn staging(&self) -> Option<&dyn Staging> {
-        self.driver.caps.staging.then_some(self)
+        self.driver.caps.staging.then_some(&self.area)
     }
 
     async fn boot(&self, spec: VmSpec) -> Result<Box<dyn VmHandle>> {
@@ -347,70 +254,6 @@ impl PreparedVm for PreparedFake {
 
     async fn discard(&self) -> Result<ExitStatus> {
         Ok(self.kill(&mut lock(&self.phase)))
-    }
-}
-
-/// Files land in `{runtime_dir}/staged`, under the names a jail would give
-/// them: `vmlinux`, `{disk id}.ext4`, `snapshots/{image dir name}`.
-#[async_trait]
-impl Staging for PreparedFake {
-    async fn stage_kernel(&self, src: &Path) -> Result<PathBuf> {
-        self.bring_in(src, &self.staging_root().join("vmlinux"), Bring::Copy)
-            .await
-    }
-
-    async fn stage_disk(&self, id: &str, source: DiskSource<'_>) -> Result<PathBuf> {
-        let how = match source {
-            DiskSource::Device(_) => Bring::Device,
-            DiskSource::Image(_) => Bring::Copy,
-            DiskSource::Handover(_) => Bring::Move,
-        };
-        let into = self.staged_disk(id)?;
-        self.bring_in(source.path(), &into, how).await
-    }
-
-    async fn unstage_disk(&self, id: &str, dst: &Path) -> Result<bool> {
-        let staged = self.staged_disk(id)?;
-        if !tokio::fs::try_exists(&staged).await.unwrap_or(false) {
-            return Ok(false);
-        }
-        match tokio::fs::rename(&staged, dst).await {
-            Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
-                tokio::fs::copy(&staged, dst).await?;
-                tokio::fs::remove_file(&staged).await?;
-            }
-            other => other?,
-        }
-        Ok(true)
-    }
-
-    async fn stage_checkpoint(&self, image: &CheckpointImage) -> Result<CheckpointImage> {
-        let root = self.staging_root();
-        let resolved = lexically_resolved(&image.dir);
-        if resolved.starts_with(&root) {
-            return Ok(CheckpointImage {
-                dir: resolved,
-                ..image.clone()
-            });
-        }
-        let name = image.dir.file_name().ok_or_else(|| {
-            Error::InvalidSpec(format!(
-                "checkpoint dir {} has no usable name",
-                image.dir.display()
-            ))
-        })?;
-        let dir = root.join("snapshots").join(name);
-        tokio::fs::create_dir_all(&dir).await?;
-        let mut entries = tokio::fs::read_dir(&image.dir).await?;
-        while let Some(entry) = entries.next_entry().await? {
-            if entry.file_type().await?.is_file() {
-                tokio::fs::copy(entry.path(), dir.join(entry.file_name())).await?;
-            }
-        }
-        Ok(CheckpointImage {
-            dir,
-            ..image.clone()
-        })
     }
 }
 

--- a/virt/arcbox-vm-driver/src/testkit/fake_staging.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_staging.rs
@@ -1,0 +1,181 @@
+//! The fake's staging area: the directory standing in for a jail's chroot.
+//!
+//! One area per VM, at `{runtime_dir}/staged`, derived from the runtime dir
+//! rather than held by whoever made it — so every grip on the same VM
+//! computes the same area instead of drifting into two.
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+
+use crate::capability::{CheckpointImage, DiskSource, Staging};
+use crate::error::{Error, Result};
+
+/// `path` with its `.` and `..` components resolved as far as they can be
+/// without touching the filesystem.
+///
+/// Enough for deciding whether a path lands inside a directory: a `..`
+/// that walks out of one is what the check exists to catch, and symlinks
+/// are beyond what a fake needs to model.
+fn lexically_resolved(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !out.pop() {
+                    out.push(component);
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// How a staged file gets into the staging area.
+#[derive(Debug, Clone, Copy)]
+enum Bring {
+    /// A stand-in for a device node.
+    Device,
+    /// A private copy; the source stays.
+    Copy,
+    /// The source is consumed.
+    Move,
+}
+
+/// One VM's staging area.
+///
+/// Files land under the names a jail would give them: `vmlinux`,
+/// `{disk id}.ext4`, `snapshots/{image dir name}`.
+#[derive(Debug, Clone)]
+pub(super) struct StagingArea {
+    root: PathBuf,
+}
+
+impl StagingArea {
+    /// The area of a VM whose scratch space is `runtime_dir`.
+    pub(super) fn new(runtime_dir: &Path) -> Self {
+        Self {
+            root: runtime_dir.join("staged"),
+        }
+    }
+
+    /// Where the disk `id` sits in the area.
+    ///
+    /// Refuses an id that is not a plain name, exactly as a real adapter
+    /// must: staging writes and replaces at this path and unstaging moves
+    /// what it finds there, so a `..` would reach a file outside the area.
+    /// The fake enforces it because it is the reference driver — a gap it
+    /// shares with the adapters is a gap no contract check can see.
+    fn staged_disk(&self, id: &str) -> Result<PathBuf> {
+        let mut components = Path::new(id).components();
+        if !matches!(components.next(), Some(std::path::Component::Normal(_)))
+            || components.next().is_some()
+        {
+            return Err(Error::InvalidSpec(format!(
+                "disk id `{id}` must be a plain name"
+            )));
+        }
+        Ok(self.root.join(format!("{id}.ext4")))
+    }
+
+    /// Brings `src` into the area at `dst`, and answers with where it
+    /// landed. A source already inside the area is left where it is — the
+    /// same short-circuit a real confinement makes.
+    async fn bring_in(&self, src: &Path, dst: &Path, how: Bring) -> Result<PathBuf> {
+        // Against the resolved path, not the written one: `starts_with`
+        // compares components, so `{staged}/../elsewhere` would look like
+        // it is already inside the area and be left where it is — and a
+        // `Handover` would then report a move that never happened. The
+        // answer names where the file is, not how it was spelled.
+        let resolved = lexically_resolved(src);
+        if resolved.starts_with(&self.root) {
+            return Ok(resolved);
+        }
+        if let Some(parent) = dst.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        match tokio::fs::remove_file(dst).await {
+            Err(e) if e.kind() != std::io::ErrorKind::NotFound => return Err(Error::Io(e)),
+            _ => {}
+        }
+        match how {
+            // A device node is not something a fake can make; a symlink is
+            // the stand-in, and it is visibly not a copy.
+            Bring::Device => tokio::fs::symlink(src, dst).await?,
+            Bring::Copy => {
+                tokio::fs::copy(src, dst).await?;
+            }
+            Bring::Move => match tokio::fs::rename(src, dst).await {
+                Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
+                    tokio::fs::copy(src, dst).await?;
+                    tokio::fs::remove_file(src).await?;
+                }
+                other => other?,
+            },
+        }
+        Ok(dst.to_path_buf())
+    }
+}
+
+#[async_trait]
+impl Staging for StagingArea {
+    async fn stage_kernel(&self, src: &Path) -> Result<PathBuf> {
+        self.bring_in(src, &self.root.join("vmlinux"), Bring::Copy)
+            .await
+    }
+
+    async fn stage_disk(&self, id: &str, source: DiskSource<'_>) -> Result<PathBuf> {
+        let how = match source {
+            DiskSource::Device(_) => Bring::Device,
+            DiskSource::Image(_) => Bring::Copy,
+            DiskSource::Handover(_) => Bring::Move,
+        };
+        let into = self.staged_disk(id)?;
+        self.bring_in(source.path(), &into, how).await
+    }
+
+    async fn unstage_disk(&self, id: &str, dst: &Path) -> Result<bool> {
+        let staged = self.staged_disk(id)?;
+        if !tokio::fs::try_exists(&staged).await.unwrap_or(false) {
+            return Ok(false);
+        }
+        match tokio::fs::rename(&staged, dst).await {
+            Err(e) if e.kind() == std::io::ErrorKind::CrossesDevices => {
+                tokio::fs::copy(&staged, dst).await?;
+                tokio::fs::remove_file(&staged).await?;
+            }
+            other => other?,
+        }
+        Ok(true)
+    }
+
+    async fn stage_checkpoint(&self, image: &CheckpointImage) -> Result<CheckpointImage> {
+        let resolved = lexically_resolved(&image.dir);
+        if resolved.starts_with(&self.root) {
+            return Ok(CheckpointImage {
+                dir: resolved,
+                ..image.clone()
+            });
+        }
+        let name = image.dir.file_name().ok_or_else(|| {
+            Error::InvalidSpec(format!(
+                "checkpoint dir {} has no usable name",
+                image.dir.display()
+            ))
+        })?;
+        let dir = self.root.join("snapshots").join(name);
+        tokio::fs::create_dir_all(&dir).await?;
+        let mut entries = tokio::fs::read_dir(&image.dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            if entry.file_type().await?.is_file() {
+                tokio::fs::copy(entry.path(), dir.join(entry.file_name())).await?;
+            }
+        }
+        Ok(CheckpointImage {
+            dir,
+            ..image.clone()
+        })
+    }
+}

--- a/virt/arcbox-vm-driver/src/testkit/fake_staging.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_staging.rs
@@ -61,6 +61,15 @@ impl StagingArea {
         }
     }
 
+    /// Removes the area and everything in it; already gone is success.
+    pub(super) async fn remove(&self) -> Result<()> {
+        match tokio::fs::remove_dir_all(&self.root).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(Error::Io(e)),
+        }
+    }
+
     /// Where the disk `id` sits in the area.
     ///
     /// Refuses an id that is not a plain name, exactly as a real adapter

--- a/virt/arcbox-vm-driver/src/testkit/fake_vm.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_vm.rs
@@ -11,11 +11,12 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
 use super::fake_driver::{Knobs, NAME};
+use super::fake_staging::StagingArea;
 use super::fake_vsock::{FakeListener, Inbound, echo_peer};
 use super::lock;
 use crate::capability::{
     AfterCheckpoint, Balloon, BalloonStats, Checkpoint, CheckpointFormat, CheckpointImage,
-    CheckpointKind, CheckpointOptions, Console, DebugSnapshot, Detach, Vsock, VsockListen,
+    CheckpointKind, CheckpointOptions, Console, DebugSnapshot, Detach, Staging, Vsock, VsockListen,
     VsockListener,
 };
 use crate::driver::{
@@ -74,6 +75,10 @@ pub(super) struct VmInner {
     /// Guest-initiated connections; shared with the prepared process the VM
     /// was booted on, so listeners bound before boot keep working.
     inbound: Arc<Inbound>,
+    /// Where this VM's files were staged. Derived from the record, so a
+    /// handle over an adopted VM names the same area the prepared process
+    /// that staged them did.
+    area: StagingArea,
     console: Mutex<Vec<u8>>,
     balloon_target_bytes: AtomicU64,
     /// Every `shutdown` this VM was asked for, in order.
@@ -96,6 +101,7 @@ impl VmInner {
         restored: bool,
     ) -> Arc<Self> {
         let (events, _) = broadcast::channel(16);
+        let area = StagingArea::new(&record.runtime_dir);
         Arc::new(Self {
             spec,
             record,
@@ -106,6 +112,7 @@ impl VmInner {
             restored,
             events,
             inbound,
+            area,
             console: Mutex::new(Vec::new()),
             balloon_target_bytes: AtomicU64::new(balloon_target_bytes),
             shutdowns: Mutex::new(Vec::new()),
@@ -257,6 +264,10 @@ impl VmHandle for FakeVm {
 
     fn detach(&self) -> Option<&dyn Detach> {
         self.vm.caps.adopt.then_some(&self.ownership)
+    }
+
+    fn staging(&self) -> Option<&dyn Staging> {
+        self.vm.caps.staging.then_some(&self.vm.area)
     }
 
     fn balloon(&self) -> Option<&dyn Balloon> {

--- a/virt/arcbox-vm-driver/src/testkit/mod.rs
+++ b/virt/arcbox-vm-driver/src/testkit/mod.rs
@@ -19,6 +19,7 @@ pub mod contract;
 pub mod fake_driver;
 pub mod fake_network;
 mod fake_prepared;
+mod fake_staging;
 mod fake_vm;
 mod fake_vsock;
 

--- a/xtask/src/commands/check_layers/rules.rs
+++ b/xtask/src/commands/check_layers/rules.rs
@@ -107,10 +107,10 @@ pub const EXCEPTIONS: &[Exception] = &[
     Exception {
         from: "arcbox-computer-runtime",
         to: "arcbox-fc-driver",
-        reason: "the runtime no longer builds the Firecracker adapter, but its \
-                 config still speaks FcDriverConfig, its checkpoints the \
-                 driver's format, and its startup sweep the jailer's chroot \
-                 layout, until a config split moves those to the port",
+        reason: "the runtime no longer builds the Firecracker adapter, nor \
+                 reads its jailer layout, but its config still speaks \
+                 FcDriverConfig and its checkpoints the driver's format, \
+                 until a config split moves those to the port",
         until: "vm-stack-redesign R3 (the config split after PR-G)",
     },
     Exception {


### PR DESCRIPTION
Two loose ends of the same shape: the runtime reached into a VM's private host area behind the driver's back, and the one caller that could not was refused.

## The port

- **`Adopt::discard_area(record, isolation)`** — removes the host area of a VM that is gone. A VM's area belongs to whichever grip owns its VMM: the `PreparedVm` that made it, or the handle of a VM the driver adopted. A VM that died with the process which booted it leaves neither, and leaves its area — under the jailer, a whole chroot holding a guest rootfs. `isolation` is passed because nothing can be read back off a dead process; already-removed is success, because a startup sweep may find what an earlier one cleared; a driver that confines nothing has no area and succeeds.
- **`VmHandle::staging()`** — the same area `PreparedVm::staging` stages into, reached from the other grip. `Some` iff `DriverCapabilities::staging`, which the contract's agreement check now asserts for the handle too.

On Firecracker, `discard_area` removes the jailer's per-VM directory `{chroot base}/{binary}/{id}` — the same directory, via the same `Jail::remove`, that `PreparedVm::discard` and an adopted handle's `shutdown` take, and the same one the sweep's old `remove_dir_if_present(chroot.parent())` removed. Staging moved off `FcPrepared` onto `JailStaging`, built from a `VmLayout` and nothing else, so `FcPrepared`, `FcHandle` and `FcProcessHandle` all reach one area; `FcProcessHandle::new` now takes the layout the adopt already built rather than just its jail.

## `record.jailer`: the flag stops deciding anything

The journal's `jailer` flag records what the config of the process that *wrote* it had, while the only area this process can name is the one its own config describes. Those disagree exactly for a record written by a differently-configured process — and gating on the flag then skipped the removal, leaving an area nothing else would ever collect. The sweep asks the driver instead, which answers "there is no area" for a config that confines nothing: the case the flag was standing in for.

**The field stays in the record.** It is `#[serde(default)]`, and an agent that predates this route still gates its chroot removal on it, so dropping it would make a downgrade skip every removal. Nothing in this agent acts on it, and the field's doc says so.

Pinned by `a_dead_vms_area_goes_whatever_its_journal_says_about_the_jailer`, which runs the sweep twice — once with `jailer: false`, once with `true`, both under a jailer-configured process — and asserts the same single `discard_area` call with this process's own isolation. Reverting the change makes it fail.

## Pause

`release_for_pause` asked the prepared VM for staging, which a computer this process *adopted* does not have, so a copy-mode one — whose staged rootfs is its only writable disk — was refused (CORE-135). The refusal cost the computer: a failed release has no recoverable arm in `releasing` the way a failed capture has in `capturing`, so a pause refused for a computer's safety killed it through its handle and left it durably `Failed`.

It asks whichever grip this process holds now. `staging_capability` takes the accessor's answer rather than the grip it came from, so one helper serves both. `unstage_disk` returning `Ok(false)` stays a refusal — in copy mode it means there is no disk to resume from — and holding no grip at all folds into the same one.

**What the pause regression proves.** Two tests, both mutation-checked (revert the fix and they fail):

- `an_adopted_copy_mode_computer_pauses_through_its_handle` (unit): a computer with a `handle` and no `prepared` pauses, its disk lands at `{vm_dir}/paused-rootfs.ext4`, and the VM is *asked* to die through its handle rather than merely dropped.
- `an_adopted_computer_on_a_copied_rootfs_pauses_and_keeps_its_disk` (manager-over-fakes): the inverted CORE-135 acceptance test — boot, hand the VM over, restart, adopt, pause. It reaches `Paused` with its disk parked.

## Known gap this uncovers, deliberately not fixed here

Resuming an adopted computer still fails, for a reason the pause refusal was hiding: the durable record redacts a computer's boot inputs when it reaches `Ready` (`redact_runtime_inputs` clears `effective_spec.kernel`), so an adopted computer's `spec.kernel` is empty and every checkpoint it takes records no kernel path for the staging that follows to bring in — `stage_kernel("")` is `ENOENT`. That is a gap in adoption, not in pause: a plain **Checkpoint** of an adopted computer is unrestorable for exactly the same reason, with no pause involved. Fixing it means deciding whether the record should stop redacting those fields (an on-disk contract change) or whether resume should re-resolve the kernel from config — a decision of its own.

The acceptance test asserts it as it behaves: the resume fails, the computer is left back at `Paused`, and its retained disk is where the pause put it. So the outcome is strictly better than before — the computer used to be killed and durably `Failed`; now it keeps its disk and is retryable.

## Rebased onto #685

The runtime no longer builds its own VMM, so `SandboxManager::with_environment` is `SandboxManager::new` and this branch's one `sandbox.rs` edit follows the rename. This PR also removes the last thing the grandfathered `arcbox-computer-runtime -> arcbox-fc-driver` exception named besides its config and checkpoint format — the jailer chroot layout the startup sweep read — so the exception's `reason` in `xtask/src/commands/check_layers/rules.rs` is corrected in the same commit that deletes that edge. The exception itself stays: `config/vmm.rs` and `sandbox/checkpoint.rs` still hold fc-driver edges, and an exception whose edge is gone fails the gate.

## Checks

`rg "jail::" computer/` is empty. `cargo fmt --all --check`; clippy `-D warnings` on the three crates; unit tests for all three; `cargo check -p arcbox-agent --target aarch64-unknown-linux-musl --all-targets`; `cargo run -p xtask -- check-layers`; `cargo check --workspace --all-targets`; `cargo doc` clean on the touched crates. CORE-135's own e2e acceptance test is untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orphan sweep teardown and pause ordering around jails and rootfs parking; mistakes could leak disk areas or leave computers unpausable, but behavior is heavily tested including CORE-135 regressions.
> 
> **Overview**
> Routes **VM host-area lifecycle** through `arcbox-vm-driver` instead of the runtime guessing jail paths or trusting stale journal flags.
> 
> **Port:** Adds **`Adopt::discard_area`** for dead VMs (jail/chroot removal using this process’s `isolation`, not the writer’s config) and **`VmHandle::staging()`** so adopted VMs share the same staging area as `PreparedVm`. Contract and fake driver cover both.
> 
> **Sweep:** Orphan reconciliation drops manual chroot teardown gated on **`record.jailer`** and calls **`discard_area`** once per dead VM. The `jailer` field stays on disk for older agents but is no longer acted on here.
> 
> **Pause (CORE-135):** Copy-mode **`release_for_pause`** unstages the rootfs via **prepared or handle** staging before killing the VMM, so adopted computers pause instead of failing (and getting killed on the release error path).
> 
> **Firecracker:** Staging consolidated in **`JailStaging`**; **`FcHandle`** / **`FcProcessHandle`** expose staging; **`discard_area`** removes the per-VM jail directory like discard/shutdown already did.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72b9e8eb5054e5d4ca6cada517fcdc23ff01fe39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->