### PR TITLE
test(e2e): the sandbox suite's phase timings stop reporting their bucket

### DIFF
--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -56,29 +56,38 @@ const SANDBOX_READY_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// How often a wait loop re-reads the state it is waiting for.
 ///
-/// This is the resolution of every phase timing in `metrics.json`, and it
-/// biases them upward: a phase whose true duration is 1.4 s is reported as
-/// whichever tick first observes it. At the 500 ms this used to be, the
-/// `sandbox_ready` bucket boundary sat at ~1.53 s — directly on top of the
-/// distribution — so the same unchanged code reported 1508 ms on one run and
-/// 2011 ms on the next, and looked *stable* at both, because a bucket has no
-/// variance. Measured 2026-08-19 against `ce4f4e78` and `86ac9e12`: the true
-/// values were 1398 ms and 1327-1462 ms, i.e. indistinguishable, while the
-/// coarse readings differed by 500 ms.
+/// This is the resolution of any phase whose span contains such a loop —
+/// directly, or inside a scenario function it calls — and it biases those
+/// phases upward: the phase is reported as whichever tick first observes it.
+/// Phases made of single calls (`daemon_ready`, `sandbox_create`,
+/// `sandbox_file_io`, `sandbox_restore`, `template_build`, `connect_json`,
+/// the `sandbox_exec_*` family) contain no loop and are unaffected.
 ///
-/// Consequence to keep in mind: **numbers recorded before this change are
-/// not comparable with numbers after it.** Every phase was inflated, by an
-/// amount that depends on where its true value fell inside a bucket — 14 ms
-/// for `sandbox_file_io`, 247 ms for `template_create`, measured the same
-/// day. Re-baseline rather than subtracting.
+/// At the 500 ms this used to be, the `sandbox_ready` bucket boundary sat at
+/// ~1.53 s — directly on top of the distribution — so the same unchanged code
+/// reported 1508 ms on one run and 2011 ms on the next, and looked *stable*
+/// at both, because a bucket has no variance. Measured 2026-08-19 against
+/// `ce4f4e78` and `86ac9e12`: the true values were 1398 ms and
+/// 1327-1462 ms, i.e. indistinguishable, while the coarse readings differed
+/// by 500 ms.
+///
+/// Consequence to keep in mind: for a phase that does contain a loop,
+/// **numbers recorded before this change are not comparable with numbers
+/// after it**, and the gap depends on where the true value fell inside a
+/// bucket — same-day pairing: `sandbox_ready` 1508 -> 1398,
+/// `template_create` 1568 -> 1321. Re-baseline those rather than subtracting
+/// a correction, and do not read a delta on a loop-free phase as this.
 const POLL_INTERVAL: Duration = Duration::from_millis(25);
 
-/// The same, for a loop whose observation is a guest `exec` round trip
-/// rather than a lock-free read on the host.
+/// The same, for a loop whose observation runs a command *inside* the
+/// sandbox being timed.
 ///
