### PR TITLE
fix(computer): route detach_all through the per-computer actor

### DIFF
--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
@@ -132,6 +132,42 @@ impl ComputerActor {
                     }
                 }
             }
+            Command::Detach { reply } => {
+                // Parked *before* the dispatch, like a removal and for a
+                // sharper reason: the handover is awaited inside the effect
+                // rather than spawned, so `Answer::Detached` always lands
+                // before this dispatch returns.
+                self.waiters.push((Answer::Detached, reply));
+                if self.dispatch(machine, Event::Detach).await {
+                    return;
+                }
+                // The machine had nothing to do, which is two different
+                // answers — and the state is what tells them apart, not the
+                // handle: a computer halfway through a stop still holds one.
+                let answer = match machine.state() {
+                    // Nothing to hand over, which is a real success: there is
+                    // no guest here this process would have killed on its way
+                    // out. A paused computer gave its VM up to its checkpoint
+                    // and a resting one has none, so the successor reinstates
+                    // all of them from the record alone. An already-detached
+                    // one is the successor's twice over — reporting a failure
+                    // would have a composer log a loss it did not take.
+                    State::Paused {}
+                    | State::Stopped {}
+                    | State::Failed {}
+                    | State::Gone {}
+                    | State::Detached {} => Ok(()),
+                    // Mid-launch or mid-teardown. The launch's resources are
+                    // still in its task rather than on the computer, and a
+                    // teardown was asked for — either way a caller that heard
+                    // `Ok` would believe a guest survived a handover that
+                    // never happened.
+                    _ => Err(self.wrong_state("Ready, Running, or Checkpointing")),
+                };
+                if let Some((_, reply)) = self.waiters.pop() {
+                    let _ = reply.send(answer);
+                }
+            }
             Command::ClaimWorkload { claim, reply } => {
                 let taken = self.dispatch(machine, Event::ClaimWorkload { claim }).await;
                 let _ = reply.send(if taken {

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
@@ -11,6 +11,22 @@ use super::*;
 
 impl ComputerActor {
     pub(super) async fn on_command(&mut self, machine: &mut Machine, command: Command) {
+        // A handed-over computer answers nothing but another handover.
+        //
+        // One rule here rather than a guard per command, because the thing
+        // that makes this state easy to miss is systematic: `detached`
+        // projects `Ready` — the wire has no variant for "the successor's" —
+        // so every gate below that reads `self.public()` is blind to it. The
+        // ones that refuse it today do so by luck of their match arms, and
+        // `Resume` did not: it read `Ready` and answered `Ok` for a computer
+        // this process no longer owned. A rule at the door cannot be
+        // forgotten by whatever command is added next.
+        if matches!(machine.state(), State::Detached {})
+            && !matches!(command, Command::Detach { .. })
+        {
+            self.refuse_handed_over(command);
+            return;
+        }
         match command {
             Command::Provision {
                 provision,
@@ -199,18 +215,6 @@ impl ComputerActor {
                 self.dispatch(machine, Event::WorkloadReleased).await;
             }
             Command::SetLifecycle { update, reply } => {
-                // A handed-over computer refuses too, and the state is what
-                // says so — it projects `Ready`, so the public gate below lets
-                // it through. What that would reach is not a timer but the
-                // record: `persist_lifecycle` fsyncs into the record the
-                // successor has already adopted, under the generation it
-                // adopted with, so the write is accepted rather than fenced.
-                // The same class as the VM race this whole transition exists
-                // to close, moved from the guest to its record.
-                if matches!(machine.state(), State::Detached {}) {
-                    let _ = reply.send(Err(self.wrong_state("a computer this process still owns")));
-                    return;
-                }
                 // `set_sandbox_lifecycle` refuses a computer on its way out:
                 // nothing is left for a deadline to fire on, and the record
                 // it would persist to is about to be a tombstone.
@@ -258,6 +262,40 @@ impl ComputerActor {
                     .get_or_insert_with(|| format!("computer {} exited unexpectedly", self.id));
                 self.dispatch(machine, Event::VmExited).await;
             }
+        }
+    }
+
+    /// Answers every caller of a computer this process has handed over.
+    ///
+    /// What it protects is not one command. `SetLifecycle` was the loud case —
+    /// `persist_lifecycle` fsyncs into the record the successor has already
+    /// adopted, under the generation it adopted with, so the write is accepted
+    /// rather than fenced, which is the VM race this transition closes moved
+    /// onto the record. But `Resume` answered `Ok` for the same reason, and
+    /// the next command would have too.
+    ///
+    /// The match stays exhaustive so that adding one forces a decision here.
+    /// `Detach` cannot reach this — the caller lets it through, because a
+    /// second handover is an idempotent no-op rather than a refusal — and the
+    /// tells have nobody to answer: `detached` swallows them anyway.
+    fn refuse_handed_over(&self, command: Command) {
+        let refused = || self.wrong_state("a computer this process still owns");
+        match command {
+            Command::Provision { reply, .. }
+            | Command::Pause { reply, .. }
+            | Command::Resume { reply, .. }
+            | Command::Stop { reply, .. }
+            | Command::Remove { reply, .. }
+            | Command::ClaimWorkload { reply, .. }
+            | Command::SetLifecycle { reply, .. }
+            | Command::Detach { reply } => {
+                let _ = reply.send(Err(refused()));
+            }
+            // Its own reply type, so it cannot join the arm above.
+            Command::Checkpoint { reply, .. } => {
+                let _ = reply.send(Err(refused()));
+            }
+            Command::WorkloadExited { .. } | Command::ReleaseWorkload | Command::VmExited => {}
         }
     }
 

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
@@ -6,6 +6,7 @@
 //! is also where a caller parks until the effect that answers it lands.
 
 use chrono::Utc;
+use tracing::warn;
 
 use super::*;
 
@@ -149,6 +150,30 @@ impl ComputerActor {
                 }
             }
             Command::Detach { reply } => {
+                // The handover answers on its own outcome and nothing else.
+                //
+                // Answer state that is still set belongs to a flow that ended
+                // with nobody parked to hear it — an idle-driven pause whose
+                // `Pausing` write was refused is the reachable one, since
+                // `Durability::Warn` softens only an unconfirmed write, not a
+                // refused one. `answer` would fold it into this reply and
+                // report a guest lost that was in fact handed over, and
+                // unretryably: the state is terminal by then, so the retry
+                // answers `Ok` and contradicts the first answer. Going through
+                // `park` would report it *instead of* attempting the handover,
+                // which is the same false loss one step earlier. So it is
+                // dropped here, and logged, because nothing else can report it
+                // now. (`Remove` carries the same hazard and predates this;
+                // its answer at least stays consistent under a retry.)
+                let stale_failure = self.answer_error.take();
+                let stale_unconfirmed = self.unconfirmed.take();
+                if let Some(detail) = stale_failure.or(stale_unconfirmed) {
+                    warn!(
+                        sandbox_id = %self.id,
+                        detail,
+                        "dropping an unreported failure from an earlier flow; the handover answers for itself"
+                    );
+                }
                 // Parked *before* the dispatch, like a removal and for a
                 // sharper reason: the handover is awaited inside the effect
                 // rather than spawned, so `Answer::Detached` always lands

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
@@ -148,21 +148,24 @@ impl ComputerActor {
                     // Nothing to hand over, which is a real success: there is
                     // no guest here this process would have killed on its way
                     // out. A paused computer gave its VM up to its checkpoint
-                    // and a resting one has none, so the successor reinstates
-                    // all of them from the record alone. An already-detached
-                    // one is the successor's twice over — reporting a failure
-                    // would have a composer log a loss it did not take.
-                    State::Paused {}
+                    // and a resting one has none; `provisioning` has not
+                    // spawned its boot yet, so no VMM exists either. The
+                    // successor reinstates all of them from the record alone.
+                    // An already-detached one is the successor's twice over —
+                    // reporting a failure would have a composer log a loss it
+                    // did not take.
+                    State::Provisioning {}
+                    | State::Paused {}
                     | State::Stopped {}
                     | State::Failed {}
                     | State::Gone {}
                     | State::Detached {} => Ok(()),
-                    // Mid-launch or mid-teardown. The launch's resources are
-                    // still in its task rather than on the computer, and a
-                    // teardown was asked for — either way a caller that heard
-                    // `Ok` would believe a guest survived a handover that
-                    // never happened.
-                    _ => Err(self.wrong_state("Ready, Running, or Checkpointing")),
+                    // Mid-launch, mid-capture or mid-teardown — all of which
+                    // do have a VM, and all of which lose it when this process
+                    // exits. That is worth reporting rather than skipping: a
+                    // caller told `Ok` would believe a guest survived a
+                    // handover that never happened.
+                    _ => Err(self.wrong_state("Ready or Running")),
                 };
                 if let Some((_, reply)) = self.waiters.pop() {
                     let _ = reply.send(answer);
@@ -196,6 +199,18 @@ impl ComputerActor {
                 self.dispatch(machine, Event::WorkloadReleased).await;
             }
             Command::SetLifecycle { update, reply } => {
+                // A handed-over computer refuses too, and the state is what
+                // says so — it projects `Ready`, so the public gate below lets
+                // it through. What that would reach is not a timer but the
+                // record: `persist_lifecycle` fsyncs into the record the
+                // successor has already adopted, under the generation it
+                // adopted with, so the write is accepted rather than fenced.
+                // The same class as the VM race this whole transition exists
+                // to close, moved from the guest to its record.
+                if matches!(machine.state(), State::Detached {}) {
+                    let _ = reply.send(Err(self.wrong_state("a computer this process still owns")));
+                    return;
+                }
                 // `set_sandbox_lifecycle` refuses a computer on its way out:
                 // nothing is left for a deadline to fire on, and the record
                 // it would persist to is about to be a tombstone.

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
@@ -181,7 +181,18 @@ impl ComputerActor {
                     // exits. That is worth reporting rather than skipping: a
                     // caller told `Ok` would believe a guest survived a
                     // handover that never happened.
-                    _ => Err(self.wrong_state("Ready or Running")),
+                    //
+                    // Phrased as a property rather than a state list, because
+                    // `wrong_state` reads `actual` off the public projection
+                    // and two states here project into any list this arm could
+                    // name: `checkpointing` reads `Ready` and a `gating` whose
+                    // own `cmd` has claimed the slot reads `Running`. Naming
+                    // the states would tell a composer "expected Ready or
+                    // Running, actual Ready" — and `detach_all` folds this
+                    // verbatim into the failure string someone diagnoses a
+                    // lost handover from.
+                    _ => Err(self
+                        .wrong_state("a computer with no launch, capture, or teardown in flight")),
                 };
                 if let Some((_, reply)) = self.waiters.pop() {
                     let _ = reply.send(answer);

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
@@ -124,29 +124,47 @@ impl ComputerActor {
                     }
                 });
             }
-            Effect::Detach => match self.tasks.detach().await {
-                // The machine has not moved yet: it emitted this effect and
-                // stayed put, so the handover's own outcome is what decides.
-                Ok(()) => {
-                    // The data plane reads the agent straight off the snapshot
-                    // and never round-trips the mailbox, so the state alone
-                    // cannot stop it — and `detached` projects `Ready`, which
-                    // is exactly what `require_alive_agent` admits. Dropping
-                    // the agent is what keeps an exec or a file write out of a
-                    // guest the successor now owns; a stop and a release do
-                    // the same for the same reason.
-                    self.forget_agent();
-                    self.queued.push_back(Event::Detached);
+            Effect::Detach => {
+                // The data plane reads the agent straight off the snapshot and
+                // never round-trips the mailbox, so the state alone cannot
+                // stop it — and `detached` projects `Ready`, which is exactly
+                // what `require_alive_agent` admits. Dropping the agent is
+                // what keeps an exec or a file write out of a guest the
+                // successor now owns; a stop and a release do the same.
+                //
+                // It goes *before* the port call, not after. Detach is the one
+                // flow whose ownership transfer happens inside an await, so
+                // forgetting afterwards would leave the whole call open for a
+                // reader to take the agent out of the snapshot and dial a VM
+                // that had already changed hands. This does not close the race
+                // — a reader that cloned the `Arc` a moment earlier still
+                // holds a working agent, and revoking that would mean routing
+                // the data plane through the mailbox, which is the hop this
+                // seam exists to avoid — but it bounds the exposure to callers
+                // already in flight rather than every caller for the duration.
+                let agent = self.snapshot_tx.borrow().agent.clone();
+                self.forget_agent();
+                match self.tasks.detach().await {
+                    // The machine has not moved yet: it emitted this effect
+                    // and stayed put, so the handover's outcome is what
+                    // decides.
+                    Ok(()) => self.queued.push_back(Event::Detached),
+                    // Stay where we are. The VM is still ours and still usable
+                    // — it simply dies with this process, which is what a
+                    // failed handover has always meant. Failing the computer
+                    // instead would write `Failed` over a record the
+                    // successor's sweep still has to read as `Ready`. Usable
+                    // includes dialable, so the agent goes back: nothing
+                    // changed hands, and the data plane must not have lost a
+                    // guest to a handover that did not happen.
+                    Err(failure) => {
+                        if let Some(agent) = agent {
+                            self.publish_agent(agent);
+                        }
+                        self.fail_waiters(failure.into_error());
+                    }
                 }
-                // Stay where we are. The VM is still ours and still usable —
-                // it simply dies with this process, which is what a failed
-                // handover has always meant. Failing the computer instead
-                // would write `Failed` over a record the successor's sweep
-                // still has to read as `Ready`.
-                Err(failure) => {
-                    self.fail_waiters(failure.into_error());
-                }
-            },
+            }
             Effect::AbortInflight => return self.abort_inflight().await,
             Effect::Publish(notify) => self.publish(notify),
             Effect::ArmTimer(timer) => self.arm(timer, state),

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
@@ -127,7 +127,17 @@ impl ComputerActor {
             Effect::Detach => match self.tasks.detach().await {
                 // The machine has not moved yet: it emitted this effect and
                 // stayed put, so the handover's own outcome is what decides.
-                Ok(()) => self.queued.push_back(Event::Detached),
+                Ok(()) => {
+                    // The data plane reads the agent straight off the snapshot
+                    // and never round-trips the mailbox, so the state alone
+                    // cannot stop it — and `detached` projects `Ready`, which
+                    // is exactly what `require_alive_agent` admits. Dropping
+                    // the agent is what keeps an exec or a file write out of a
+                    // guest the successor now owns; a stop and a release do
+                    // the same for the same reason.
+                    self.forget_agent();
+                    self.queued.push_back(Event::Detached);
+                }
                 // Stay where we are. The VM is still ours and still usable —
                 // it simply dies with this process, which is what a failed
                 // handover has always meant. Failing the computer instead

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
@@ -144,7 +144,19 @@ impl ComputerActor {
                 // already in flight rather than every caller for the duration.
                 let agent = self.snapshot_tx.borrow().agent.clone();
                 self.forget_agent();
-                match self.tasks.detach().await {
+                // Bounded because this one is awaited inline; see
+                // [`DETACH_TIMEOUT`]. A driver that hangs here loses this
+                // computer, not the whole pass.
+                let handover = match tokio::time::timeout(DETACH_TIMEOUT, self.tasks.detach()).await
+                {
+                    Ok(handover) => handover,
+                    Err(_) => Err(TaskFailure::recoverable(VmmError::Process(format!(
+                        "handing computer {} over did not finish within {}s",
+                        self.id,
+                        DETACH_TIMEOUT.as_secs()
+                    )))),
+                };
+                match handover {
                     // The machine has not moved yet: it emitted this effect
                     // and stayed put, so the handover's outcome is what
                     // decides.

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
@@ -124,6 +124,19 @@ impl ComputerActor {
                     }
                 });
             }
+            Effect::Detach => match self.tasks.detach().await {
+                // The machine has not moved yet: it emitted this effect and
+                // stayed put, so the handover's own outcome is what decides.
+                Ok(()) => self.queued.push_back(Event::Detached),
+                // Stay where we are. The VM is still ours and still usable —
+                // it simply dies with this process, which is what a failed
+                // handover has always meant. Failing the computer instead
+                // would write `Failed` over a record the successor's sweep
+                // still has to read as `Ready`.
+                Err(failure) => {
+                    self.fail_waiters(failure.into_error());
+                }
+            },
             Effect::AbortInflight => return self.abort_inflight().await,
             Effect::Publish(notify) => self.publish(notify),
             Effect::ArmTimer(timer) => self.arm(timer, state),

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
@@ -167,6 +167,13 @@ pub enum Command {
         force: bool,
         reply: Reply,
     },
+    /// Give the VM up without stopping it, so the next process can adopt it
+    /// (`detach_all`, on graceful shutdown). A terminal transition like the two
+    /// above, and here for the same reason: it is the actor that serializes
+    /// them, so a handover cannot race the stop of the same computer.
+    Detach {
+        reply: Reply,
+    },
     /// Take the single-workload slot.
     ClaimWorkload {
         claim: WorkloadClaim,

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
@@ -75,6 +75,18 @@ mod inflight;
 /// before giving up and retrying. Until that signal the task owns resources
 /// the computer does not, so aborting it would strand them.
 const HANDOFF_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long the handover's port call may take before it is treated as a failed
+/// handover.
+///
+/// [`Effect::Detach`] is the one port call awaited on the actor task itself, so
+/// this bound is what keeps "releasing ownership has no wait in it" a property
+/// of this crate rather than a promise made about a driver two crates away.
+/// Today's is an atomic store and a oneshot send; one that ever did real work —
+/// an fsync'd adoption record, a remote control plane — would otherwise stall
+/// the command loop unpreemptibly, and every computer behind this one in a
+/// handover pass with it. A timeout leaves the computer exactly where a refused
+/// handover does: ours, usable, and dying with this process.
+const DETACH_TIMEOUT: Duration = Duration::from_secs(5);
 /// Backoff bounds for a teardown that could not take the handoff. Mirrors
 /// `cleanup::TTL_REMOVE_RETRY_*`; PR-F2 puts them on the injected `Clock`.
 const RETRY_INITIAL: Duration = Duration::from_millis(250);

--- a/computer/arcbox-computer-runtime/src/lifecycle/effect.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/effect.rs
@@ -87,6 +87,7 @@ pub(super) enum Answer {
     Paused,
     Stopped,
     Removed,
+    Detached,
 }
 
 /// A side effect emitted by a transition, executed by the actor.
@@ -128,6 +129,14 @@ pub(super) enum Effect {
     SpawnRelease {
         scope: ReleaseScope,
     },
+    /// Hand the VM to the next process. Unlike every other flow this is not a
+    /// `Spawn*`: releasing ownership has no wait in it, so the actor awaits it
+    /// in the same dispatch and raises [`Event::Detached`] only if it worked —
+    /// which is what lets a failed handover leave the computer where it was
+    /// instead of needing a state to come back from.
+    ///
+    /// [`Event::Detached`]: super::event::Event::Detached
+    Detach,
     /// Wait out the boot task's resource handoff, then abort it.
     AbortInflight,
     Publish(Notify),

--- a/computer/arcbox-computer-runtime/src/lifecycle/event.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/event.rs
@@ -68,6 +68,11 @@ pub(super) enum Event {
     Remove {
         force: bool,
     },
+    /// Give the VM up without stopping it, so the next process can adopt it.
+    /// Only the states holding a settled live handle act on it; everywhere
+    /// else the actor answers, because a computer mid-launch or mid-teardown
+    /// has nothing a successor could take.
+    Detach,
     ClaimWorkload {
         claim: WorkloadClaim,
     },
@@ -95,6 +100,11 @@ pub(super) enum Event {
     ReleasedForPause,
     StopDone,
     RemoveDone,
+    /// The handover succeeded: the VM is the next process's, and dropping this
+    /// process's handle no longer kills it. Raised by the effect rather than by
+    /// a sub-task — a handover that *failed* leaves the computer exactly where
+    /// it was, so there is no failure edge to model.
+    Detached,
     /// A recoverable failure: whatever usable state the computer had survives.
     Failure,
     /// The guest is quiesced with no verb able to thaw it — the port is

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows.rs
@@ -201,6 +201,10 @@ impl ComputerTasks for ComputerFlows {
         self.release_scope(scope).await
     }
 
+    async fn detach(&self) -> TaskResult {
+        self.detach_vm().await
+    }
+
     fn adopted_agent(&self) -> Option<Arc<dyn GuestAgent>> {
         self.agent().ok()
     }

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use tracing::info;
+use tracing::{debug, info};
 
 use super::ComputerFlows;
 use crate::error::VmmError;
@@ -109,15 +109,22 @@ impl ComputerFlows {
     /// describes the guest it names, and after the driver has released it a
     /// drop no longer kills. Nothing durable is written — the record already
     /// says `Ready`, which is what the successor's sweep adopts from.
+    ///
+    /// This is also the only place that can tell a real handover from an `Ok`
+    /// there was nothing behind, so it is where each one is logged: the answer
+    /// the actor gives its caller carries no payload, and `detach_all` would
+    /// otherwise report a saved guest per paused or resting computer it asked.
     pub(super) async fn detach_vm(&self) -> TaskResult {
         let handle = self.computer.lock().unwrap().handle.clone();
         // No VM to hand over, or a driver that runs its VMs in-process and
         // never produced a handle a successor could pick up — the same
         // reasoning the startup sweep applies to `Adopt`.
         let Some(handle) = handle else {
+            debug!(sandbox_id = %self.id, "no vm to hand to the next process");
             return Ok(());
         };
         let Some(detach) = handle.detach() else {
+            debug!(sandbox_id = %self.id, "the driver holds its vms in-process; nothing to hand over");
             return Ok(());
         };
         detach.detach().await.map_err(|error| {
@@ -126,6 +133,7 @@ impl ComputerFlows {
                 self.id
             )))
         })?;
+        info!(sandbox_id = %self.id, "handed the computer's vm to the next process");
         Ok(())
     }
 

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
@@ -103,6 +103,32 @@ impl ComputerFlows {
         Ok(())
     }
 
+    /// Hand this computer's VM to the next process.
+    ///
+    /// The handle deliberately stays on the computer: the read path still
+    /// describes the guest it names, and after the driver has released it a
+    /// drop no longer kills. Nothing durable is written — the record already
+    /// says `Ready`, which is what the successor's sweep adopts from.
+    pub(super) async fn detach_vm(&self) -> TaskResult {
+        let handle = self.computer.lock().unwrap().handle.clone();
+        // No VM to hand over, or a driver that runs its VMs in-process and
+        // never produced a handle a successor could pick up — the same
+        // reasoning the startup sweep applies to `Adopt`.
+        let Some(handle) = handle else {
+            return Ok(());
+        };
+        let Some(detach) = handle.detach() else {
+            return Ok(());
+        };
+        detach.detach().await.map_err(|error| {
+            TaskFailure::recoverable(VmmError::Process(format!(
+                "hand computer {} to the next process: {error}",
+                self.id
+            )))
+        })?;
+        Ok(())
+    }
+
     pub(super) async fn release_scope(&self, scope: ReleaseScope) -> TaskResult {
         let services = &self.services;
         let outcome = match scope {

--- a/computer/arcbox-computer-runtime/src/lifecycle/machine.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/machine.rs
@@ -365,10 +365,18 @@ impl ComputerLifecycle {
             // this process no longer owns. Refusing costs the departing
             // process's capture; accepting would corrupt the successor's
             // guest, and the caller hears which computer it lost.
+            // `Detached` is swallowed for the same reason as the `Detach` that
+            // would have produced it, and not only because none can arrive
+            // today: `Effect::Detach` is awaited inline, so its completion is
+            // drained inside the dispatch that asked for it, and this state
+            // never asks. Were it ever spawned like every sibling flow, a
+            // completion landing here would inherit `active`'s arm and detach
+            // mid-capture — exactly the corruption the refusal above prevents.
             Event::ClaimWorkload { .. }
             | Event::Pause { .. }
             | Event::Checkpoint
             | Event::Detach
+            | Event::Detached
             | Event::IdleExpired { .. } => Handled,
             _ => Super,
         }

--- a/computer/arcbox-computer-runtime/src/lifecycle/machine.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/machine.rs
@@ -238,8 +238,10 @@ impl ComputerLifecycle {
         }
     }
 
-    /// The three states holding a settled live handle — which is exactly the
-    /// set a handover can act on, and why `Detach` sits beside `Stop` here.
+    /// The states holding a settled live handle, which is why `Detach` sits
+    /// beside `Stop` here. `checkpointing` is the one member that refuses it:
+    /// its capture sub-task holds a clone of the handle and would keep driving
+    /// a guest this process had handed over.
     #[superstate(superstate = "computer")]
     fn active(event: &Event, context: &mut Effects) -> Outcome {
         match event {
@@ -355,9 +357,18 @@ impl ComputerLifecycle {
                 context.emit(Effect::ArmTimer(Timer::Idle));
                 Transition(State::ready())
             }
+            // A handover is refused here, unlike in the rest of `active`. The
+            // capture runs in a sub-task that cloned the handle before it
+            // started, and `Detach` stands nothing down — the driver's detach
+            // only releases the reaper, leaving the handle fully functional —
+            // so the task would go on to freeze, snapshot and resume a guest
+            // this process no longer owns. Refusing costs the departing
+            // process's capture; accepting would corrupt the successor's
+            // guest, and the caller hears which computer it lost.
             Event::ClaimWorkload { .. }
             | Event::Pause { .. }
             | Event::Checkpoint
+            | Event::Detach
             | Event::IdleExpired { .. } => Handled,
             _ => Super,
         }

--- a/computer/arcbox-computer-runtime/src/lifecycle/machine.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/machine.rs
@@ -238,12 +238,30 @@ impl ComputerLifecycle {
         }
     }
 
+    /// The three states holding a settled live handle — which is exactly the
+    /// set a handover can act on, and why `Detach` sits beside `Stop` here.
     #[superstate(superstate = "computer")]
     fn active(event: &Event, context: &mut Effects) -> Outcome {
         match event {
             Event::Stop { budget_ms } => {
                 context.stop(*budget_ms, false);
                 Transition(State::stopping())
+            }
+            // No transition: the port call decides. A handover that fails
+            // leaves a computer that is still ours and still usable, so the
+            // machine must not have moved off the state it came from.
+            Event::Detach => {
+                context.emit(Effect::Detach);
+                Handled
+            }
+            Event::Detached => {
+                context.emit(Effect::Answer(Answer::Detached));
+                // The TTL and idle windows belong to whoever owns the VM, and
+                // that is no longer this process; leaving them armed would have
+                // an expiry tear down a guest the successor is adopting.
+                context.emit(Effect::CancelTimer(Timer::Ttl));
+                context.emit(Effect::CancelTimer(Timer::Idle));
+                Transition(State::detached())
             }
             _ => Super,
         }
@@ -491,6 +509,21 @@ impl ComputerLifecycle {
             | Event::VmExited => Handled,
             _ => Super,
         }
+    }
+
+    /// Handed to the next process: this one no longer owns the VM.
+    ///
+    /// Deliberately **not** under `computer`, unlike every other resting state.
+    /// A `Remove` or a TTL expiry reaching that superstate would release TAP,
+    /// the CoW device and the jail out from under a live guest the successor
+    /// has adopted, and a `Stop` would drive `handle.shutdown` into a handle
+    /// whose waiter has stood down — burning the budget and then SIGKILLing the
+    /// VM that was just reported as handed over. Swallowing everything here is
+    /// what makes the handover final. The record is left exactly as it was,
+    /// which is what the successor's sweep adopts from.
+    #[state]
+    fn detached() -> Outcome {
+        Handled
     }
 
     /// The record is forgotten; the actor is on its way out.

--- a/computer/arcbox-computer-runtime/src/lifecycle/projection.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/projection.rs
@@ -28,6 +28,10 @@ impl State {
             Self::Capturing {} | Self::Releasing {} => SandboxState::Pausing,
             Self::Paused {} => SandboxState::Paused,
             Self::Stopping {} | Self::Removing {} => SandboxState::Stopping,
+            // A handed-over computer is still a live, usable guest — it just
+            // belongs to the next process. That is what its record says and
+            // what the successor adopts it as, so it is what a caller sees.
+            Self::Detached {} => SandboxState::Ready,
             // A removed computer is gone from the map; nothing reads `gone`.
             Self::Stopped {} | Self::Gone {} => SandboxState::Stopped,
             Self::Failed {} => SandboxState::Failed,
@@ -60,7 +64,12 @@ impl State {
                 PersistPhase::Starting
             }),
             Self::Gone {} => None,
-            Self::Ready {} | Self::Running {} | Self::Checkpointing {} => Some(PersistPhase::Ready),
+            // A handover writes no record, and that is the point: the successor's
+            // sweep adopts a `Ready` computer, and any other phase would have it
+            // reinstated as `Failed` instead of taken back.
+            Self::Ready {} | Self::Running {} | Self::Checkpointing {} | Self::Detached {} => {
+                Some(PersistPhase::Ready)
+            }
             Self::Capturing {} | Self::Releasing {} => Some(PersistPhase::Pausing),
             Self::Paused {} => Some(PersistPhase::Paused),
             Self::Resuming {} => Some(PersistPhase::Resuming),

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks.rs
@@ -162,6 +162,15 @@ pub trait ComputerTasks: Send + Sync + 'static {
     /// Release the resources `scope` names.
     async fn release(&self, scope: ReleaseScope) -> TaskResult;
 
+    /// Give the VM up without stopping it, so the next process can adopt it.
+    ///
+    /// `Ok` with nothing to hand over — no handle, or a driver that runs its
+    /// VMs in-process and has no `Detach` — is a real success: there is no VM
+    /// this process would have killed on the way out. Unlike the other verbs
+    /// this one is awaited inside the actor's dispatch rather than spawned; see
+    /// [`Effect::Detach`](super::effect::Effect::Detach).
+    async fn detach(&self) -> TaskResult;
+
     /// The agent reaching a computer this process never launched: the one
     /// the startup sweep took back, whose handle it already holds.
     ///

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
@@ -1441,7 +1441,9 @@ async fn a_handover_during_a_capture_is_refused() {
 async fn the_agent_is_gone_before_the_handover_reaches_the_driver() {
     let mut harness = Harness::start(Boot::Completes, no_deadlines()).await;
     harness.boot_to_ready().await;
-    *harness.script.detach_takes.lock().unwrap() = Some(Duration::from_secs(30));
+    // Slow enough to observe the window, inside `DETACH_TIMEOUT` so the
+    // handover still lands.
+    *harness.script.detach_takes.lock().unwrap() = Some(Duration::from_secs(2));
 
     let detaching = harness.send(|reply| Command::Detach { reply });
     // Far enough in for the effect to have reached the port call and parked
@@ -1457,8 +1459,99 @@ async fn the_agent_is_gone_before_the_handover_reaches_the_driver() {
         "the data plane could still dial a vm that is changing hands"
     );
 
-    tokio::time::sleep(Duration::from_secs(30)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
     detaching.ok().await;
+}
+
+/// A handover answers for itself, not for whatever an earlier flow left behind.
+///
+/// A flow that ends with nobody parked leaves its failure in `answer_error` for
+/// the next caller to hear, and `answer` folds that into whichever reply it
+/// reaches next. Reached by a handover, it reports a guest lost that was in
+/// fact handed over — and unretryably, since the state is terminal by then and
+/// the retry answers `Ok`, contradicting the first answer. A composer told that
+/// logs a loss it did not take, on the one pass whose whole output is the list
+/// of guests it could not save.
+#[tokio::test(start_paused = true)]
+async fn a_handover_is_not_answered_by_an_earlier_flows_failure() {
+    let mut harness = Harness::recorded(
+        Boot::Completes,
+        Deadlines {
+            ttl: None,
+            idle_timeout_seconds: 2,
+            on_idle: IdleAction::Pause,
+        },
+    )
+    .await;
+    harness.boot_to_ready().await;
+
+    // A record at `Starting` refuses `Pausing` (not a durable edge) and admits
+    // the `Ready` the failed pause reverts to — so the idle pause below fails
+    // its write with no caller parked to hear it, and the computer comes back
+    // usable with that failure still owed to someone.
+    let record_path = harness.dir.path().join("sandbox-records").join("box.json");
+    let mut record: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&record_path).unwrap()).unwrap();
+    assert_eq!(record["phase"], "ready");
+    record["phase"] = serde_json::Value::String("starting".to_owned());
+    std::fs::write(&record_path, serde_json::to_string(&record).unwrap()).unwrap();
+
+    // Past the idle window: the pause fires, its `Pausing` write is refused,
+    // and the computer reverts to a usable `Ready`.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    assert!(
+        !harness.script.calls().contains(&"checkpoint"),
+        "the pause the refused write was recording must not have run"
+    );
+    assert_eq!(harness.snapshot.borrow().state, SandboxState::Ready);
+
+    harness.send(|reply| Command::Detach { reply }).ok().await;
+    assert!(
+        harness.script.calls().contains(&"detach"),
+        "the handover did not reach the driver"
+    );
+    assert_eq!(harness.snapshot.borrow().state, SandboxState::Ready);
+}
+
+/// A port call that does not return is a failed handover, not a wedged actor.
+///
+/// This is the only port call awaited on the actor task itself, so the bound is
+/// what keeps the "releasing ownership has no wait in it" premise inside this
+/// crate: a driver that hung here would otherwise hold the command loop
+/// unpreemptibly, and with it every computer queued behind this one in a
+/// handover pass. The outcome is the refusal's — the computer stays ours,
+/// dialable, and stoppable.
+#[tokio::test(start_paused = true)]
+async fn a_handover_that_does_not_return_fails_the_handover_alone() {
+    let mut harness = Harness::start(Boot::Completes, no_deadlines()).await;
+    harness.boot_to_ready().await;
+    *harness.script.detach_takes.lock().unwrap() = Some(Duration::from_secs(600));
+
+    let error = harness
+        .send(|reply| Command::Detach { reply })
+        .error()
+        .await;
+    assert!(error.to_string().contains("did not finish"), "{error}");
+    assert_eq!(
+        harness.snapshot.borrow().state,
+        SandboxState::Ready,
+        "a handover that timed out moved the computer"
+    );
+    assert!(
+        harness.snapshot.borrow().agent.is_some(),
+        "a handover that timed out left the computer undialable"
+    );
+
+    // And the actor is still serving: the stall cost this computer its
+    // handover, not the mailbox.
+    harness
+        .send(|reply| Command::Stop {
+            budget: Duration::from_secs(1),
+            reply,
+        })
+        .ok()
+        .await;
+    assert!(harness.script.calls().contains(&"stop"));
 }
 
 /// A handed-over computer answers nothing but another handover.

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
@@ -1299,3 +1299,100 @@ async fn a_refused_handover_leaves_the_computer_usable() {
         .await;
     assert!(harness.script.calls().contains(&"stop"));
 }
+
+/// A handover drops the guest agent, so the data plane stops reaching a VM
+/// this process no longer owns.
+///
+/// The exec and file verbs read the agent straight off the snapshot and never
+/// round-trip the mailbox — that is the whole point of the seam — so the
+/// terminal state alone cannot stop them. `detached` projects `Ready`, which
+/// is exactly what `require_alive_agent` admits, so without this an exec would
+/// keep landing in a guest the successor had adopted. A stop and a release
+/// forget the agent for the same reason.
+#[tokio::test(start_paused = true)]
+async fn a_handover_takes_the_guest_agent_off_the_snapshot() {
+    let mut harness = Harness::start(Boot::Completes, no_deadlines()).await;
+    harness.boot_to_ready().await;
+    assert!(
+        harness.snapshot.borrow().agent.is_some(),
+        "a ready computer is dialable"
+    );
+
+    harness.send(|reply| Command::Detach { reply }).ok().await;
+    assert!(
+        harness.snapshot.borrow().agent.is_none(),
+        "the data plane can still reach a handed-over guest"
+    );
+}
+
+/// A handed-over computer refuses `SetLifecycle`.
+///
+/// It projects `Ready`, so the public-state gate lets it through, and what it
+/// would reach is not a timer but the record: `persist_lifecycle` fsyncs into
+/// the record the successor has already adopted, under the generation it
+/// adopted with — so the write is accepted rather than fenced. The same race
+/// this transition exists to close, moved from the guest to its record.
+#[tokio::test(start_paused = true)]
+async fn a_handed_over_computer_refuses_a_lifecycle_update() {
+    let mut harness = Harness::recorded(Boot::Completes, no_deadlines()).await;
+    harness.boot_to_ready().await;
+    harness.send(|reply| Command::Detach { reply }).ok().await;
+
+    let error = harness
+        .send(|reply| Command::SetLifecycle {
+            update: LifecycleUpdate {
+                ttl_seconds: Some(60),
+                ..LifecycleUpdate::default()
+            },
+            reply,
+        })
+        .error()
+        .await;
+    assert!(
+        matches!(error, VmmError::WrongState { .. }),
+        "a handed-over record was written: {error}"
+    );
+}
+
+/// A handover ordered while a capture is in flight is refused.
+///
+/// The capture sub-task cloned the handle before it started and the driver's
+/// detach only stands the reaper down, so accepting would leave this process
+/// freezing, snapshotting and resuming a guest the successor had adopted.
+#[tokio::test(start_paused = true)]
+async fn a_handover_during_a_capture_is_refused() {
+    let mut harness = Harness::start(Boot::Completes, no_deadlines()).await;
+    harness.boot_to_ready().await;
+    *harness.script.checkpoint_takes.lock().unwrap() = Some(Duration::from_secs(30));
+
+    let (reply, capture) = oneshot::channel();
+    harness
+        .commands
+        .send(Command::Checkpoint {
+            spec: CaptureSpec {
+                name: "snap".to_owned(),
+                labels: std::collections::HashMap::new(),
+            },
+            reply,
+        })
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let error = harness
+        .send(|reply| Command::Detach { reply })
+        .error()
+        .await;
+    assert!(
+        matches!(error, VmmError::WrongState { .. }),
+        "a handover during a capture must be refused: {error}"
+    );
+    assert!(
+        !harness.script.calls().contains(&"detach"),
+        "the port was reached while a capture held the handle: {:?}",
+        harness.script.calls()
+    );
+
+    // The capture it stood aside for still owns the guest and still answers.
+    tokio::time::sleep(Duration::from_secs(31)).await;
+    capture.await.unwrap().unwrap();
+}

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
@@ -79,6 +79,9 @@ struct Script {
     /// How long the stop holds the computer in `stopping`, which is how a test
     /// observes something arriving while a teardown is in flight.
     stop_takes: Mutex<Option<Duration>>,
+    /// How long the handover's port call takes, which is how a test observes
+    /// the snapshot during the one await that transfers ownership.
+    detach_takes: Mutex<Option<Duration>>,
 }
 
 impl Script {
@@ -97,6 +100,7 @@ impl Script {
             cleanup_finished: AtomicBool::new(false),
             detach_fails: AtomicBool::new(false),
             stop_takes: Mutex::new(None),
+            detach_takes: Mutex::new(None),
         })
     }
 
@@ -210,6 +214,10 @@ impl ComputerTasks for Script {
 
     async fn detach(&self) -> TaskResult {
         self.record("detach");
+        let takes = *self.detach_takes.lock().unwrap();
+        if let Some(takes) = takes {
+            tokio::time::sleep(takes).await;
+        }
         if self.detach_fails.load(Ordering::SeqCst) {
             return Err(TaskFailure::recoverable(VmmError::Process(
                 "the vmm would not be handed over".into(),
@@ -1288,6 +1296,14 @@ async fn a_refused_handover_leaves_the_computer_usable() {
         SandboxState::Ready,
         "a refused handover moved the computer"
     );
+    // Usable includes dialable. The agent comes off the snapshot before the
+    // port call, so a handover that then fails has to put it back — nothing
+    // changed hands, and the data plane must not lose a guest to a handover
+    // that did not happen.
+    assert!(
+        harness.snapshot.borrow().agent.is_some(),
+        "a refused handover left the computer undialable"
+    );
 
     // Still this process's to stop, and the stop still runs.
     harness
@@ -1395,4 +1411,37 @@ async fn a_handover_during_a_capture_is_refused() {
     // The capture it stood aside for still owns the guest and still answers.
     tokio::time::sleep(Duration::from_secs(31)).await;
     capture.await.unwrap().unwrap();
+}
+
+/// The agent comes off the snapshot *before* the port call, not after.
+///
+/// Detach is the one flow whose ownership transfer happens inside an await, so
+/// forgetting afterwards leaves the whole call open for a reader to take the
+/// agent out of the snapshot and dial a VM that has already changed hands. It
+/// does not close the race — a reader holding an `Arc` cloned a moment earlier
+/// still has a working agent, and revoking that would mean routing the data
+/// plane through the mailbox — but it bounds the exposure to callers already
+/// in flight rather than every caller for the duration of the handover.
+#[tokio::test(start_paused = true)]
+async fn the_agent_is_gone_before_the_handover_reaches_the_driver() {
+    let mut harness = Harness::start(Boot::Completes, no_deadlines()).await;
+    harness.boot_to_ready().await;
+    *harness.script.detach_takes.lock().unwrap() = Some(Duration::from_secs(30));
+
+    let detaching = harness.send(|reply| Command::Detach { reply });
+    // Far enough in for the effect to have reached the port call and parked
+    // there, and nowhere near its completion.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert_eq!(
+        harness.script.calls().last().copied(),
+        Some("detach"),
+        "the port call has not started yet"
+    );
+    assert!(
+        harness.snapshot.borrow().agent.is_none(),
+        "the data plane could still dial a vm that is changing hands"
+    );
+
+    tokio::time::sleep(Duration::from_secs(30)).await;
+    detaching.ok().await;
 }

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
@@ -74,6 +74,11 @@ struct Script {
     gate_takes: Mutex<Option<Duration>>,
     /// Whether a boot that never handed off got to finish its own teardown.
     cleanup_finished: AtomicBool,
+    /// The handover the driver refuses: the computer must stay where it was.
+    detach_fails: AtomicBool,
+    /// How long the stop holds the computer in `stopping`, which is how a test
+    /// observes something arriving while a teardown is in flight.
+    stop_takes: Mutex<Option<Duration>>,
 }
 
 impl Script {
@@ -90,6 +95,8 @@ impl Script {
             release_takes: Mutex::new(None),
             gate_takes: Mutex::new(None),
             cleanup_finished: AtomicBool::new(false),
+            detach_fails: AtomicBool::new(false),
+            stop_takes: Mutex::new(None),
         })
     }
 
@@ -194,6 +201,20 @@ impl ComputerTasks for Script {
 
     async fn stop(&self, _budget: Duration, _drain: Drain) -> TaskResult {
         self.record("stop");
+        let takes = *self.stop_takes.lock().unwrap();
+        if let Some(takes) = takes {
+            tokio::time::sleep(takes).await;
+        }
+        Ok(())
+    }
+
+    async fn detach(&self) -> TaskResult {
+        self.record("detach");
+        if self.detach_fails.load(Ordering::SeqCst) {
+            return Err(TaskFailure::recoverable(VmmError::Process(
+                "the vmm would not be handed over".into(),
+            )));
+        }
         Ok(())
     }
 
@@ -1157,4 +1178,124 @@ async fn a_refused_failure_write_still_releases_and_keeps_the_journal() {
         harness.has_journal(),
         "and the journal stays: nothing proved the failure durable"
     );
+}
+
+/// A handover ordered while a stop is in flight is refused (CORE-145).
+///
+/// This is the race the ticket is about: an in-flight `StopSandbox` is the
+/// main reason a composer's drain budget expires, so the trigger for
+/// `detach_all` and the concurrent writer it would race are the same event.
+/// The stop wins because it was asked for first — the guest is meant to go
+/// away — and the actor is what makes that a decision rather than a race.
+#[tokio::test(start_paused = true)]
+async fn a_handover_ordered_during_a_stop_is_refused() {
+    let mut harness = Harness::start(Boot::Completes, no_deadlines()).await;
+    harness.boot_to_ready().await;
+    *harness.script.stop_takes.lock().unwrap() = Some(Duration::from_secs(30));
+
+    let stopping = harness.send(|reply| Command::Stop {
+        budget: Duration::from_secs(60),
+        reply,
+    });
+    harness.settled(SandboxState::Stopping).await;
+
+    let error = harness
+        .send(|reply| Command::Detach { reply })
+        .error()
+        .await;
+    assert!(
+        matches!(error, VmmError::WrongState { .. }),
+        "a handover during a teardown must be refused, not raced: {error}"
+    );
+    assert!(
+        !harness.script.calls().contains(&"detach"),
+        "the port was reached anyway: {:?}",
+        harness.script.calls()
+    );
+
+    // And the stop it stood aside for still finishes.
+    tokio::time::sleep(Duration::from_secs(31)).await;
+    stopping.ok().await;
+}
+
+/// Nothing reaches a VM this process has handed over.
+///
+/// Without the terminal state a stop landing here would drive
+/// `handle.shutdown` into a handle whose reaper has stood down, wait out the
+/// whole budget for an exit that is never published, and then SIGKILL the VM
+/// the successor is adopting.
+#[tokio::test(start_paused = true)]
+async fn a_teardown_after_a_handover_never_reaches_the_vm() {
+    let mut harness = Harness::start(Boot::Completes, no_deadlines()).await;
+    harness.boot_to_ready().await;
+    harness.send(|reply| Command::Detach { reply }).ok().await;
+    assert!(harness.script.calls().contains(&"detach"));
+
+    let stop = harness
+        .send(|reply| Command::Stop {
+            budget: Duration::from_secs(1),
+            reply,
+        })
+        .error()
+        .await;
+    assert!(
+        matches!(stop, VmmError::WrongState { .. }),
+        "a stop after a handover must be refused: {stop}"
+    );
+    let removed = harness
+        .send(|reply| Command::Remove { force: true, reply })
+        .error()
+        .await;
+    assert!(
+        matches!(removed, VmmError::WrongState { .. }),
+        "a forced remove after a handover must be refused: {removed}"
+    );
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let calls = harness.script.calls();
+    assert!(
+        !calls.contains(&"stop") && !calls.contains(&"release"),
+        "a handed-over vm was torn down anyway: {calls:?}"
+    );
+    // A second handover is a no-op rather than an error: `detach_all` fans out
+    // over whatever is in the map, and reporting a failure for a computer that
+    // is already the successor's would have a composer log a loss it did not
+    // take.
+    harness.send(|reply| Command::Detach { reply }).ok().await;
+}
+
+/// A handover the driver refuses leaves a computer that is still ours.
+///
+/// It dies with this process, which is what a failed handover has always
+/// meant — but it must not be recorded `Failed` on the way out, because the
+/// successor's sweep reads that record and would reinstate a perfectly good
+/// guest as failed instead of adopting it.
+#[tokio::test(start_paused = true)]
+async fn a_refused_handover_leaves_the_computer_usable() {
+    let mut harness = Harness::start(Boot::Completes, no_deadlines()).await;
+    harness.boot_to_ready().await;
+    harness.script.detach_fails.store(true, Ordering::SeqCst);
+
+    let error = harness
+        .send(|reply| Command::Detach { reply })
+        .error()
+        .await;
+    assert!(
+        error.to_string().contains("would not be handed over"),
+        "{error}"
+    );
+    assert_eq!(
+        harness.snapshot.borrow().state,
+        SandboxState::Ready,
+        "a refused handover moved the computer"
+    );
+
+    // Still this process's to stop, and the stop still runs.
+    harness
+        .send(|reply| Command::Stop {
+            budget: Duration::from_secs(1),
+            reply,
+        })
+        .ok()
+        .await;
+    assert!(harness.script.calls().contains(&"stop"));
 }

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
@@ -1398,9 +1398,24 @@ async fn a_handover_during_a_capture_is_refused() {
         .send(|reply| Command::Detach { reply })
         .error()
         .await;
+    let VmmError::WrongState {
+        expected, actual, ..
+    } = &error
+    else {
+        panic!("a handover during a capture must be refused: {error}");
+    };
+    // `wrong_state` reads `actual` off the public projection, and a capture
+    // projects `Ready` — so an expected side phrased as a state list would say
+    // "expected Ready or Running, actual Ready" and contradict itself. This is
+    // the string `detach_all` folds into the failure someone diagnoses a lost
+    // handover from, so it has to stay legible.
+    let actual_word = actual.to_lowercase();
     assert!(
-        matches!(error, VmmError::WrongState { .. }),
-        "a handover during a capture must be refused: {error}"
+        !expected
+            .to_lowercase()
+            .split(|c: char| !c.is_alphanumeric())
+            .any(|word| word == actual_word),
+        "the refusal names the state it is refusing: expected {expected}, actual {actual}"
     );
     assert!(
         !harness.script.calls().contains(&"detach"),

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
@@ -1445,3 +1445,101 @@ async fn the_agent_is_gone_before_the_handover_reaches_the_driver() {
     tokio::time::sleep(Duration::from_secs(30)).await;
     detaching.ok().await;
 }
+
+/// A handed-over computer answers nothing but another handover.
+///
+/// The per-command version of this guard only ever covered the command whose
+/// bug was noticed. `detached` projects `Ready` — the wire has no variant for
+/// "the successor's" — so every gate reading the public state is blind to it:
+/// `Resume` read `Ready`, matched its live-computer arm, and answered `Ok` for
+/// a computer this process no longer owned. This walks the reply-bearing
+/// surface so a command added later cannot quietly inherit that.
+#[tokio::test(start_paused = true)]
+async fn a_handed_over_computer_answers_nothing_but_another_handover() {
+    async fn refused(waiter: Waiter, verb: &str) {
+        let error = waiter.error().await;
+        assert!(
+            matches!(error, VmmError::WrongState { .. }),
+            "{verb} was accepted by a handed-over computer: {error}"
+        );
+    }
+
+    let mut harness = Harness::recorded(Boot::Completes, no_deadlines()).await;
+    harness.boot_to_ready().await;
+    harness.send(|reply| Command::Detach { reply }).ok().await;
+
+    refused(
+        harness.send(|reply| Command::Resume {
+            reason: "test".to_owned(),
+            reply,
+        }),
+        "resume",
+    )
+    .await;
+    refused(
+        harness.send(|reply| Command::Pause {
+            reason: PauseReason::Requested,
+            reply,
+        }),
+        "pause",
+    )
+    .await;
+    refused(
+        harness.send(|reply| Command::ClaimWorkload {
+            claim: WorkloadClaim::Api,
+            reply,
+        }),
+        "claim",
+    )
+    .await;
+    refused(
+        harness.send(|reply| Command::SetLifecycle {
+            update: LifecycleUpdate {
+                ttl_seconds: Some(60),
+                ..LifecycleUpdate::default()
+            },
+            reply,
+        }),
+        "set-lifecycle",
+    )
+    .await;
+    refused(
+        harness.send(|reply| Command::Stop {
+            budget: Duration::from_secs(1),
+            reply,
+        }),
+        "stop",
+    )
+    .await;
+    refused(
+        harness.send(|reply| Command::Remove { force: true, reply }),
+        "remove",
+    )
+    .await;
+
+    // The capture surface too, which carries its own reply type.
+    let (reply, capture) = oneshot::channel();
+    harness
+        .commands
+        .send(Command::Checkpoint {
+            spec: CaptureSpec {
+                name: "snap".to_owned(),
+                labels: std::collections::HashMap::new(),
+            },
+            reply,
+        })
+        .unwrap();
+    assert!(matches!(
+        capture.await.unwrap().unwrap_err(),
+        VmmError::WrongState { .. }
+    ));
+
+    // Nothing reached the guest, and a second handover is still the idempotent
+    // no-op `detach_all` needs it to be.
+    let calls = harness.script.calls();
+    assert!(
+        !calls.contains(&"stop") && !calls.contains(&"release") && !calls.contains(&"checkpoint"),
+        "a handed-over vm was driven anyway: {calls:?}"
+    );
+    harness.send(|reply| Command::Detach { reply }).ok().await;
+}

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/harness.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/harness.rs
@@ -67,10 +67,11 @@ pub(super) fn ordinal(state: State) -> usize {
         State::Failed {} => 14,
         State::Removing {} => 15,
         State::Gone {} => 16,
+        State::Detached {} => 17,
     }
 }
 
-pub(super) const LEAVES: usize = 17;
+pub(super) const LEAVES: usize = 18;
 
 /// One event of every shape the actor can deliver. `Recovered` and `Adopted`
 /// are excluded: they seed a machine rather than move one, and are roots of
@@ -116,6 +117,8 @@ pub(super) fn alphabet() -> Vec<Event> {
         Event::Remove { force: false },
         Event::Remove { force: true },
         Event::RemoveDone,
+        Event::Detach,
+        Event::Detached,
         Event::Failure,
         Event::Frozen,
         Event::Stranded,
@@ -238,5 +241,17 @@ pub(super) fn ready_machine() -> (Machine, Effects) {
         Event::ResourcesHandedOff,
         Event::AgentReady,
         Event::Gated,
+    ])
+}
+
+/// A computer whose VM has been handed to the next process.
+pub(super) fn detached_machine() -> (Machine, Effects) {
+    reach(&[
+        Event::Provision(Provision::Boot { warm: false }),
+        Event::ResourcesHandedOff,
+        Event::AgentReady,
+        Event::Gated,
+        Event::Detach,
+        Event::Detached,
     ])
 }

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
@@ -1,7 +1,9 @@
 //! The rules that must hold in every state: recovery's seeding, and the gates
 //! `stop_sandbox`, `cleanup::begin_removal` and the two deadline timers apply.
 
-use super::harness::{ALL_PHASES, BUDGET_MS, explore, ordinal, reach, ready_machine, step};
+use super::harness::{
+    ALL_PHASES, BUDGET_MS, detached_machine, explore, ordinal, reach, ready_machine, step,
+};
 use crate::lifecycle::effect::{
     Answer, Durability, Effect, Effects, Notify, RecordEnd, ReleaseScope, Timer,
 };
@@ -166,20 +168,26 @@ fn a_stop_only_acts_while_the_guest_serves() {
 }
 
 #[test]
-fn a_non_forced_remove_is_refused_exactly_where_the_computer_is_busy() {
+fn a_non_forced_remove_is_refused_where_the_computer_is_busy_or_handed_over() {
     // `cleanup::begin_removal` refuses `!force` on Running and Starting; the
     // machine mirrors that on the states projecting them. A removal already
     // under way (or done) coalesces instead.
     for node in explore() {
         let (mut sm, mut context) = reach(&node.path);
         let (_, effects) = step(&mut sm, &mut context, &Event::Remove { force: false });
-        let busy = matches!(
+        let refused = matches!(
             node.state.to_public(),
             SandboxState::Starting | SandboxState::Running
-        ) || matches!(node.state, State::Removing {} | State::Gone {});
+        ) || matches!(
+            node.state,
+            // Not busy — not ours. A handed-over computer projects `Ready`,
+            // so without its own arm here it would be the one state a
+            // non-forced remove tore down out from under its successor.
+            State::Removing {} | State::Gone {} | State::Detached {}
+        );
         assert_eq!(
             effects.is_empty(),
-            busy,
+            refused,
             "non-forced remove from {:?} emitted {effects:?}",
             node.state
         );
@@ -189,7 +197,14 @@ fn a_non_forced_remove_is_refused_exactly_where_the_computer_is_busy() {
 #[test]
 fn a_forced_remove_tears_down_from_every_live_state() {
     for node in explore() {
-        if matches!(node.state, State::Removing {} | State::Gone {}) {
+        // `detached` is live but not this process's to destroy: the VM belongs
+        // to the successor, and `force` is not a licence to reach into another
+        // process's guest. Pinned by
+        // `a_handed_over_computer_refuses_every_teardown`.
+        if matches!(
+            node.state,
+            State::Removing {} | State::Gone {} | State::Detached {}
+        ) {
             continue;
         }
         let (mut sm, mut context) = reach(&node.path);
@@ -229,15 +244,22 @@ fn a_forced_remove_tears_down_from_every_live_state() {
 }
 
 #[test]
-fn the_ttl_cap_destroys_everywhere_except_a_resting_or_removed_computer() {
+fn the_ttl_cap_destroys_everywhere_except_a_resting_removed_or_handed_over_computer() {
     for node in explore() {
         let (mut sm, mut context) = reach(&node.path);
         let (_, effects) = step(&mut sm, &mut context, &Event::TtlExpired);
         // `deadlines::ttl_due` drops the timer once a computer is terminal,
-        // and a removal in flight coalesces.
+        // and a removal in flight coalesces. A handed-over computer's lifetime
+        // is the successor's to cap — this process's timer firing would
+        // destroy a guest another one is adopting — which is why the handover
+        // cancels both timers on the way in.
         let inert = matches!(
             node.state,
-            State::Stopped {} | State::Failed {} | State::Removing {} | State::Gone {}
+            State::Stopped {}
+                | State::Failed {}
+                | State::Removing {}
+                | State::Gone {}
+                | State::Detached {}
         );
         assert_eq!(
             effects.is_empty(),
@@ -246,6 +268,110 @@ fn the_ttl_cap_destroys_everywhere_except_a_resting_or_removed_computer() {
             node.state
         );
     }
+}
+
+/// A handover only acts where a settled live handle exists (CORE-145).
+///
+/// The complement is the point: a computer mid-launch still has its resources
+/// in the boot task rather than on itself, and one mid-teardown was asked to
+/// go away — handing either over would give the successor something its record
+/// does not describe. Everywhere the machine declines, the actor answers, so
+/// declining must also leave the computer exactly where it was.
+#[test]
+fn a_handover_only_acts_where_a_live_handle_is_settled() {
+    for node in explore() {
+        let (mut sm, mut context) = reach(&node.path);
+        let (after, effects) = step(&mut sm, &mut context, &Event::Detach);
+        let acts = matches!(
+            node.state,
+            State::Ready {} | State::Running {} | State::Checkpointing {}
+        );
+        assert_eq!(
+            effects.is_empty(),
+            !acts,
+            "detach from {:?} emitted {effects:?}",
+            node.state
+        );
+        if acts {
+            // The port call decides, so the machine must not have moved yet:
+            // a handover that fails leaves a computer that is still ours.
+            assert_eq!(effects, vec![Effect::Detach], "{:?}", node.state);
+        }
+        assert_eq!(
+            ordinal(after),
+            ordinal(node.state),
+            "detach moved {:?} before its port call reported",
+            node.state
+        );
+    }
+}
+
+/// Nothing this process does may reach a VM it has handed over.
+///
+/// The failure this pins is the expensive half of CORE-145: a `Stop` landing
+/// after the handover drives `handle.shutdown` into a handle whose reaper has
+/// stood down, burns the whole budget waiting for an exit that is never
+/// published, and then SIGKILLs the VM the successor is adopting — while its
+/// release hands back TAP, the CoW device and the jail underneath it.
+#[test]
+fn a_handed_over_computer_refuses_every_teardown() {
+    for event in [
+        Event::Stop {
+            budget_ms: BUDGET_MS,
+        },
+        Event::Remove { force: false },
+        Event::Remove { force: true },
+        Event::TtlExpired,
+        Event::IdleExpired {
+            action: IdleAction::Kill,
+        },
+        Event::IdleExpired {
+            action: IdleAction::Pause,
+        },
+        Event::Pause {
+            reason: crate::lifecycle::event::PauseReason::Requested,
+        },
+        Event::Checkpoint,
+        // Its exit is the successor's to observe; this process stopped
+        // watching when it let go.
+        Event::VmExited,
+        Event::Failure,
+        Event::Detach,
+    ] {
+        let (mut sm, mut context) = detached_machine();
+        assert!(matches!(sm.state(), State::Detached {}));
+        let (after, effects) = step(&mut sm, &mut context, &event);
+        assert!(
+            matches!(after, State::Detached {}),
+            "{event:?} moved a handed-over computer to {after:?}"
+        );
+        assert!(
+            effects.is_empty(),
+            "{event:?} acted on a handed-over computer: {effects:?}"
+        );
+    }
+}
+
+/// The handover cancels both deadline timers, and answers its caller.
+#[test]
+fn a_handover_drops_the_timers_it_no_longer_owns() {
+    let (mut sm, mut context) = ready_machine();
+    let (_, effects) = step(&mut sm, &mut context, &Event::Detach);
+    assert_eq!(effects, vec![Effect::Detach]);
+
+    let (state, effects) = step(&mut sm, &mut context, &Event::Detached);
+    assert!(matches!(state, State::Detached {}));
+    assert_eq!(
+        effects,
+        vec![
+            Effect::Answer(Answer::Detached),
+            Effect::CancelTimer(Timer::Ttl),
+            Effect::CancelTimer(Timer::Idle),
+        ]
+    );
+    // No durable write: the successor's sweep adopts from a `Ready` record,
+    // and any other phase would have it reinstated as `Failed` instead.
+    assert_eq!(state.durable(), Some(PersistPhase::Ready));
 }
 
 #[test]

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
@@ -275,17 +275,16 @@ fn the_ttl_cap_destroys_everywhere_except_a_resting_removed_or_handed_over_compu
 /// The complement is the point: a computer mid-launch still has its resources
 /// in the boot task rather than on itself, and one mid-teardown was asked to
 /// go away — handing either over would give the successor something its record
-/// does not describe. Everywhere the machine declines, the actor answers, so
-/// declining must also leave the computer exactly where it was.
+/// does not describe. `checkpointing` is excluded for a third reason, pinned
+/// by `a_handover_is_refused_while_a_capture_is_in_flight`. Everywhere the
+/// machine declines, the actor answers, so declining must also leave the
+/// computer exactly where it was.
 #[test]
 fn a_handover_only_acts_where_a_live_handle_is_settled() {
     for node in explore() {
         let (mut sm, mut context) = reach(&node.path);
         let (after, effects) = step(&mut sm, &mut context, &Event::Detach);
-        let acts = matches!(
-            node.state,
-            State::Ready {} | State::Running {} | State::Checkpointing {}
-        );
+        let acts = matches!(node.state, State::Ready {} | State::Running {});
         assert_eq!(
             effects.is_empty(),
             !acts,
@@ -350,6 +349,45 @@ fn a_handed_over_computer_refuses_every_teardown() {
             "{event:?} acted on a handed-over computer: {effects:?}"
         );
     }
+}
+
+/// A capture in flight refuses the handover.
+///
+/// `checkpointing` sits under `active` beside `ready` and `running`, so it
+/// would otherwise inherit the arm. Its capture runs in a sub-task that cloned
+/// the handle before it started, and the driver's detach only stands the
+/// reaper down — the handle stays fully functional — so the task would go on
+/// to freeze, snapshot and resume a guest the successor had already adopted,
+/// while `detached` silently swallowed its `CaptureDone`. Nothing on the
+/// handover path preempts it: `Effect::Detach` is awaited inline and never
+/// reaches `spawn`, and the arm emits no `AbortInflight`.
+#[test]
+fn a_handover_is_refused_while_a_capture_is_in_flight() {
+    let (mut sm, mut context) = ready_machine();
+    let (state, _) = step(&mut sm, &mut context, &Event::Checkpoint);
+    assert!(matches!(state, State::Checkpointing {}));
+
+    let (after, effects) = step(&mut sm, &mut context, &Event::Detach);
+    assert!(
+        matches!(after, State::Checkpointing {}),
+        "the handover moved a computer mid-capture to {after:?}"
+    );
+    assert!(
+        effects.is_empty(),
+        "the handover acted while a capture held the handle: {effects:?}"
+    );
+
+    // And once the capture is done the computer hands over normally.
+    let (state, _) = step(
+        &mut sm,
+        &mut context,
+        &Event::CaptureDone {
+            snapshot_id: "snap".to_owned(),
+        },
+    );
+    assert!(matches!(state, State::Ready {}));
+    let (_, effects) = step(&mut sm, &mut context, &Event::Detach);
+    assert_eq!(effects, vec![Effect::Detach]);
 }
 
 /// The handover cancels both deadline timers, and answers its caller.

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
@@ -305,6 +305,39 @@ fn a_handover_only_acts_where_a_live_handle_is_settled() {
     }
 }
 
+/// A handover *completion* lands only where the handover was asked for.
+///
+/// The companion to the rule above, and the one that would otherwise go
+/// unstated: `Event::Detached` is in the alphabet, so `explore` drives it into
+/// every state and would record a Checkpointing→Detached edge as legitimate.
+/// It is unreachable only because `Effect::Detach` is awaited inline — spawn it
+/// like every sibling flow and a completion could land on a state that refused
+/// the handover, detaching a guest whose capture sub-task is still driving it.
+#[test]
+fn a_handover_completion_only_lands_where_the_handover_was_asked_for() {
+    for node in explore() {
+        let (mut sm, mut context) = reach(&node.path);
+        let (after, effects) = step(&mut sm, &mut context, &Event::Detached);
+        let asked = matches!(node.state, State::Ready {} | State::Running {});
+        assert_eq!(
+            effects.is_empty(),
+            !asked,
+            "a handover completion in {:?} emitted {effects:?}",
+            node.state
+        );
+        if asked {
+            assert!(matches!(after, State::Detached {}), "{:?}", node.state);
+        } else {
+            assert_eq!(
+                ordinal(after),
+                ordinal(node.state),
+                "a stray handover completion moved {:?}",
+                node.state
+            );
+        }
+    }
+}
+
 /// Nothing this process does may reach a VM it has handed over.
 ///
 /// The failure this pins is the expensive half of CORE-145: a `Stop` landing

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/projections.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/projections.rs
@@ -46,6 +46,7 @@ fn every_leaf_projects_onto_a_public_state() {
         &[SandboxState::Failed],                          // failed
         &[SandboxState::Stopping],                        // removing
         &[SandboxState::Stopped],                         // gone
+        &[SandboxState::Ready],                           // detached
     ];
     for node in explore() {
         let public = node.state.to_public();
@@ -81,6 +82,7 @@ fn every_leaf_projects_onto_a_durable_phase() {
         &[Some(P::Failed)],                   // failed
         &[Some(P::Removing)],                 // removing
         &[None],                              // gone: the record is forgotten
+        &[Some(P::Ready)],                    // detached: a handover writes nothing
     ];
     for node in explore() {
         let durable = node.state.durable();

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -930,6 +930,27 @@ fn forget_computer(computers: &Computers, id: &SandboxId, incarnation: Uuid) {
     }
 }
 
+/// Whether `id`'s entry is still this exact incarnation's — the inverse of
+/// [`forget_computer`], and the question an unanswerable mailbox raises.
+///
+/// Every ending unregisters: the actor's own loop tail whatever stopped it, the
+/// record it forgets on a removal, and [`ActorReservation::drop`] for a create
+/// that unwound before spawning one. A re-created id installs a fresh
+/// incarnation over the departed one, so this is `false` there too. What is
+/// left is an incarnation *still here* whose mailbox no longer answers: an
+/// actor whose task died without finishing, and the one case where a
+/// computer's resources outlive the thing that was managing them.
+///
+/// Reads nothing the actor owns, so it stays answerable for a computer whose
+/// runtime mutex a panic has poisoned.
+fn still_registered(computers: &Computers, id: &SandboxId, incarnation: Uuid) -> bool {
+    computers
+        .read()
+        .unwrap()
+        .get(id)
+        .is_some_and(|current| current.incarnation == incarnation)
+}
+
 #[cfg(test)]
 mod tests {
     use arcbox_constants::paths::{ARCBOX_RUNTIME_BIN_DIR, JAILER_CHROOT_BASE};
@@ -1178,5 +1199,37 @@ mod tests {
         );
         drop(replacement);
         assert!(!computers.read().unwrap().contains_key("same"));
+    }
+
+    /// Registration is per incarnation, which is what lets a handover pass
+    /// tell an actor that finished from one that died.
+    ///
+    /// `detach_all` reads this after an unanswerable mailbox: `false` means
+    /// the actor ended and unregistered (or its id was re-created since), so
+    /// nothing was lost, while `true` means its task went away without
+    /// finishing and its guest is still out there.
+    #[test]
+    fn registration_is_per_incarnation() {
+        let computers: Computers = Arc::new(RwLock::new(HashMap::new()));
+        let id = "box".to_owned();
+        let departing = reserve_actor(&computers, &id, placeholder("box")).unwrap();
+        let incarnation = departing.incarnation;
+        assert!(still_registered(&computers, &id, incarnation));
+
+        // A different incarnation of a live id is not this one.
+        assert!(!still_registered(&computers, &id, Uuid::new_v4()));
+
+        // An actor still holding its claim while unable to answer: the case
+        // worth reporting.
+        std::mem::forget(departing);
+        assert!(still_registered(&computers, &id, incarnation));
+
+        // And once it has let go — its own exit, or a replacement taking the
+        // id — that incarnation is no longer registered.
+        forget_computer(&computers, &id, incarnation);
+        assert!(!still_registered(&computers, &id, incarnation));
+        let replacement = reserve_actor(&computers, &id, placeholder("box")).unwrap();
+        assert!(!still_registered(&computers, &id, incarnation));
+        assert!(still_registered(&computers, &id, replacement.incarnation));
     }
 }

--- a/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
@@ -556,8 +556,14 @@ impl SandboxManager {
     pub async fn detach_all(&self) -> Result<()> {
         // The sweep adopts and kills VMs by the same deterministic names, so
         // racing it is the same class of bug; `stop_sandbox` and
-        // `remove_sandbox` wait it out for exactly this reason.
-        self.await_reconcile().await?;
+        // `remove_sandbox` wait it out for exactly this reason. Its *failure*
+        // is not propagated the way theirs is: this is the process's last
+        // chance to save every guest it holds, and refusing the whole handover
+        // because the sweep failed would kill all of them to report a fault in
+        // something that has already finished.
+        if let Err(error) = self.await_reconcile().await {
+            warn!(%error, "the startup sweep failed; handing over anyway");
+        }
         let computers: Vec<(SandboxId, Mailbox)> = self
             .computers
             .read()

--- a/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
@@ -12,6 +12,18 @@ pub(super) enum WarmPolicy {
     Disabled,
 }
 
+/// How long a handover pass waits for the startup sweep before going ahead
+/// without it.
+///
+/// The sweep bounds only its adoptions (`reconcile::ADOPT_TIMEOUT`); the kill
+/// and the CoW teardown it may run instead are unbounded. Every other verb
+/// waits for it indefinitely because a slow sweep only delays them, whereas
+/// this is the process's last chance to save the guests it holds — a pass that
+/// waits out an unbounded sweep loses all of them, including the computers the
+/// sweep has nothing to do with. Ten seconds mirrors the sweep's own
+/// per-computer bound: past that it is not about to finish.
+const SWEEP_WAIT_BUDGET: Duration = Duration::from_secs(10);
+
 impl SandboxManager {
     /// Replay a durable Create outcome without resolving its template again.
     pub async fn replay_sandbox_create(
@@ -556,33 +568,85 @@ impl SandboxManager {
     pub async fn detach_all(&self) -> Result<()> {
         // The sweep adopts and kills VMs by the same deterministic names, so
         // racing it is the same class of bug; `stop_sandbox` and
-        // `remove_sandbox` wait it out for exactly this reason. Its *failure*
-        // is not propagated the way theirs is: this is the process's last
-        // chance to save every guest it holds, and refusing the whole handover
-        // because the sweep failed would kill all of them to report a fault in
-        // something that has already finished.
-        if let Err(error) = self.await_reconcile().await {
-            warn!(%error, "the startup sweep failed; handing over anyway");
+        // `remove_sandbox` wait it out for exactly this reason. Neither its
+        // failure nor its slowness is propagated the way theirs is — see
+        // `SWEEP_WAIT_BUDGET`.
+        match tokio::time::timeout(SWEEP_WAIT_BUDGET, self.await_reconcile()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => warn!(%error, "the startup sweep failed; handing over anyway"),
+            Err(_) => warn!(
+                seconds = SWEEP_WAIT_BUDGET.as_secs(),
+                "the startup sweep is still running; handing over anyway"
+            ),
         }
-        let computers: Vec<(SandboxId, Mailbox)> = self
+        // The incarnation rides along for the one answer the mailbox cannot
+        // tell apart on its own; see the `NotFound` arms below.
+        let computers: Vec<(SandboxId, Mailbox, Uuid)> = self
             .computers
             .read()
             .unwrap()
             .iter()
-            .map(|(id, computer)| (id.clone(), computer.mailbox.clone()))
+            .map(|(id, computer)| (id.clone(), computer.mailbox.clone(), computer.incarnation))
             .collect();
 
+        // Concurrently, because the actor is already the serializer: per
+        // computer these asks are ordered by its mailbox, and between
+        // computers there is nothing to order. Sequentially, one actor that
+        // cannot reach its command loop — a teardown waiting out an in-flight
+        // boot's resource handoff parks the actor for up to two
+        // `HANDOFF_TIMEOUT`s, and a create holds its mailbox unserved until it
+        // spawns — would spend the composer's remaining deadline on behalf of
+        // every computer behind it, and those guests die unasked.
+        let mut asks = tokio::task::JoinSet::new();
+        for (id, mailbox, incarnation) in computers {
+            asks.spawn(async move {
+                let answer = mailbox.ask(&id, |reply| Command::Detach { reply }).await;
+                (id, incarnation, answer)
+            });
+        }
+
+        let mut asked = 0_usize;
         let mut failures = Vec::new();
-        for (id, mailbox) in computers {
-            match mailbox.ask(&id, |reply| Command::Detach { reply }).await {
-                Ok(()) => info!(sandbox_id = %id, "handed the sandbox's vm to the next process"),
-                // The actor finished between the snapshot and the ask, so its
-                // computer is already gone — there is nothing left to hand
-                // over and nothing was lost.
-                Err(VmmError::NotFound(_)) => {}
+        while let Some(joined) = asks.join_next().await {
+            asked += 1;
+            let (id, incarnation, answer) = match joined {
+                Ok(answered) => answered,
+                // The ask itself reports everything the actor can do to it, so
+                // a join error is this runtime coming down mid-pass — there is
+                // no computer id left to attribute it to.
+                Err(error) => {
+                    failures.push(format!("a handover could not be asked for: {error}"));
+                    continue;
+                }
+            };
+            match answer {
+                Ok(()) => {}
+                // The mailbox closed, or the reply was dropped. Both arrive as
+                // `NotFound`, and whether either cost a guest is answered by
+                // the registry rather than by the error: every clean ending
+                // unregisters — the actor's own loop tail, the record it
+                // forgets, and the reservation of a create that unwound before
+                // spawning one — so an incarnation still registered is one
+                // whose actor died without finishing. Its VM is live,
+                // unhanded, and dies with this process, which is the one thing
+                // this pass exists to report.
+                Err(VmmError::NotFound(_))
+                    if !super::still_registered(&self.computers, &id, incarnation) => {}
+                Err(VmmError::NotFound(_)) => failures.push(format!(
+                    "{id}: its actor stopped without answering, so the vm was not handed over"
+                )),
                 Err(error) => failures.push(format!("{id}: {error}")),
             }
         }
+        // Deliberately a count of what was *asked*, not of guests saved: an
+        // `Ok` also comes back from a paused, stopped or still-provisioning
+        // computer that had no VM to give up. Only `detach_vm` knows a handle
+        // really changed hands, and that is where each one is logged.
+        info!(
+            computers = asked,
+            failures = failures.len(),
+            "asked every computer to hand its vm to the next process"
+        );
         if failures.is_empty() {
             return Ok(());
         }

--- a/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
@@ -543,25 +543,37 @@ impl SandboxManager {
     /// nothing to hand over — the same reasoning the sweep applies to
     /// `Adopt`. The `PreparedVm` a booted sandbox also holds needs no such
     /// step: it kills on drop only while it is still unconsumed.
+    ///
+    /// Each handover goes through its computer's actor (CORE-145). Detach is a
+    /// terminal transition, and the actor is what serializes those: taking the
+    /// handles straight out of the map let a handover run concurrently with the
+    /// `Stop` of the same computer — the very stop whose 30s budget is why a
+    /// composer's drain deadline expires and this gets called at all. Either
+    /// order damaged the guest: a stop reaching a detached handle waits out a
+    /// stood-down reaper and then SIGKILLs the VM it was just told had been
+    /// handed over, and its release hands TAP, the CoW device and the jail back
+    /// while the successor is adopting them.
     pub async fn detach_all(&self) -> Result<()> {
-        let live: Vec<(SandboxId, Arc<dyn VmHandle>)> = self
+        // The sweep adopts and kills VMs by the same deterministic names, so
+        // racing it is the same class of bug; `stop_sandbox` and
+        // `remove_sandbox` wait it out for exactly this reason.
+        self.await_reconcile().await?;
+        let computers: Vec<(SandboxId, Mailbox)> = self
             .computers
             .read()
             .unwrap()
             .iter()
-            .filter_map(|(id, computer)| {
-                let handle = computer.snapshot.borrow().handle.clone();
-                handle.map(|handle| (id.clone(), handle))
-            })
+            .map(|(id, computer)| (id.clone(), computer.mailbox.clone()))
             .collect();
 
         let mut failures = Vec::new();
-        for (id, handle) in live {
-            let Some(detach) = handle.detach() else {
-                continue;
-            };
-            match detach.detach().await {
-                Ok(_) => info!(sandbox_id = %id, "handed the sandbox's vm to the next process"),
+        for (id, mailbox) in computers {
+            match mailbox.ask(&id, |reply| Command::Detach { reply }).await {
+                Ok(()) => info!(sandbox_id = %id, "handed the sandbox's vm to the next process"),
+                // The actor finished between the snapshot and the ask, so its
+                // computer is already gone — there is nothing left to hand
+                // over and nothing was lost.
+                Err(VmmError::NotFound(_)) => {}
                 Err(error) => failures.push(format!("{id}: {error}")),
             }
         }

--- a/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
+++ b/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
@@ -19,6 +19,7 @@
 mod support;
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use arcbox_computer_runtime::testkit::agent::Reply;
 use arcbox_computer_runtime::{
@@ -1144,6 +1145,90 @@ async fn an_adopted_computer_on_a_copied_rootfs_refuses_to_pause() {
         "the guest the refusal was protecting is killed by the failure path"
     );
     assert_eq!(fixture.settle_network_cleanups().await, vec![id]);
+}
+
+/// Nothing this process does may reach a VM it has handed over (CORE-145).
+///
+/// `detach_all` used to clone handles straight out of the map, so a handover
+/// and the `Stop` of the same computer had no mutual exclusion. This is the
+/// expensive half: the stop drives `handle.shutdown` into a handle whose
+/// reaper has stood down, waits out its whole budget for an exit that is never
+/// published, and then SIGKILLs the VM the successor is adopting — while its
+/// release hands TAP and the CoW device back underneath it.
+#[tokio::test]
+async fn a_teardown_after_a_handover_never_reaches_the_vm() {
+    let fixture = Fixture::jailed().await;
+    let id = fixture.ready("handed-over").await;
+    let vm = arcbox_vm_driver::VmId::new(&id).unwrap();
+
+    fixture.manager.detach_all().await.unwrap();
+    assert!(
+        !fixture.driver().owned_vms().contains(&vm),
+        "the handover did not reach the driver"
+    );
+
+    let stopped = fixture.manager.stop_sandbox(&id, 30).await.unwrap_err();
+    assert!(
+        matches!(stopped, VmmError::WrongState { .. }),
+        "a stop after a handover must be refused: {stopped}"
+    );
+    let removed = fixture.manager.remove_sandbox(&id, true).await.unwrap_err();
+    assert!(
+        matches!(removed, VmmError::WrongState { .. }),
+        "a forced remove after a handover must be refused: {removed}"
+    );
+
+    assert!(
+        fixture.driver().shutdowns(&vm).is_empty(),
+        "the handed-over vm was asked to die: {:?}",
+        fixture.driver().shutdowns(&vm)
+    );
+    assert!(
+        fixture.settle_network_cleanups().await.is_empty(),
+        "the successor's guest had its address taken back"
+    );
+}
+
+/// And the handover stands aside for a teardown already in flight.
+///
+/// The trigger and the race are the same event: an in-flight `StopSandbox`
+/// carrying a 30s budget is the main reason a composer's drain deadline
+/// expires and `detach_all` gets called at all. The stop was asked for first
+/// and the guest is meant to go away, so it wins — and the computer is
+/// reported as one that could not be handed over rather than silently raced.
+#[tokio::test]
+async fn a_handover_during_a_stop_is_refused_and_reported() {
+    let fixture = Fixture::jailed().await;
+    fixture.agent().on(&["/bin/wedged"], Reply::NeverExits);
+    let id = fixture.booted(never_exits("draining")).await;
+    fixture.await_state(&id, SandboxState::Running).await;
+
+    // The workload never exits, so the stop sits in its drain for the whole
+    // budget — the window the handover used to be able to reach into.
+    let manager = Arc::clone(&fixture.manager);
+    let stopping = tokio::spawn({
+        let id = id.clone();
+        // Shorter than the 30s a real `StopSandbox` carries: what this test
+        // needs is the window, and the drain polls every 100ms inside it.
+        async move { manager.stop_sandbox(&id, 5).await }
+    });
+    fixture.await_state(&id, SandboxState::Stopping).await;
+
+    let error = fixture.manager.detach_all().await.unwrap_err();
+    assert!(
+        error.to_string().contains(&*id),
+        "the handover failure must name the computer it lost: {error}"
+    );
+    assert!(
+        fixture
+            .driver()
+            .owned_vms()
+            .contains(&arcbox_vm_driver::VmId::new(&id).unwrap()),
+        "a computer mid-teardown was handed over anyway"
+    );
+
+    stopping.await.unwrap().unwrap();
+    fixture.await_state(&id, SandboxState::Stopped).await;
 }
 
 /// A computer whose VMM did not survive the gap comes back `Failed`, not


### PR DESCRIPTION
Closes CORE-145.

`SandboxManager::detach_all` was the one terminal transition that did not go
through the per-computer actor. It cloned each `Arc<dyn VmHandle>` straight out
of the map and called the driver, so a graceful-shutdown handover could run
concurrently with the `Stop` or `Remove` of the same computer.

Those are not independent events. An in-flight `StopSandbox` carrying a 30s
budget is the main reason a composer's drain deadline expires and `detach_all`
gets called at all — and dropping a tonic server future does not cancel the
handler, because connections are spawned (`serve_connection` is a bare
`tokio::spawn`; the outer future only awaits `signal_tx.closed()`). So the stop
keeps running while the composer detaches.

## What each order did to the guest

**Stop after detach** is the expensive one, and the likelier interleaving since
the detach is what the timeout triggers:

- `FcProcess::detach` tells the reaper to stand down and `Exited` is never
  published for a detached process, so `stop_vm`'s `handle.shutdown(Graceful)`
  waits out its **entire** budget for an exit that cannot arrive, warns, and
  falls through to `process.kill()` — SIGKILL on the VM that was just reported
  as successfully handed over — then returns `ReapTimeout`.
- `shutdown` also runs `unlink_vsock()`, removing the socket the successor's
  adopted handle dials.
- `release_scope(Runtime)` then hands TAP, the CoW device and the jail back
  while the successor is adopting them.

**Detach during a stop** hands the next process a VM a teardown is halfway
through killing.

## The fix

Detach becomes a lifecycle transition of its own, so the actor serializes it
against the other two.

- `Event::Detach` sits on the `active` superstate — exactly the three states
  holding a settled live handle — beside `Event::Stop`. It emits
  `Effect::Detach` and does **not** transition: the port call decides, and a
  handover that fails must leave a computer that is still ours and still usable
  rather than needing a state to come back from.
- The effect is awaited in the dispatch rather than spawned like every other
  flow. Releasing ownership has no wait in it, and spawning would force an
  intermediate state whose failure arm has nowhere correct to go — `failed`
  would write `Failed` over a record the successor's sweep still has to read as
  `Ready`. `queued` already exists for feeding an effect's outcome back into
  the same dispatch.
- Success lands in a new `detached` state, deliberately **not** under the
  `computer` superstate, so `Remove`, the TTL cap, `VmExited` and every failure
  event are swallowed. That placement is what closes the stop-after-detach path
  above.
- Nothing durable is written. The successor's sweep adopts from a `Ready`
  record; any other phase would have it reinstated as `Failed` instead.

`detach_all` now fans out over the mailboxes, keeps its best-effort
collect-and-report contract, skips an actor that finished in between
(`NotFound` — its computer is already gone), and waits out the startup sweep
first as `stop_sandbox`/`remove_sandbox` do.

Refusals fall out of the existing "machine had nothing to do → the actor
decides what the caller is told" contract. A computer mid-launch or
mid-teardown answers `WrongState`; one with nothing to hand over (paused,
resting, already detached) answers `Ok`. That answer keys off the machine
state, not the runtime handle — a computer halfway through a stop still holds
one, which is exactly the case that must not report success.

## Invariants

Three existing invariants asserted rules the new state breaks by design. Each
was extended to name the exception rather than drop the case, and
`a_handed_over_computer_refuses_every_teardown` pins why:

- a non-forced remove is refused on a handed-over computer,
- a forced remove does not tear one down,
- the TTL cap does not destroy one.

## Tests

- `cargo test -p arcbox-computer-runtime --lib` — 210 pass, incl. new machine
  invariants (`a_handover_only_acts_where_a_live_handle_is_settled`,
  `a_handed_over_computer_refuses_every_teardown`,
  `a_handover_drops_the_timers_it_no_longer_owns`) and actor tests over the
  `ComputerTasks` seam (handover during a stop refused; teardown after a
  handover never reaching the VM; a refused handover leaving the computer
  usable).
- `cargo test -p arcbox-computer-runtime --test manager_over_fakes` — 34 pass.
  New: `a_teardown_after_a_handover_never_reaches_the_vm` (asserts
  `shutdowns(&vm)` is empty and no network cleanup ran) and
  `a_handover_during_a_stop_is_refused_and_reported`. The three pre-existing
  `detach_all` tests are unchanged, which is the compatibility proof.
- `cargo fmt --check`, `cargo clippy` (zero new warnings), `cargo xtask
  check-layers` — clean.

`tests/e2e.rs` also calls `detach_all` but is `#[ignore]`d behind
`FC_BINARY`/`FC_KERNEL`/`FC_ROOTFS` and root, so it needs the `test-vm-linux`
runner rather than this host.


## Expected consumer

`detach_all` has no production caller in this repo — only `tests/manager_over_fakes.rs` and the `#[ignore]`d `tests/e2e.rs`. The consumer is the **platform node-agent** (`platform#146`), which calls it from its graceful-shutdown path once its drain deadline expires; the platform is holding for this fix rather than writing a workaround. So the change lands ahead of its caller by design, and the invariants above are enforced by the HSM and its tests rather than by any path CI exercises end to end.

## A deliberate trade: `Detached → SandboxState::Ready`

A client sees `Ready` for a computer that refuses every lifecycle verb with a wrong-state error. That is the honest option of the ones available — the wire enum has no `Detached` variant, the guest really is running, and the successor adopts it as `Ready` — but it is a trade, not a free mapping, and it is the reason two of the review findings existed: `SetLifecycle` and the data plane both gated on the public projection and therefore let a handed-over computer through. Both now gate on the machine state instead. Anything else that reasons about a handed-over computer should do the same: the state is authoritative, the projection is not.
