### PR TITLE
ci(guest): run the agent's unit tests on the Linux runner

### DIFF
--- a/.github/workflows/test-vm-linux.yml
+++ b/.github/workflows/test-vm-linux.yml
@@ -113,6 +113,22 @@ jobs:
         # to run here as library tests.
         run: cargo test -p arcbox-computer-runtime --test manager_over_fakes
 
+      - name: Container DNS aliases over the public API
+        # Compose-alias extraction, driven through `arcbox_agent::dns`
+        # rather than from inside the crate. Named for the same reason as
+        # the step above: `--lib --bins` selects no `--test` targets, so an
+        # integration target has to be asked for by name or it runs
+        # nowhere. Pure string handling — no KVM, no root, no Firecracker.
+        #
+        # The crate's other unprivileged `--test` target,
+        # port_forward_cleanup, is deliberately NOT here: it re-includes
+        # src/agent/linux/port_forward.rs by #[path] so those tests run on
+        # a macOS dev host, and on Linux `--bins` above already runs them
+        # from the bin target. The remaining two (sandbox_manager_e2e,
+        # sandbox_service_manager) need root + KVM + Firecracker and belong
+        # to the jobs below.
+        run: cargo test -p arcbox-agent --test dns_aliases
+
   # ---------------------------------------------------------------------------
   # Job 2: integration tests — requires root (TAP interface creation)
   # ---------------------------------------------------------------------------

--- a/.github/workflows/test-vm-linux.yml
+++ b/.github/workflows/test-vm-linux.yml
@@ -88,19 +88,20 @@ jobs:
         # --bins covers the vm-agent guest handlers, whose tests are
         # target_os = "linux" and never run under the macOS workspace job.
         #
-        # arcbox-agent is here for both halves of that same reason, and it
-        # needs both flags. The macOS workspace job excludes it by name
-        # (`cargo test --workspace --exclude arcbox-agent`, ci.yml) and its
-        # substantive modules are target_os = "linux" anyway, so this
-        # unprivileged runner is the only place its unit tests can execute
-        # at all — they never had until now. Its lib target re-exports only
-        # what the integration tests need; the larger module tree (agent/,
-        # init, nfs, supervisor) hangs off the bin, so dropping --bins
-        # would silently take most of that suite with it. The crate is
-        # deliberately NOT in the clippy step above: it carries a
-        # pre-existing pedantic backlog no gate has ever caught, and
-        # -D warnings on it would fail this job for reasons unrelated to
-        # the change under test (see guest/AGENTS.md).
+        # arcbox-agent is here for both halves of that same reason. The
+        # macOS workspace job excludes it by name (`cargo test --workspace
+        # --exclude arcbox-agent`, ci.yml) and its substantive modules are
+        # target_os = "linux" anyway, so this unprivileged runner is the
+        # only place its unit tests can execute at all — and until now
+        # nothing asked it to. --bins is what makes that real: lib.rs
+        # re-exports only what the integration tests need, so most of the
+        # crate's test modules are declared by main.rs and --lib alone
+        # reaches just over half of them (counts in guest/AGENTS.md).
+        #
+        # The crate is deliberately NOT in the clippy step above: it
+        # carries a pre-existing pedantic backlog no gate has ever caught,
+        # and -D warnings on it would fail this job for reasons unrelated
+        # to the change under test (see guest/AGENTS.md).
         run: cargo test --lib --bins -p arcbox-computer-runtime -p arcbox-vm-proto -p arcbox-vm-driver -p arcbox-fc-driver -p arcbox-tap-net -p arcbox-vm-agent -p arcbox-snapshot -p arcbox-agent
 
       - name: Manager lifecycle over the fakes

--- a/.github/workflows/test-vm-linux.yml
+++ b/.github/workflows/test-vm-linux.yml
@@ -87,7 +87,21 @@ jobs:
       - name: Unit tests
         # --bins covers the vm-agent guest handlers, whose tests are
         # target_os = "linux" and never run under the macOS workspace job.