-/// The round trip costs tens of milliseconds and runs *inside* the sandbox
-/// being timed, so polling it at [`POLL_INTERVAL`] would not observe sooner —
-/// it would only add load to the thing under measurement.
+/// Neither interval observes anything host-local — `Inspect` is an RPC that
+/// crosses to the manager in the System VM. The difference is what happens
+/// at the far end: a guest `exec` starts a process in the nested VM under
+/// test, which costs tens of milliseconds and adds load to the very thing
+/// the phase is measuring. Polling it at [`POLL_INTERVAL`] would not observe
+/// sooner; it would only make the measurement worse.
 const GUEST_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 pub struct SandboxSmokeConfig {

--- a/tests/e2e/src/sandbox.rs
+++ b/tests/e2e/src/sandbox.rs
@@ -54,6 +54,33 @@ const READY_TIMEOUT: Duration = Duration::from_secs(360);
 /// rootfs build inside the guest).
 const SANDBOX_READY_TIMEOUT: Duration = Duration::from_secs(120);
 
+/// How often a wait loop re-reads the state it is waiting for.
+///
+/// This is the resolution of every phase timing in `metrics.json`, and it
+/// biases them upward: a phase whose true duration is 1.4 s is reported as
+/// whichever tick first observes it. At the 500 ms this used to be, the
+/// `sandbox_ready` bucket boundary sat at ~1.53 s — directly on top of the
+/// distribution — so the same unchanged code reported 1508 ms on one run and
+/// 2011 ms on the next, and looked *stable* at both, because a bucket has no
+/// variance. Measured 2026-08-19 against `ce4f4e78` and `86ac9e12`: the true
+/// values were 1398 ms and 1327-1462 ms, i.e. indistinguishable, while the
+/// coarse readings differed by 500 ms.
+///
+/// Consequence to keep in mind: **numbers recorded before this change are
+/// not comparable with numbers after it.** Every phase was inflated, by an
+/// amount that depends on where its true value fell inside a bucket — 14 ms
+/// for `sandbox_file_io`, 247 ms for `template_create`, measured the same
+/// day. Re-baseline rather than subtracting.
+const POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// The same, for a loop whose observation is a guest `exec` round trip
+/// rather than a lock-free read on the host.
+///
+/// The round trip costs tens of milliseconds and runs *inside* the sandbox
+/// being timed, so polling it at [`POLL_INTERVAL`] would not observe sooner —
+/// it would only add load to the thing under measurement.
+const GUEST_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
 pub struct SandboxSmokeConfig {
     pub skip_build: bool,
     pub keep_test_dir: bool,
@@ -335,7 +362,7 @@ async fn drive_sandboxes(
             if Instant::now() > deadline {
                 bail!("initial cmd never ran (last_exited_at still unset)");
             }
-            tokio::time::sleep(Duration::from_millis(500)).await;
+            tokio::time::sleep(POLL_INTERVAL).await;
         }
     }
     let info = inspect(&mut sandboxes, "smoke1").await?;
@@ -870,7 +897,7 @@ async fn template_catalog_scenario(
         if Instant::now() > deadline {
             bail!("template defaults not observable in the guest: {out:?}");
         }
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(GUEST_POLL_INTERVAL).await;
     }
     metrics.record("template_create", create_started.elapsed().as_secs_f64());
     info!("bare-name create resolved the published version and applied its default cmd + env");
@@ -1753,7 +1780,7 @@ async fn expose_cleanup_scenario(sandboxes: &mut SandboxServiceClient<Channel>) 
         {
             Err(status) if status.code() == tonic::Code::NotFound => break,
             Ok(_) | Err(_) if Instant::now() < reap_deadline => {
-                tokio::time::sleep(Duration::from_millis(500)).await;
+                tokio::time::sleep(POLL_INTERVAL).await;
             }
             Ok(info) => bail!(
                 "sandbox never TTL-reaped (state: {:?})",
@@ -1771,7 +1798,7 @@ async fn expose_cleanup_scenario(sandboxes: &mut SandboxServiceClient<Channel>) 
         match std::net::TcpListener::bind(("127.0.0.1", host_port)) {
             Ok(_) => break,
             Err(_) if Instant::now() < release_deadline => {
-                tokio::time::sleep(Duration::from_millis(500)).await;
+                tokio::time::sleep(POLL_INTERVAL).await;
             }
             Err(error) => {
                 bail!("host port {host_port} never released after the TTL reap: {error}")
@@ -2372,7 +2399,7 @@ async fn wait_for_state(
                 info.state()
             );
         }
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(POLL_INTERVAL).await;
     }
 }
 


### PR DESCRIPTION
## What this is

Every wait loop in `tests/e2e/src/sandbox.rs` re-read the state it was waiting for every 500 ms. That interval is the resolution of every phase timing in `metrics.json`, and it biases them upward: a phase is reported as whichever tick first observes it, never as what it took.

## How it surfaced

Validating R3's PR-G against the recorded baselines, `sandbox_ready` read 1508 ms before the phase and 2011 ms after — a 33% regression, and it looked solid, because both readings reproduced to ±1 ms across runs.

They reproduced because a bucket has no variance. The `sandbox_ready` boundary sits at ~1.53 s (`inspect` + `sleep(500)` × 3), directly on top of the distribution, so the metric was reporting which side of 1.53 s that run's tail landed on.

Measured the same day on the same host with a 25 ms poll:

| | `ce4f4e78` (pre PR-G) | `86ac9e12` (post) |
|---|---|---|
| 500 ms poll | 1508 | 2011, 2012 |
| 25 ms poll | 1398 | 1327, 1413, 1440, 1462 |

There is no regression. There was never a measurement either.

## What changes

The interval becomes a documented constant. A second constant covers the one loop that observes through a guest `exec` rather than a host-side read: that round trip costs tens of milliseconds and runs *inside* the sandbox being timed, so polling it at 25 ms would add load rather than resolution.

## What this costs

**Numbers recorded before this change are not comparable with numbers after it.** Every phase was inflated, by an amount that depends on where its true value fell inside a bucket — measured on one same-day pairing: `sandbox_file_io` +14 ms, `sandbox_ready` +110 ms, `sandbox_pause_resume` +147 ms, `template_create` +247 ms. The baselines in Linear and in the campaign notes have to be re-taken, not adjusted.

## Validation

`cargo xtask e2e --test sandbox --repeat 3` green on master with the change (three runs, above), plus one run at `ce4f4e78` for the pairing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing and documentation in the sandbox e2e suite; no production runtime behavior changes.
> 
> **Overview**
> **E2e sandbox smoke** wait loops no longer sleep **500 ms** between checks. They use named **`POLL_INTERVAL` (25 ms)** for host-side waits (`wait_for_state`, initial-cmd grace, TTL reap, host port release) and **`GUEST_POLL_INTERVAL` (100 ms)** for the template-create loop that polls via guest `exec`.
> 
> Inline comments document that loop-based phase metrics were **biased upward** by the old interval (e.g. `sandbox_ready` looked like a 500 ms swing and stable across runs). **Prior `metrics.json` baselines for those phases are not comparable** after this change; they need re-baselining, not a fixed offset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab2c1a46732efd885881f6af5ba69e808f19a41a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->