-        run: cargo test --lib --bins -p arcbox-computer-runtime -p arcbox-vm-proto -p arcbox-vm-driver -p arcbox-fc-driver -p arcbox-tap-net -p arcbox-vm-agent -p arcbox-snapshot
+        #
+        # arcbox-agent is here for both halves of that same reason, and it
+        # needs both flags. The macOS workspace job excludes it by name
+        # (`cargo test --workspace --exclude arcbox-agent`, ci.yml) and its
+        # substantive modules are target_os = "linux" anyway, so this
+        # unprivileged runner is the only place its unit tests can execute
+        # at all — they never had until now. Its lib target re-exports only
+        # what the integration tests need; the larger module tree (agent/,
+        # init, nfs, supervisor) hangs off the bin, so dropping --bins
+        # would silently take most of that suite with it. The crate is
+        # deliberately NOT in the clippy step above: it carries a
+        # pre-existing pedantic backlog no gate has ever caught, and
+        # -D warnings on it would fail this job for reasons unrelated to
+        # the change under test (see guest/AGENTS.md).
+        run: cargo test --lib --bins -p arcbox-computer-runtime -p arcbox-vm-proto -p arcbox-vm-driver -p arcbox-fc-driver -p arcbox-tap-net -p arcbox-vm-agent -p arcbox-snapshot -p arcbox-agent
 
       - name: Manager lifecycle over the fakes
         # The manager's own flows (create, boot, exec, files, pause, resume,

--- a/guest/AGENTS.md
+++ b/guest/AGENTS.md
@@ -19,12 +19,21 @@ non-obvious invariants and failure signatures.
   (`--workspace --exclude arcbox-agent`, `.github/workflows/ci.yml`), and the
   substantive modules are `target_os = "linux"` regardless — so the sole gate
   is the `Unit tests` step of `.github/workflows/test-vm-linux.yml`
-  (`cargo test --lib --bins … -p arcbox-agent`, unprivileged ubuntu). **Both
-  flags are load-bearing**: `lib.rs` re-exports only what the integration
-  tests need, so most of the suite — `agent/`, `init`, `nfs`, `supervisor` —
-  hangs off the *bin* target and `--lib` alone would miss it. That workflow
+  (`cargo test --lib --bins … -p arcbox-agent`, unprivileged ubuntu).
+  **`--bins` is the load-bearing half.** `lib.rs` re-exports only what the
+  integration tests need, so the bin target is a strict superset: of the 184
+  distinct test functions, `--lib` reaches 103 and the other 81 exist only
+  under `--bins` (`agent/` incl. `linux/port_forward` and `linux/runtime`,
+  `boot_done`, `init`, `nfs`, `live_exports`, `runtime_materialize`,
+  `containerd_config`, `shutdown`, and `main.rs`'s own `parse_mode` tests).
+  Every module declared by both targets is compiled and run twice, which is
+  why the job reports 287 executions for 184 functions. That workflow
   triggers on `guest/arcbox-agent/**`, so a change here is gated; a change
-  that reaches the agent only through a dependency is not.
+  that reaches the agent only through a dependency is not. Two integration
+  targets under `tests/` are still gated by nothing: `dns_aliases` (7 tests
+  against the public `dns` API) and `port_forward_cleanup` (a `#[path]` shim
+  that re-includes `agent/linux/port_forward.rs` purely so its tests can run
+  on macOS — on Linux the bin target now runs them anyway).
 - **CI still never lints the agent — you must, locally.** No job runs clippy
   on it: the macOS gate excludes it, the Linux `Unit tests` job deliberately
   keeps it out of the `-D warnings` clippy step (a pre-existing

--- a/guest/AGENTS.md
+++ b/guest/AGENTS.md
@@ -14,12 +14,23 @@ non-obvious invariants and failure signatures.
   `cargo test -p arcbox-agent` only exercises the stub + pure helpers and proves
   *nothing* about guest behavior. Build for `aarch64-unknown-linux-musl` (recipe
   in `guest/arcbox-agent/README.md` / root CLAUDE.md) and validate through e2e.
-- **CI never lints the agent — you must, locally.** The workspace gate excludes
-  it (`cargo clippy --workspace --exclude arcbox-agent -- -D warnings`,
-  `.github/workflows/ci.yml`; the build and test steps exclude it too) and no
-  job runs clippy against `aarch64-unknown-linux-musl` (`release.yml` only
-  `cargo build`s that target). So `agent/linux` carries a pre-existing
-  pedantic/nursery warning backlog no gate catches. Run
+- **The unit tests run on Linux only, and in exactly one job.** The macOS
+  workspace gate excludes the crate by name from clippy, build *and* test
+  (`--workspace --exclude arcbox-agent`, `.github/workflows/ci.yml`), and the
+  substantive modules are `target_os = "linux"` regardless — so the sole gate
+  is the `Unit tests` step of `.github/workflows/test-vm-linux.yml`
+  (`cargo test --lib --bins … -p arcbox-agent`, unprivileged ubuntu). **Both
+  flags are load-bearing**: `lib.rs` re-exports only what the integration
+  tests need, so most of the suite — `agent/`, `init`, `nfs`, `supervisor` —
+  hangs off the *bin* target and `--lib` alone would miss it. That workflow
+  triggers on `guest/arcbox-agent/**`, so a change here is gated; a change
+  that reaches the agent only through a dependency is not.
+- **CI still never lints the agent — you must, locally.** No job runs clippy
+  on it: the macOS gate excludes it, the Linux `Unit tests` job deliberately
+  keeps it out of the `-D warnings` clippy step (a pre-existing
+  pedantic/nursery backlog would fail that job for reasons unrelated to the
+  change under test), and nothing lints `aarch64-unknown-linux-musl` at all
+  (`release.yml` only `cargo build`s that target). Run
   `cargo clippy -p arcbox-agent --target aarch64-unknown-linux-musl --all-targets`
   and hold *your changed lines* to zero new warnings; do NOT bulk-fix the
   backlog in an unrelated PR — it buries your diff.

--- a/guest/AGENTS.md
+++ b/guest/AGENTS.md
@@ -33,20 +33,26 @@ non-obvious invariants and failure signatures.
   `containerd_config`, `shutdown`, and `main.rs`'s own `parse_mode` tests).
   Every module declared by both targets is compiled and run twice, which is
   why the job reports 287 executions for 184 functions.
-- **Two holes in that gate, both by omission rather than design.** The
+- **One hole left in that gate, by omission rather than design.** The
   workflow is `paths:`-filtered: it covers `guest/arcbox-agent/**` *and* most
   of the crate's own workspace dependencies (`arcbox-computer-runtime`,
   `arcbox-fc-driver`, `arcbox-tap-net`, `arcbox-snapshot`,
   `arcbox-constants`, `Cargo.lock`), so a change to any of those re-runs the
   agent's tests — but a dependency *absent* from that list does not:
-  `arcbox-connect`, `arcbox-pty`, `arcbox-dns`, `arcbox-logging`. And
-  `--lib --bins` selects no `--test` targets, so two under `tests/` still run
-  nowhere: `dns_aliases` (7 tests against the public `dns` API) and
-  `port_forward_cleanup` (a `#[path]` shim re-including
-  `agent/linux/port_forward.rs` purely so its tests can run on macOS — on
-  Linux the bin target now runs them anyway). A bare `--tests` is not the fix:
-  it would drag in `sandbox_manager_e2e` and `sandbox_service_manager`, which
-  need root, KVM and Firecracker.
+  `arcbox-connect`, `arcbox-pty`, `arcbox-dns`, `arcbox-logging`.
+- **An integration target runs nowhere until a step names it.**
+  `--lib --bins` selects no `--test` targets, so each one needs asking for:
+  `dns_aliases`, the compose-alias tests against the public `dns` API, has
+  its own step beside `Manager lifecycle over the fakes`. A bare `--tests` is
+  not the shortcut — it would pull in `sandbox_manager_e2e` and
+  `sandbox_service_manager`, which need root, KVM and Firecracker and are
+  already driven by the privileged jobs below. `port_forward_cleanup` is left
+  out deliberately and is not a gap: it re-includes
+  `agent/linux/port_forward.rs` by `#[path]`, and what that buys is coverage
+  on the **macOS dev host** — the primary dev platform, where a plain
+  `cargo test -p arcbox-agent` picks up those 11 tests and the Linux job
+  cannot help. On Linux the bin target already runs the same tests, so adding
+  it to this job would buy nothing.
 - **CI still never lints the agent — you must, locally.** No job runs clippy
   on it: the macOS gate excludes it, the Linux `Unit tests` job deliberately
   keeps it out of the `-D warnings` clippy step (a pre-existing

--- a/guest/AGENTS.md
+++ b/guest/AGENTS.md
@@ -20,6 +20,11 @@ non-obvious invariants and failure signatures.
   substantive modules are `target_os = "linux"` regardless — so the sole gate
   is the `Unit tests` step of `.github/workflows/test-vm-linux.yml`
   (`cargo test --lib --bins … -p arcbox-agent`, unprivileged ubuntu).
+  `cargo fmt --check` is the exception to the exclusions: that same macOS job
+  runs it workspace-wide with no `--exclude`, and cargo-fmt walks every
+  member of a virtual manifest, so rustfmt is the one gate this crate has
+  never escaped — do not add it to another job's `-p` list thinking it is
+  ungated.
   **`--bins` is the load-bearing half.** `lib.rs` re-exports only what the
   integration tests need, so the bin target is a strict superset: of the 184
   distinct test functions, `--lib` reaches 103 and the other 81 exist only
@@ -27,13 +32,21 @@ non-obvious invariants and failure signatures.
   `boot_done`, `init`, `nfs`, `live_exports`, `runtime_materialize`,
   `containerd_config`, `shutdown`, and `main.rs`'s own `parse_mode` tests).
   Every module declared by both targets is compiled and run twice, which is
-  why the job reports 287 executions for 184 functions. That workflow
-  triggers on `guest/arcbox-agent/**`, so a change here is gated; a change
-  that reaches the agent only through a dependency is not. Two integration
-  targets under `tests/` are still gated by nothing: `dns_aliases` (7 tests
-  against the public `dns` API) and `port_forward_cleanup` (a `#[path]` shim
-  that re-includes `agent/linux/port_forward.rs` purely so its tests can run
-  on macOS — on Linux the bin target now runs them anyway).
+  why the job reports 287 executions for 184 functions.
+- **Two holes in that gate, both by omission rather than design.** The
+  workflow is `paths:`-filtered: it covers `guest/arcbox-agent/**` *and* most
+  of the crate's own workspace dependencies (`arcbox-computer-runtime`,
+  `arcbox-fc-driver`, `arcbox-tap-net`, `arcbox-snapshot`,
+  `arcbox-constants`, `Cargo.lock`), so a change to any of those re-runs the
+  agent's tests — but a dependency *absent* from that list does not:
+  `arcbox-connect`, `arcbox-pty`, `arcbox-dns`, `arcbox-logging`. And
+  `--lib --bins` selects no `--test` targets, so two under `tests/` still run
+  nowhere: `dns_aliases` (7 tests against the public `dns` API) and
+  `port_forward_cleanup` (a `#[path]` shim re-including
+  `agent/linux/port_forward.rs` purely so its tests can run on macOS — on
+  Linux the bin target now runs them anyway). A bare `--tests` is not the fix:
+  it would drag in `sandbox_manager_e2e` and `sandbox_service_manager`, which
+  need root, KVM and Firecracker.
 - **CI still never lints the agent — you must, locally.** No job runs clippy
   on it: the macOS gate excludes it, the Linux `Unit tests` job deliberately
   keeps it out of the `-D warnings` clippy step (a pre-existing

--- a/guest/AGENTS.md
+++ b/guest/AGENTS.md
@@ -26,13 +26,15 @@ non-obvious invariants and failure signatures.
   never escaped — do not add it to another job's `-p` list thinking it is
   ungated.
   **`--bins` is the load-bearing half.** `lib.rs` re-exports only what the
-  integration tests need, so the bin target is a strict superset: of the 184
-  distinct test functions, `--lib` reaches 103 and the other 81 exist only
+  integration tests need, so the bin target is a strict superset: of the 189
+  distinct test functions, `--lib` reaches 108 and the other 81 exist only
   under `--bins` (`agent/` incl. `linux/port_forward` and `linux/runtime`,
   `boot_done`, `init`, `nfs`, `live_exports`, `runtime_materialize`,
   `containerd_config`, `shutdown`, and `main.rs`'s own `parse_mode` tests).
   Every module declared by both targets is compiled and run twice, which is
-  why the job reports 287 executions for 184 functions.
+  why the job reports 297 executions for 189 functions. (Counts read off the
+  job on 2026-08-19; they drift as tests are added, but the *shape* — bin a
+  strict superset, ~81 of them unreachable via `--lib` — is the durable part.)
 - **One hole left in that gate, by omission rather than design.** The
   workflow is `paths:`-filtered: it covers `guest/arcbox-agent/**` *and* most
   of the crate's own workspace dependencies (`arcbox-computer-runtime`,
@@ -42,7 +44,7 @@ non-obvious invariants and failure signatures.
   `arcbox-connect`, `arcbox-pty`, `arcbox-dns`, `arcbox-logging`.
 - **An integration target runs nowhere until a step names it.**
   `--lib --bins` selects no `--test` targets, so each one needs asking for:
-  `dns_aliases`, the compose-alias tests against the public `dns` API, has
+  `dns_aliases`, the 7 compose-alias tests against the public `dns` API, has
   its own step beside `Manager lifecycle over the fakes`. A bare `--tests` is
   not the shortcut — it would pull in `sandbox_manager_e2e` and
   `sandbox_service_manager`, which need root, KVM and Firecracker and are


### PR DESCRIPTION
## The gap

189 distinct `#[test]`/`#[tokio::test]` functions across 33 files under `guest/arcbox-agent/src`, plus a 7-test integration target beside them, had never been executed by any CI job.

- `ci.yml` (macOS) runs `cargo test --workspace --exclude arcbox-agent` — excluded by name. It could not have run them even without the exclusion: the substantive modules are `cfg(target_os = "linux")`.
- `test-vm-linux.yml`'s `Unit tests` step runs `cargo test --lib --bins` over seven packages; `arcbox-agent` was not one of them.
- Its other jobs run named `--test` targets (`sandbox_service_manager`, `sandbox_manager_e2e`). Those compile the lib, so a compile break would surface — but `--test <name>` never runs a package's unit tests.

So the Linux runner is the only place this suite can execute, and nothing there asked it to.

## The change

Two steps in the unprivileged `Unit tests` job — no root, no KVM, no Firecracker:

1. `-p arcbox-agent` added to the existing `cargo test --lib --bins`.
2. A named step for `--test dns_aliases`, since `--lib --bins` selects no `--test` targets.

**`--bins` is the load-bearing flag**, and the measurement says by how much: the bin target is a strict superset of the lib target. `lib.rs` re-exports only what the integration tests need, so `--lib` reaches 108 of the 189 functions and the other 81 — the whole `agent/` tree (including `linux/port_forward` and `linux/runtime`), `boot_done`, `init`, `nfs`, `live_exports`, `runtime_materialize`, `containerd_config`, `shutdown`, and `main.rs`'s own `parse_mode` tests — have no other route into a test binary.

The crate deliberately stays out of that job's `-D warnings` clippy step. `guest/AGENTS.md` is explicit that `agent/linux` carries a pre-existing pedantic/nursery backlog no gate has ever caught; gating on it here would fail the job for reasons unrelated to whatever change is under test, and bulk-fixing it would bury this diff.

`port_forward_cleanup` is deliberately **not** added, and is not a gap. It re-includes `src/agent/linux/port_forward.rs` by `#[path]`, and what that buys is coverage on the macOS dev host — the primary dev platform, and the one place this Linux job cannot help. Verified on this host: `cargo test -p arcbox-agent` compiles all six targets, and `--test port_forward_cleanup` reports 11 passed. On Linux the bin target already runs those same tests.

## Result

Green on the first-ever run, and on every run since — nothing to fix. From run [32241904141](https://github.com/arcboxlabs/arcbox/actions/runs/32241904141/job/96034097612):

```
Running unittests src/lib.rs   → 108 passed; 0 failed; 0 ignored
Running unittests src/main.rs  → 189 passed; 0 failed; 0 ignored
Running tests/dns_aliases.rs   →   7 passed; 0 failed; 0 ignored
```

297 unit executions for 189 distinct functions — the modules both targets declare are compiled and run twice — plus the 7 in their own step.

That it is green is not luck: everything in the crate that needs root, a device or a live guest already lives behind the `--test` targets the privileged jobs run. The unit modules are parsers, state machines and tempdir-backed filesystem logic.

Counts come from the job that executed them, not from a hand count, and they moved once during the PR: master gained #687 (the `config/` split) mid-flight, and since PR runs build the merge commit, its 5 new tests are included. The shape did not move — bin remained a strict superset with exactly 81 bin-only tests.

Also verified locally before each push: `cargo check -p arcbox-agent --target aarch64-unknown-linux-musl --all-targets` clean, `cargo fmt --check` clean, and the macOS-runnable subset green.

## Review threads

Both pullfrog threads answered and resolved — one fixed, one refuted with a reproduction. Details in the threads.

## Note on the one red in this PR's history

`SandboxService -> SandboxManager integration` timed out once at 40m23s, hung inside `sudo apt-get update` in its `Install protoc` step — before the cache restore, before KVM, before any cargo invocation, in a job this PR does not touch. Runner apt-mirror stall; the re-run took 5m48s, in line with master's 5-8 min. Explained with the log excerpt in a comment below.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI workflow and contributor documentation only; no guest runtime or production code paths are modified.
> 
> **Overview**
> **Linux VM CI** now exercises `arcbox-agent` for the first time: the unprivileged **Unit tests** step adds `-p arcbox-agent` with **`--lib --bins`**, which is required because most guest tests live on the bin target and are unreachable via `--lib` alone. The crate stays **out of the job’s `-D warnings` clippy** step so a pre-existing pedantic backlog does not fail unrelated changes.
> 
> A new step runs **`cargo test -p arcbox-agent --test dns_aliases`** (compose-alias / public DNS API tests). **`port_forward_cleanup`** is intentionally omitted on Linux because those tests already run via `--bins`; privileged e2e targets remain in the jobs below.
> 
> **`guest/AGENTS.md`** is updated to document where agent tests run, the `--bins` vs `--lib` split, path-filter gaps for some dependencies, and which integration test targets need explicit workflow steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 191ea96376611de3805f3dc5671bee9034bf6b2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->