### PR TITLE
refactor(computer)!: the runtime's types are named for what they run

### DIFF
--- a/computer/arcbox-computer-runtime/README.md
+++ b/computer/arcbox-computer-runtime/README.md
@@ -19,7 +19,7 @@ arcbox-daemon  ──vsock──►  arcbox-agent        ──vsock──►  v
 ```
 
 `arcbox-agent` is this crate's only consumer: it owns the `sandbox.v1`
-surface and the vsock transport, and calls `SandboxManager` underneath.
+surface and the vsock transport, and calls `ComputerManager` underneath.
 There are no service implementations, no tonic, and no daemon here.
 
 The **`vm-agent`** binary that becomes PID 1 *inside* each sandbox is a
@@ -40,13 +40,13 @@ once, here.
 
 ```rust
 use std::sync::Arc;
-use arcbox_computer_runtime::{NodeEnvironment, RuntimeConfig, SandboxManager, ComputerSpec};
+use arcbox_computer_runtime::{NodeEnvironment, RuntimeConfig, ComputerManager, ComputerSpec};
 
 // `environment` is the composer's; see below.
-let manager = Arc::new(SandboxManager::new(RuntimeConfig::default(), environment)?);
+let manager = Arc::new(ComputerManager::new(RuntimeConfig::default(), environment)?);
 
 let (id, ip) = manager
-    .create_sandbox(ComputerSpec {
+    .create_computer(ComputerSpec {
         vcpus: 1,
         memory_mib: 512,
         ..Default::default()
@@ -72,7 +72,7 @@ This crate builds none of them and names no VMM: whoever composes the node
 does. For the System VM that is `arcbox_agent::sandbox::node_environment`.
 
 - `driver` — the VMM behind `arcbox_vm_driver::VmDriver`. It must claim
-  `Prepare` and `Staging` and offer `vsock`, or `SandboxManager::new`
+  `Prepare` and `Staging` and offer `vsock`, or `ComputerManager::new`
   refuses it.
 - `network` — what the NICs attach to, behind
   `arcbox_vm_driver::net::GuestNetwork`. It must offer `NetworkReconcile`.

--- a/computer/arcbox-computer-runtime/README.md
+++ b/computer/arcbox-computer-runtime/README.md
@@ -40,13 +40,13 @@ once, here.
 
 ```rust
 use std::sync::Arc;
-use arcbox_computer_runtime::{NodeEnvironment, RuntimeConfig, SandboxManager, SandboxSpec};
+use arcbox_computer_runtime::{NodeEnvironment, RuntimeConfig, SandboxManager, ComputerSpec};
 
 // `environment` is the composer's; see below.
 let manager = Arc::new(SandboxManager::new(RuntimeConfig::default(), environment)?);
 
 let (id, ip) = manager
-    .create_sandbox(SandboxSpec {
+    .create_sandbox(ComputerSpec {
         vcpus: 1,
         memory_mib: 512,
         ..Default::default()

--- a/computer/arcbox-computer-runtime/README.md
+++ b/computer/arcbox-computer-runtime/README.md
@@ -40,7 +40,7 @@ once, here.
 
 ```rust
 use std::sync::Arc;
-use arcbox_computer_runtime::{NodeEnvironment, RuntimeConfig, ComputerManager, ComputerSpec};
+use arcbox_computer_runtime::{ComputerManager, ComputerSpec, NodeEnvironment, RuntimeConfig};
 
 // `environment` is the composer's; see below.
 let manager = Arc::new(ComputerManager::new(RuntimeConfig::default(), environment)?);

--- a/computer/arcbox-computer-runtime/src/agent/vm_proto.rs
+++ b/computer/arcbox-computer-runtime/src/agent/vm_proto.rs
@@ -35,7 +35,7 @@ use tokio::sync::mpsc;
 use tracing::warn;
 
 use crate::agent::{ExitStatus, OutputChunk};
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 
 // Exec-channel vocabulary, shared with vm-agent through `arcbox-vm-proto`.
 pub use arcbox_vm_proto::exec::{AGENT_PORT, MSG_WAIT_PORT, READY_PORT, StartCommand, WaitPortReq};
@@ -114,7 +114,7 @@ pub(crate) async fn connect_to_port(vsock: &dyn Vsock, port: u32) -> Result<Unix
             Err(error) => return Err(error.into()),
         }
         if tokio::time::Instant::now() >= deadline {
-            return Err(VmmError::Vsock(format!(
+            return Err(ComputerError::Vsock(format!(
                 "vsock port {port} did not become ready within {}s",
                 AGENT_READY_TIMEOUT.as_secs(),
             )));
@@ -156,7 +156,7 @@ fn into_unix_stream(conn: VsockConn) -> Result<UnixStream> {
             stream.set_nonblocking(true)?;
             Ok(UnixStream::from_std(stream)?)
         }
-        IoMode::Blocking => Err(VmmError::Vsock(
+        IoMode::Blocking => Err(ComputerError::Vsock(
             "vsock connection requires blocking I/O, which the guest-agent client cannot drive"
                 .into(),
         )),
@@ -170,13 +170,13 @@ pub(crate) async fn wait_ready(listener: &mut dyn VsockListener) -> Result<()> {
     let conn = listener
         .accept()
         .await
-        .map_err(|e| VmmError::Vsock(format!("accept on ready socket: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("accept on ready socket: {e}")))?;
     let mut stream = into_unix_stream(conn)?;
     let mut byte = [0u8; 1];
     stream
         .read(&mut byte)
         .await
-        .map_err(|e| VmmError::Vsock(format!("read ready byte: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("read ready byte: {e}")))?;
     Ok(())
 }
 
@@ -249,7 +249,7 @@ async fn drain_output<R: AsyncReadExt + Unpin>(
             }
             Err(e) => {
                 let _ = tx
-                    .send(Err(VmmError::Vsock(format!("agent read error: {e}"))))
+                    .send(Err(ComputerError::Vsock(format!("agent read error: {e}"))))
                     .await;
                 break;
             }
@@ -355,11 +355,11 @@ mod tests {
         // Each final error keeps its native shape through the conversion:
         // an I/O failure stays `Io`, a driver `WrongState` stays
         // `WrongState` (the guest agent maps that to 412, not 500).
-        type Native = fn(&VmmError) -> bool;
+        type Native = fn(&ComputerError) -> bool;
         let finals: [(arcbox_vm_driver::Error, Native); 2] = [
             (
                 arcbox_vm_driver::Error::Io(std::io::ErrorKind::BrokenPipe.into()),
-                |err| matches!(err, VmmError::Io(_)),
+                |err| matches!(err, ComputerError::Io(_)),
             ),
             (
                 arcbox_vm_driver::Error::WrongState {
@@ -369,7 +369,7 @@ mod tests {
                     ),
                     expected: "running",
                 },
-                |err| matches!(err, VmmError::WrongState { expected, actual, .. } if expected == "running" && actual.starts_with("exited")),
+                |err| matches!(err, ComputerError::WrongState { expected, actual, .. } if expected == "running" && actual.starts_with("exited")),
             ),
         ];
         for (error, native) in finals {
@@ -385,7 +385,7 @@ mod tests {
         let vsock = ScriptedVsock::new([]);
         let err = connect_to_port(&vsock, AGENT_PORT).await.unwrap_err();
         assert!(
-            matches!(err, VmmError::Vsock(ref m) if m.contains("did not become ready within 30s")),
+            matches!(err, ComputerError::Vsock(ref m) if m.contains("did not become ready within 30s")),
             "unexpected error: {err}"
         );
         assert!(vsock.dials() > 1);
@@ -396,7 +396,7 @@ mod tests {
         let vsock = ScriptedVsock::new([Ok(IoMode::Blocking)]);
         let err = connect_to_port(&vsock, AGENT_PORT).await.unwrap_err();
         assert!(
-            matches!(err, VmmError::Vsock(ref m) if m.contains("blocking I/O")),
+            matches!(err, ComputerError::Vsock(ref m) if m.contains("blocking I/O")),
             "unexpected error: {err}"
         );
     }

--- a/computer/arcbox-computer-runtime/src/agent/vm_proto/clock.rs
+++ b/computer/arcbox-computer-runtime/src/agent/vm_proto/clock.rs
@@ -7,7 +7,7 @@ use tracing::info;
 
 use super::{MSG_CLOCK_SYNC, MSG_EXIT, connect_to_agent, read_frame, write_frame};
 use crate::agent::ClockSync;
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 
 /// Synchronise the guest clock to the current host time.
 ///
@@ -28,10 +28,10 @@ pub async fn sync_clock(vsock: &dyn Vsock) -> Result<ClockSync> {
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map_err(|e| VmmError::Vsock(format!("system time error: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("system time error: {e}")))?;
 
     let secs = i64::try_from(now.as_secs())
-        .map_err(|e| VmmError::Vsock(format!("unix timestamp overflow: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("unix timestamp overflow: {e}")))?;
     let nanos = now.subsec_nanos();
 
     let result = sync_clock_on_stream(&mut stream, secs, nanos).await;
@@ -58,20 +58,20 @@ async fn sync_clock_on_stream<S: tokio::io::AsyncReadExt + tokio::io::AsyncWrite
 
     write_frame(stream, MSG_CLOCK_SYNC, &payload)
         .await
-        .map_err(|e| VmmError::Vsock(format!("write MSG_CLOCK_SYNC: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("write MSG_CLOCK_SYNC: {e}")))?;
 
     let (msg_type, payload) = tokio::time::timeout(Duration::from_secs(5), read_frame(stream))
         .await
-        .map_err(|_| VmmError::Vsock("clock sync: timed out waiting for response".into()))?
-        .map_err(|e| VmmError::Vsock(format!("read clock sync response: {e}")))?;
+        .map_err(|_| ComputerError::Vsock("clock sync: timed out waiting for response".into()))?
+        .map_err(|e| ComputerError::Vsock(format!("read clock sync response: {e}")))?;
 
     if msg_type != MSG_EXIT {
-        return Err(VmmError::Vsock(format!(
+        return Err(ComputerError::Vsock(format!(
             "clock sync: unexpected response type 0x{msg_type:02x}"
         )));
     }
     if payload.len() < 4 {
-        return Err(VmmError::Vsock(format!(
+        return Err(ComputerError::Vsock(format!(
             "clock sync: payload too short ({} bytes, expected 4)",
             payload.len()
         )));

--- a/computer/arcbox-computer-runtime/src/agent/vm_proto/clock.rs
+++ b/computer/arcbox-computer-runtime/src/agent/vm_proto/clock.rs
@@ -12,7 +12,7 @@ use crate::error::{ComputerError, Result};
 /// Synchronise the guest clock to the current host time.
 ///
 /// Sends [`MSG_CLOCK_SYNC`] to the exec channel (vsock port 52) and waits for
-/// `MSG_EXIT`.  Called immediately after `restore_sandbox()` completes so
+/// `MSG_EXIT`.  Called immediately after `restore_computer()` completes so
 /// the guest does not run with a stale timestamp from snapshot creation time,
 /// and by the cold-boot path as the agent-readiness gate. `Err` means the
 /// round trip itself failed (connect, transport, malformed reply); an agent

--- a/computer/arcbox-computer-runtime/src/agent/vm_proto/exec.rs
+++ b/computer/arcbox-computer-runtime/src/agent/vm_proto/exec.rs
@@ -7,7 +7,7 @@ use arcbox_vm_proto::exec::{MSG_EOF, MSG_RESIZE, MSG_SIGNAL, MSG_START, MSG_STDI
 
 use super::{StartCommand, connect_to_agent, drain_output, write_frame};
 use crate::agent::{ExecInputMsg, OutputChunk};
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 
 /// Run a command in the sandbox and stream its output.
 ///
@@ -24,15 +24,15 @@ pub async fn run(
 
     // Send the start command.
     let payload = serde_json::to_vec(&start)
-        .map_err(|e| VmmError::Vsock(format!("serialize StartCommand: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("serialize StartCommand: {e}")))?;
     write_frame(&mut stream, MSG_START, &payload)
         .await
-        .map_err(|e| VmmError::Vsock(format!("write MSG_START: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("write MSG_START: {e}")))?;
 
     // No stdin for run(): close immediately.
     write_frame(&mut stream, MSG_EOF, &[])
         .await
-        .map_err(|e| VmmError::Vsock(format!("write MSG_EOF: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("write MSG_EOF: {e}")))?;
 
     let (tx, rx) = mpsc::channel(64);
     tokio::spawn(async move {
@@ -59,11 +59,11 @@ pub async fn exec(
 
     // Send the start command.
     let payload = serde_json::to_vec(&start)
-        .map_err(|e| VmmError::Vsock(format!("serialize StartCommand: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("serialize StartCommand: {e}")))?;
     let (mut read_half, mut write_half) = tokio::io::split(stream);
     write_frame(&mut write_half, MSG_START, &payload)
         .await
-        .map_err(|e| VmmError::Vsock(format!("write MSG_START: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("write MSG_START: {e}")))?;
 
     let (in_tx, mut in_rx) = mpsc::channel::<ExecInputMsg>(32);
     let (out_tx, out_rx) = mpsc::channel::<Result<OutputChunk>>(64);

--- a/computer/arcbox-computer-runtime/src/agent/vm_proto/files.rs
+++ b/computer/arcbox-computer-runtime/src/agent/vm_proto/files.rs
@@ -6,7 +6,7 @@
 //! the path consumers name. This module is the tokio client the
 //! manager drives: one vsock connection per operation, dialed through the
 //! driver port's [`Vsock`] capability, timeouts, and the mapping of the
-//! agent's errno-prefixed `FILE_ERR` payloads onto typed [`VmmError`]
+//! agent's errno-prefixed `FILE_ERR` payloads onto typed [`ComputerError`]
 //! variants (`decode_file_err`).
 
 use std::time::Duration;
@@ -18,7 +18,7 @@ use tokio::net::UnixStream;
 
 use super::{MAX_FRAME_SIZE, connect_to_port, read_frame, write_frame};
 use crate::agent::{DirWatch, FsEvents};
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 
 /// Per-operation timeout for file I/O over vsock.
 const FILE_IO_TIMEOUT: Duration = Duration::from_mins(1);
@@ -57,7 +57,7 @@ pub(super) async fn write_file(
     data: &[u8],
 ) -> Result<()> {
     if data.len() > MAX_FILE_SIZE {
-        return Err(VmmError::Vsock(format!(
+        return Err(ComputerError::Vsock(format!(
             "file too large ({} bytes, max {MAX_FILE_SIZE})",
             data.len()
         )));
@@ -65,37 +65,37 @@ pub(super) async fn write_file(
 
     tokio::time::timeout(FILE_IO_TIMEOUT, write_file_inner(vsock, path, mode, data))
         .await
-        .map_err(|_| VmmError::Vsock("file write: timed out".into()))?
+        .map_err(|_| ComputerError::Vsock("file write: timed out".into()))?
 }
 
 async fn write_file_inner(vsock: &dyn Vsock, path: &str, mode: u32, data: &[u8]) -> Result<()> {
     let mut stream = connect_to_port(vsock, FILE_PORT).await?;
 
     let req = serde_json::to_vec(&WriteReq { path, mode })
-        .map_err(|e| VmmError::Vsock(format!("serialize WriteReq: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("serialize WriteReq: {e}")))?;
     write_frame(&mut stream, FILE_WRITE_REQ, &req)
         .await
-        .map_err(|e| VmmError::Vsock(format!("write FILE_WRITE_REQ: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("write FILE_WRITE_REQ: {e}")))?;
 
     // Stream data in MAX_FRAME_SIZE chunks.
     for chunk in data.chunks(MAX_FRAME_SIZE) {
         write_frame(&mut stream, FILE_DATA, chunk)
             .await
-            .map_err(|e| VmmError::Vsock(format!("write FILE_DATA: {e}")))?;
+            .map_err(|e| ComputerError::Vsock(format!("write FILE_DATA: {e}")))?;
     }
     write_frame(&mut stream, FILE_DONE, &[])
         .await
-        .map_err(|e| VmmError::Vsock(format!("write FILE_DONE: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("write FILE_DONE: {e}")))?;
 
     // Read the agent's response.
     let (resp_type, payload) = read_frame(&mut stream)
         .await
-        .map_err(|e| VmmError::Vsock(format!("read write response: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("read write response: {e}")))?;
 
     match resp_type {
         FILE_ACK => Ok(()),
         FILE_ERR => Err(decode_file_err(&payload)),
-        other => Err(VmmError::Vsock(format!(
+        other => Err(ComputerError::Vsock(format!(
             "file write: unexpected response type 0x{other:02x}"
         ))),
     }
@@ -105,29 +105,29 @@ async fn write_file_inner(vsock: &dyn Vsock, path: &str, mode: u32, data: &[u8])
 pub(super) async fn read_file(vsock: &dyn Vsock, path: &str) -> Result<Vec<u8>> {
     tokio::time::timeout(FILE_IO_TIMEOUT, read_file_inner(vsock, path))
         .await
-        .map_err(|_| VmmError::Vsock("file read: timed out".into()))?
+        .map_err(|_| ComputerError::Vsock("file read: timed out".into()))?
 }
 
 async fn read_file_inner(vsock: &dyn Vsock, path: &str) -> Result<Vec<u8>> {
     let mut stream = connect_to_port(vsock, FILE_PORT).await?;
 
     let req = serde_json::to_vec(&ReadReq { path })
-        .map_err(|e| VmmError::Vsock(format!("serialize ReadReq: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("serialize ReadReq: {e}")))?;
     write_frame(&mut stream, FILE_READ_REQ, &req)
         .await
-        .map_err(|e| VmmError::Vsock(format!("write FILE_READ_REQ: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("write FILE_READ_REQ: {e}")))?;
 
     // Collect FILE_DATA chunks until FILE_DONE or FILE_ERR.
     let mut buf = Vec::new();
     loop {
         let (frame_type, payload) = read_frame(&mut stream)
             .await
-            .map_err(|e| VmmError::Vsock(format!("read file data: {e}")))?;
+            .map_err(|e| ComputerError::Vsock(format!("read file data: {e}")))?;
         match frame_type {
             FILE_DATA => {
                 buf.extend_from_slice(&payload);
                 if buf.len() > MAX_FILE_SIZE {
-                    return Err(VmmError::Vsock(format!(
+                    return Err(ComputerError::Vsock(format!(
                         "file too large (>{MAX_FILE_SIZE} bytes)"
                     )));
                 }
@@ -135,7 +135,7 @@ async fn read_file_inner(vsock: &dyn Vsock, path: &str) -> Result<Vec<u8>> {
             FILE_DONE => return Ok(buf),
             FILE_ERR => return Err(decode_file_err(&payload)),
             other => {
-                return Err(VmmError::Vsock(format!(
+                return Err(ComputerError::Vsock(format!(
                     "file read: unexpected frame type 0x{other:02x}"
                 )));
             }
@@ -148,16 +148,16 @@ async fn read_file_inner(vsock: &dyn Vsock, path: &str) -> Result<Vec<u8>> {
 /// Every verb — path verbs and read/write alike — carries the errno
 /// prefixes from [`proto`]; anything else (including all errors from old
 /// vm-agents) stays a vsock error.
-fn decode_file_err(payload: &[u8]) -> VmmError {
+fn decode_file_err(payload: &[u8]) -> ComputerError {
     let text = String::from_utf8_lossy(payload).into_owned();
     if let Some(path) = text.strip_prefix(proto::ERR_NOT_FOUND) {
-        VmmError::PathNotFound(path.to_owned())
+        ComputerError::PathNotFound(path.to_owned())
     } else if let Some(path) = text.strip_prefix(proto::ERR_NOT_A_DIRECTORY) {
-        VmmError::NotADirectory(path.to_owned())
+        ComputerError::NotADirectory(path.to_owned())
     } else if let Some(path) = text.strip_prefix(proto::ERR_NOT_EMPTY) {
-        VmmError::DirectoryNotEmpty(path.to_owned())
+        ComputerError::DirectoryNotEmpty(path.to_owned())
     } else {
-        VmmError::Vsock(text)
+        ComputerError::Vsock(text)
     }
 }
 
@@ -169,32 +169,32 @@ async fn unary_file_op(
     req: &(impl Serialize + Sync),
     ok_type: u8,
 ) -> Result<Vec<u8>> {
-    let payload =
-        serde_json::to_vec(req).map_err(|e| VmmError::Vsock(format!("serialize request: {e}")))?;
+    let payload = serde_json::to_vec(req)
+        .map_err(|e| ComputerError::Vsock(format!("serialize request: {e}")))?;
     let op = async {
         let mut stream = connect_to_port(vsock, FILE_PORT).await?;
         write_frame(&mut stream, req_type, &payload)
             .await
-            .map_err(|e| VmmError::Vsock(format!("write request 0x{req_type:02x}: {e}")))?;
+            .map_err(|e| ComputerError::Vsock(format!("write request 0x{req_type:02x}: {e}")))?;
         let (resp_type, resp) = read_frame(&mut stream)
             .await
-            .map_err(|e| VmmError::Vsock(format!("read response: {e}")))?;
+            .map_err(|e| ComputerError::Vsock(format!("read response: {e}")))?;
         match resp_type {
             t if t == ok_type => Ok(resp),
             FILE_ERR => Err(decode_file_err(&resp)),
-            other => Err(VmmError::Vsock(format!(
+            other => Err(ComputerError::Vsock(format!(
                 "unexpected response type 0x{other:02x}"
             ))),
         }
     };
     tokio::time::timeout(FILE_IO_TIMEOUT, op)
         .await
-        .map_err(|_| VmmError::Vsock("file operation timed out".into()))?
+        .map_err(|_| ComputerError::Vsock("file operation timed out".into()))?
 }
 
 fn parse_json<T: serde::de::DeserializeOwned>(payload: &[u8]) -> Result<T> {
     serde_json::from_slice(payload)
-        .map_err(|e| VmmError::Vsock(format!("malformed agent response: {e}")))
+        .map_err(|e| ComputerError::Vsock(format!("malformed agent response: {e}")))
 }
 
 /// Stat one path inside the sandbox (symlinks reported, not followed).
@@ -230,7 +230,7 @@ pub(super) async fn make_dir(vsock: &dyn Vsock, path: &str, mode: u32) -> Result
 
 /// Remove a file, symlink, or directory inside the sandbox. A non-empty
 /// directory requires `recursive` and fails with
-/// [`VmmError::DirectoryNotEmpty`] otherwise.
+/// [`ComputerError::DirectoryNotEmpty`] otherwise.
 pub(super) async fn remove_entry(vsock: &dyn Vsock, path: &str, recursive: bool) -> Result<()> {
     let req = RemoveReq {
         path: path.to_owned(),
@@ -269,7 +269,7 @@ impl FsEvents for VsockWatch {
             .stream
             .read(&mut ty)
             .await
-            .map_err(|e| VmmError::Vsock(format!("watch read: {e}")))?;
+            .map_err(|e| ComputerError::Vsock(format!("watch read: {e}")))?;
         if n == 0 {
             return Ok(None);
         }
@@ -277,21 +277,24 @@ impl FsEvents for VsockWatch {
             .stream
             .read_u32_le()
             .await
-            .map_err(|e| VmmError::Vsock(format!("watch read: {e}")))? as usize;
+            .map_err(|e| ComputerError::Vsock(format!("watch read: {e}")))?
+            as usize;
         if len > MAX_FRAME_SIZE {
-            return Err(VmmError::Vsock(format!("watch frame too large: {len}")));
+            return Err(ComputerError::Vsock(format!(
+                "watch frame too large: {len}"
+            )));
         }
         let mut payload = vec![0u8; len];
         if len > 0 {
             self.stream
                 .read_exact(&mut payload)
                 .await
-                .map_err(|e| VmmError::Vsock(format!("watch read: {e}")))?;
+                .map_err(|e| ComputerError::Vsock(format!("watch read: {e}")))?;
         }
         match ty[0] {
             FILE_EVENT => Ok(Some(parse_json(&payload)?)),
             FILE_ERR => Err(decode_file_err(&payload)),
-            other => Err(VmmError::Vsock(format!(
+            other => Err(ComputerError::Vsock(format!(
                 "unexpected watch frame type 0x{other:02x}"
             ))),
         }
@@ -307,26 +310,26 @@ pub(super) async fn watch_dir(vsock: &dyn Vsock, path: &str, recursive: bool) ->
         recursive,
     };
     let payload = serde_json::to_vec(&req)
-        .map_err(|e| VmmError::Vsock(format!("serialize WatchReq: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("serialize WatchReq: {e}")))?;
     let setup = async {
         let mut stream = connect_to_port(vsock, FILE_PORT).await?;
         write_frame(&mut stream, FILE_WATCH_REQ, &payload)
             .await
-            .map_err(|e| VmmError::Vsock(format!("write FILE_WATCH_REQ: {e}")))?;
+            .map_err(|e| ComputerError::Vsock(format!("write FILE_WATCH_REQ: {e}")))?;
         let (resp_type, resp) = read_frame(&mut stream)
             .await
-            .map_err(|e| VmmError::Vsock(format!("read watch ack: {e}")))?;
+            .map_err(|e| ComputerError::Vsock(format!("read watch ack: {e}")))?;
         match resp_type {
             FILE_ACK => Ok(DirWatch::new(Box::new(VsockWatch { stream }))),
             FILE_ERR => Err(decode_file_err(&resp)),
-            other => Err(VmmError::Vsock(format!(
+            other => Err(ComputerError::Vsock(format!(
                 "unexpected watch ack type 0x{other:02x}"
             ))),
         }
     };
     tokio::time::timeout(FILE_IO_TIMEOUT, setup)
         .await
-        .map_err(|_| VmmError::Vsock("watch setup timed out".into()))?
+        .map_err(|_| ComputerError::Vsock("watch setup timed out".into()))?
 }
 
 #[cfg(test)]
@@ -539,20 +542,20 @@ mod tests {
     fn file_err_prefixes_decode_to_typed_errors() {
         assert!(matches!(
             decode_file_err(b"ENOENT: /a/b"),
-            VmmError::PathNotFound(p) if p == "/a/b"
+            ComputerError::PathNotFound(p) if p == "/a/b"
         ));
         assert!(matches!(
             decode_file_err(b"ENOTDIR: /a/file"),
-            VmmError::NotADirectory(p) if p == "/a/file"
+            ComputerError::NotADirectory(p) if p == "/a/file"
         ));
         assert!(matches!(
             decode_file_err(b"ENOTEMPTY: /a/dir"),
-            VmmError::DirectoryNotEmpty(p) if p == "/a/dir"
+            ComputerError::DirectoryNotEmpty(p) if p == "/a/dir"
         ));
         // Old-agent / free-form errors stay vsock errors.
         assert!(matches!(
             decode_file_err(b"read file: boom"),
-            VmmError::Vsock(m) if m == "read file: boom"
+            ComputerError::Vsock(m) if m == "read file: boom"
         ));
     }
 
@@ -615,7 +618,7 @@ mod tests {
         .await;
 
         let err = remove_entry(&vsock, "/full", false).await.unwrap_err();
-        assert!(matches!(err, VmmError::DirectoryNotEmpty(p) if p == "/full"));
+        assert!(matches!(err, ComputerError::DirectoryNotEmpty(p) if p == "/full"));
     }
 
     #[tokio::test]
@@ -629,7 +632,7 @@ mod tests {
         .await;
 
         let err = read_file(&vsock, "/missing").await.unwrap_err();
-        assert!(matches!(err, VmmError::PathNotFound(p) if p == "/missing"));
+        assert!(matches!(err, ComputerError::PathNotFound(p) if p == "/missing"));
     }
 
     #[tokio::test]
@@ -652,7 +655,7 @@ mod tests {
         let err = write_file(&vsock, "/plain.txt/sub", 0, b"x")
             .await
             .unwrap_err();
-        assert!(matches!(err, VmmError::NotADirectory(p) if p == "/plain.txt/sub"));
+        assert!(matches!(err, ComputerError::NotADirectory(p) if p == "/plain.txt/sub"));
     }
 
     #[tokio::test]
@@ -694,6 +697,6 @@ mod tests {
         .await;
 
         let err = watch_dir(&vsock, "/missing", false).await.unwrap_err();
-        assert!(matches!(err, VmmError::PathNotFound(p) if p == "/missing"));
+        assert!(matches!(err, ComputerError::PathNotFound(p) if p == "/missing"));
     }
 }

--- a/computer/arcbox-computer-runtime/src/agent/vm_proto/net.rs
+++ b/computer/arcbox-computer-runtime/src/agent/vm_proto/net.rs
@@ -7,7 +7,7 @@ use arcbox_vm_driver::Vsock;
 use tracing::info;
 
 use super::{MSG_EXIT, MSG_NET_RECONFIG, connect_to_agent, read_frame, write_frame};
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 /// Re-address the guest network after a fresh-network snapshot restore.
 ///
 /// Sends [`MSG_NET_RECONFIG`] to the exec channel (vsock port 52) and waits
@@ -39,31 +39,31 @@ async fn net_reconfig_on_stream<S: tokio::io::AsyncReadExt + tokio::io::AsyncWri
     cmd: &crate::boot_proto::NetReconfigCommand,
 ) -> Result<()> {
     let payload = serde_json::to_vec(cmd)
-        .map_err(|e| VmmError::Vsock(format!("encode NetReconfigCommand: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("encode NetReconfigCommand: {e}")))?;
 
     write_frame(stream, MSG_NET_RECONFIG, &payload)
         .await
-        .map_err(|e| VmmError::Vsock(format!("write MSG_NET_RECONFIG: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("write MSG_NET_RECONFIG: {e}")))?;
 
     let (msg_type, payload) = tokio::time::timeout(Duration::from_secs(5), read_frame(stream))
         .await
-        .map_err(|_| VmmError::Vsock("net reconfig: timed out waiting for response".into()))?
-        .map_err(|e| VmmError::Vsock(format!("read net reconfig response: {e}")))?;
+        .map_err(|_| ComputerError::Vsock("net reconfig: timed out waiting for response".into()))?
+        .map_err(|e| ComputerError::Vsock(format!("read net reconfig response: {e}")))?;
 
     if msg_type != MSG_EXIT {
-        return Err(VmmError::Vsock(format!(
+        return Err(ComputerError::Vsock(format!(
             "net reconfig: unexpected response type 0x{msg_type:02x}"
         )));
     }
     if payload.len() < 4 {
-        return Err(VmmError::Vsock(format!(
+        return Err(ComputerError::Vsock(format!(
             "net reconfig: payload too short ({} bytes, expected 4)",
             payload.len()
         )));
     }
     let code = i32::from_le_bytes(payload[..4].try_into().unwrap());
     if code != 0 {
-        return Err(VmmError::Vsock(format!(
+        return Err(ComputerError::Vsock(format!(
             "net reconfig: agent returned exit code {code}"
         )));
     }

--- a/computer/arcbox-computer-runtime/src/agent/vm_proto/wait_port.rs
+++ b/computer/arcbox-computer-runtime/src/agent/vm_proto/wait_port.rs
@@ -7,7 +7,7 @@ use arcbox_vm_driver::Vsock;
 
 use super::{MSG_EXIT, MSG_WAIT_PORT, WaitPortReq, connect_to_agent, read_frame, write_frame};
 use crate::agent::PortWait;
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 /// Wait until the guest's TCP listen table has a listener on `port`.
 ///
 /// Sends [`MSG_WAIT_PORT`] to the exec channel; the vm-agent watches
@@ -34,24 +34,24 @@ async fn wait_for_port_on_stream<S: tokio::io::AsyncReadExt + tokio::io::AsyncWr
         timeout_ms: u64::try_from(timeout.as_millis()).unwrap_or(u64::MAX),
     };
     let payload = serde_json::to_vec(&req)
-        .map_err(|e| VmmError::Vsock(format!("encode WaitPortReq: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("encode WaitPortReq: {e}")))?;
     write_frame(stream, MSG_WAIT_PORT, &payload)
         .await
-        .map_err(|e| VmmError::Vsock(format!("write MSG_WAIT_PORT: {e}")))?;
+        .map_err(|e| ComputerError::Vsock(format!("write MSG_WAIT_PORT: {e}")))?;
 
     let read_deadline = timeout + Duration::from_secs(5);
     let (msg_type, payload) = tokio::time::timeout(read_deadline, read_frame(stream))
         .await
-        .map_err(|_| VmmError::Vsock("wait for port: timed out waiting for response".into()))?
-        .map_err(|e| VmmError::Vsock(format!("read wait-port response: {e}")))?;
+        .map_err(|_| ComputerError::Vsock("wait for port: timed out waiting for response".into()))?
+        .map_err(|e| ComputerError::Vsock(format!("read wait-port response: {e}")))?;
 
     if msg_type != MSG_EXIT {
-        return Err(VmmError::Vsock(format!(
+        return Err(ComputerError::Vsock(format!(
             "wait for port: unexpected response type 0x{msg_type:02x}"
         )));
     }
     if payload.len() < 4 {
-        return Err(VmmError::Vsock(format!(
+        return Err(ComputerError::Vsock(format!(
             "wait for port: payload too short ({} bytes, expected 4)",
             payload.len()
         )));
@@ -59,7 +59,7 @@ async fn wait_for_port_on_stream<S: tokio::io::AsyncReadExt + tokio::io::AsyncWr
     match i32::from_le_bytes(payload[..4].try_into().unwrap()) {
         0 => Ok(PortWait::Listening),
         1 => Ok(PortWait::Deadline),
-        code => Err(VmmError::Vsock(format!(
+        code => Err(ComputerError::Vsock(format!(
             "wait for port: agent returned exit code {code}"
         ))),
     }

--- a/computer/arcbox-computer-runtime/src/config.rs
+++ b/computer/arcbox-computer-runtime/src/config.rs
@@ -12,4 +12,4 @@ mod runtime;
 // it meaning; re-exported so `crate::config::SnapshotType` still resolves.
 pub use arcbox_snapshot::SnapshotType;
 pub use jailer::JailerConfig;
-pub use runtime::{DefaultVmConfig, FirecrackerConfig, GrpcConfig, NetworkConfig, RuntimeConfig};
+pub use runtime::{ComputerConfig, DefaultVmConfig, GrpcConfig, NetworkConfig, RuntimeConfig};

--- a/computer/arcbox-computer-runtime/src/config/jailer.rs
+++ b/computer/arcbox-computer-runtime/src/config/jailer.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use arcbox_vm_driver::{CgroupSpec, IsolationSpec};
 use serde::{Deserialize, Serialize};
 
-use crate::error::VmmError;
+use crate::error::ComputerError;
 
 /// The per-VM isolation half of `[firecracker.jailer]`.
 ///
@@ -47,7 +47,7 @@ impl JailerConfig {
 }
 
 impl TryFrom<&JailerConfig> for IsolationSpec {
-    type Error = VmmError;
+    type Error = ComputerError;
 
     /// Who the VMM runs as, where its chroot lives, which namespaces and
     /// cgroup it enters.
@@ -55,7 +55,7 @@ impl TryFrom<&JailerConfig> for IsolationSpec {
     /// A `parent_cgroup` without a `cgroup_version` keeps the jailer's own
     /// default, version 1, made explicit here because the spec's
     /// [`CgroupSpec`] always names a version.
-    fn try_from(jc: &JailerConfig) -> Result<Self, VmmError> {
+    fn try_from(jc: &JailerConfig) -> Result<Self, ComputerError> {
         let cgroup = match (jc.cgroup_version.as_deref(), jc.parent_cgroup.as_deref()) {
             (None, None) => None,
             (version, parent) => Some(CgroupSpec {
@@ -64,7 +64,7 @@ impl TryFrom<&JailerConfig> for IsolationSpec {
                     Some("1") => 1,
                     Some("2") => 2,
                     Some(other) => {
-                        return Err(VmmError::Config(format!(
+                        return Err(ComputerError::Config(format!(
                             "jailer cgroup_version must be \"1\" or \"2\", got {other:?}"
                         )));
                     }
@@ -154,7 +154,7 @@ mod tests {
         jc.cgroup_version = Some("v2".into());
         assert!(matches!(
             IsolationSpec::try_from(&jc),
-            Err(VmmError::Config(_))
+            Err(ComputerError::Config(_))
         ));
     }
 }

--- a/computer/arcbox-computer-runtime/src/config/runtime.rs
+++ b/computer/arcbox-computer-runtime/src/config/runtime.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 
 use super::JailerConfig;
 
@@ -131,8 +131,9 @@ impl Default for RuntimeConfig {
 impl RuntimeConfig {
     /// Load configuration from a TOML file.
     pub fn from_file(path: &str) -> Result<Self> {
-        let content = std::fs::read_to_string(path).map_err(|e| VmmError::Config(e.to_string()))?;
-        toml::from_str(&content).map_err(|e| VmmError::Config(e.to_string()))
+        let content =
+            std::fs::read_to_string(path).map_err(|e| ComputerError::Config(e.to_string()))?;
+        toml::from_str(&content).map_err(|e| ComputerError::Config(e.to_string()))
     }
 }
 
@@ -217,7 +218,7 @@ mod tests {
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
-            crate::error::VmmError::Config(_)
+            crate::error::ComputerError::Config(_)
         ));
     }
 }

--- a/computer/arcbox-computer-runtime/src/config/runtime.rs
+++ b/computer/arcbox-computer-runtime/src/config/runtime.rs
@@ -8,7 +8,7 @@ use super::JailerConfig;
 /// config file spells it out (`/etc/arcbox/vmm.toml` in the System VM).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuntimeConfig {
-    pub firecracker: FirecrackerConfig,
+    pub firecracker: ComputerConfig,
     pub network: NetworkConfig,
     pub grpc: GrpcConfig,
     pub defaults: DefaultVmConfig,
@@ -16,16 +16,18 @@ pub struct RuntimeConfig {
 
 /// The `[firecracker]` keys this runtime reads.
 ///
-/// The section is named for the VMM because that is what a deployed
-/// `vmm.toml` has always called it, and the on-disk vocabulary is frozen
-/// (`computer/AGENTS.md`) — but nothing here is Firecracker's. The keys
+/// The `firecracker` *key* is named for the VMM because that is what a
+/// deployed `vmm.toml` has always called it, and the on-disk vocabulary
+/// is frozen (`computer/AGENTS.md`); the type is not, and nothing in it
+/// is Firecracker's — a data directory, an isolation spec, and the pool
+/// and copy-on-write policy every computer this runtime boots. The keys
 /// that configure a VMM adapter (its binaries, its process-level flags,
 /// the sandbox datapath) belong to whoever builds that adapter, and are
 /// read out of this same section by the composer; serde ignores what it
 /// does not know, so one section serves both halves and the file's shape
 /// is unchanged.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FirecrackerConfig {
+pub struct ComputerConfig {
     /// Jailer isolation for every sandbox VMM (absent = no isolation).
     #[serde(default)]
     pub jailer: Option<JailerConfig>,
@@ -101,7 +103,7 @@ pub struct DefaultVmConfig {
 impl Default for RuntimeConfig {
     fn default() -> Self {
         Self {
-            firecracker: FirecrackerConfig {
+            firecracker: ComputerConfig {
                 jailer: None,
                 data_dir: "/var/lib/firecracker-vmm".into(),
                 pool_size: default_pool_size(),
@@ -155,7 +157,7 @@ mod tests {
     fn pool_size_defaults_to_one_spare_slot() {
         assert_eq!(RuntimeConfig::default().firecracker.pool_size, 1);
         // A config written before the knob existed still loads with the default.
-        let cfg: FirecrackerConfig = toml::from_str("data_dir = \"/var/lib/vmm\"\n").unwrap();
+        let cfg: ComputerConfig = toml::from_str("data_dir = \"/var/lib/vmm\"\n").unwrap();
         assert_eq!(cfg.pool_size, 1);
     }
 
@@ -163,10 +165,10 @@ mod tests {
     fn warm_create_defaults_on_and_parses_the_escape_hatch() {
         assert!(RuntimeConfig::default().firecracker.warm_create);
         // A config written before the knob existed still loads with the default.
-        let cfg: FirecrackerConfig = toml::from_str("data_dir = \"/var/lib/vmm\"\n").unwrap();
+        let cfg: ComputerConfig = toml::from_str("data_dir = \"/var/lib/vmm\"\n").unwrap();
         assert!(cfg.warm_create);
         // The escape hatch is reachable by config alone.
-        let cfg: FirecrackerConfig =
+        let cfg: ComputerConfig =
             toml::from_str("data_dir = \"/var/lib/vmm\"\nwarm_create = false\n").unwrap();
         assert!(!cfg.warm_create);
     }
@@ -175,10 +177,10 @@ mod tests {
     fn dmsetup_candidates_absent_is_none_and_explicit_lists_parse_as_written() {
         // A config written before the field existed still loads; the
         // absence is preserved so the composer can supply its own list.
-        let cfg: FirecrackerConfig = toml::from_str("data_dir = \"/var/lib/vmm\"\n").unwrap();
+        let cfg: ComputerConfig = toml::from_str("data_dir = \"/var/lib/vmm\"\n").unwrap();
         assert_eq!(cfg.dmsetup_candidates, None);
         // An explicit list is used exactly as written.
-        let cfg: FirecrackerConfig = toml::from_str(
+        let cfg: ComputerConfig = toml::from_str(
             "data_dir = \"/var/lib/vmm\"\n\
              dmsetup_candidates = [\"/opt/arcbox/dmsetup\", \"/sbin/dmsetup\"]\n",
         )
@@ -193,7 +195,7 @@ mod tests {
             )
         );
         // An empty list is a deliberate "no dmsetup" — CoW off.
-        let cfg: FirecrackerConfig = toml::from_str(
+        let cfg: ComputerConfig = toml::from_str(
             "data_dir = \"/var/lib/vmm\"\n\
              dmsetup_candidates = []\n",
         )

--- a/computer/arcbox-computer-runtime/src/environment.rs
+++ b/computer/arcbox-computer-runtime/src/environment.rs
@@ -4,7 +4,7 @@
 //! with its known busybox userland, or a stock distro on a bare-metal
 //! node — and every part that differs is supplied here rather than built
 //! in the code. There is no default and no member is optional:
-//! [`SandboxManager::new`](crate::SandboxManager::new) builds none of the
+//! [`ComputerManager::new`](crate::ComputerManager::new) builds none of the
 //! four, so what VMM its Computers run on is the composer's decision and
 //! never a fallback taken here (vm-stack-redesign R3, charter D4).
 //!
@@ -30,7 +30,7 @@ pub struct NodeEnvironment {
     /// flows spawn the VMM ahead of the guest, every flow stages the files
     /// its computer boots from, and the guest agent is reached over vsock.
     /// A driver that cannot is refused by
-    /// [`SandboxManager::new`](crate::SandboxManager::new) rather than at
+    /// [`ComputerManager::new`](crate::ComputerManager::new) rather than at
     /// the first boot.
     pub driver: Arc<dyn VmDriver>,
     /// What the sandboxes' NICs attach to, behind the guest-network port

--- a/computer/arcbox-computer-runtime/src/error.rs
+++ b/computer/arcbox-computer-runtime/src/error.rs
@@ -1,8 +1,8 @@
 use thiserror::Error;
 
-/// Core VMM error type.
+/// This runtime's error type.
 #[derive(Debug, Error)]
-pub enum VmmError {
+pub enum ComputerError {
     /// The requested VM was not found.
     #[error("VM not found: {0}")]
     NotFound(String),
@@ -113,7 +113,7 @@ pub enum VmmError {
 
     /// The operation's side effects committed — the sandbox exists and is
     /// running — but the acknowledging record's durability is unconfirmed.
-    /// Distinct from [`VmmError::Unavailable`] so callers with a fallback
+    /// Distinct from [`ComputerError::Unavailable`] so callers with a fallback
     /// (warm create) can tell "nothing happened, retry freely" from "it
     /// happened, do NOT re-execute".
     #[error("sandbox {id} committed, but ACK durability is unconfirmed: {detail}")]
@@ -140,13 +140,13 @@ pub enum VmmError {
 }
 
 /// Convenience alias.
-pub type Result<T> = std::result::Result<T, VmmError>;
+pub type Result<T> = std::result::Result<T, ComputerError>;
 
 /// Variant-for-variant, so a snapshot or template failure keeps the exact
 /// shape callers already match on — the daemon maps `TemplateNotFound`
 /// and `TemplateVersionExists` onto their own wire codes, and folding
 /// either into a generic error would change the surface.
-impl From<arcbox_snapshot::SnapshotError> for VmmError {
+impl From<arcbox_snapshot::SnapshotError> for ComputerError {
     fn from(err: arcbox_snapshot::SnapshotError) -> Self {
         use arcbox_error::CommonError;
         use arcbox_snapshot::SnapshotError as S;
@@ -168,13 +168,13 @@ impl From<arcbox_snapshot::SnapshotError> for VmmError {
 
 /// Variant-for-variant where a native shape exists, so a driver-reported
 /// `NotFound` or `WrongState` keeps the wire code the equivalent native
-/// error already has (the guest agent classifies `VmmError` by variant;
+/// error already has (the guest agent classifies `ComputerError` by variant;
 /// anything it does not know becomes a 500), and so do the guest
 /// network's two protocol answers — retry-later and failed precondition,
 /// the 503 and 412 of the cleanup-token protocol. What has no native
 /// shape — an adapter fault, a checkpoint another driver wrote — stays
-/// [`VmmError::Driver`] with the port error intact for its `source` chain.
-impl From<arcbox_vm_driver::Error> for VmmError {
+/// [`ComputerError::Driver`] with the port error intact for its `source` chain.
+impl From<arcbox_vm_driver::Error> for ComputerError {
     fn from(err: arcbox_vm_driver::Error) -> Self {
         use arcbox_vm_driver::Error as D;
         match err {
@@ -203,13 +203,13 @@ impl From<arcbox_vm_driver::Error> for VmmError {
 }
 
 /// A durable write that never landed is an I/O failure; one that landed
-/// without a confirmed rename is [`VmmError::Unavailable`] — the caller
+/// without a confirmed rename is [`ComputerError::Unavailable`] — the caller
 /// may retry, and the retry is safe because the write is idempotent.
 ///
 /// Callers that can do better than this (the sandbox record store keeps
 /// the record and warns) match on [`AtomicWriteError`] themselves instead
 /// of going through here.
-impl From<arcbox_atomic_file::AtomicWriteError> for VmmError {
+impl From<arcbox_atomic_file::AtomicWriteError> for ComputerError {
     fn from(err: arcbox_atomic_file::AtomicWriteError) -> Self {
         use arcbox_atomic_file::AtomicWriteError;
         match err {
@@ -227,19 +227,19 @@ mod tests {
 
     #[test]
     fn test_not_found_display() {
-        let e = VmmError::NotFound("vm-123".into());
+        let e = ComputerError::NotFound("vm-123".into());
         assert_eq!(e.to_string(), "VM not found: vm-123");
     }
 
     #[test]
     fn test_already_exists_display() {
-        let e = VmmError::AlreadyExists("my-vm".into());
+        let e = ComputerError::AlreadyExists("my-vm".into());
         assert_eq!(e.to_string(), "VM already exists: my-vm");
     }
 
     #[test]
     fn test_wrong_state_display() {
-        let e = VmmError::WrongState {
+        let e = ComputerError::WrongState {
             id: "vm-1".into(),
             expected: "running".into(),
             actual: "stopped".into(),
@@ -253,14 +253,14 @@ mod tests {
     #[test]
     fn test_from_io_error() {
         let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
-        let vmm_err = VmmError::from(io_err);
-        assert!(matches!(vmm_err, VmmError::Io(_)));
-        assert!(vmm_err.to_string().contains("I/O error"));
+        let err = ComputerError::from(io_err);
+        assert!(matches!(err, ComputerError::Io(_)));
+        assert!(err.to_string().contains("I/O error"));
     }
 
     #[test]
     fn test_network_error_display() {
-        let e = VmmError::Network("TAP creation failed".into());
+        let e = ComputerError::Network("TAP creation failed".into());
         assert_eq!(e.to_string(), "network error: TAP creation failed");
     }
 
@@ -272,14 +272,14 @@ mod tests {
     fn the_ports_cleanup_answers_keep_their_classification() {
         use arcbox_vm_driver::Error as D;
 
-        let retry = VmmError::from(D::Unavailable("startup cleanup pending".into()));
+        let retry = ComputerError::from(D::Unavailable("startup cleanup pending".into()));
         assert!(
-            matches!(&retry, VmmError::Unavailable(m) if m == "startup cleanup pending"),
+            matches!(&retry, ComputerError::Unavailable(m) if m == "startup cleanup pending"),
             "{retry}"
         );
-        let mismatch = VmmError::from(D::PreconditionFailed("token b is not token a".into()));
+        let mismatch = ComputerError::from(D::PreconditionFailed("token b is not token a".into()));
         assert!(
-            matches!(&mismatch, VmmError::FailedPrecondition(m) if m == "token b is not token a"),
+            matches!(&mismatch, ComputerError::FailedPrecondition(m) if m == "token b is not token a"),
             "{mismatch}"
         );
     }

--- a/computer/arcbox-computer-runtime/src/lib.rs
+++ b/computer/arcbox-computer-runtime/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! # Public API
 //!
-//! - [`SandboxManager`] — top-level sandbox orchestrator
+//! - [`ComputerManager`] — top-level sandbox orchestrator
 //! - [`NodeEnvironment`] — the four environment-specific components a
 //!   composer supplies, all required: the VM driver, the guest network,
 //!   the guest-agent factory, and the copy-on-write rootfs manager
@@ -79,9 +79,9 @@ pub use error::{ComputerError, Result};
 pub use rootfs::{RootfsBuilder, RootfsPaths};
 pub use sandbox::pause_reason;
 pub use sandbox::{
-    CheckpointInfo, CheckpointSummary, ComputerEvent, ComputerId, ComputerInfo, ComputerMountSpec,
-    ComputerNetworkIdentity, ComputerNetworkInfo, ComputerNetworkSpec, ComputerSpec, ComputerState,
-    ComputerSummary, IdleAction, LifecycleUpdate, RestoreComputerSpec, SandboxManager,
+    CheckpointInfo, CheckpointSummary, ComputerEvent, ComputerId, ComputerInfo, ComputerManager,
+    ComputerMountSpec, ComputerNetworkIdentity, ComputerNetworkInfo, ComputerNetworkSpec,
+    ComputerSpec, ComputerState, ComputerSummary, IdleAction, LifecycleUpdate, RestoreComputerSpec,
     TemplateWarmRef,
 };
 pub use sandbox::{

--- a/computer/arcbox-computer-runtime/src/lib.rs
+++ b/computer/arcbox-computer-runtime/src/lib.rs
@@ -38,7 +38,7 @@
 //! - [`RootfsBuilder`] — OCI/overlay2 → ext4 with `/sbin/vm-agent` injected,
 //!   and the default busybox image; the composer supplies [`RootfsPaths`]
 //! - [`SandboxState`] — a computer's public lifecycle state
-//! - [`RuntimeConfig`] / [`SandboxSpec`] — configuration types
+//! - [`RuntimeConfig`] / [`ComputerSpec`] — configuration types
 //!
 //! This crate names no VMM and no network implementation. Sandboxes reach
 //! both only through `arcbox-vm-driver`'s ports, and the composer supplies
@@ -79,9 +79,9 @@ pub use error::{ComputerError, Result};
 pub use rootfs::{RootfsBuilder, RootfsPaths};
 pub use sandbox::pause_reason;
 pub use sandbox::{
-    CheckpointInfo, CheckpointSummary, IdleAction, LifecycleUpdate, RestoreSandboxSpec,
-    SandboxEvent, SandboxId, SandboxInfo, SandboxManager, SandboxMountSpec, SandboxNetworkIdentity,
-    SandboxNetworkInfo, SandboxNetworkSpec, SandboxSpec, SandboxState, SandboxSummary,
+    CheckpointInfo, CheckpointSummary, ComputerId, ComputerMountSpec, ComputerNetworkIdentity,
+    ComputerNetworkInfo, ComputerNetworkSpec, ComputerSpec, IdleAction, LifecycleUpdate,
+    RestoreComputerSpec, SandboxEvent, SandboxInfo, SandboxManager, SandboxState, SandboxSummary,
     TemplateWarmRef,
 };
 pub use sandbox::{

--- a/computer/arcbox-computer-runtime/src/lib.rs
+++ b/computer/arcbox-computer-runtime/src/lib.rs
@@ -75,7 +75,7 @@ pub use arcbox_snapshot::{snapshot, snapshot_cow, template_catalog};
 pub use agent::{ExecInputMsg, ExitStatus, OutputChunk, PortWait, StartCommand};
 pub use config::{DefaultVmConfig, FirecrackerConfig, GrpcConfig, NetworkConfig, RuntimeConfig};
 pub use environment::NodeEnvironment;
-pub use error::{Result, VmmError};
+pub use error::{ComputerError, Result};
 pub use rootfs::{RootfsBuilder, RootfsPaths};
 pub use sandbox::pause_reason;
 pub use sandbox::{

--- a/computer/arcbox-computer-runtime/src/lib.rs
+++ b/computer/arcbox-computer-runtime/src/lib.rs
@@ -73,7 +73,7 @@ pub use arcbox_vm_proto::file as file_proto;
 pub use arcbox_snapshot::{snapshot, snapshot_cow, template_catalog};
 
 pub use agent::{ExecInputMsg, ExitStatus, OutputChunk, PortWait, StartCommand};
-pub use config::{DefaultVmConfig, FirecrackerConfig, GrpcConfig, NetworkConfig, RuntimeConfig};
+pub use config::{ComputerConfig, DefaultVmConfig, GrpcConfig, NetworkConfig, RuntimeConfig};
 pub use environment::NodeEnvironment;
 pub use error::{ComputerError, Result};
 pub use rootfs::{RootfsBuilder, RootfsPaths};

--- a/computer/arcbox-computer-runtime/src/lib.rs
+++ b/computer/arcbox-computer-runtime/src/lib.rs
@@ -37,7 +37,7 @@
 //!   `arcbox-vm-proto` vsock client as its one implementation
 //! - [`RootfsBuilder`] — OCI/overlay2 → ext4 with `/sbin/vm-agent` injected,
 //!   and the default busybox image; the composer supplies [`RootfsPaths`]
-//! - [`SandboxState`] — a computer's public lifecycle state
+//! - [`ComputerState`] — a computer's public lifecycle state
 //! - [`RuntimeConfig`] / [`ComputerSpec`] — configuration types
 //!
 //! This crate names no VMM and no network implementation. Sandboxes reach
@@ -79,9 +79,9 @@ pub use error::{ComputerError, Result};
 pub use rootfs::{RootfsBuilder, RootfsPaths};
 pub use sandbox::pause_reason;
 pub use sandbox::{
-    CheckpointInfo, CheckpointSummary, ComputerId, ComputerMountSpec, ComputerNetworkIdentity,
-    ComputerNetworkInfo, ComputerNetworkSpec, ComputerSpec, IdleAction, LifecycleUpdate,
-    RestoreComputerSpec, SandboxEvent, SandboxInfo, SandboxManager, SandboxState, SandboxSummary,
+    CheckpointInfo, CheckpointSummary, ComputerEvent, ComputerId, ComputerInfo, ComputerMountSpec,
+    ComputerNetworkIdentity, ComputerNetworkInfo, ComputerNetworkSpec, ComputerSpec, ComputerState,
+    ComputerSummary, IdleAction, LifecycleUpdate, RestoreComputerSpec, SandboxManager,
     TemplateWarmRef,
 };
 pub use sandbox::{

--- a/computer/arcbox-computer-runtime/src/lib.rs
+++ b/computer/arcbox-computer-runtime/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! # Public API
 //!
-//! - [`ComputerManager`] — top-level sandbox orchestrator
+//! - [`ComputerManager`] — top-level computer orchestrator
 //! - [`NodeEnvironment`] — the four environment-specific components a
 //!   composer supplies, all required: the VM driver, the guest network,
 //!   the guest-agent factory, and the copy-on-write rootfs manager

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
@@ -70,7 +70,7 @@ impl ComputerActor {
                 }
                 // A stop asked for during a launch is deferred until the
                 // launch resolves, rather than refused as today's
-                // `stop_sandbox` does: the alternative is a stop racing a
+                // `stop_computer` does: the alternative is a stop racing a
                 // boot that is still acquiring resources.
                 if launching(*machine.state()) {
                     self.pending_stop.get_or_insert(budget);
@@ -79,7 +79,7 @@ impl ComputerActor {
                 }
                 match self.public() {
                     ComputerState::Stopping => self.park(Answer::Stopped, reply),
-                    // `stop_sandbox`'s retry. A `Stopped` write that was
+                    // `stop_computer`'s retry. A `Stopped` write that was
                     // visible but not confirmed kept the crash journal, and
                     // a second stop is the only thing that finishes it —
                     // answering `Ok` would leave a journal naming resources
@@ -106,7 +106,7 @@ impl ComputerActor {
                     // release that failed, a panicked sub-task — is re-driven
                     // instead: `removing` swallows the retry, so nothing else
                     // would ever answer it, and a retried
-                    // `remove_sandbox_impl` re-runs the teardown today.
+                    // `remove_computer_impl` re-runs the teardown today.
                     State::Removing {} => {
                         if self.inflight.is_none() && self.retry.is_none() {
                             self.restart_teardown(*machine.state()).await;
@@ -160,7 +160,7 @@ impl ComputerActor {
                 self.dispatch(machine, Event::WorkloadReleased).await;
             }
             Command::SetLifecycle { update, reply } => {
-                // `set_sandbox_lifecycle` refuses a computer on its way out:
+                // `set_computer_lifecycle` refuses a computer on its way out:
                 // nothing is left for a deadline to fire on, and the record
                 // it would persist to is about to be a tombstone.
                 if matches!(
@@ -194,7 +194,7 @@ impl ComputerActor {
                 }
                 // The timers live in this task; the record is what a restart
                 // re-arms them from, so an acknowledged change has to be on
-                // disk as well (`set_sandbox_lifecycle` today).
+                // disk as well (`set_computer_lifecycle` today).
                 let persisted = self.persist_lifecycle();
                 self.rearm(*machine.state());
                 // `Inspect` reports the deadlines, so the read view has to

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
@@ -45,7 +45,7 @@ impl ComputerActor {
                 } else {
                     // Pausing a paused computer is a no-op.
                     let _ = reply.send(match self.public() {
-                        SandboxState::Paused => Ok(()),
+                        ComputerState::Paused => Ok(()),
                         _ => Err(self.wrong_state("Ready")),
                     });
                 }
@@ -57,7 +57,7 @@ impl ComputerActor {
                 } else {
                     // Resuming a live computer is a no-op.
                     let _ = reply.send(match self.public() {
-                        SandboxState::Ready | SandboxState::Running => Ok(()),
+                        ComputerState::Ready | ComputerState::Running => Ok(()),
                         _ => Err(self.wrong_state("Paused")),
                     });
                 }
@@ -78,13 +78,13 @@ impl ComputerActor {
                     return;
                 }
                 match self.public() {
-                    SandboxState::Stopping => self.park(Answer::Stopped, reply),
+                    ComputerState::Stopping => self.park(Answer::Stopped, reply),
                     // `stop_sandbox`'s retry. A `Stopped` write that was
                     // visible but not confirmed kept the crash journal, and
                     // a second stop is the only thing that finishes it —
                     // answering `Ok` would leave a journal naming resources
                     // that are already gone for the next startup sweep.
-                    SandboxState::Stopped => {
+                    ComputerState::Stopped => {
                         let _ = reply.send(self.finish_stop());
                     }
                     _ => {
@@ -165,7 +165,7 @@ impl ComputerActor {
                 // it would persist to is about to be a tombstone.
                 if matches!(
                     self.public(),
-                    SandboxState::Stopping | SandboxState::Stopped | SandboxState::Failed
+                    ComputerState::Stopping | ComputerState::Stopped | ComputerState::Failed
                 ) {
                     let _ = reply.send(Err(
                         self.wrong_state("a live computer (not stopping, stopped, or failed)")

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
@@ -232,7 +232,7 @@ impl ComputerActor {
     fn park(&mut self, answer: Answer, reply: Reply) {
         match self.answer_error.take() {
             Some(detail) => {
-                let _ = reply.send(Err(VmmError::Unavailable(detail)));
+                let _ = reply.send(Err(ComputerError::Unavailable(detail)));
             }
             None => self.waiters.push((answer, reply)),
         }
@@ -247,8 +247,8 @@ impl ComputerActor {
                 let _ = reply.send(match (&failed, &unconfirmed) {
                     // The flow reached its answer, but a step of it failed
                     // loudly on the way; the caller hears that first.
-                    (Some(detail), _) => Err(VmmError::Unavailable(detail.clone())),
-                    (None, Some(detail)) => Err(VmmError::AckUnconfirmed {
+                    (Some(detail), _) => Err(ComputerError::Unavailable(detail.clone())),
+                    (None, Some(detail)) => Err(ComputerError::AckUnconfirmed {
                         id: self.id.clone(),
                         detail: detail.clone(),
                     }),
@@ -266,10 +266,10 @@ impl ComputerActor {
     /// unconfirmed one it left behind.
     fn acknowledged(&mut self) -> Result<()> {
         if let Some(detail) = self.answer_error.take() {
-            return Err(VmmError::Unavailable(detail));
+            return Err(ComputerError::Unavailable(detail));
         }
         match self.unconfirmed.take() {
-            Some(detail) => Err(VmmError::AckUnconfirmed {
+            Some(detail) => Err(ComputerError::AckUnconfirmed {
                 id: self.id.clone(),
                 detail,
             }),
@@ -283,19 +283,19 @@ impl ComputerActor {
     /// A parked `Remove` is the exception: a failure elsewhere is what starts
     /// its teardown, so the removal is what answers it. The removal's own
     /// release failure is [`Self::fail_every_waiter`].
-    pub(super) fn fail_waiters(&mut self, error: VmmError) -> usize {
+    pub(super) fn fail_waiters(&mut self, error: ComputerError) -> usize {
         self.fail_parked(error, false)
     }
 
     /// [`Self::fail_waiters`], including the parked removals — for the one
     /// failure no later answer can reach, a removal's own release.
-    pub(super) fn fail_every_waiter(&mut self, error: VmmError) -> usize {
+    pub(super) fn fail_every_waiter(&mut self, error: ComputerError) -> usize {
         self.fail_parked(error, true)
     }
 
     /// The typed error goes to the first caller; further ones (coalesced
     /// verbs) get its text, since an error is not `Clone`.
-    fn fail_parked(&mut self, error: VmmError, removals_too: bool) -> usize {
+    fn fail_parked(&mut self, error: ComputerError, removals_too: bool) -> usize {
         let text = error.to_string();
         let mut typed = Some(error);
         let mut answered = 0;
@@ -307,15 +307,15 @@ impl ComputerActor {
                 answered += 1;
                 let _ = reply.send(Err(typed
                     .take()
-                    .unwrap_or_else(|| VmmError::Other(text.clone()))));
+                    .unwrap_or_else(|| ComputerError::Other(text.clone()))));
             }
         }
         self.waiters = remaining;
         answered
     }
 
-    fn wrong_state(&self, expected: &str) -> VmmError {
-        VmmError::WrongState {
+    fn wrong_state(&self, expected: &str) -> ComputerError {
+        ComputerError::WrongState {
             id: self.id.clone(),
             expected: expected.to_owned(),
             actual: self.public().to_string(),

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/commands.rs
@@ -217,7 +217,7 @@ impl ComputerActor {
             return Ok(());
         };
         self.records
-            .transition(&self.id, generation, SandboxTransition::Stopped)?
+            .transition(&self.id, generation, ComputerTransition::Stopped)?
             .confirmed("computer stop retry")?;
         // The write just confirmed, so whatever blocked the first clear is
         // answered.

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
@@ -202,7 +202,7 @@ impl ComputerActor {
             // crash journal — which is exactly what `GateJournal` means.
             Err(error) if matches!(durability, Durability::GateJournal) => {
                 error!(
-                    sandbox_id = %self.id,
+                    computer_id = %self.id,
                     %error,
                     phase = phase.as_str(),
                     "durable write was refused; keeping the crash journal"
@@ -220,14 +220,14 @@ impl ComputerActor {
         let phase = phase.as_str();
         match durability {
             Durability::Warn => {
-                warn!(sandbox_id = %self.id, error, phase, "durable write is unconfirmed; continuing");
+                warn!(computer_id = %self.id, error, phase, "durable write is unconfirmed; continuing");
                 Flow::Continue
             }
             Durability::GateJournal => {
                 // The gate *is* the handling: an unconfirmed write keeps the
                 // crash journal, so a restart still finds the resources it
                 // records.
-                warn!(sandbox_id = %self.id, error, phase, "durable write is unconfirmed; keeping the crash journal");
+                warn!(computer_id = %self.id, error, phase, "durable write is unconfirmed; keeping the crash journal");
                 self.journal_blocked = true;
                 Flow::Continue
             }
@@ -326,7 +326,7 @@ impl ComputerActor {
             }
             Err(error) => {
                 error!(
-                    sandbox_id = %self.id,
+                    computer_id = %self.id,
                     %error,
                     retry_millis = self.retry_backoff.as_millis(),
                     "the computer's record would not delete; retrying the teardown"
@@ -373,11 +373,11 @@ impl ComputerActor {
             return;
         }
         if let Err(error) = crate::sandbox::reconcile::clear_state_record(&self.vm_dir) {
-            error!(sandbox_id = %self.id, %error, "crash journal cleanup is not durable");
+            error!(computer_id = %self.id, %error, "crash journal cleanup is not durable");
         }
     }
 
-    pub(super) fn public(&self) -> SandboxState {
+    pub(super) fn public(&self) -> ComputerState {
         self.snapshot_tx.borrow().state
     }
 
@@ -415,7 +415,7 @@ impl ComputerActor {
     }
 
     fn publish(&mut self, notify: Notify) {
-        let event = SandboxEvent::new(&self.id, notify_action(notify));
+        let event = ComputerEvent::new(&self.id, notify_action(notify));
         let event = match notify {
             Notify::Failed => {
                 let error = self.error.clone().unwrap_or_default();

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
@@ -195,8 +195,8 @@ impl ComputerActor {
             // What that costs depends on what the phase was for. A phase the
             // flow is *about to act on* — `Stopping` before a shutdown,
             // `Removing` before a release, `Resuming` before a resume — must
-            // stop it, which is what `stop_sandbox`, `begin_removal` and
-            // `resume_sandbox` do with their `?`. A phase that only records
+            // stop it, which is what `stop_computer`, `begin_removal` and
+            // `resume_computer` do with their `?`. A phase that only records
             // where the computer *ended up* must not: `persist_boot_failure`
             // reports the failure and lets the release run, keeping the
             // crash journal — which is exactly what `GateJournal` means.
@@ -295,7 +295,7 @@ impl ComputerActor {
     /// id.
     ///
     /// A refusal stalls the teardown rather than continuing past it:
-    /// `remove_sandbox_impl` propagates a failed `finish_remove` *before* it
+    /// `remove_computer_impl` propagates a failed `finish_remove` *before* it
     /// drops its map entry, because the record still owns the id and only a
     /// retry that re-runs the deletion can free it. Reporting the removal
     /// done here would leave that id un-creatable until the next startup
@@ -314,7 +314,7 @@ impl ComputerActor {
                 if let Some(error) = commit.durability_error {
                     self.unconfirmed = Some(error);
                 }
-                // Before REMOVED is announced, as `remove_sandbox_impl` drops
+                // Before REMOVED is announced, as `remove_computer_impl` drops
                 // its map entry before broadcasting: a reader that acts on
                 // the event must not still find the computer.
                 (self.unregister)();

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
@@ -276,7 +276,7 @@ impl ComputerActor {
     /// way, before anything is torn down.
     fn fail_write(&mut self, detail: &str) -> Flow {
         let message = format!("computer {} {detail}", self.id);
-        let error = VmmError::Unavailable(message.clone());
+        let error = ComputerError::Unavailable(message.clone());
         self.error = Some(error.to_string());
         // Parked to be reported only when nobody was there to hear it: the
         // flows that answer immediately (a cold create) have nothing parked,

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/effects.rs
@@ -24,7 +24,7 @@ impl ComputerActor {
             Effect::CommitRestored { durability } => {
                 return self.commit(
                     PersistPhase::Ready,
-                    SandboxTransition::ReadyWithOutcome(self.outcome.clone()),
+                    ComputerTransition::ReadyWithOutcome(self.outcome.clone()),
                     durability,
                 );
             }
@@ -146,15 +146,15 @@ impl ComputerActor {
 
     fn persist(&mut self, phase: PersistPhase, durability: Durability) -> Flow {
         let transition = match phase {
-            PersistPhase::Starting => SandboxTransition::Starting(self.outcome.clone()),
-            PersistPhase::Ready => SandboxTransition::Ready,
-            PersistPhase::Stopping => SandboxTransition::Stopping,
-            PersistPhase::Stopped => SandboxTransition::Stopped,
+            PersistPhase::Starting => ComputerTransition::Starting(self.outcome.clone()),
+            PersistPhase::Ready => ComputerTransition::Ready,
+            PersistPhase::Stopping => ComputerTransition::Stopping,
+            PersistPhase::Stopped => ComputerTransition::Stopped,
             PersistPhase::Failed => {
-                SandboxTransition::Failed(self.error.clone().unwrap_or_default())
+                ComputerTransition::Failed(self.error.clone().unwrap_or_default())
             }
-            PersistPhase::Removing => SandboxTransition::Removing,
-            PersistPhase::Pausing => SandboxTransition::Pausing,
+            PersistPhase::Removing => ComputerTransition::Removing,
+            PersistPhase::Pausing => ComputerTransition::Pausing,
             PersistPhase::Paused => {
                 // What a paused computer retains, recorded where every
                 // reader of it looks: `Inspect` and `List` size the
@@ -166,11 +166,11 @@ impl ComputerActor {
                 runtime
                     .pause_snapshot_id
                     .clone_from(&self.pause_snapshot_id);
-                SandboxTransition::Paused {
+                ComputerTransition::Paused {
                     snapshot_id: self.pause_snapshot_id.clone().unwrap_or_default(),
                 }
             }
-            PersistPhase::Resuming => SandboxTransition::Resuming,
+            PersistPhase::Resuming => ComputerTransition::Resuming,
             // The provisioning intent is written before there is a machine to
             // ask for it, so no transition names it.
             PersistPhase::Creating => return Flow::Continue,
@@ -181,7 +181,7 @@ impl ComputerActor {
     fn commit(
         &mut self,
         phase: PersistPhase,
-        transition: SandboxTransition,
+        transition: ComputerTransition,
         durability: Durability,
     ) -> Flow {
         let Some(generation) = self.generation else {
@@ -247,7 +247,7 @@ impl ComputerActor {
                 // `Failure` and fail the same callers twice.
                 let reverted = self.commit(
                     PersistPhase::Paused,
-                    SandboxTransition::Paused {
+                    ComputerTransition::Paused {
                         snapshot_id: self.pause_snapshot_id.clone().unwrap_or_default(),
                     },
                     Durability::Warn,

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/inflight.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/inflight.rs
@@ -96,7 +96,7 @@ impl ComputerActor {
             // finishes the job. Carrying on would delete both while whatever
             // the panicking task never transferred was still out there.
             Ok(Err(error)) if !error.is_cancelled() => {
-                error!(sandbox_id = %self.id, %error, "a computer sub-task panicked");
+                error!(computer_id = %self.id, %error, "a computer sub-task panicked");
                 self.fail_every_waiter(ComputerError::Process(format!(
                     "computer {} sub-task panicked: {error}",
                     self.id
@@ -116,7 +116,7 @@ impl ComputerActor {
     /// the teardown waits on.
     fn stall(&mut self, task: Preemptible) -> Flow {
         warn!(
-            sandbox_id = %self.id,
+            computer_id = %self.id,
             retry_millis = self.retry_backoff.as_millis(),
             "the computer's in-flight work still owns resources; retrying the teardown"
         );
@@ -196,7 +196,7 @@ impl ComputerActor {
     pub(super) async fn on_completion(&mut self, machine: &mut Machine, completion: Completion) {
         if completion.epoch != self.epoch {
             debug!(
-                sandbox_id = %self.id,
+                computer_id = %self.id,
                 stale = completion.epoch,
                 current = self.epoch,
                 "dropping a superseded sub-task's completion"
@@ -253,7 +253,7 @@ impl ComputerActor {
             Report::Released(ReleaseScope::Runtime) => None,
             Report::Stopped => Some(Event::StopDone),
             Report::Failed(failure) => {
-                error!(sandbox_id = %self.id, error = failure.message(), "computer sub-task failed");
+                error!(computer_id = %self.id, error = failure.message(), "computer sub-task failed");
                 self.error = Some(failure.message());
                 let event = failure.event();
                 let error = failure.into_error();
@@ -330,7 +330,7 @@ impl ComputerActor {
         }
         self.pending_stop = None;
         match self.public() {
-            SandboxState::Ready | SandboxState::Running => {
+            ComputerState::Ready | ComputerState::Running => {
                 let budget_ms = u64::try_from(budget.as_millis()).unwrap_or(u64::MAX);
                 self.dispatch(machine, Event::Stop { budget_ms }).await;
             }

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/inflight.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/inflight.rs
@@ -90,7 +90,7 @@ impl ComputerActor {
             Err(_) => return self.stall(task),
             // A cancelled task is what we asked for. A panicked one is not:
             // `cancel_and_join_boot` maps it onto an error that leaves
-            // `remove_sandbox_impl` through `?`, so the release and the
+            // `remove_computer_impl` through `?`, so the release and the
             // record unlink never run — the record and its journal survive
             // for the startup sweep, and a retry (whose join is clean)
             // finishes the job. Carrying on would delete both while whatever
@@ -145,7 +145,7 @@ impl ComputerActor {
 
     /// Re-drives a teardown that stopped rather than finished — its release
     /// failed, a durable write was refused, or a panicked sub-task abandoned
-    /// it. Today's equivalent is a retried `remove_sandbox_impl`, which
+    /// it. Today's equivalent is a retried `remove_computer_impl`, which
     /// re-runs the whole teardown including the `Removing` write.
     pub(super) async fn restart_teardown(&mut self, state: State) {
         if self.stalled.is_some() {
@@ -272,7 +272,7 @@ impl ComputerActor {
                 if matches!(machine.state(), State::Removing {}) {
                     // The removal's own release: `removing` coalesces the
                     // failure, so nothing else will ever answer its caller —
-                    // and `remove_sandbox_impl` hands this error straight back
+                    // and `remove_computer_impl` hands this error straight back
                     // today. A flow whose *own* failure started this removal
                     // has its error parked, and the two are composed.
                     let error = match self.unwinding.take() {

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/inflight.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/inflight.rs
@@ -38,7 +38,7 @@ impl ComputerActor {
     /// that succeeds leaves the actor alive, so not even its exit answers.
     fn abandon_capture(&mut self) {
         if let Some(reply) = self.capture_reply.take() {
-            let _ = reply.send(Err(VmmError::Unavailable(format!(
+            let _ = reply.send(Err(ComputerError::Unavailable(format!(
                 "computer {}: the checkpoint was preempted by another operation",
                 self.id
             ))));
@@ -97,7 +97,7 @@ impl ComputerActor {
             // the panicking task never transferred was still out there.
             Ok(Err(error)) if !error.is_cancelled() => {
                 error!(sandbox_id = %self.id, %error, "a computer sub-task panicked");
-                self.fail_every_waiter(VmmError::Process(format!(
+                self.fail_every_waiter(ComputerError::Process(format!(
                     "computer {} sub-task panicked: {error}",
                     self.id
                 )));
@@ -258,8 +258,9 @@ impl ComputerActor {
                 let event = failure.event();
                 let error = failure.into_error();
                 if let Some(reply) = self.capture_reply.take() {
-                    let _ =
-                        reply.send(Err(VmmError::Other(self.error.clone().unwrap_or_default())));
+                    let _ = reply.send(Err(ComputerError::Other(
+                        self.error.clone().unwrap_or_default(),
+                    )));
                 }
                 // A launch that failed has nothing left to stop, so a stop
                 // deferred behind it got what it asked for. Answered before
@@ -275,9 +276,9 @@ impl ComputerActor {
                     // today. A flow whose *own* failure started this removal
                     // has its error parked, and the two are composed.
                     let error = match self.unwinding.take() {
-                        Some(cause) => {
-                            VmmError::Unavailable(format!("{cause}; teardown incomplete: {error}"))
-                        }
+                        Some(cause) => ComputerError::Unavailable(format!(
+                            "{cause}; teardown incomplete: {error}"
+                        )),
                         None => error,
                     };
                     self.fail_every_waiter(error);

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
@@ -64,7 +64,7 @@ use crate::sandbox::record::{
 use crate::sandbox::types::action;
 use crate::sandbox::workload::WorkloadClaim;
 use crate::sandbox::{
-    CheckpointInfo, IdleAction, LifecycleUpdate, SandboxEvent, SandboxId, SandboxState,
+    CheckpointInfo, ComputerId, IdleAction, LifecycleUpdate, SandboxEvent, SandboxState,
 };
 
 mod commands;
@@ -100,7 +100,7 @@ impl Mailbox {
     /// Asks the actor for something and waits for its answer.
     pub(crate) async fn ask<T>(
         &self,
-        id: &SandboxId,
+        id: &ComputerId,
         command: impl FnOnce(oneshot::Sender<Result<T>>) -> Command,
     ) -> Result<T> {
         let (reply, answer) = oneshot::channel();
@@ -355,7 +355,7 @@ enum Flow {
 
 /// The lifecycle actor.
 pub struct ComputerActor {
-    id: SandboxId,
+    id: ComputerId,
     /// The resources this computer holds, shared with the sub-tasks the
     /// actor spawns. The actor is the only other writer: it mirrors the
     /// public state into it, records the workload's exit, and projects the
@@ -454,7 +454,7 @@ pub enum Seeded {
 
 /// What one actor is built from.
 pub struct ComputerSeed {
-    pub id: SandboxId,
+    pub id: ComputerId,
     pub runtime: Arc<Mutex<ComputerRuntime>>,
     pub unregister: Arc<dyn Fn() + Send + Sync>,
     pub generation: Option<Uuid>,

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
@@ -64,7 +64,7 @@ use crate::sandbox::record::{
 use crate::sandbox::types::action;
 use crate::sandbox::workload::WorkloadClaim;
 use crate::sandbox::{
-    CheckpointInfo, ComputerId, IdleAction, LifecycleUpdate, SandboxEvent, SandboxState,
+    CheckpointInfo, ComputerEvent, ComputerId, ComputerState, IdleAction, LifecycleUpdate,
 };
 
 mod commands;
@@ -227,7 +227,7 @@ pub struct Deadlines {
 /// for it.
 #[derive(Clone)]
 pub struct ComputerSnapshot {
-    pub state: SandboxState,
+    pub state: ComputerState,
     pub agent: Option<Arc<dyn GuestAgent>>,
     /// The running VM, for the graceful hand-over a process exit does.
     pub handle: Option<Arc<dyn VmHandle>>,
@@ -251,7 +251,7 @@ impl ComputerSnapshot {
     ///
     /// Everything but the agent, which the actor publishes and withdraws
     /// with the guest's reachability rather than reading it off the runtime.
-    pub fn project(runtime: &ComputerRuntime, state: SandboxState, deadlines: Deadlines) -> Self {
+    pub fn project(runtime: &ComputerRuntime, state: ComputerState, deadlines: Deadlines) -> Self {
         Self {
             state,
             agent: None,
@@ -370,7 +370,7 @@ pub struct ComputerActor {
     generation: Option<Uuid>,
     vm_dir: PathBuf,
     records: Arc<SandboxRecordStore>,
-    events_tx: broadcast::Sender<SandboxEvent>,
+    events_tx: broadcast::Sender<ComputerEvent>,
     tasks: Arc<dyn ComputerTasks>,
     seeded: Seeded,
     commands: mpsc::UnboundedReceiver<Command>,
@@ -460,7 +460,7 @@ pub struct ComputerSeed {
     pub generation: Option<Uuid>,
     pub vm_dir: PathBuf,
     pub records: Arc<SandboxRecordStore>,
-    pub events_tx: broadcast::Sender<SandboxEvent>,
+    pub events_tx: broadcast::Sender<ComputerEvent>,
     pub tasks: Arc<dyn ComputerTasks>,
     pub deadlines: Deadlines,
     pub timers_enabled: watch::Receiver<bool>,
@@ -633,7 +633,7 @@ impl ComputerActor {
 
         if before.to_public() != after.to_public() {
             debug!(
-                sandbox_id = %self.id,
+                computer_id = %self.id,
                 from = %before.to_public(),
                 to = %after.to_public(),
                 "computer lifecycle transition"

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
@@ -336,7 +336,7 @@ enum StalledStep {
     /// The in-flight sub-task has not handed its resources over.
     Handoff,
     /// The durable record would not delete. Until it does, the id is still
-    /// owned — `remove_sandbox_impl` propagates that failure rather than
+    /// owned — `remove_computer_impl` propagates that failure rather than
     /// dropping its map entry, because only a retry can free the id.
     Record(RecordEnd),
 }
@@ -362,7 +362,7 @@ pub struct ComputerActor {
     /// read snapshot from it.
     runtime: Arc<Mutex<ComputerRuntime>>,
     /// Drops this computer's registry entry. Called when the record is
-    /// forgotten, before REMOVED is announced — `remove_sandbox_impl`'s own
+    /// forgotten, before REMOVED is announced — `remove_computer_impl`'s own
     /// order — and again when the actor stops for any other reason.
     unregister: Arc<dyn Fn() + Send + Sync>,
     /// The durable record's generation, `None` for a computer with no record
@@ -385,14 +385,14 @@ pub struct ComputerActor {
     waiters: Vec<(Answer, Reply)>,
     capture_reply: Option<oneshot::Sender<Result<CheckpointInfo>>>,
     /// A graceful stop asked for while a launch was in flight, dispatched as
-    /// soon as the launch resolves. Today's `stop_sandbox` answers
+    /// soon as the launch resolves. Today's `stop_computer` answers
     /// `WrongState` there; deferring is what the engine's actor does and what
     /// the R3 plan specifies (§B.3).
     pending_stop: Option<Duration>,
     inflight: Option<Preemptible>,
     epoch: u64,
     /// The teardown parked on a step it could not finish, replayed when a
-    /// retry takes it. This is `cleanup::expire_sandbox`'s retry loop,
+    /// retry takes it. This is `cleanup::expire_computer`'s retry loop,
     /// collapsed into the actor.
     stalled: Option<Stalled>,
     /// What the step currently being applied stalled on, read by
@@ -434,7 +434,7 @@ pub struct ComputerActor {
     idle: Option<Pin<Box<tokio::time::Sleep>>>,
     retry: Option<Pin<Box<tokio::time::Sleep>>>,
     /// `false` keeps both deadline timers unarmed: a manager that was never
-    /// shared (`SandboxManager::into_shared`) fires no timers, which unit
+    /// shared (`ComputerManager::into_shared`) fires no timers, which unit
     /// tests of unrelated surfaces rely on.
     timers_enabled: watch::Receiver<bool>,
 }

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
@@ -59,7 +59,7 @@ use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox::policy::deadlines;
 use crate::sandbox::record::{
-    PersistPhase, SandboxProvisionOutcome, SandboxRecordStore, SandboxTransition,
+    ComputerProvisionOutcome, ComputerRecordStore, ComputerTransition, PersistPhase,
 };
 use crate::sandbox::types::action;
 use crate::sandbox::workload::WorkloadClaim;
@@ -143,7 +143,7 @@ pub enum Command {
     /// answered by READY, which is what its caller waits for.
     Provision {
         provision: Provision,
-        outcome: SandboxProvisionOutcome,
+        outcome: ComputerProvisionOutcome,
         reply: Reply,
     },
     /// Capture a user checkpoint; answered with the catalog entry.
@@ -287,7 +287,7 @@ struct Completion {
 /// What a completed sub-task tells the actor.
 enum Report {
     Booted(Arc<dyn GuestAgent>),
-    Restored(Arc<dyn GuestAgent>, SandboxProvisionOutcome),
+    Restored(Arc<dyn GuestAgent>, ComputerProvisionOutcome),
     Resumed(Arc<dyn GuestAgent>),
     Gated,
     Captured(CheckpointInfo),
@@ -369,7 +369,7 @@ pub struct ComputerActor {
     /// — the durable effects are then no-ops, as they are today.
     generation: Option<Uuid>,
     vm_dir: PathBuf,
-    records: Arc<SandboxRecordStore>,
+    records: Arc<ComputerRecordStore>,
     events_tx: broadcast::Sender<ComputerEvent>,
     tasks: Arc<dyn ComputerTasks>,
     seeded: Seeded,
@@ -408,7 +408,7 @@ pub struct ComputerActor {
     /// pause's own, which names itself.
     capture: Option<CaptureSpec>,
     /// The provision outcome the `Starting` and atomic-`Ready` writes carry.
-    outcome: SandboxProvisionOutcome,
+    outcome: ComputerProvisionOutcome,
     /// Attributes of the events a transition asks for.
     pause_reason: PauseReason,
     resume_reason: String,
@@ -459,7 +459,7 @@ pub struct ComputerSeed {
     pub unregister: Arc<dyn Fn() + Send + Sync>,
     pub generation: Option<Uuid>,
     pub vm_dir: PathBuf,
-    pub records: Arc<SandboxRecordStore>,
+    pub records: Arc<ComputerRecordStore>,
     pub events_tx: broadcast::Sender<ComputerEvent>,
     pub tasks: Arc<dyn ComputerTasks>,
     pub deadlines: Deadlines,
@@ -501,7 +501,7 @@ impl ComputerActor {
             error: None,
             pause_snapshot_id: None,
             capture: None,
-            outcome: SandboxProvisionOutcome::default(),
+            outcome: ComputerProvisionOutcome::default(),
             pause_reason: PauseReason::Requested,
             resume_reason: crate::sandbox::pause_reason::RESUME.to_owned(),
             exit: None,

--- a/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/actor/mod.rs
@@ -55,7 +55,7 @@ use arcbox_vm_driver::VmHandle;
 use arcbox_vm_driver::net::NetworkLease;
 
 use crate::agent::{ExitStatus, GuestAgent};
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox::policy::deadlines;
 use crate::sandbox::record::{
@@ -106,8 +106,10 @@ impl Mailbox {
         let (reply, answer) = oneshot::channel();
         self.0
             .send(command(reply))
-            .map_err(|_| VmmError::NotFound(id.clone()))?;
-        answer.await.map_err(|_| VmmError::NotFound(id.clone()))?
+            .map_err(|_| ComputerError::NotFound(id.clone()))?;
+        answer
+            .await
+            .map_err(|_| ComputerError::NotFound(id.clone()))?
     }
 
     /// Tells the actor something it does not answer.
@@ -419,7 +421,7 @@ pub struct ComputerActor {
     answer_error: Option<String>,
     /// The failure a removal is unwinding, held until that removal ends.
     /// Its caller must not hear before the id is free again.
-    unwinding: Option<VmmError>,
+    unwinding: Option<ComputerError>,
     /// A journal clear owed to a release that is still running: the journal
     /// records exactly the resources a restart would have to reclaim, so it
     /// may only be dropped once they are gone.
@@ -611,10 +613,10 @@ impl ComputerActor {
         // stop deferred behind a launch a removal then preempted, say —
         // would otherwise learn only that its channel closed.
         for (_, reply) in self.waiters.drain(..) {
-            let _ = reply.send(Err(VmmError::NotFound(self.id.clone())));
+            let _ = reply.send(Err(ComputerError::NotFound(self.id.clone())));
         }
         if let Some(reply) = self.capture_reply.take() {
-            let _ = reply.send(Err(VmmError::NotFound(self.id.clone())));
+            let _ = reply.send(Err(ComputerError::NotFound(self.id.clone())));
         }
     }
 

--- a/computer/arcbox-computer-runtime/src/lifecycle/effect.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/effect.rs
@@ -99,7 +99,7 @@ pub(super) enum Effect {
     /// `Ready` reached in one hop from `Creating`: the restore path's atomic
     /// commit, which carries the provision outcome the skipped `Starting`
     /// write would have persisted. It is the one durable move outside the
-    /// edge set — `SandboxRecord::apply` allows it only from `Creating`
+    /// edge set — `ComputerRecord::apply` allows it only from `Creating`
     /// (`atomic_ready`), so no other state may emit it.
     CommitRestored {
         durability: Durability,

--- a/computer/arcbox-computer-runtime/src/lifecycle/effect.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/effect.rs
@@ -158,7 +158,7 @@ impl Effects {
         self.emit(Effect::SpawnRelease { scope });
     }
 
-    /// The graceful stop: `stop_sandbox`. `drain` says whether a workload is
+    /// The graceful stop: `stop_computer`. `drain` says whether a workload is
     /// running and owed the budget to finish first — the machine knows,
     /// because it is the state the stop came from.
     pub(super) fn stop(&mut self, budget_ms: u64, drain: bool) {
@@ -168,7 +168,7 @@ impl Effects {
         self.emit(Effect::SpawnStop { budget_ms, drain });
     }
 
-    /// Shared teardown: what `remove_sandbox_impl` does once its busy gate has
+    /// Shared teardown: what `remove_computer_impl` does once its busy gate has
     /// passed. The bounded handoff wait lives inside `AbortInflight`.
     pub(super) fn removal(&mut self) {
         self.emit(Effect::AbortInflight);
@@ -178,7 +178,7 @@ impl Effects {
         self.release(ReleaseScope::Full);
     }
 
-    /// Shared failure: `sandbox::boot::fail_live_sandbox` — persist `Failed`,
+    /// Shared failure: `sandbox::boot::fail_live_computer` — persist `Failed`,
     /// release the runtime, clear the journal behind both, drop the timers,
     /// publish FAILED. The journal clear is gated on the write being
     /// confirmed *and* the release completing: what it records is the

--- a/computer/arcbox-computer-runtime/src/lifecycle/event.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/event.rs
@@ -108,7 +108,7 @@ pub(super) enum Event {
     /// leaves the retained pause state intact and parks back at `Paused`; one
     /// that did not leaves a half-allocated computer, and recording that as
     /// cleanly `Paused` would have the restart sweep `Reinstate` it as
-    /// resumable and drop its journal as a stale pause. `resume_sandbox`
+    /// resumable and drop its journal as a stale pause. `resume_computer`
     /// has always been two-valued here (`ResumeFailure::unwound`); the
     /// vocabulary now is too.
     Stranded,

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows.rs
@@ -31,8 +31,8 @@ use crate::config::RuntimeConfig;
 use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox::pool::SlotPool;
-use crate::sandbox::record::SandboxProvisionOutcome;
-use crate::sandbox::record::SandboxRecordStore;
+use crate::sandbox::record::ComputerProvisionOutcome;
+use crate::sandbox::record::ComputerRecordStore;
 use crate::sandbox::warm::WarmPublishTicket;
 use crate::sandbox::{CheckpointInfo, ComputerEvent, ComputerId, NetworkAttachment};
 use crate::snapshot::{SnapshotCatalog, SnapshotMeta};
@@ -53,7 +53,7 @@ pub struct ComputerServices {
     pub agents: Arc<dyn GuestAgentFactory>,
     pub config: Arc<RuntimeConfig>,
     pub cow_manager: Arc<CowManager>,
-    pub records: Arc<SandboxRecordStore>,
+    pub records: Arc<ComputerRecordStore>,
     pub snapshots: Arc<SnapshotCatalog>,
     pub events_tx: broadcast::Sender<ComputerEvent>,
     pub pool: Arc<SlotPool>,
@@ -177,7 +177,7 @@ impl ComputerTasks for ComputerFlows {
     async fn restore(
         &self,
         origin: RestoreOrigin,
-    ) -> TaskResult<(Arc<dyn GuestAgent>, SandboxProvisionOutcome)> {
+    ) -> TaskResult<(Arc<dyn GuestAgent>, ComputerProvisionOutcome)> {
         self.restore_vm(origin).await
     }
 

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows.rs
@@ -34,7 +34,7 @@ use crate::sandbox::pool::SlotPool;
 use crate::sandbox::record::SandboxProvisionOutcome;
 use crate::sandbox::record::SandboxRecordStore;
 use crate::sandbox::warm::WarmPublishTicket;
-use crate::sandbox::{CheckpointInfo, NetworkAttachment, SandboxEvent, SandboxId};
+use crate::sandbox::{CheckpointInfo, ComputerId, NetworkAttachment, SandboxEvent};
 use crate::snapshot::{SnapshotCatalog, SnapshotMeta};
 use crate::snapshot_cow::CowManager;
 
@@ -93,7 +93,7 @@ pub struct RestoreLaunch {
 
 /// One computer's flows.
 pub struct ComputerFlows {
-    id: SandboxId,
+    id: ComputerId,
     computer: Arc<Mutex<ComputerRuntime>>,
     services: Arc<ComputerServices>,
     mailbox: WeakMailbox,
@@ -102,7 +102,7 @@ pub struct ComputerFlows {
 
 impl ComputerFlows {
     pub fn new(
-        id: SandboxId,
+        id: ComputerId,
         computer: Arc<Mutex<ComputerRuntime>>,
         services: Arc<ComputerServices>,
         mailbox: &Mailbox,

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows.rs
@@ -28,7 +28,7 @@ use super::event::RestoreOrigin;
 use super::tasks::{CaptureSpec, ComputerTasks, Drain, TaskFailure, TaskResult};
 use crate::agent::{GuestAgent, GuestAgentFactory};
 use crate::config::RuntimeConfig;
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox::pool::SlotPool;
 use crate::sandbox::record::SandboxProvisionOutcome;
@@ -126,7 +126,7 @@ impl ComputerFlows {
             (computer.handle.clone(), computer.net_identity.clone())
         };
         let handle = handle.ok_or_else(|| {
-            VmmError::Vsock(format!("computer {} has no running vm to reach", self.id))
+            ComputerError::Vsock(format!("computer {} has no running vm to reach", self.id))
         })?;
         self.services.agents.connect(handle, identity.as_ref())
     }
@@ -135,7 +135,7 @@ impl ComputerFlows {
     fn mailbox(&self) -> Result<Mailbox> {
         self.mailbox
             .upgrade()
-            .ok_or_else(|| VmmError::NotFound(self.id.clone()))
+            .ok_or_else(|| ComputerError::NotFound(self.id.clone()))
     }
 
     fn take_launch(&self) -> Launch {
@@ -146,7 +146,7 @@ impl ComputerFlows {
     /// `Provision` is missing. Unreachable in practice; reported rather than
     /// panicked so a wiring mistake fails one computer, not the process.
     fn wrong_launch(&self, wanted: &str) -> TaskFailure {
-        TaskFailure::recoverable(VmmError::Other(format!(
+        TaskFailure::recoverable(ComputerError::Other(format!(
             "computer {} was asked to {wanted} with no such launch",
             self.id
         )))

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows.rs
@@ -34,7 +34,7 @@ use crate::sandbox::pool::SlotPool;
 use crate::sandbox::record::SandboxProvisionOutcome;
 use crate::sandbox::record::SandboxRecordStore;
 use crate::sandbox::warm::WarmPublishTicket;
-use crate::sandbox::{CheckpointInfo, ComputerId, NetworkAttachment, SandboxEvent};
+use crate::sandbox::{CheckpointInfo, ComputerEvent, ComputerId, NetworkAttachment};
 use crate::snapshot::{SnapshotCatalog, SnapshotMeta};
 use crate::snapshot_cow::CowManager;
 
@@ -55,7 +55,7 @@ pub struct ComputerServices {
     pub cow_manager: Arc<CowManager>,
     pub records: Arc<SandboxRecordStore>,
     pub snapshots: Arc<SnapshotCatalog>,
-    pub events_tx: broadcast::Sender<SandboxEvent>,
+    pub events_tx: broadcast::Sender<ComputerEvent>,
     pub pool: Arc<SlotPool>,
 }
 

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/boot.rs
@@ -1,7 +1,7 @@
 //! The cold-boot flows: bringing the VM up, and the readiness gate READY is
 //! withheld for.
 //!
-//! `boot_sandbox`'s two halves, split where the machine splits them. What was
+//! `boot_computer`'s two halves, split where the machine splits them. What was
 //! the tail's own bookkeeping — the generation re-checks, the `Ready` /
 //! `Starting` assignment, the durable `Ready` write, the READY event and the
 //! failure handling — belongs to the actor now; what is left is the work.
@@ -56,7 +56,7 @@ impl ComputerFlows {
             Ok(booted) => booted,
             // Whatever the boot had not yet handed over goes onto the
             // computer, so the release the failure spawns finds it. This is
-            // `boot_sandbox`'s `updated_current` branch, reached without the
+            // `boot_computer`'s `updated_current` branch, reached without the
             // generation check the actor makes redundant.
             Err(failure) => {
                 let mut computer = self.computer.lock().unwrap();

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/boot.rs
@@ -20,7 +20,7 @@ use crate::lifecycle::tasks::{TaskFailure, TaskResult};
 use crate::sandbox::boot::run_ready_probe;
 use crate::sandbox::warm::{WarmPublishTicket, publish_after_boot};
 use crate::sandbox::workload::{WorkloadClaim, WorkloadSlot, start_run_workload};
-use crate::sandbox::{ComputerId, ComputerSpec, SandboxState};
+use crate::sandbox::{ComputerId, ComputerSpec, ComputerState};
 
 impl ComputerFlows {
     pub(super) async fn boot_vm(
@@ -115,7 +115,7 @@ impl ComputerFlows {
                 // reservation the boot's own `cmd` is owed — so the
                 // checkpoint's precondition is what this pipeline set, not
                 // what an API caller would see.
-                SandboxState::Starting,
+                ComputerState::Starting,
             )
             .await
             .map_err(TaskFailure::frozen)?;
@@ -167,20 +167,20 @@ impl ComputerFlows {
         let slot = match self.workload_slot() {
             Ok(slot) => slot,
             Err(error) => {
-                warn!(sandbox_id = %self.id, %error, "the initial cmd found no computer to claim");
+                warn!(computer_id = %self.id, %error, "the initial cmd found no computer to claim");
                 return false;
             }
         };
         match start_run_workload(agent, start, slot, WorkloadClaim::Initial).await {
             Ok(mut rx) => {
-                info!(sandbox_id = %self.id, "initial cmd started");
+                info!(computer_id = %self.id, "initial cmd started");
                 // Nothing consumes an initial cmd's output; drain it so the
                 // exit chunk still reaches the watcher.
                 tokio::spawn(async move { while rx.recv().await.is_some() {} });
                 true
             }
             Err(error) => {
-                warn!(sandbox_id = %self.id, %error, "initial cmd failed to start");
+                warn!(computer_id = %self.id, %error, "initial cmd failed to start");
                 false
             }
         }

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/boot.rs
@@ -20,7 +20,7 @@ use crate::lifecycle::tasks::{TaskFailure, TaskResult};
 use crate::sandbox::boot::run_ready_probe;
 use crate::sandbox::warm::{WarmPublishTicket, publish_after_boot};
 use crate::sandbox::workload::{WorkloadClaim, WorkloadSlot, start_run_workload};
-use crate::sandbox::{SandboxId, SandboxSpec, SandboxState};
+use crate::sandbox::{ComputerId, ComputerSpec, SandboxState};
 
 impl ComputerFlows {
     pub(super) async fn boot_vm(
@@ -148,7 +148,7 @@ impl ComputerFlows {
     /// `false` when there was nothing to start or the guest refused it.
     pub(super) async fn start_initial_cmd(
         &self,
-        spec: &SandboxSpec,
+        spec: &ComputerSpec,
         agent: &dyn GuestAgent,
     ) -> bool {
         if spec.cmd.is_empty() {
@@ -225,7 +225,7 @@ impl Attachment {
 /// The single-workload slot as the actor owns it: the claim, its rollback and
 /// the exit are all lifecycle transitions, so all three are mailbox verbs.
 pub struct ActorSlot {
-    pub id: SandboxId,
+    pub id: ComputerId,
     pub mailbox: Mailbox,
 }
 

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/boot.rs
@@ -13,7 +13,7 @@ use tracing::{info, warn};
 
 use super::{ComputerFlows, Launch};
 use crate::agent::{GuestAgent, StartCommand};
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::lifecycle::actor::{Command, Mailbox, WorkloadOutcome};
 use crate::lifecycle::tasks::boot::{do_boot, wait_for_agent};
 use crate::lifecycle::tasks::{TaskFailure, TaskResult};
@@ -130,7 +130,7 @@ impl ComputerFlows {
         let started = self.start_initial_cmd(&spec, agent.as_ref()).await;
         if let Some(probe) = spec.ready_probe.clone() {
             run_ready_probe(&probe, agent.as_ref()).await.map_err(|e| {
-                TaskFailure::recoverable(VmmError::FailedPrecondition(format!(
+                TaskFailure::recoverable(ComputerError::FailedPrecondition(format!(
                     "ready probe failed: {e}"
                 )))
             })?;

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/restore.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/restore.rs
@@ -16,7 +16,7 @@ use tracing::{info, warn};
 
 use super::{ComputerFlows, Launch, RestoreLaunch, warm_create};
 use crate::agent::GuestAgent;
-use crate::error::VmmError;
+use crate::error::ComputerError;
 use crate::lifecycle::event::RestoreOrigin;
 use crate::lifecycle::tasks::restore::{RestoreTimings, RestoreVm, RestoredVm, restore_vm};
 use crate::lifecycle::tasks::resume::restore_paused;
@@ -50,7 +50,7 @@ impl ComputerFlows {
             .unwrap_or_default();
         let vm_dir = self.computer.lock().unwrap().vm_dir.clone();
         let Some(jailer) = services.config.firecracker.jailer.clone() else {
-            return Err(TaskFailure::recoverable(VmmError::Config(
+            return Err(TaskFailure::recoverable(ComputerError::Config(
                 "checkpoint restore requires jailer isolation; direct mode embeds shared origin \
                  paths"
                     .into(),
@@ -180,14 +180,14 @@ impl ComputerFlows {
         };
         let recoverable = TaskFailure::recoverable;
         let snapshot_id = snapshot_id.ok_or_else(|| {
-            recoverable(VmmError::Snapshot(format!(
+            recoverable(ComputerError::Snapshot(format!(
                 "paused computer {} has no pause checkpoint recorded",
                 self.id
             )))
         })?;
         let services = &self.services;
         let jailer = services.config.firecracker.jailer.clone().ok_or_else(|| {
-            recoverable(VmmError::Config(
+            recoverable(ComputerError::Config(
                 "computer resume requires jailer isolation".into(),
             ))
         })?;

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/restore.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/restore.rs
@@ -21,8 +21,8 @@ use crate::lifecycle::event::RestoreOrigin;
 use crate::lifecycle::tasks::restore::{RestoreTimings, RestoreVm, RestoredVm, restore_vm};
 use crate::lifecycle::tasks::resume::restore_paused;
 use crate::lifecycle::tasks::{TaskFailure, TaskResult};
-use crate::sandbox::reconcile::{JournaledLease, SandboxStateRecord, write_state_record};
-use crate::sandbox::record::SandboxProvisionOutcome;
+use crate::sandbox::reconcile::{ComputerStateRecord, JournaledLease, write_state_record};
+use crate::sandbox::record::ComputerProvisionOutcome;
 use crate::sandbox::{journaled_pid, pool};
 
 impl ComputerFlows {
@@ -32,7 +32,7 @@ impl ComputerFlows {
     pub(super) async fn restore_vm(
         &self,
         origin: RestoreOrigin,
-    ) -> TaskResult<(Arc<dyn GuestAgent>, SandboxProvisionOutcome)> {
+    ) -> TaskResult<(Arc<dyn GuestAgent>, ComputerProvisionOutcome)> {
         let Launch::Restore(launch) = self.take_launch() else {
             return Err(self.wrong_launch("restore"));
         };
@@ -93,7 +93,7 @@ impl ComputerFlows {
             // so it is written before anything is torn down.
             Err(failure) => {
                 let pool_slot_id = self.computer.lock().unwrap().pool_slot_id.clone();
-                let journal = SandboxStateRecord::new(
+                let journal = ComputerStateRecord::new(
                     &self.id,
                     failure.prepared.as_deref().and_then(journaled_pid),
                     lease
@@ -165,7 +165,7 @@ impl ComputerFlows {
             &snapshot_id,
         );
 
-        Ok((agent, SandboxProvisionOutcome { ip_address }))
+        Ok((agent, ComputerProvisionOutcome { ip_address }))
     }
 
     /// Bring a paused computer back in place, onto a fresh network.

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/restore.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/restore.rs
@@ -106,7 +106,7 @@ impl ComputerFlows {
                 .map(|record| record.with_pool_slot(pool_slot_id.as_deref()))
                 .and_then(|record| write_state_record(&vm_dir, &record));
                 if let Err(error) = journal {
-                    warn!(sandbox_id = %self.id, %error, "the failed restore's journal was not written");
+                    warn!(computer_id = %self.id, %error, "the failed restore's journal was not written");
                 }
                 let mut computer = self.computer.lock().unwrap();
                 computer.prepared = failure.prepared;
@@ -142,7 +142,7 @@ impl ComputerFlows {
         // is not restore latency.
         let ms = |d: Duration| u64::try_from(d.as_millis()).unwrap_or(u64::MAX);
         info!(
-            sandbox_id = %self.id,
+            computer_id = %self.id,
             snapshot_id = %snapshot_id,
             pool_hit,
             warm_create = warm_create(origin),
@@ -241,14 +241,14 @@ impl ComputerFlows {
         // frees the memory-sized image.
         if let Err(error) = services.snapshots.delete_by_id(&snapshot_id) {
             warn!(
-                sandbox_id = %self.id,
+                computer_id = %self.id,
                 snapshot_id = %snapshot_id,
                 %error,
                 "resumed, but deleting the pause checkpoint failed"
             );
         }
         info!(
-            sandbox_id = %self.id,
+            computer_id = %self.id,
             total_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
             "computer resumed from pause checkpoint"
         );

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
@@ -12,7 +12,7 @@ use crate::lifecycle::tasks::pause::release_for_pause;
 use crate::lifecycle::tasks::release::{release_everything, release_runtime_resources};
 use crate::lifecycle::tasks::{CaptureSpec, Drain, TaskFailure, TaskResult};
 use crate::sandbox::pause::PAUSE_SNAPSHOT_NAME;
-use crate::sandbox::{CheckpointInfo, SandboxState};
+use crate::sandbox::{CheckpointInfo, ComputerState};
 
 /// How often a stop looks for the workload it is draining to finish.
 const DRAIN_POLL: Duration = Duration::from_millis(100);
@@ -33,13 +33,13 @@ impl ComputerFlows {
             Some(spec) => CheckpointRequest {
                 name: spec.name,
                 labels: spec.labels,
-                expected_state: SandboxState::Ready,
+                expected_state: ComputerState::Ready,
                 resume_after: !hold,
             },
             None => CheckpointRequest {
                 name: PAUSE_SNAPSHOT_NAME.to_owned(),
                 labels: std::collections::HashMap::new(),
-                expected_state: SandboxState::Pausing,
+                expected_state: ComputerState::Pausing,
                 resume_after: !hold,
             },
         };
@@ -99,7 +99,7 @@ impl ComputerFlows {
         // area its files were staged into, then TAP/IP and the CoW device;
         // the record itself stays inspectable until Remove.
         self.release_scope(ReleaseScope::Runtime).await?;
-        info!(sandbox_id = %self.id, "computer stopped");
+        info!(computer_id = %self.id, "computer stopped");
         Ok(())
     }
 

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
@@ -115,7 +115,7 @@ impl ComputerFlows {
                 )
                 .await
             }
-            // Unreachable: `pause_sandbox` refuses direct mode before it
+            // Unreachable: `pause_computer` refuses direct mode before it
             // claims anything, because a direct-mode vmstate pins origin
             // paths and could never resume.
             ReleaseScope::KeepDisk if services.config.firecracker.jailer.is_none() => {

--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/teardown.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use tracing::info;
 
 use super::ComputerFlows;
-use crate::error::VmmError;
+use crate::error::ComputerError;
 use crate::lifecycle::effect::ReleaseScope;
 use crate::lifecycle::tasks::checkpoint::{CheckpointFailure, CheckpointRequest, checkpoint_impl};
 use crate::lifecycle::tasks::pause::release_for_pause;
@@ -88,7 +88,7 @@ impl ComputerFlows {
                 .shutdown(arcbox_vm_driver::ShutdownMode::Graceful { timeout: remaining })
                 .await
                 .map_err(|error| {
-                    TaskFailure::recoverable(VmmError::Process(format!(
+                    TaskFailure::recoverable(ComputerError::Process(format!(
                         "shut down computer {}: {error}",
                         self.id
                     )))
@@ -119,7 +119,7 @@ impl ComputerFlows {
             // claims anything, because a direct-mode vmstate pins origin
             // paths and could never resume.
             ReleaseScope::KeepDisk if services.config.firecracker.jailer.is_none() => {
-                Err(VmmError::Config(
+                Err(ComputerError::Config(
                     "computer pause requires jailer isolation; direct mode cannot resume".into(),
                 ))
             }

--- a/computer/arcbox-computer-runtime/src/lifecycle/projection.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/projection.rs
@@ -3,34 +3,34 @@
 //!
 //! They are deliberately different. `running` is the workload hot path and
 //! writes no record, so it is durably `Ready`; `gating` and `removing` have no
-//! `SandboxState` of their own.
+//! `ComputerState` of their own.
 
 use super::machine::State;
-use crate::sandbox::SandboxState;
+use crate::sandbox::ComputerState;
 use crate::sandbox::record::PersistPhase;
 
 impl State {
     /// What a caller sees. Today a gated computer reads `Starting` (a boot
     /// owing its initial `cmd` holds it there) and a removal writes `Stopping`.
-    pub(super) fn to_public(self) -> SandboxState {
+    pub(super) fn to_public(self) -> ComputerState {
         match self {
             Self::Provisioning {}
             | Self::Staging {}
             | Self::Booting {}
             | Self::Restoring { .. }
-            | Self::Resuming {} => SandboxState::Starting,
+            | Self::Resuming {} => ComputerState::Starting,
             // A gate whose reservation the boot's own `cmd` has taken is
             // already running that workload, which is what a caller sees.
-            Self::Gating { claimed: false, .. } => SandboxState::Starting,
-            Self::Gating { claimed: true, .. } => SandboxState::Running,
-            Self::Ready {} | Self::Checkpointing {} => SandboxState::Ready,
-            Self::Running {} => SandboxState::Running,
-            Self::Capturing {} | Self::Releasing {} => SandboxState::Pausing,
-            Self::Paused {} => SandboxState::Paused,
-            Self::Stopping {} | Self::Removing {} => SandboxState::Stopping,
+            Self::Gating { claimed: false, .. } => ComputerState::Starting,
+            Self::Gating { claimed: true, .. } => ComputerState::Running,
+            Self::Ready {} | Self::Checkpointing {} => ComputerState::Ready,
+            Self::Running {} => ComputerState::Running,
+            Self::Capturing {} | Self::Releasing {} => ComputerState::Pausing,
+            Self::Paused {} => ComputerState::Paused,
+            Self::Stopping {} | Self::Removing {} => ComputerState::Stopping,
             // A removed computer is gone from the map; nothing reads `gone`.
-            Self::Stopped {} | Self::Gone {} => SandboxState::Stopped,
-            Self::Failed {} => SandboxState::Failed,
+            Self::Stopped {} | Self::Gone {} => ComputerState::Stopped,
+            Self::Failed {} => ComputerState::Failed,
         }
     }
 

--- a/computer/arcbox-computer-runtime/src/lifecycle/runtime.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/runtime.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use crate::agent::ExitStatus;
-use crate::sandbox::{SandboxId, SandboxSpec, SandboxState};
+use crate::sandbox::{ComputerId, ComputerSpec, SandboxState};
 use crate::snapshot_cow::CowHandle;
 
 /// A computer's runtime state as its actor and its sub-tasks share it.
@@ -31,13 +31,13 @@ pub type Runtime = Arc<Mutex<ComputerRuntime>>;
 /// the one thing an abort must not be able to strand.
 pub struct ComputerRuntime {
     /// Unique identifier.
-    pub id: SandboxId,
+    pub id: ComputerId,
     /// Durable lifecycle record generation.
     pub(crate) record_generation: Option<Uuid>,
     /// User-supplied labels.
     pub labels: HashMap<String, String>,
     /// Original creation spec.
-    pub spec: SandboxSpec,
+    pub spec: ComputerSpec,
     /// The public lifecycle state, mirrored here from the actor's machine on
     /// every transition. A sub-task reads it to see a teardown that started
     /// while it was running — the cooperative half of preemption, which an
@@ -106,8 +106,8 @@ pub struct ComputerRuntime {
 
 impl ComputerRuntime {
     pub(crate) fn new(
-        id: SandboxId,
-        spec: SandboxSpec,
+        id: ComputerId,
+        spec: ComputerSpec,
         network: Option<NetworkLease>,
         vm_dir: PathBuf,
     ) -> Self {
@@ -115,8 +115,8 @@ impl ComputerRuntime {
     }
 
     pub(crate) fn new_with_generation(
-        id: SandboxId,
-        spec: SandboxSpec,
+        id: ComputerId,
+        spec: ComputerSpec,
         network: Option<NetworkLease>,
         vm_dir: PathBuf,
         generation: Uuid,
@@ -125,8 +125,8 @@ impl ComputerRuntime {
     }
 
     fn new_inner(
-        id: SandboxId,
-        spec: SandboxSpec,
+        id: ComputerId,
+        spec: ComputerSpec,
         network: Option<NetworkLease>,
         vm_dir: PathBuf,
         record_generation: Option<Uuid>,

--- a/computer/arcbox-computer-runtime/src/lifecycle/runtime.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/runtime.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use crate::agent::ExitStatus;
-use crate::sandbox::{ComputerId, ComputerSpec, SandboxState};
+use crate::sandbox::{ComputerId, ComputerSpec, ComputerState};
 use crate::snapshot_cow::CowHandle;
 
 /// A computer's runtime state as its actor and its sub-tasks share it.
@@ -42,7 +42,7 @@ pub struct ComputerRuntime {
     /// every transition. A sub-task reads it to see a teardown that started
     /// while it was running — the cooperative half of preemption, which an
     /// abort alone cannot cover before the resource handoff has landed.
-    pub state: SandboxState,
+    pub state: ComputerState,
     /// The VMM process this sandbox's VM runs on, as the driver prepared
     /// it (`arcbox_vm_driver::PreparedVm`): pid and API socket known,
     /// shared with the boot task, taken by cleanup to kill and reap it.
@@ -136,7 +136,7 @@ impl ComputerRuntime {
             record_generation,
             labels: spec.labels.clone(),
             spec,
-            state: SandboxState::Starting,
+            state: ComputerState::Starting,
             prepared: None,
             handle: None,
             net_identity: None,

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks.rs
@@ -29,7 +29,7 @@ pub mod resume;
 use super::effect::ReleaseScope;
 use super::event::{Event, RestoreOrigin};
 use crate::agent::GuestAgent;
-use crate::error::VmmError;
+use crate::error::ComputerError;
 use crate::sandbox::CheckpointInfo;
 use crate::sandbox::record::SandboxProvisionOutcome;
 
@@ -46,13 +46,13 @@ pub type TaskResult<T = ()> = std::result::Result<T, TaskFailure>;
 #[derive(Debug)]
 pub struct TaskFailure {
     event: Event,
-    error: VmmError,
+    error: ComputerError,
 }
 
 impl TaskFailure {
     /// Whatever usable state the computer had survives: the flow unwound what
     /// it had allocated.
-    pub fn recoverable(error: VmmError) -> Self {
+    pub fn recoverable(error: ComputerError) -> Self {
         Self {
             event: Event::Failure,
             error,
@@ -61,7 +61,7 @@ impl TaskFailure {
 
     /// The guest is quiesced with no verb able to thaw it: the port is
     /// hold-then-kill by design, so the computer cannot go back to `Ready`.
-    pub fn frozen(error: VmmError) -> Self {
+    pub fn frozen(error: ComputerError) -> Self {
         Self {
             event: Event::Frozen,
             error,
@@ -70,7 +70,7 @@ impl TaskFailure {
 
     /// The flow could not unwind what it had allocated, so the computer
     /// cannot go back to the phase it came from — see [`Event::Stranded`].
-    pub fn stranded(error: VmmError) -> Self {
+    pub fn stranded(error: ComputerError) -> Self {
         Self {
             event: Event::Stranded,
             error,
@@ -88,7 +88,7 @@ impl TaskFailure {
     }
 
     /// The error the parked caller gets.
-    pub(super) fn into_error(self) -> VmmError {
+    pub(super) fn into_error(self) -> ComputerError {
         self.error
     }
 }

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks.rs
@@ -31,7 +31,7 @@ use super::event::{Event, RestoreOrigin};
 use crate::agent::GuestAgent;
 use crate::error::ComputerError;
 use crate::sandbox::CheckpointInfo;
-use crate::sandbox::record::SandboxProvisionOutcome;
+use crate::sandbox::record::ComputerProvisionOutcome;
 
 /// What a sub-task hands back: its own success value, or the failure class
 /// the machine branches on.
@@ -144,7 +144,7 @@ pub trait ComputerTasks: Send + Sync + 'static {
     async fn restore(
         &self,
         origin: RestoreOrigin,
-    ) -> TaskResult<(Arc<dyn GuestAgent>, SandboxProvisionOutcome)>;
+    ) -> TaskResult<(Arc<dyn GuestAgent>, ComputerProvisionOutcome)>;
 
     /// Capture a checkpoint. `hold` keeps the guest quiesced afterwards (the
     /// pause path): progress past the memory image would diverge from the

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
@@ -21,7 +21,7 @@ use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox::boot::{StageError, create_rootfs_symlink, stage_rootfs_cow_or_copy};
 use crate::sandbox::spec::build_vm_spec;
-use crate::sandbox::{self, ComputerSpec, NetworkAttachment, SandboxState};
+use crate::sandbox::{self, ComputerSpec, ComputerState, NetworkAttachment};
 use crate::snapshot_cow::{CowHandle, CowManager};
 
 pub type BootOutput = (Arc<dyn VmHandle>, Box<dyn ReadyGate>);
@@ -105,15 +105,15 @@ pub async fn wait_for_agent(
                 Ok(Ok(ClockSync::Synced)) => {}
                 Ok(Ok(ClockSync::AgentError(code))) => {
                     warn!(
-                        sandbox_id = %id, code,
+                        computer_id = %id, code,
                         "agent could not set the clock; continuing with a possibly skewed clock"
                     );
                 }
                 Ok(Err(error)) => {
-                    warn!(sandbox_id = %id, %error, "cold-boot clock sync failed; continuing");
+                    warn!(computer_id = %id, %error, "cold-boot clock sync failed; continuing");
                 }
                 Err(_) => {
-                    warn!(sandbox_id = %id, "cold-boot clock sync timed out; continuing");
+                    warn!(computer_id = %id, "cold-boot clock sync timed out; continuing");
                 }
             }
         });
@@ -203,7 +203,7 @@ pub async fn do_boot(
         computer.state
     };
 
-    if matches!(state, SandboxState::Stopping | SandboxState::Stopped) {
+    if matches!(state, ComputerState::Stopping | ComputerState::Stopped) {
         complete_resource_handoff(&mut resource_handoff);
         return Err(BootFailure {
             error: ComputerError::WrongState {
@@ -302,7 +302,7 @@ pub async fn do_boot(
                         return Err(e.into());
                     }
                     debug!(
-                        sandbox_id = %id,
+                        computer_id = %id,
                         error = %e,
                         "dm-snapshot unavailable, using rootfs directly"
                     );
@@ -331,7 +331,7 @@ pub async fn do_boot(
         prepared: None,
         cow_handle: None,
     })?;
-    if matches!(state, SandboxState::Stopping | SandboxState::Stopped) {
+    if matches!(state, ComputerState::Stopping | ComputerState::Stopped) {
         return Err(BootFailure {
             error: ComputerError::WrongState {
                 id: id.to_owned(),

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
@@ -17,7 +17,7 @@ use tracing::{debug, warn};
 
 use crate::agent::{ClockSync, GuestAgent, GuestAgentFactory, ReadyGate};
 use crate::config::RuntimeConfig;
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox::boot::{StageError, create_rootfs_symlink, stage_rootfs_cow_or_copy};
 use crate::sandbox::spec::build_vm_spec;
@@ -37,7 +37,7 @@ const AGENT_GATE_TIMEOUT: Duration = Duration::from_secs(35);
 const CLOCK_SYNC_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct BootFailure {
-    pub error: VmmError,
+    pub error: ComputerError,
     pub prepared: Option<Arc<dyn PreparedVm>>,
     pub cow_handle: Option<CowHandle>,
 }
@@ -74,8 +74,10 @@ pub async fn wait_for_agent(
         Ok(agent) => {
             match tokio::time::timeout(AGENT_GATE_TIMEOUT, ready_gate.wait(handle, &agent)).await {
                 Ok(Ok(())) => Ok(agent),
-                Ok(Err(error)) => Err(VmmError::Vsock(format!("agent readiness gate: {error}"))),
-                Err(_) => Err(VmmError::Vsock(format!(
+                Ok(Err(error)) => Err(ComputerError::Vsock(format!(
+                    "agent readiness gate: {error}"
+                ))),
+                Err(_) => Err(ComputerError::Vsock(format!(
                     "agent readiness gate: the guest agent did not answer within {}s",
                     AGENT_GATE_TIMEOUT.as_secs()
                 ))),
@@ -204,7 +206,7 @@ pub async fn do_boot(
     if matches!(state, SandboxState::Stopping | SandboxState::Stopped) {
         complete_resource_handoff(&mut resource_handoff);
         return Err(BootFailure {
-            error: VmmError::WrongState {
+            error: ComputerError::WrongState {
                 id: id.to_owned(),
                 expected: "a sandbox still booting".into(),
                 actual: state.to_string(),
@@ -331,7 +333,7 @@ pub async fn do_boot(
     })?;
     if matches!(state, SandboxState::Stopping | SandboxState::Stopped) {
         return Err(BootFailure {
-            error: VmmError::WrongState {
+            error: ComputerError::WrongState {
                 id: id.to_owned(),
                 expected: "a sandbox still booting".into(),
                 actual: state.to_string(),
@@ -347,7 +349,7 @@ pub async fn do_boot(
     // listening — otherwise the guest is reset and the one readiness event
     // is lost. Which observer that is, and whether there is one at all, is
     // the agent port's business.
-    let failed = |error: VmmError| BootFailure {
+    let failed = |error: ComputerError| BootFailure {
         error,
         prepared: None,
         cow_handle: None,

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
@@ -184,7 +184,7 @@ pub async fn do_boot(
     };
 
     let process_pid = sandbox::journaled_pid(&*prepared);
-    let journal_error = sandbox::reconcile::SandboxStateRecord::new(
+    let journal_error = sandbox::reconcile::ComputerStateRecord::new(
         id,
         process_pid,
         net.map(NetworkAttachment::journaled),
@@ -241,7 +241,7 @@ pub async fn do_boot(
     let paths: Result<(PathBuf, PathBuf)> = async {
         if fc_cfg.jailer.is_some() {
             let journal = |cow: Option<&CowHandle>| {
-                sandbox::reconcile::SandboxStateRecord::new(
+                sandbox::reconcile::ComputerStateRecord::new(
                     id,
                     process_pid,
                     net.map(NetworkAttachment::journaled),
@@ -286,7 +286,7 @@ pub async fn do_boot(
             let rootfs = match cow_manager.setup(id, &spec.rootfs).await {
                 Ok(handle) => {
                     cow_handle = Some(handle);
-                    let record = sandbox::reconcile::SandboxStateRecord::new(
+                    let record = sandbox::reconcile::ComputerStateRecord::new(
                         id,
                         process_pid,
                         net.map(NetworkAttachment::journaled),

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
@@ -21,7 +21,7 @@ use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox::boot::{StageError, create_rootfs_symlink, stage_rootfs_cow_or_copy};
 use crate::sandbox::spec::build_vm_spec;
-use crate::sandbox::{self, NetworkAttachment, SandboxSpec, SandboxState};
+use crate::sandbox::{self, ComputerSpec, NetworkAttachment, SandboxState};
 use crate::snapshot_cow::{CowHandle, CowManager};
 
 pub type BootOutput = (Arc<dyn VmHandle>, Box<dyn ReadyGate>);
@@ -146,7 +146,7 @@ pub async fn wait_for_agent(
 )]
 pub async fn do_boot(
     id: &str,
-    spec: &SandboxSpec,
+    spec: &ComputerSpec,
     net: Option<&NetworkAttachment>,
     vm_dir: &Path,
     driver: &dyn VmDriver,

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
@@ -4,7 +4,7 @@
 //! Moved here from `sandbox::boot` by R3 PR-F1b, unchanged: these are the
 //! bodies `Effect::SpawnBoot` and `Effect::SpawnGate` name, and the actor
 //! will run them through [`ComputerTasks`](super::ComputerTasks) once PR-F2
-//! flips the manager. Until then `sandbox::boot::boot_sandbox` is still the
+//! flips the manager. Until then `sandbox::boot::boot_computer` is still the
 //! caller.
 
 use std::path::{Path, PathBuf};

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/checkpoint.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/checkpoint.rs
@@ -21,7 +21,7 @@ use tracing::info;
 use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox::policy::settle::{self, Capture, GuestHold, Settlement};
-use crate::sandbox::{CheckpointInfo, ComputerId, SandboxState};
+use crate::sandbox::{CheckpointInfo, ComputerId, ComputerState};
 use crate::snapshot::{SnapshotCatalog, SnapshotDraft};
 
 /// What a single [`checkpoint_impl`] call should capture, and how it should
@@ -34,7 +34,7 @@ pub struct CheckpointRequest {
     /// State the instance must be in. The Checkpoint RPC and the warm-create
     /// publisher require `Ready`; pause has already claimed the instance and
     /// moved it to `Pausing` (CORE-21).
-    pub expected_state: SandboxState,
+    pub expected_state: ComputerState,
     /// Resume the guest once the snapshot files are written.
     ///
     /// False only for pause, whose whole point is that the guest must never
@@ -81,13 +81,13 @@ struct CheckpointSource {
 
 fn checkpoint_source(
     computer: &Arc<Mutex<ComputerRuntime>>,
-    sandbox_id: &ComputerId,
-    expected_state: SandboxState,
+    computer_id: &ComputerId,
+    expected_state: ComputerState,
 ) -> Result<CheckpointSource> {
     let inst = computer.lock().unwrap();
     if inst.state != expected_state {
         return Err(ComputerError::WrongState {
-            id: sandbox_id.clone(),
+            id: computer_id.clone(),
             expected: expected_state.to_string(),
             actual: inst.state.to_string(),
         });
@@ -96,7 +96,7 @@ fn checkpoint_source(
         .handle
         .clone()
         .ok_or_else(|| ComputerError::WrongState {
-            id: sandbox_id.clone(),
+            id: computer_id.clone(),
             expected: format!("{expected_state} (VM handle available)"),
             actual: inst.state.to_string(),
         })?;
@@ -124,14 +124,14 @@ fn checkpoint_source(
 pub async fn checkpoint_impl(
     computer: &Arc<Mutex<ComputerRuntime>>,
     snapshots: &SnapshotCatalog,
-    sandbox_id: &ComputerId,
+    computer_id: &ComputerId,
     request: CheckpointRequest,
 ) -> std::result::Result<CheckpointInfo, CheckpointFailure> {
     let resume_after = request.resume_after;
-    let source = checkpoint_source(computer, sandbox_id, request.expected_state)
+    let source = checkpoint_source(computer, computer_id, request.expected_state)
         .map_err(CheckpointFailure::Recoverable)?;
     let handle = Arc::clone(&source.handle);
-    let outcome = capture(snapshots, sandbox_id, source, request).await;
+    let outcome = capture(snapshots, computer_id, source, request).await;
     let settlement = settle::settlement(
         handle.state(),
         if resume_after {
@@ -149,7 +149,7 @@ pub async fn checkpoint_impl(
         (Ok(info), Settlement::AsRequested) => Ok(info),
         (Ok(info), Settlement::Frozen) => {
             Err(CheckpointFailure::Frozen(ComputerError::Process(format!(
-                "sandbox {sandbox_id} stayed frozen after checkpoint {}: the driver could not \
+                "sandbox {computer_id} stayed frozen after checkpoint {}: the driver could not \
                  resume the guest",
                 info.snapshot_id
             ))))
@@ -163,7 +163,7 @@ pub async fn checkpoint_impl(
 /// commit to the catalog.
 async fn capture(
     snapshots: &SnapshotCatalog,
-    sandbox_id: &ComputerId,
+    computer_id: &ComputerId,
     source: CheckpointSource,
     request: CheckpointRequest,
 ) -> Result<CheckpointInfo> {
@@ -178,7 +178,7 @@ async fn capture(
     // the checkpoint recorded and only a per-VM chroot makes those private.
     let checkpoint = source.handle.checkpoint().ok_or_else(|| {
         ComputerError::FailedPrecondition(format!(
-            "sandbox {sandbox_id} cannot be checkpointed: checkpoints require jailer \
+            "sandbox {computer_id} cannot be checkpointed: checkpoints require jailer \
              isolation, and this VM runs without it"
         ))
     })?;
@@ -186,7 +186,7 @@ async fn capture(
     // Staging directory outside the catalog: the snapshot becomes visible
     // only on commit, and dropping `pending` on any error below takes the
     // directory and whatever partial vmstate/mem it holds with it.
-    let pending = snapshots.begin(sandbox_id)?;
+    let pending = snapshots.begin(computer_id)?;
 
     // The driver owns the freeze: it pauses the guest, writes the capture
     // (into the jail and out to the staging dir), and resumes — or, for
@@ -228,7 +228,7 @@ async fn capture(
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_default();
 
-    info!(sandbox_id, snapshot_id = %meta.id, "sandbox checkpointed");
+    info!(computer_id, snapshot_id = %meta.id, "sandbox checkpointed");
     Ok(CheckpointInfo {
         snapshot_id: meta.id,
         snapshot_dir: snap_dir_path,

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/checkpoint.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/checkpoint.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, Mutex};
 use arcbox_vm_driver::{AfterCheckpoint, CheckpointKind, CheckpointOptions, VmHandle};
 use tracing::info;
 
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox::policy::settle::{self, Capture, GuestHold, Settlement};
 use crate::sandbox::{CheckpointInfo, SandboxId, SandboxState};
@@ -48,20 +48,20 @@ pub struct CheckpointRequest {
 pub enum CheckpointFailure {
     /// The guest is running — the driver resumed it, or the failure came
     /// before the capture — and the sandbox is as usable as it was.
-    Recoverable(VmmError),
+    Recoverable(ComputerError),
     /// The guest is frozen and nothing can thaw it: the driver's own resume
     /// after the capture failed (it settles the guest before reporting, and
     /// this is the case where that settling itself failed), or the capture
     /// held the guest on request and a later step failed. The port has no
     /// resume verb, so the sandbox is unusable and the caller must fail it —
     /// kill, release, durable `Failed` — rather than report it Ready.
-    Frozen(VmmError),
+    Frozen(ComputerError),
 }
 
 impl CheckpointFailure {
     /// The error, for a caller whose next step disposes of the sandbox
     /// either way.
-    pub fn into_error(self) -> VmmError {
+    pub fn into_error(self) -> ComputerError {
         match self {
             Self::Recoverable(error) | Self::Frozen(error) => error,
         }
@@ -86,17 +86,20 @@ fn checkpoint_source(
 ) -> Result<CheckpointSource> {
     let inst = computer.lock().unwrap();
     if inst.state != expected_state {
-        return Err(VmmError::WrongState {
+        return Err(ComputerError::WrongState {
             id: sandbox_id.clone(),
             expected: expected_state.to_string(),
             actual: inst.state.to_string(),
         });
     }
-    let handle = inst.handle.clone().ok_or_else(|| VmmError::WrongState {
-        id: sandbox_id.clone(),
-        expected: format!("{expected_state} (VM handle available)"),
-        actual: inst.state.to_string(),
-    })?;
+    let handle = inst
+        .handle
+        .clone()
+        .ok_or_else(|| ComputerError::WrongState {
+            id: sandbox_id.clone(),
+            expected: format!("{expected_state} (VM handle available)"),
+            actual: inst.state.to_string(),
+        })?;
     Ok(CheckpointSource {
         kernel_path: inst.spec.kernel.clone(),
         rootfs_path: inst.spec.rootfs.clone(),
@@ -145,7 +148,7 @@ pub async fn checkpoint_impl(
     match (outcome, settlement) {
         (Ok(info), Settlement::AsRequested) => Ok(info),
         (Ok(info), Settlement::Frozen) => {
-            Err(CheckpointFailure::Frozen(VmmError::Process(format!(
+            Err(CheckpointFailure::Frozen(ComputerError::Process(format!(
                 "sandbox {sandbox_id} stayed frozen after checkpoint {}: the driver could not \
                  resume the guest",
                 info.snapshot_id
@@ -174,7 +177,7 @@ async fn capture(
     // checkpoints only jailed VMs, because a restore reopens the disk paths
     // the checkpoint recorded and only a per-VM chroot makes those private.
     let checkpoint = source.handle.checkpoint().ok_or_else(|| {
-        VmmError::FailedPrecondition(format!(
+        ComputerError::FailedPrecondition(format!(
             "sandbox {sandbox_id} cannot be checkpointed: checkpoints require jailer \
              isolation, and this VM runs without it"
         ))

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/checkpoint.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/checkpoint.rs
@@ -21,7 +21,7 @@ use tracing::info;
 use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox::policy::settle::{self, Capture, GuestHold, Settlement};
-use crate::sandbox::{CheckpointInfo, SandboxId, SandboxState};
+use crate::sandbox::{CheckpointInfo, ComputerId, SandboxState};
 use crate::snapshot::{SnapshotCatalog, SnapshotDraft};
 
 /// What a single [`checkpoint_impl`] call should capture, and how it should
@@ -81,7 +81,7 @@ struct CheckpointSource {
 
 fn checkpoint_source(
     computer: &Arc<Mutex<ComputerRuntime>>,
-    sandbox_id: &SandboxId,
+    sandbox_id: &ComputerId,
     expected_state: SandboxState,
 ) -> Result<CheckpointSource> {
     let inst = computer.lock().unwrap();
@@ -124,7 +124,7 @@ fn checkpoint_source(
 pub async fn checkpoint_impl(
     computer: &Arc<Mutex<ComputerRuntime>>,
     snapshots: &SnapshotCatalog,
-    sandbox_id: &SandboxId,
+    sandbox_id: &ComputerId,
     request: CheckpointRequest,
 ) -> std::result::Result<CheckpointInfo, CheckpointFailure> {
     let resume_after = request.resume_after;
@@ -163,7 +163,7 @@ pub async fn checkpoint_impl(
 /// commit to the catalog.
 async fn capture(
     snapshots: &SnapshotCatalog,
-    sandbox_id: &SandboxId,
+    sandbox_id: &ComputerId,
     source: CheckpointSource,
     request: CheckpointRequest,
 ) -> Result<CheckpointInfo> {

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
@@ -30,7 +30,7 @@ use std::sync::{Arc, Mutex};
 use arcbox_vm_driver::net::GuestNetwork;
 
 use crate::config::RuntimeConfig;
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox::pause::PAUSED_ROOTFS_FILE;
 use crate::sandbox::{self, ROOTFS_DISK_ID, SandboxId};
@@ -97,7 +97,7 @@ pub async fn release_for_pause(
             None => false,
         };
         if !parked {
-            return Err(VmmError::Snapshot(format!(
+            return Err(ComputerError::Snapshot(format!(
                 "computer {id} runs on a copied rootfs but nothing could be taken out of its \
                  vm's area; pausing it would leave nothing to resume from"
             )));
@@ -122,7 +122,7 @@ pub async fn release_for_pause(
         if detached != retained && detached.exists() {
             tokio::fs::rename(&detached, &retained)
                 .await
-                .map_err(VmmError::Io)?;
+                .map_err(ComputerError::Io)?;
         }
     }
 
@@ -309,7 +309,7 @@ mod tests {
         .await;
 
         match refused {
-            Err(VmmError::Snapshot(message)) => {
+            Err(ComputerError::Snapshot(message)) => {
                 assert!(message.contains("nothing to resume from"), "{message}");
             }
             other => panic!("expected a refusal, got {other:?}"),

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
@@ -104,7 +104,7 @@ pub async fn release_for_pause(
         }
     }
 
-    super::release::kill_sandbox_process(id, arc).await?;
+    super::release::kill_computer_process(id, arc).await?;
     let owner = super::release::resource_owner(id, arc);
 
     // Disk: detach the overlay but keep its COW file.

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/pause.rs
@@ -33,7 +33,7 @@ use crate::config::RuntimeConfig;
 use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox::pause::PAUSED_ROOTFS_FILE;
-use crate::sandbox::{self, ROOTFS_DISK_ID, SandboxId};
+use crate::sandbox::{self, ComputerId, ROOTFS_DISK_ID};
 use crate::snapshot_cow::CowManager;
 
 /// Free the VM and the network of a checkpointed sandbox while keeping its
@@ -50,7 +50,7 @@ use crate::snapshot_cow::CowManager;
 /// overlay renamed onto the sandbox-id path, so `Paused` is always reached
 /// with every retained resource keyed by the sandbox id.
 pub async fn release_for_pause(
-    id: &SandboxId,
+    id: &ComputerId,
     arc: &Arc<Mutex<ComputerRuntime>>,
     config: &RuntimeConfig,
     cow_manager: &CowManager,
@@ -153,7 +153,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::sandbox::SandboxSpec;
+    use crate::sandbox::ComputerSpec;
     use crate::snapshot_cow::CowOptions;
 
     /// Which grip on its VM a computer holds.
@@ -202,7 +202,7 @@ mod tests {
         }
         let mut computer = ComputerRuntime::new(
             "job".to_owned(),
-            SandboxSpec::default(),
+            ComputerSpec::default(),
             None,
             vm_dir.clone(),
         );

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/release.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/release.rs
@@ -23,7 +23,7 @@ use arcbox_vm_driver::ShutdownMode;
 use arcbox_vm_driver::net::GuestNetwork;
 
 use crate::config::RuntimeConfig;
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox;
 use crate::snapshot_cow::CowManager;
@@ -119,14 +119,14 @@ pub async fn kill_sandbox_process(id: &str, arc: &Arc<Mutex<ComputerRuntime>>) -
     if let Some(prepared) = prepared {
         if let Err(error) = prepared.discard().await {
             arc.lock().unwrap().prepared = Some(prepared);
-            return Err(VmmError::Process(format!(
+            return Err(ComputerError::Process(format!(
                 "release the vmm of sandbox {id}: {error}"
             )));
         }
     } else if let Some(handle) = handle
         && let Err(error) = handle.shutdown(ShutdownMode::Kill).await
     {
-        return Err(VmmError::Process(format!(
+        return Err(ComputerError::Process(format!(
             "release the adopted vmm of sandbox {id}: {error}"
         )));
     }
@@ -168,7 +168,7 @@ pub async fn release_everything(
     if let Err(e) = tokio::fs::remove_dir_all(&vm_dir).await
         && e.kind() != std::io::ErrorKind::NotFound
     {
-        return Err(VmmError::Io(e));
+        return Err(ComputerError::Io(e));
     }
     Ok(())
 }

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/release.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/release.rs
@@ -43,7 +43,7 @@ pub async fn release_runtime_resources(
     network: &Arc<dyn GuestNetwork>,
     cow_manager: &Arc<CowManager>,
 ) -> Result<()> {
-    kill_sandbox_process(id, arc).await?;
+    kill_computer_process(id, arc).await?;
 
     // Teardown dm-snapshot CoW device (must happen after the VMM exits
     // because it holds the block device open).
@@ -104,7 +104,7 @@ pub fn resource_owner(id: &str, arc: &Arc<Mutex<ComputerRuntime>>) -> String {
 /// bounded wait elapsed) restores whichever grip it took, and keeps the
 /// handle, so a retry can finish the job. Idempotent — both are `take()`n,
 /// and killing an exited VM just reports its status.
-pub async fn kill_sandbox_process(id: &str, arc: &Arc<Mutex<ComputerRuntime>>) -> Result<()> {
+pub async fn kill_computer_process(id: &str, arc: &Arc<Mutex<ComputerRuntime>>) -> Result<()> {
     let (prepared, handle) = {
         let mut inst = arc.lock().unwrap();
         let prepared = inst.prepared.take();

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
@@ -177,7 +177,7 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
                     // chroot, and CoW invisible to reconciliation.
                     if let Err(error) = sandbox::reconcile::clear_state_record(&slot_vm_dir) {
                         warn!(
-                            sandbox_id = %new_id,
+                            computer_id = %new_id,
                             slot_id = %slot_id,
                             error = %error,
                             "claimed slot journal not cleared; the startup sweep will reconcile it"
@@ -186,7 +186,7 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
                         && error.kind() != std::io::ErrorKind::NotFound
                     {
                         warn!(
-                            sandbox_id = %new_id,
+                            computer_id = %new_id,
                             slot_id = %slot_id,
                             error = %error,
                             "claimed slot runtime dir not removed"
@@ -384,10 +384,10 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
             {
                 Ok(Ok(ClockSync::Synced)) => {}
                 Ok(Ok(ClockSync::AgentError(code))) => {
-                    warn!(sandbox_id = %id, code, "agent could not set the clock after restore");
+                    warn!(computer_id = %id, code, "agent could not set the clock after restore");
                 }
-                Ok(Err(e)) => warn!(sandbox_id = %id, "clock sync after restore failed: {e}"),
-                Err(_) => warn!(sandbox_id = %id, "clock sync after restore timed out"),
+                Ok(Err(e)) => warn!(computer_id = %id, "clock sync after restore failed: {e}"),
+                Err(_) => warn!(computer_id = %id, "clock sync after restore timed out"),
             }
         });
     }

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
@@ -27,7 +27,7 @@ use tracing::warn;
 
 use crate::agent::{ClockSync, GuestAgent, GuestAgentFactory};
 use crate::config::{JailerConfig, RuntimeConfig};
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::sandbox;
 use crate::sandbox::boot::{StageError, stage_rootfs_cow_or_copy};
@@ -93,7 +93,7 @@ pub struct RestoreTimings {
 /// A restore that failed before its commit, carrying whatever it had already
 /// acquired so the caller can unwind it (`rollback_restore`).
 pub struct RestoreFailure {
-    pub error: VmmError,
+    pub error: ComputerError,
     pub prepared: Option<Arc<dyn PreparedVm>>,
     pub cow_handle: Option<CowHandle>,
 }
@@ -279,7 +279,7 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
                 // gets the same CoW semantics (block-level template
                 // sharing, sparse COW).
                 let rootfs = snap_meta.rootfs_path.as_deref().ok_or_else(|| {
-                    VmmError::Snapshot(format!(
+                    ComputerError::Snapshot(format!(
                         "checkpoint {} records no rootfs template; there is no disk to restore \
                          it onto",
                         snap_meta.id
@@ -421,7 +421,7 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
             agent.reconfigure_network(&cmd),
         )
         .await
-        .map_err(|_| VmmError::Vsock("net reconfig after restore timed out".into()))
+        .map_err(|_| ComputerError::Vsock("net reconfig after restore timed out".into()))
         .and_then(|r| r)
     };
 

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
@@ -144,7 +144,7 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
             // and crash reconciliation key the chroot and dm/CoW teardown
             // on it (see release_runtime_resources / sweep_orphans).
             instance.lock().unwrap().pool_slot_id = Some(slot.slot_id.clone());
-            let handover = sandbox::reconcile::SandboxStateRecord::new(
+            let handover = sandbox::reconcile::ComputerStateRecord::new(
                 new_id,
                 sandbox::journaled_pid(&*slot.prepared),
                 lease
@@ -236,7 +236,7 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
 
             let pid = sandbox::journaled_pid(&*spawned_prepared);
             let journal = |cow: Option<&CowHandle>| {
-                sandbox::reconcile::SandboxStateRecord::new(
+                sandbox::reconcile::ComputerStateRecord::new(
                     new_id,
                     pid,
                     lease
@@ -452,7 +452,7 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
     // Persist cleanup metadata before handing runtime resources to the
     // instance. A failed durable write aborts and unwinds every resource.
     let adopted_slot = instance.lock().unwrap().pool_slot_id.clone();
-    let final_journal = sandbox::reconcile::SandboxStateRecord::new(
+    let final_journal = sandbox::reconcile::ComputerStateRecord::new(
         new_id,
         sandbox::journaled_pid(&*prepared),
         lease

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
@@ -24,7 +24,7 @@ use crate::error::{ComputerError, Result};
 use crate::sandbox::pause::{PAUSED_ROOTFS_FILE, ResumeFailure, ResumedRuntime};
 use crate::sandbox::reconcile::JournaledLease;
 use crate::sandbox::spec::restore_spec;
-use crate::sandbox::{self, ROOTFS_DISK_ID, SandboxId};
+use crate::sandbox::{self, ComputerId, ROOTFS_DISK_ID};
 use crate::snapshot::SnapshotMeta;
 use crate::snapshot_cow::{CowHandle, CowManager};
 
@@ -39,7 +39,7 @@ use crate::snapshot_cow::{CowHandle, CowManager};
     reason = "the resume spans the resource set its computer owns"
 )]
 pub async fn restore_paused(
-    id: &SandboxId,
+    id: &ComputerId,
     jailer: &JailerConfig,
     snap_meta: &SnapshotMeta,
     vm_dir: &Path,
@@ -258,7 +258,7 @@ pub async fn restore_paused(
 /// that failed before it handed the parked disk over never moved it, so
 /// the file is still sitting in `vm_dir` where a clean pause left it.
 async fn park_copy_mode_rootfs(
-    id: &SandboxId,
+    id: &ComputerId,
     vm_dir: &Path,
     config: &RuntimeConfig,
     prepared: Option<&Arc<dyn PreparedVm>>,
@@ -290,7 +290,7 @@ async fn park_copy_mode_rootfs(
     reason = "the unwind spans everything the failed resume re-created"
 )]
 async fn unwind_resume(
-    id: &SandboxId,
+    id: &ComputerId,
     vm_dir: &Path,
     config: &RuntimeConfig,
     cow_manager: &CowManager,

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
@@ -66,7 +66,7 @@ pub async fn restore_paused(
         if networked {
             lease = Some(
                 network
-                    .reserve(&VmId::new(id.as_str())?, sandbox::sandbox_network_policy())
+                    .reserve(&VmId::new(id.as_str())?, sandbox::computer_network_policy())
                     .await?,
             );
         }

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
@@ -20,7 +20,7 @@ use tracing::warn;
 
 use crate::agent::{ClockSync, GuestAgentFactory};
 use crate::config::{JailerConfig, RuntimeConfig};
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::sandbox::pause::{PAUSED_ROOTFS_FILE, ResumeFailure, ResumedRuntime};
 use crate::sandbox::reconcile::JournaledLease;
 use crate::sandbox::spec::restore_spec;
@@ -112,7 +112,7 @@ pub async fn restore_paused(
         let preserved_cow = sandbox::preserved_cow_file(config, id);
         let rootfs = if preserved_cow.exists() {
             let template = snap_meta.rootfs_path.as_deref().ok_or_else(|| {
-                VmmError::Snapshot(format!(
+                ComputerError::Snapshot(format!(
                     "pause checkpoint for {id} records no rootfs template"
                 ))
             })?;
@@ -132,7 +132,7 @@ pub async fn restore_paused(
             // of a guest rootfs, and nothing else holds a copy of it.
             let parked = vm_dir.join(PAUSED_ROOTFS_FILE);
             if !parked.exists() {
-                return Err(VmmError::Snapshot(format!(
+                return Err(ComputerError::Snapshot(format!(
                     "paused sandbox {id} has neither a preserved overlay nor a parked rootfs"
                 )));
             }
@@ -208,7 +208,7 @@ pub async fn restore_paused(
                 agent.reconfigure_network(&cmd),
             )
             .await
-            .map_err(|_| VmmError::Vsock("net reconfig after resume timed out".into()))
+            .map_err(|_| ComputerError::Vsock("net reconfig after resume timed out".into()))
             .and_then(|r| r)?;
         }
 

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
@@ -76,7 +76,7 @@ pub async fn restore_paused(
             // journal and the datapath cannot disagree.
             let net =
                 net.map(|lease| JournaledLease::from_snapshot(lease, snap_meta.net_invariant));
-            sandbox::reconcile::SandboxStateRecord::new(id, pid, net, cow, config, None)
+            sandbox::reconcile::ComputerStateRecord::new(id, pid, net, cow, config, None)
                 .and_then(|record| sandbox::reconcile::write_state_record(vm_dir, &record))
         };
         journal(None, None, lease.as_ref())?;

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
@@ -182,10 +182,10 @@ pub async fn restore_paused(
                 {
                     Ok(Ok(ClockSync::Synced)) => {}
                     Ok(Ok(ClockSync::AgentError(code))) => {
-                        warn!(sandbox_id = %id, code, "agent could not set the clock after resume");
+                        warn!(computer_id = %id, code, "agent could not set the clock after resume");
                     }
-                    Ok(Err(e)) => warn!(sandbox_id = %id, "clock sync after resume failed: {e}"),
-                    Err(_) => warn!(sandbox_id = %id, "clock sync after resume timed out"),
+                    Ok(Err(e)) => warn!(computer_id = %id, "clock sync after resume failed: {e}"),
+                    Err(_) => warn!(computer_id = %id, "clock sync after resume timed out"),
                 }
             });
         }
@@ -275,7 +275,7 @@ async fn park_copy_mode_rootfs(
     {
         Ok(_) => true,
         Err(error) => {
-            warn!(sandbox_id = %id, error = %error, "resume unwind: parking rootfs failed");
+            warn!(computer_id = %id, error = %error, "resume unwind: parking rootfs failed");
             false
         }
     }
@@ -304,7 +304,7 @@ async fn unwind_resume(
     if let Some(prepared) = prepared {
         // SIGKILL plus the driver's bounded wait for the reaper.
         if let Err(error) = prepared.discard().await {
-            warn!(sandbox_id = %id, error = %error, "resume unwind: the vmm did not exit");
+            warn!(computer_id = %id, error = %error, "resume unwind: the vmm did not exit");
             clean = false;
         }
     }
@@ -312,19 +312,19 @@ async fn unwind_resume(
     if let Some(handle) = cow_handle
         && let Err(error) = cow_manager.detach_keep_cow(&handle).await
     {
-        warn!(sandbox_id = %id, error = %error, "resume unwind: overlay detach failed");
+        warn!(computer_id = %id, error = %error, "resume unwind: overlay detach failed");
         clean = false;
     }
 
     if let Some(lease) = net_lease
         && let Err(error) = network.quarantine(lease).await
     {
-        warn!(sandbox_id = %id, error = %error, "resume unwind: network quarantine failed");
+        warn!(computer_id = %id, error = %error, "resume unwind: network quarantine failed");
         clean = false;
     }
 
     if clean && let Err(error) = sandbox::reconcile::clear_state_record(vm_dir) {
-        warn!(sandbox_id = %id, error = %error, "resume unwind: journal removal failed");
+        warn!(computer_id = %id, error = %error, "resume unwind: journal removal failed");
         clean = false;
     }
     clean

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
@@ -17,7 +17,7 @@ use tokio::sync::{broadcast, mpsc, oneshot, watch};
 
 use crate::agent::{GuestAgent, GuestAgentFactory};
 use crate::config::RuntimeConfig;
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::lifecycle::actor::{
     Command, ComputerActor, ComputerSeed, ComputerSnapshot, Deadlines, Seeded, WorkloadOutcome,
 };
@@ -126,7 +126,7 @@ impl ComputerTasks for Script {
                 drop(handed_off);
                 tokio::time::sleep(Duration::from_secs(2)).await;
                 self.cleanup_finished.store(true, Ordering::SeqCst);
-                Err(TaskFailure::recoverable(VmmError::Process(
+                Err(TaskFailure::recoverable(ComputerError::Process(
                     "the vmm would not spawn".into(),
                 )))
             }
@@ -163,7 +163,7 @@ impl ComputerTasks for Script {
         }
         self.restore_finished.store(true, Ordering::SeqCst);
         if self.restore_fails.load(Ordering::SeqCst) {
-            return Err(TaskFailure::recoverable(VmmError::Process(
+            return Err(TaskFailure::recoverable(ComputerError::Process(
                 "the checkpoint would not load".into(),
             )));
         }
@@ -208,7 +208,7 @@ impl ComputerTasks for Script {
             tokio::time::sleep(takes).await;
         }
         if self.release_fails.load(Ordering::SeqCst) {
-            return Err(TaskFailure::recoverable(VmmError::Process(
+            return Err(TaskFailure::recoverable(ComputerError::Process(
                 "the vmm would not die".into(),
             )));
         }
@@ -392,7 +392,7 @@ impl Waiter {
         self.0.await.unwrap().unwrap();
     }
 
-    async fn error(self) -> VmmError {
+    async fn error(self) -> ComputerError {
         self.0.await.unwrap().unwrap_err()
     }
 }
@@ -779,7 +779,7 @@ async fn a_claim_the_machine_refuses_is_answered_wrong_state() {
         })
         .error()
         .await;
-    assert!(matches!(error, VmmError::WrongState { .. }), "{error}");
+    assert!(matches!(error, ComputerError::WrongState { .. }), "{error}");
 
     // ...and a non-forced remove is refused for the same reason.
     let error = harness
@@ -789,7 +789,7 @@ async fn a_claim_the_machine_refuses_is_answered_wrong_state() {
         })
         .error()
         .await;
-    assert!(matches!(error, VmmError::WrongState { .. }), "{error}");
+    assert!(matches!(error, ComputerError::WrongState { .. }), "{error}");
 }
 
 /// A restore that fails is unwound by a force remove, and its caller must not

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
@@ -29,7 +29,7 @@ use crate::sandbox::reconcile::{SandboxStateRecord, write_state_record};
 use crate::sandbox::record::{SandboxProvisionOutcome, SandboxRecordStore};
 use crate::sandbox::workload::WorkloadClaim;
 use crate::sandbox::{
-    CheckpointInfo, ComputerSpec, IdleAction, LifecycleUpdate, SandboxEvent, SandboxState,
+    CheckpointInfo, ComputerEvent, ComputerSpec, ComputerState, IdleAction, LifecycleUpdate,
 };
 use crate::testkit::agent::FakeAgentFactory;
 
@@ -223,7 +223,7 @@ struct Harness {
     registered: Arc<AtomicBool>,
     runtime: crate::lifecycle::runtime::Runtime,
     snapshot: watch::Receiver<ComputerSnapshot>,
-    events: broadcast::Receiver<SandboxEvent>,
+    events: broadcast::Receiver<ComputerEvent>,
     script: Arc<Script>,
     actor: tokio::task::JoinHandle<()>,
     _timers: watch::Sender<bool>,
@@ -260,7 +260,7 @@ impl Harness {
         )));
         let (snapshot_tx, snapshot) = watch::channel(ComputerSnapshot::project(
             &runtime.lock().unwrap(),
-            SandboxState::Starting,
+            ComputerState::Starting,
             deadlines,
         ));
         let (timers, timers_enabled) = watch::channel(true);
@@ -335,11 +335,11 @@ impl Harness {
         })
         .ok()
         .await;
-        self.settled(SandboxState::Ready).await;
+        self.settled(ComputerState::Ready).await;
     }
 
     /// Waits for the snapshot to reach `state`.
-    async fn settled(&mut self, state: SandboxState) {
+    async fn settled(&mut self, state: ComputerState) {
         self.snapshot
             .wait_for(|snapshot| snapshot.state == state)
             .await
@@ -365,7 +365,7 @@ impl Harness {
     }
 
     /// The next event carrying `action`.
-    async fn next_event(&mut self, action: &str) -> SandboxEvent {
+    async fn next_event(&mut self, action: &str) -> ComputerEvent {
         loop {
             let event = self.events.recv().await.expect("the event bus stays open");
             if event.action == action {
@@ -592,7 +592,7 @@ async fn a_failure_keeps_its_crash_journal_when_the_release_fails() {
     harness.script.release_fails.store(true, Ordering::SeqCst);
 
     harness.commands.send(Command::VmExited).unwrap();
-    harness.settled(SandboxState::Failed).await;
+    harness.settled(ComputerState::Failed).await;
     harness.awaited("release").await;
     tokio::task::yield_now().await;
     assert!(
@@ -608,7 +608,7 @@ async fn a_failure_drops_its_crash_journal_once_the_release_is_done() {
     assert!(harness.has_journal());
 
     harness.commands.send(Command::VmExited).unwrap();
-    harness.settled(SandboxState::Failed).await;
+    harness.settled(ComputerState::Failed).await;
     while harness.has_journal() {
         tokio::task::yield_now().await;
     }
@@ -749,7 +749,7 @@ async fn a_stop_during_the_gates_own_cmd_is_still_deferred() {
         })
         .ok()
         .await;
-    harness.settled(SandboxState::Running).await;
+    harness.settled(ComputerState::Running).await;
     let stopped = harness.send(|reply| Command::Stop {
         budget: Duration::from_secs(30),
         reply,
@@ -855,7 +855,7 @@ async fn a_paused_computer_records_what_it_retained() {
     // is the very next thing a client does, and the effects that write those
     // fields run after the transition published the snapshot.
     let snapshot = harness.snapshot.borrow();
-    assert_eq!(snapshot.state, SandboxState::Paused);
+    assert_eq!(snapshot.state, ComputerState::Paused);
     assert_eq!(snapshot.pause_snapshot_id.as_deref(), Some("snap"));
     assert!(snapshot.paused_at.is_some());
 }
@@ -1146,7 +1146,7 @@ async fn a_refused_failure_write_still_releases_and_keeps_the_journal() {
     std::fs::create_dir(&record_path).unwrap();
 
     harness.commands.send(Command::VmExited).unwrap();
-    harness.settled(SandboxState::Failed).await;
+    harness.settled(ComputerState::Failed).await;
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     assert!(

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
@@ -29,7 +29,7 @@ use crate::sandbox::reconcile::{SandboxStateRecord, write_state_record};
 use crate::sandbox::record::{SandboxProvisionOutcome, SandboxRecordStore};
 use crate::sandbox::workload::WorkloadClaim;
 use crate::sandbox::{
-    CheckpointInfo, IdleAction, LifecycleUpdate, SandboxEvent, SandboxSpec, SandboxState,
+    CheckpointInfo, ComputerSpec, IdleAction, LifecycleUpdate, SandboxEvent, SandboxState,
 };
 use crate::testkit::agent::FakeAgentFactory;
 
@@ -254,7 +254,7 @@ impl Harness {
         let (commands, commands_rx) = mpsc::unbounded_channel();
         let runtime = Arc::new(Mutex::new(ComputerRuntime::new(
             "box".to_owned(),
-            SandboxSpec::default(),
+            ComputerSpec::default(),
             None,
             dir.path().to_path_buf(),
         )));
@@ -279,9 +279,9 @@ impl Harness {
                 .provision_intent(
                     "box",
                     "key",
-                    SandboxSpec {
+                    ComputerSpec {
                         id: Some("box".to_owned()),
-                        ..SandboxSpec::default()
+                        ..ComputerSpec::default()
                     },
                 )
                 .unwrap()

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
@@ -25,8 +25,8 @@ use crate::lifecycle::effect::ReleaseScope;
 use crate::lifecycle::event::{PauseReason, Provision, RestoreOrigin};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::lifecycle::tasks::{CaptureSpec, ComputerTasks, Drain, TaskFailure, TaskResult};
-use crate::sandbox::reconcile::{SandboxStateRecord, write_state_record};
-use crate::sandbox::record::{SandboxProvisionOutcome, SandboxRecordStore};
+use crate::sandbox::reconcile::{ComputerStateRecord, write_state_record};
+use crate::sandbox::record::{ComputerProvisionOutcome, ComputerRecordStore};
 use crate::sandbox::workload::WorkloadClaim;
 use crate::sandbox::{
     CheckpointInfo, ComputerEvent, ComputerSpec, ComputerState, IdleAction, LifecycleUpdate,
@@ -155,7 +155,7 @@ impl ComputerTasks for Script {
     async fn restore(
         &self,
         _origin: RestoreOrigin,
-    ) -> TaskResult<(Arc<dyn GuestAgent>, SandboxProvisionOutcome)> {
+    ) -> TaskResult<(Arc<dyn GuestAgent>, ComputerProvisionOutcome)> {
         self.record("restore");
         let takes = *self.restore_takes.lock().unwrap();
         if let Some(takes) = takes {
@@ -167,7 +167,7 @@ impl ComputerTasks for Script {
                 "the checkpoint would not load".into(),
             )));
         }
-        Ok((Arc::clone(&self.agent), SandboxProvisionOutcome::default()))
+        Ok((Arc::clone(&self.agent), ComputerProvisionOutcome::default()))
     }
 
     async fn checkpoint(
@@ -266,10 +266,10 @@ impl Harness {
         let (timers, timers_enabled) = watch::channel(true);
         if journal {
             let config = RuntimeConfig::default();
-            let record = SandboxStateRecord::new("box", None, None, None, &config, None).unwrap();
+            let record = ComputerStateRecord::new("box", None, None, None, &config, None).unwrap();
             write_state_record(dir.path(), &record).unwrap();
         }
-        let records = Arc::new(SandboxRecordStore::new(dir.path()).unwrap());
+        let records = Arc::new(ComputerRecordStore::new(dir.path()).unwrap());
         // No durable record by default: these tests exercise the actor, not
         // the store, so the record writes are no-ops. The crash journal is
         // not — it is a file beside them, and its ordering is the thing
@@ -330,7 +330,7 @@ impl Harness {
     async fn boot_to_ready(&mut self) {
         self.send(|reply| Command::Provision {
             provision: Provision::Boot { warm: false },
-            outcome: SandboxProvisionOutcome::default(),
+            outcome: ComputerProvisionOutcome::default(),
             reply,
         })
         .ok()
@@ -448,7 +448,7 @@ async fn a_force_remove_preempts_a_boot_that_has_handed_its_resources_over() {
     harness
         .send(|reply| Command::Provision {
             provision: Provision::Boot { warm: false },
-            outcome: SandboxProvisionOutcome::default(),
+            outcome: ComputerProvisionOutcome::default(),
             reply,
         })
         .ok()
@@ -474,7 +474,7 @@ async fn a_teardown_stalls_until_the_boot_hands_its_resources_over() {
     harness
         .send(|reply| Command::Provision {
             provision: Provision::Boot { warm: false },
-            outcome: SandboxProvisionOutcome::default(),
+            outcome: ComputerProvisionOutcome::default(),
             reply,
         })
         .ok()
@@ -504,7 +504,7 @@ async fn a_superseded_tasks_completion_cannot_drive_the_machine() {
     // on the handoff at the moment the task signals it and completes.
     let created = harness.send(|reply| Command::Provision {
         provision: Provision::Boot { warm: false },
-        outcome: SandboxProvisionOutcome::default(),
+        outcome: ComputerProvisionOutcome::default(),
         reply,
     });
     let removed = harness.send(|reply| Command::Remove { force: true, reply });
@@ -524,7 +524,7 @@ async fn a_stop_during_a_launch_is_served_once_the_launch_lands() {
     let mut harness = Harness::start(Boot::Completes, no_deadlines()).await;
     let created = harness.send(|reply| Command::Provision {
         provision: Provision::Boot { warm: false },
-        outcome: SandboxProvisionOutcome::default(),
+        outcome: ComputerProvisionOutcome::default(),
         reply,
     });
     let stopped = harness.send(|reply| Command::Stop {
@@ -650,7 +650,7 @@ async fn a_panicked_sub_task_is_reported_rather_than_swallowed() {
     let harness = Harness::start(Boot::HandsOffThenPanics, no_deadlines()).await;
     harness.send(|reply| Command::Provision {
         provision: Provision::Boot { warm: false },
-        outcome: SandboxProvisionOutcome::default(),
+        outcome: ComputerProvisionOutcome::default(),
         reply,
     });
     let error = harness
@@ -679,7 +679,7 @@ async fn a_boot_that_never_handed_off_is_joined_so_its_own_cleanup_finishes() {
     let harness = Harness::start(Boot::DropsHandoffThenCleansUp, no_deadlines()).await;
     harness.send(|reply| Command::Provision {
         provision: Provision::Boot { warm: false },
-        outcome: SandboxProvisionOutcome::default(),
+        outcome: ComputerProvisionOutcome::default(),
         reply,
     });
     // Let the actor observe the dropped signal before the teardown asks.
@@ -708,7 +708,7 @@ async fn a_restore_is_joined_rather_than_aborted() {
         provision: Provision::Restore {
             origin: RestoreOrigin::Restore,
         },
-        outcome: SandboxProvisionOutcome::default(),
+        outcome: ComputerProvisionOutcome::default(),
         reply,
     });
     tokio::task::yield_now().await;
@@ -733,7 +733,7 @@ async fn a_stop_during_the_gates_own_cmd_is_still_deferred() {
     harness
         .send(|reply| Command::Provision {
             provision: Provision::Boot { warm: false },
-            outcome: SandboxProvisionOutcome::default(),
+            outcome: ComputerProvisionOutcome::default(),
             reply,
         })
         .ok()
@@ -810,7 +810,7 @@ async fn a_failed_restore_answers_only_once_its_teardown_has_freed_the_id() {
         provision: Provision::Restore {
             origin: RestoreOrigin::WarmCreate,
         },
-        outcome: SandboxProvisionOutcome::default(),
+        outcome: ComputerProvisionOutcome::default(),
         reply,
     });
 
@@ -1138,7 +1138,7 @@ async fn a_refused_failure_write_still_releases_and_keeps_the_journal() {
     let mut harness = Harness::recorded(Boot::Completes, no_deadlines()).await;
     harness.boot_to_ready().await;
     let journal =
-        SandboxStateRecord::new("box", None, None, None, &RuntimeConfig::default(), None).unwrap();
+        ComputerStateRecord::new("box", None, None, None, &RuntimeConfig::default(), None).unwrap();
     write_state_record(harness.dir.path(), &journal).unwrap();
 
     let record_path = harness.dir.path().join("sandbox-records").join("box.json");

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/actor.rs
@@ -467,7 +467,7 @@ async fn a_force_remove_preempts_a_boot_that_has_handed_its_resources_over() {
 #[tokio::test(start_paused = true)]
 async fn a_teardown_stalls_until_the_boot_hands_its_resources_over() {
     // Aborting before the handoff would strand whatever the task still owns,
-    // so the teardown re-parks the task and retries — `expire_sandbox`'s
+    // so the teardown re-parks the task and retries — `expire_computer`'s
     // backoff loop, collapsed into the actor.
     let handoff_at = Duration::from_secs(25);
     let mut harness = Harness::start(Boot::HandsOffAfter(handoff_at), no_deadlines()).await;
@@ -519,7 +519,7 @@ async fn a_superseded_tasks_completion_cannot_drive_the_machine() {
 
 #[tokio::test(start_paused = true)]
 async fn a_stop_during_a_launch_is_served_once_the_launch_lands() {
-    // Today's `stop_sandbox` answers WrongState here; the actor defers it,
+    // Today's `stop_computer` answers WrongState here; the actor defers it,
     // which is what stops a stop from racing a boot mid-acquisition.
     let mut harness = Harness::start(Boot::Completes, no_deadlines()).await;
     let created = harness.send(|reply| Command::Provision {
@@ -584,7 +584,7 @@ async fn the_idle_window_is_the_actors_own_timer() {
 async fn a_failure_keeps_its_crash_journal_when_the_release_fails() {
     // The journal names exactly the resources a restart would have to
     // reclaim, so it may only go once the release that frees them has
-    // *finished* — `fail_live_sandbox` gates on the write being confirmed
+    // *finished* — `fail_live_computer` gates on the write being confirmed
     // AND the cleanup completing, and so must this.
     let mut harness = Harness::journalled(Boot::Completes, no_deadlines()).await;
     harness.boot_to_ready().await;
@@ -617,7 +617,7 @@ async fn a_failure_drops_its_crash_journal_once_the_release_is_done() {
 #[tokio::test(start_paused = true)]
 async fn a_removal_whose_release_fails_answers_its_caller() {
     // `removing` coalesces the failure, so nothing else ever will — and
-    // `remove_sandbox_impl` hands the release error straight back today.
+    // `remove_computer_impl` hands the release error straight back today.
     let mut harness = Harness::start(Boot::Completes, no_deadlines()).await;
     harness.boot_to_ready().await;
     harness.script.release_fails.store(true, Ordering::SeqCst);
@@ -658,7 +658,7 @@ async fn a_panicked_sub_task_is_reported_rather_than_swallowed() {
         .error()
         .await;
     assert!(error.to_string().contains("panicked"), "{error}");
-    // The teardown stopped where `remove_sandbox_impl` stops — no release —
+    // The teardown stopped where `remove_computer_impl` stops — no release —
     // so the record and its crash journal survive for the startup sweep.
     assert!(!harness.script.calls().contains(&"release"));
 
@@ -830,7 +830,7 @@ async fn a_failed_restore_answers_only_once_its_teardown_has_freed_the_id() {
 /// A paused computer records what it retained where its readers look.
 ///
 /// `Inspect` and `List` size the checkpoint and the disk overlay from the
-/// runtime, and a resume finds its checkpoint there — `pause_sandbox` wrote
+/// runtime, and a resume finds its checkpoint there — `pause_computer` wrote
 /// both at the `Paused` commit, and nothing else does.
 #[tokio::test(start_paused = true)]
 async fn a_paused_computer_records_what_it_retained() {
@@ -890,7 +890,7 @@ async fn an_idle_pause_says_so_on_its_event() {
 /// A record that will not delete stalls the teardown instead of reporting it
 /// done.
 ///
-/// `remove_sandbox_impl` propagates a failed `finish_remove` *before* it drops
+/// `remove_computer_impl` propagates a failed `finish_remove` *before* it drops
 /// its map entry: the record still owns the id, and only a retry that re-runs
 /// the deletion can free it. Unregistering and announcing REMOVED anyway
 /// would leave that id un-creatable — `cancel_pending_or_missing` refuses

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/flows.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/flows.rs
@@ -352,7 +352,7 @@ fn a_user_checkpoint_holds_ready_and_writes_no_record() {
     }
 
     // A recoverable failure returns to Ready without a record write, exactly
-    // as `checkpoint_sandbox` does today — with the idle window restarted,
+    // as `checkpoint_computer` does today — with the idle window restarted,
     // since the expiry swallowed above consumed a one-shot timer.
     let (state, effects) = step(&mut sm, &mut context, &Event::Failure);
     assert_eq!(state.to_public(), ComputerState::Ready);
@@ -563,7 +563,7 @@ fn a_released_claim_reopens_the_computer_and_balances_its_running() {
     assert!(effects.contains(&Effect::ArmTimer(Timer::Idle)));
 }
 
-/// Only a stop that has a workload to drain asks for one. `stop_sandbox`
+/// Only a stop that has a workload to drain asks for one. `stop_computer`
 /// polls for the workload's exit within the budget and skips that poll
 /// entirely when nothing is running — a computer that is merely `Ready`
 /// would otherwise spend the whole budget waiting for an exit that cannot

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/flows.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/flows.rs
@@ -9,7 +9,7 @@ use crate::lifecycle::event::{Event, PauseReason, Provision, RestoreOrigin};
 use crate::lifecycle::machine::State;
 use crate::sandbox::record::PersistPhase;
 use crate::sandbox::workload::WorkloadClaim;
-use crate::sandbox::{IdleAction, SandboxState};
+use crate::sandbox::{ComputerState, IdleAction};
 
 #[test]
 fn a_cold_create_stages_boots_gates_and_only_then_announces_ready() {
@@ -21,7 +21,7 @@ fn a_cold_create_stages_boots_gates_and_only_then_announces_ready() {
         &mut context,
         &Event::Provision(Provision::Boot { warm: true }),
     );
-    assert_eq!(state.to_public(), SandboxState::Starting);
+    assert_eq!(state.to_public(), ComputerState::Starting);
     assert_eq!(
         effects,
         vec![
@@ -43,7 +43,7 @@ fn a_cold_create_stages_boots_gates_and_only_then_announces_ready() {
     // READY is withheld until the gate (warm publish, initial cmd, probe) is
     // through, and its durable commit refuses on an unconfirmed write.
     let (state, effects) = step(&mut sm, &mut context, &Event::Gated);
-    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(state.to_public(), ComputerState::Ready);
     assert_eq!(
         effects,
         vec![
@@ -77,7 +77,7 @@ fn a_restore_commits_ready_in_one_hop_before_its_gate() {
     );
 
     let (state, effects) = step(&mut sm, &mut context, &Event::Restored);
-    assert_eq!(state.to_public(), SandboxState::Starting);
+    assert_eq!(state.to_public(), ComputerState::Starting);
     assert!(matches!(
         state,
         State::Gating {
@@ -104,7 +104,7 @@ fn a_restore_commits_ready_in_one_hop_before_its_gate() {
     // second write would put an fsync on the restore's hot path and could
     // refuse a computer that is already durably `Ready`.
     let (state, effects) = step(&mut sm, &mut context, &Event::Gated);
-    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(state.to_public(), ComputerState::Ready);
     assert_eq!(
         effects,
         vec![
@@ -144,7 +144,7 @@ fn the_boots_own_cmd_claims_the_slot_the_gate_reserved_for_it() {
     // A cmd-carrying boot reads `Running` from here on, exactly as the
     // instance does today — an Inspect during the gate cannot see `Ready`
     // and steal the slot.
-    assert_eq!(state.to_public(), SandboxState::Running);
+    assert_eq!(state.to_public(), ComputerState::Running);
     assert_eq!(effects, vec![Effect::Publish(Notify::Running)]);
 
     // A second initial claim is the same workload twice: refused, for the
@@ -175,7 +175,7 @@ fn the_boots_own_cmd_claims_the_slot_the_gate_reserved_for_it() {
     );
 
     let (state, effects) = step(&mut sm, &mut context, &Event::WorkloadExited);
-    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(state.to_public(), ComputerState::Ready);
     assert_eq!(
         effects,
         vec![Effect::Publish(Notify::Idle), Effect::ArmTimer(Timer::Idle)]
@@ -207,7 +207,7 @@ fn a_workload_round_trip_cancels_and_re_arms_the_idle_timer() {
             claim: WorkloadClaim::Api,
         },
     );
-    assert_eq!(state.to_public(), SandboxState::Running);
+    assert_eq!(state.to_public(), ComputerState::Running);
     assert_eq!(
         effects,
         vec![
@@ -217,7 +217,7 @@ fn a_workload_round_trip_cancels_and_re_arms_the_idle_timer() {
     );
 
     let (state, effects) = step(&mut sm, &mut context, &Event::WorkloadExited);
-    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(state.to_public(), ComputerState::Ready);
     assert_eq!(
         effects,
         vec![Effect::Publish(Notify::Idle), Effect::ArmTimer(Timer::Idle)]
@@ -234,7 +234,7 @@ fn a_pause_captures_releases_and_parks_at_paused() {
             reason: PauseReason::Requested,
         },
     );
-    assert_eq!(state.to_public(), SandboxState::Pausing);
+    assert_eq!(state.to_public(), ComputerState::Pausing);
     assert_eq!(
         effects,
         vec![
@@ -252,13 +252,13 @@ fn a_pause_captures_releases_and_parks_at_paused() {
             snapshot_id: "snap".to_owned(),
         },
     );
-    assert_eq!(state.to_public(), SandboxState::Pausing);
+    assert_eq!(state.to_public(), ComputerState::Pausing);
     assert_eq!(effects, vec![release(ReleaseScope::KeepDisk)]);
 
     // Paused commits only once every runtime resource is gone, and the crash
     // journal is cleared only behind that confirmed write.
     let (state, effects) = step(&mut sm, &mut context, &Event::ReleasedForPause);
-    assert_eq!(state.to_public(), SandboxState::Paused);
+    assert_eq!(state.to_public(), ComputerState::Paused);
     assert_eq!(
         effects,
         vec![
@@ -281,7 +281,7 @@ fn a_recoverable_capture_failure_leaves_a_usable_computer() {
         },
     );
     let (state, effects) = step(&mut sm, &mut context, &Event::Failure);
-    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(state.to_public(), ComputerState::Ready);
     assert_eq!(
         effects,
         vec![
@@ -305,7 +305,7 @@ fn a_frozen_guest_fails_the_computer_from_either_capture_path() {
         };
         step(&mut sm, &mut context, &event);
         let (state, effects) = step(&mut sm, &mut context, &Event::Frozen);
-        assert_eq!(state.to_public(), SandboxState::Failed, "pause={pause}");
+        assert_eq!(state.to_public(), ComputerState::Failed, "pause={pause}");
         assert_eq!(
             effects,
             vec![
@@ -324,7 +324,7 @@ fn a_frozen_guest_fails_the_computer_from_either_capture_path() {
 fn a_user_checkpoint_holds_ready_and_writes_no_record() {
     let (mut sm, mut context) = ready_machine();
     let (state, effects) = step(&mut sm, &mut context, &Event::Checkpoint);
-    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(state.to_public(), ComputerState::Ready);
     assert_eq!(
         effects,
         vec![
@@ -355,7 +355,7 @@ fn a_user_checkpoint_holds_ready_and_writes_no_record() {
     // as `checkpoint_sandbox` does today — with the idle window restarted,
     // since the expiry swallowed above consumed a one-shot timer.
     let (state, effects) = step(&mut sm, &mut context, &Event::Failure);
-    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(state.to_public(), ComputerState::Ready);
     assert_eq!(effects, vec![Effect::ArmTimer(Timer::Idle)]);
 }
 
@@ -365,7 +365,7 @@ fn resume_reverts_to_paused_when_the_restore_unwinds() {
         phase: PersistPhase::Paused,
     }]);
     let (state, effects) = step(&mut sm, &mut context, &Event::Resume);
-    assert_eq!(state.to_public(), SandboxState::Starting);
+    assert_eq!(state.to_public(), ComputerState::Starting);
     assert_eq!(
         effects,
         vec![
@@ -378,7 +378,7 @@ fn resume_reverts_to_paused_when_the_restore_unwinds() {
     );
 
     let (state, effects) = step(&mut sm, &mut context, &Event::Failure);
-    assert_eq!(state.to_public(), SandboxState::Paused);
+    assert_eq!(state.to_public(), ComputerState::Paused);
     assert_eq!(
         effects,
         vec![
@@ -390,7 +390,7 @@ fn resume_reverts_to_paused_when_the_restore_unwinds() {
     // ...and a second attempt still resumes to Ready.
     step(&mut sm, &mut context, &Event::Resume);
     let (state, effects) = step(&mut sm, &mut context, &Event::Restored);
-    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(state.to_public(), ComputerState::Ready);
     assert_eq!(
         effects,
         vec![
@@ -415,7 +415,7 @@ fn a_resume_that_could_not_unwind_fails_instead_of_parking_at_paused() {
         Event::Resume,
     ]);
     let (state, effects) = step(&mut sm, &mut context, &Event::Stranded);
-    assert_eq!(state.to_public(), SandboxState::Failed);
+    assert_eq!(state.to_public(), ComputerState::Failed);
     assert_eq!(
         effects,
         vec![
@@ -439,7 +439,7 @@ fn a_stop_drains_through_stopping_and_clears_the_journal() {
             budget_ms: BUDGET_MS,
         },
     );
-    assert_eq!(state.to_public(), SandboxState::Stopping);
+    assert_eq!(state.to_public(), ComputerState::Stopping);
     assert_eq!(
         effects,
         vec![
@@ -455,11 +455,11 @@ fn a_stop_drains_through_stopping_and_clears_the_journal() {
 
     // The VM exiting is what we asked for, not a failure.
     let (state, effects) = step(&mut sm, &mut context, &Event::VmExited);
-    assert_eq!(state.to_public(), SandboxState::Stopping);
+    assert_eq!(state.to_public(), ComputerState::Stopping);
     assert!(effects.is_empty());
 
     let (state, effects) = step(&mut sm, &mut context, &Event::StopDone);
-    assert_eq!(state.to_public(), SandboxState::Stopped);
+    assert_eq!(state.to_public(), ComputerState::Stopped);
     assert_eq!(
         effects,
         vec![
@@ -535,10 +535,10 @@ fn a_released_claim_reopens_the_computer_and_balances_its_running() {
             claim: WorkloadClaim::Api,
         },
     );
-    assert_eq!(state.to_public(), SandboxState::Running);
+    assert_eq!(state.to_public(), ComputerState::Running);
 
     let (state, effects) = step(&mut sm, &mut context, &Event::WorkloadReleased);
-    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(state.to_public(), ComputerState::Ready);
     assert_eq!(
         effects,
         vec![Effect::Publish(Notify::Idle), Effect::ArmTimer(Timer::Idle)]
@@ -554,12 +554,12 @@ fn a_released_claim_reopens_the_computer_and_balances_its_running() {
             claim: WorkloadClaim::Initial,
         },
     ]);
-    assert_eq!(sm.state().to_public(), SandboxState::Running);
+    assert_eq!(sm.state().to_public(), ComputerState::Running);
     let (state, effects) = step(&mut sm, &mut context, &Event::WorkloadReleased);
-    assert_eq!(state.to_public(), SandboxState::Starting);
+    assert_eq!(state.to_public(), ComputerState::Starting);
     assert_eq!(effects, vec![Effect::Publish(Notify::Idle)]);
     let (state, effects) = step(&mut sm, &mut context, &Event::Gated);
-    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(state.to_public(), ComputerState::Ready);
     assert!(effects.contains(&Effect::ArmTimer(Timer::Idle)));
 }
 
@@ -598,7 +598,7 @@ fn only_a_running_computer_drains_before_its_guest_is_shut_down() {
             budget_ms: BUDGET_MS,
         },
     );
-    assert_eq!(state.to_public(), SandboxState::Stopping);
+    assert_eq!(state.to_public(), ComputerState::Stopping);
     assert!(effects.contains(&Effect::SpawnStop {
         budget_ms: BUDGET_MS,
         drain: true,
@@ -618,7 +618,7 @@ fn a_gate_failure_unwinds_the_way_its_own_half_of_the_transaction_can() {
         Event::AgentReady,
     ]);
     let (state, effects) = step(&mut sm, &mut context, &Event::Failure);
-    assert_eq!(state.to_public(), SandboxState::Failed);
+    assert_eq!(state.to_public(), ComputerState::Failed);
     assert!(effects.contains(&persist(PersistPhase::Failed, Durability::GateJournal)));
 
     let (mut sm, mut context) = reach(&[
@@ -628,7 +628,7 @@ fn a_gate_failure_unwinds_the_way_its_own_half_of_the_transaction_can() {
         Event::Restored,
     ]);
     let (state, effects) = step(&mut sm, &mut context, &Event::Failure);
-    assert_eq!(state.to_public(), SandboxState::Stopping);
+    assert_eq!(state.to_public(), ComputerState::Stopping);
     assert!(matches!(state, State::Removing {}));
     assert!(effects.contains(&persist(PersistPhase::Removing, Durability::Warn)));
     assert!(effects.contains(&release(ReleaseScope::Full)));

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/harness.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/harness.rs
@@ -207,7 +207,7 @@ pub(super) fn explore() -> Vec<Node> {
                         );
                         phase = Some(*next);
                     }
-                    // The one move outside the edge set: `SandboxRecord::
+                    // The one move outside the edge set: `ComputerRecord::
                     // apply` waives it for `ReadyWithOutcome`, and only from
                     // `Creating`, so the machine must never emit it elsewhere.
                     Effect::CommitRestored { .. } => {

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
@@ -1,5 +1,5 @@
 //! The rules that must hold in every state: recovery's seeding, and the gates
-//! `stop_sandbox`, `cleanup::begin_removal` and the two deadline timers apply.
+//! `stop_computer`, `cleanup::begin_removal` and the two deadline timers apply.
 
 use super::harness::{ALL_PHASES, BUDGET_MS, explore, ordinal, reach, ready_machine, step};
 use crate::lifecycle::effect::{
@@ -132,7 +132,7 @@ fn only_ready_and_the_gates_own_cmd_take_the_workload_slot() {
 /// Drives a cold create through to `ready`, discarding effects.
 #[test]
 fn a_stop_only_acts_while_the_guest_serves() {
-    // `stop_sandbox` accepts Ready/Running/Stopping (and retries idempotently
+    // `stop_computer` accepts Ready/Running/Stopping (and retries idempotently
     // from Stopped), answering WrongState elsewhere. Only the first two are a
     // state change, so re-entering `stopping` emits nothing; everything else
     // the machine swallows for the actor to answer.
@@ -290,7 +290,7 @@ fn the_idle_policy_only_fires_on_a_ready_computer() {
 
 /// An idle expiry can only reach a computer that is still idle.
 ///
-/// `expire_sandbox` took a `force` flag for exactly this: the TTL cap
+/// `expire_computer` took a `force` flag for exactly this: the TTL cap
 /// destroys regardless of activity, while the idle detector passed
 /// `force = false` so a non-forced removal would refuse a computer that had
 /// turned busy between the timer firing and the teardown claiming it. The

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/invariants.rs
@@ -10,7 +10,7 @@ use crate::lifecycle::machine::State;
 use crate::sandbox::policy::recovery::{JournalEvidence, RecoveryAction, plan};
 use crate::sandbox::record::PersistPhase;
 use crate::sandbox::workload::WorkloadClaim;
-use crate::sandbox::{IdleAction, SandboxState};
+use crate::sandbox::{ComputerState, IdleAction};
 
 /// `sandbox::policy::recovery::plan`'s verdict for a phase whose journal the
 /// startup sweep tore down — the evidence a seeded machine corresponds to.
@@ -34,12 +34,12 @@ fn recovery_seeds_the_state_its_own_verdict_leaves_behind() {
             // resumes it: the machine stays where a fresh one starts.
             RecoveryAction::LeaveResumable => {
                 assert_eq!(state.durable(), Some(PersistPhase::Creating), "{phase:?}");
-                assert_eq!(state.to_public(), SandboxState::Starting, "{phase:?}");
+                assert_eq!(state.to_public(), ComputerState::Starting, "{phase:?}");
             }
             // Recovery already wrote `Failed`; the machine only adopts it.
             RecoveryAction::Fail => {
                 assert_eq!(state.durable(), Some(PersistPhase::Failed), "{phase:?}");
-                assert_eq!(state.to_public(), SandboxState::Failed, "{phase:?}");
+                assert_eq!(state.to_public(), ComputerState::Failed, "{phase:?}");
             }
             RecoveryAction::Reinstate(public) => {
                 assert_eq!(state.durable(), Some(phase), "{phase:?}");
@@ -76,11 +76,11 @@ fn recovery_seeds_the_state_its_own_verdict_leaves_behind() {
 fn an_adopted_computer_is_seeded_ready_without_a_launch() {
     assert_eq!(
         plan(PersistPhase::Ready, JournalEvidence::Adopted),
-        RecoveryAction::Reinstate(SandboxState::Ready),
+        RecoveryAction::Reinstate(ComputerState::Ready),
     );
     let (sm, mut context) = reach(&[Event::Adopted]);
     let state = *sm.state();
-    assert_eq!(state.to_public(), SandboxState::Ready);
+    assert_eq!(state.to_public(), ComputerState::Ready);
     assert_eq!(state.durable(), Some(PersistPhase::Ready));
 
     // And it is a real `ready`, not a look-alike: it accepts work, pauses,
@@ -93,11 +93,11 @@ fn an_adopted_computer_is_seeded_ready_without_a_launch() {
             claim: WorkloadClaim::Api,
         },
     );
-    assert_eq!(state.to_public(), SandboxState::Running);
+    assert_eq!(state.to_public(), ComputerState::Running);
 }
 
 /// Who may take the single-workload slot, over every state — the rule
-/// `workload::claim_workload` enforced against `SandboxState`.
+/// `workload::claim_workload` enforced against `ComputerState`.
 ///
 /// The two claims differ in exactly one place: the readiness gate holds the
 /// slot for the boot's own `cmd`, and an `Api` claim cannot reach a computer
@@ -115,7 +115,7 @@ fn only_ready_and_the_gates_own_cmd_take_the_workload_slot() {
                 || (claim == WorkloadClaim::Initial
                     && matches!(before, State::Gating { claimed: false, .. }));
             assert_eq!(
-                after.to_public() == SandboxState::Running && !effects.is_empty(),
+                after.to_public() == ComputerState::Running && !effects.is_empty(),
                 allowed,
                 "{before:?} with {claim:?}"
             );
@@ -175,7 +175,7 @@ fn a_non_forced_remove_is_refused_exactly_where_the_computer_is_busy() {
         let (_, effects) = step(&mut sm, &mut context, &Event::Remove { force: false });
         let busy = matches!(
             node.state.to_public(),
-            SandboxState::Starting | SandboxState::Running
+            ComputerState::Starting | ComputerState::Running
         ) || matches!(node.state, State::Removing {} | State::Gone {});
         assert_eq!(
             effects.is_empty(),
@@ -274,7 +274,7 @@ fn the_idle_policy_only_fires_on_a_ready_computer() {
             action: IdleAction::Pause,
         },
     );
-    assert_eq!(state.to_public(), SandboxState::Pausing);
+    assert_eq!(state.to_public(), ComputerState::Pausing);
     assert!(effects.contains(&Effect::Publish(Notify::Pausing)));
 
     let (mut sm, mut context) = ready_machine();

--- a/computer/arcbox-computer-runtime/src/lifecycle/tests/projections.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tests/projections.rs
@@ -1,7 +1,7 @@
 //! Reachability, and the two projections over every leaf.
 
 use super::harness::{LEAVES, explore, ordinal};
-use crate::sandbox::SandboxState;
+use crate::sandbox::ComputerState;
 use crate::sandbox::record::PersistPhase;
 
 #[test]
@@ -28,24 +28,24 @@ fn every_leaf_projects_onto_a_public_state() {
     // one leaf with two answers: the boot's own `cmd` claims the workload
     // slot before READY, and from there a caller reads `Running` — which is
     // what stops an Inspect-polling client from stealing that slot.
-    let expected: [&[SandboxState]; LEAVES] = [
-        &[SandboxState::Starting],                        // provisioning
-        &[SandboxState::Starting],                        // staging
-        &[SandboxState::Starting],                        // booting
-        &[SandboxState::Starting],                        // restoring
-        &[SandboxState::Starting, SandboxState::Running], // gating
-        &[SandboxState::Ready],                           // ready
-        &[SandboxState::Running],                         // running
-        &[SandboxState::Ready],                           // checkpointing
-        &[SandboxState::Pausing],                         // capturing
-        &[SandboxState::Pausing],                         // releasing
-        &[SandboxState::Paused],                          // paused
-        &[SandboxState::Starting],                        // resuming
-        &[SandboxState::Stopping],                        // stopping
-        &[SandboxState::Stopped],                         // stopped
-        &[SandboxState::Failed],                          // failed
-        &[SandboxState::Stopping],                        // removing
-        &[SandboxState::Stopped],                         // gone
+    let expected: [&[ComputerState]; LEAVES] = [
+        &[ComputerState::Starting],                         // provisioning
+        &[ComputerState::Starting],                         // staging
+        &[ComputerState::Starting],                         // booting
+        &[ComputerState::Starting],                         // restoring
+        &[ComputerState::Starting, ComputerState::Running], // gating
+        &[ComputerState::Ready],                            // ready
+        &[ComputerState::Running],                          // running
+        &[ComputerState::Ready],                            // checkpointing
+        &[ComputerState::Pausing],                          // capturing
+        &[ComputerState::Pausing],                          // releasing
+        &[ComputerState::Paused],                           // paused
+        &[ComputerState::Starting],                         // resuming
+        &[ComputerState::Stopping],                         // stopping
+        &[ComputerState::Stopped],                          // stopped
+        &[ComputerState::Failed],                           // failed
+        &[ComputerState::Stopping],                         // removing
+        &[ComputerState::Stopped],                          // gone
     ];
     for node in explore() {
         let public = node.state.to_public();

--- a/computer/arcbox-computer-runtime/src/rootfs.rs
+++ b/computer/arcbox-computer-runtime/src/rootfs.rs
@@ -30,7 +30,7 @@ use arcbox_snapshot::snapshot_cow::BlockTools;
 use tokio::process::Command;
 use uuid::Uuid;
 
-use crate::error::VmmError;
+use crate::error::ComputerError;
 
 /// Capacity of the default busybox rootfs image. The image file is written
 /// sparsely; per-sandbox writes land in the dm-snapshot COW overlay, so this
@@ -86,8 +86,8 @@ impl RootfsBuilder {
     }
 }
 
-fn rootfs_err(error: anyhow::Error) -> VmmError {
-    VmmError::Rootfs(format!("{error:#}"))
+fn rootfs_err(error: anyhow::Error) -> ComputerError {
+    ComputerError::Rootfs(format!("{error:#}"))
 }
 
 /// Check if a file has a valid ext4 superblock magic (0x53EF at offset 0x438).

--- a/computer/arcbox-computer-runtime/src/rootfs.rs
+++ b/computer/arcbox-computer-runtime/src/rootfs.rs
@@ -123,7 +123,7 @@ impl RootfsBuilder {
     ///
     /// `pinned` are images that must survive the superseded-image sweep
     /// because a snapshot still needs them as its dm-snapshot origin
-    /// (`SandboxManager::pinned_rootfs_paths`).
+    /// (`ComputerManager::pinned_rootfs_paths`).
     ///
     /// Returns the path to the generated (or cached) ext4 image.
     pub async fn convert_layer_to_rootfs(

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -94,7 +94,7 @@ pub(crate) type Computers = Arc<RwLock<HashMap<ComputerId, ComputerRef>>>;
 /// Manages the full lifecycle of multiple sandbox microVMs.
 pub struct SandboxManager {
     computers: Computers,
-    records: Arc<record::SandboxRecordStore>,
+    records: Arc<record::ComputerRecordStore>,
     /// What every computer's flows are built from — the driver, the guest
     /// network, the agent factory, the record store, the catalogs and the
     /// pool. One `Arc`, cloned into each actor.
@@ -182,7 +182,7 @@ impl SandboxManager {
                 )));
             }
         }
-        let records = Arc::new(record::SandboxRecordStore::new(Path::new(
+        let records = Arc::new(record::ComputerRecordStore::new(Path::new(
             &config.firecracker.data_dir,
         ))?);
         drop(records.load_all()?);
@@ -672,7 +672,7 @@ pub(crate) fn catalogued_checkpoint(meta: &SnapshotMeta) -> Result<CheckpointIma
 /// site. On the sweep path it costs that record its reconciliation — the
 /// journal is skipped rather than acted on, and every resource it names
 /// is held (`reconcile::sweep_orphans`). On a record *load* it costs
-/// every record theirs: [`SandboxRecordStore::load_all`] validates each
+/// every record theirs: [`ComputerRecordStore::load_all`] validates each
 /// id and propagates, so one rejection aborts the whole startup read,
 /// which is the stronger reason the cap is absent. It also runs against
 /// snapshot / execution ids that never become a VM identity at all. Both

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -1,11 +1,11 @@
-//! `SandboxManager` — orchestrates sandbox microVM lifecycle.
+//! `ComputerManager` — orchestrates sandbox microVM lifecycle.
 //!
 //! A sandbox is a short-lived, strongly-isolated microVM decoupled from its
 //! workload: when the initial `cmd` process exits the sandbox transitions back
 //! to `Ready` rather than stopping, and continues accepting `Run` calls until
 //! an explicit `Stop`/`Remove` or TTL expiry.
 //!
-//! `create_sandbox` returns immediately with state `"starting"`.  The VM boots
+//! `create_computer` returns immediately with state `"starting"`.  The VM boots
 //! in a background task which broadcasts a `"ready"` event on success.
 
 use std::collections::HashMap;
@@ -80,7 +80,7 @@ type ReconcileResult = std::result::Result<(), Arc<str>>;
 /// What replaced `Arc<Mutex<ComputerRuntime>>`. Every verb is a send on the
 /// mailbox and every read is a borrow of the snapshot, so neither the map
 /// lock nor a per-computer mutex is ever held across an await — the
-/// discipline `list_sandboxes` used to have to state.
+/// discipline `list_computers` used to have to state.
 #[derive(Clone)]
 pub(crate) struct ComputerRef {
     mailbox: Mailbox,
@@ -92,7 +92,7 @@ pub(crate) struct ComputerRef {
 pub(crate) type Computers = Arc<RwLock<HashMap<ComputerId, ComputerRef>>>;
 
 /// Manages the full lifecycle of multiple sandbox microVMs.
-pub struct SandboxManager {
+pub struct ComputerManager {
     computers: Computers,
     records: Arc<record::ComputerRecordStore>,
     /// What every computer's flows are built from — the driver, the guest
@@ -122,7 +122,7 @@ pub struct SandboxManager {
     timers_enabled: tokio::sync::watch::Sender<bool>,
 }
 
-impl SandboxManager {
+impl ComputerManager {
     /// Create a new manager from the given configuration, over the
     /// environment-specific components the composer supplies.
     ///
@@ -475,7 +475,7 @@ impl SandboxManager {
     /// before asking. The gate this used to take could therefore only ever
     /// have fired for a sandbox that has no lease to report anyway, and it
     /// has no non-blocking form on the port.
-    pub fn sandbox_network_identity(&self, id: &str) -> Result<ComputerNetworkIdentity> {
+    pub fn computer_network_identity(&self, id: &str) -> Result<ComputerNetworkIdentity> {
         let snapshot = self.snapshot(&id.to_owned())?;
         let lease = snapshot
             .lease
@@ -541,7 +541,7 @@ pub(super) fn netmask(prefix_len: u8) -> std::net::Ipv4Addr {
 
 /// The connectivity every sandbox gets: egress through the host's address,
 /// which is what the System VM's netfilter provides for the pool.
-pub(super) const fn sandbox_network_policy() -> NetworkPolicy {
+pub(super) const fn computer_network_policy() -> NetworkPolicy {
     NetworkPolicy {
         mode: NetworkMode::Nat,
     }
@@ -575,25 +575,25 @@ pub struct ComputerNetworkIdentity {
     pub expose: HostIngress,
 }
 
-/// The guest network's cleanup protocol, which [`SandboxManager::new`]
+/// The guest network's cleanup protocol, which [`ComputerManager::new`]
 /// requires — the quarantine ledger gates every address the pool hands
 /// out, and the startup sweep gates the pool itself.
 pub(super) fn reconcile_capability(network: &dyn GuestNetwork) -> &dyn NetworkReconcile {
     network
         .reconcile()
-        .expect("SandboxManager::new requires the guest network's reconcile capability")
+        .expect("ComputerManager::new requires the guest network's reconcile capability")
 }
 
-/// The driver's `Prepare` capability, which [`SandboxManager::new`]
+/// The driver's `Prepare` capability, which [`ComputerManager::new`]
 /// requires — the boot, pool, and restore flows all spawn the VMM before
 /// there is a guest to run on it.
 pub(crate) fn prepare_capability(driver: &dyn VmDriver) -> &dyn Prepare {
     driver
         .prepare()
-        .expect("SandboxManager::new requires the driver's Prepare capability")
+        .expect("ComputerManager::new requires the driver's Prepare capability")
 }
 
-/// A grip's `Staging` capability, which [`SandboxManager::new`] requires —
+/// A grip's `Staging` capability, which [`ComputerManager::new`] requires —
 /// every flow that puts a guest on a VMM first brings that guest's files
 /// into the area the VMM can reach, and pause takes its disk back out of
 /// it.
@@ -603,7 +603,7 @@ pub(crate) fn prepare_capability(driver: &dyn VmDriver) -> &dyn Prepare {
 /// booted here asks its [`PreparedVm`] and one this process adopted asks
 /// its [`VmHandle`](arcbox_vm_driver::VmHandle).
 pub(crate) fn staging_capability(staging: Option<&dyn Staging>) -> &dyn Staging {
-    staging.expect("SandboxManager::new requires the driver's Staging capability")
+    staging.expect("ComputerManager::new requires the driver's Staging capability")
 }
 
 /// The VMM's pid as the crash journal records it: what a restart sweep
@@ -665,7 +665,7 @@ pub(crate) fn catalogued_checkpoint(meta: &SnapshotMeta) -> Result<CheckpointIma
 /// restricted to `[A-Za-z0-9_-]`. This rejects path traversal (`/`, `\`, `..`),
 /// NUL and whitespace. The narrower rule a VMM imposes on the id it runs under
 /// is *not* checked here — that is [`VmId`]'s, applied by
-/// [`validate_new_sandbox_id`] where an id becomes a VM identity.
+/// [`validate_new_computer_id`] where an id becomes a VM identity.
 ///
 /// Deliberately NO length cap here: this also runs against persisted
 /// records, and what one legacy over-long id would cost differs by call
@@ -677,7 +677,7 @@ pub(crate) fn catalogued_checkpoint(meta: &SnapshotMeta) -> Result<CheckpointIma
 /// which is the stronger reason the cap is absent. It also runs against
 /// snapshot / execution ids that never become a VM identity at all. Both
 /// limits the driver imposes are enforced only where a sandbox id enters
-/// the system: [`validate_new_sandbox_id`].
+/// the system: [`validate_new_computer_id`].
 ///
 /// The gap between this alphabet and [`VmId`]'s is not academic: `_` is
 /// legal here and is not a `VmId`, so every record a pre-#680 process
@@ -719,7 +719,7 @@ pub(super) fn validate_id(kind: &str, id: &str) -> Result<()> {
 /// every attempt while the VMM is up and bound inside its chroot; caught
 /// by the CORE-107 prewarm e2e, whose 51-char builder id overflowed the
 /// stock budget).
-pub(super) fn validate_new_sandbox_id(
+pub(super) fn validate_new_computer_id(
     id: &str,
     driver: &dyn VmDriver,
     config: &RuntimeConfig,
@@ -873,7 +873,7 @@ impl Drop for ActorReservation {
 
 /// Everything an actor needs that the reservation does not already hold.
 ///
-/// Assembled from the manager's own pieces rather than from `&SandboxManager`
+/// Assembled from the manager's own pieces rather than from `&ComputerManager`
 /// so the startup sweep can seed actors too: it runs in a task spawned from
 /// the constructor, before the manager it belongs to exists.
 pub(crate) struct ActorSpawn {
@@ -962,14 +962,14 @@ mod tests {
             ),
         ] {
             let driver = FakeDriver::builder().capabilities(capabilities).build();
-            let error = SandboxManager::new(config.clone(), environment(driver))
+            let error = ComputerManager::new(config.clone(), environment(driver))
                 .err()
                 .unwrap_or_else(|| panic!("a driver without {name} is refused"));
             assert!(matches!(error, ComputerError::Config(_)), "{error}");
             assert!(error.to_string().contains(name), "{error}");
         }
 
-        let manager = SandboxManager::new(config.clone(), environment(FakeDriver::new()))
+        let manager = ComputerManager::new(config.clone(), environment(FakeDriver::new()))
             .expect("a driver with every needed capability is accepted");
         assert_eq!(manager.services.driver.name(), "fake");
     }
@@ -1038,23 +1038,23 @@ mod tests {
     /// constants in `arcbox-fc-driver`
     /// (`the_deployed_jail_layout_admits_the_ids_a_node_mints`).
     #[test]
-    fn a_new_sandbox_id_is_held_to_the_drivers_own_budget() {
+    fn a_new_computer_id_is_held_to_the_drivers_own_budget() {
         let mut config = jailed_config();
         let budget = CONTROL_PLANE_ID.len();
         let driver = FakeDriver::builder().jailed_id_budget(budget).build();
-        assert!(validate_new_sandbox_id(CONTROL_PLANE_ID, &driver, &config).is_ok());
-        assert!(validate_new_sandbox_id(&"a".repeat(budget), &driver, &config).is_ok());
-        assert!(validate_new_sandbox_id(&"a".repeat(budget + 1), &driver, &config).is_err());
+        assert!(validate_new_computer_id(CONTROL_PLANE_ID, &driver, &config).is_ok());
+        assert!(validate_new_computer_id(&"a".repeat(budget), &driver, &config).is_ok());
+        assert!(validate_new_computer_id(&"a".repeat(budget + 1), &driver, &config).is_err());
 
         // A tighter budget refuses what the looser one took, rather than
         // silently reintroducing the connect timeout.
         let tighter = FakeDriver::builder().jailed_id_budget(budget - 1).build();
-        assert!(validate_new_sandbox_id(CONTROL_PLANE_ID, &tighter, &config).is_err());
+        assert!(validate_new_computer_id(CONTROL_PLANE_ID, &tighter, &config).is_err());
 
         // A driver that reports no budget for this isolation bounds
         // nothing: only `VmId`'s own 64-byte ceiling is left.
         config.firecracker.jailer = None;
-        assert!(validate_new_sandbox_id(&"a".repeat(budget + 1), &tighter, &config).is_ok());
+        assert!(validate_new_computer_id(&"a".repeat(budget + 1), &tighter, &config).is_ok());
     }
 
     /// CORE-140. Firecracker validates the `--id` it is handed and refuses it
@@ -1069,13 +1069,13 @@ mod tests {
             .build();
         for _ in 0..2 {
             let error =
-                validate_new_sandbox_id(&CONTROL_PLANE_ID.replacen('-', "_", 1), &driver, &config)
+                validate_new_computer_id(&CONTROL_PLANE_ID.replacen('-', "_", 1), &driver, &config)
                     .expect_err("firecracker would refuse to run under this id");
             assert!(
                 matches!(&error, ComputerError::Config(message) if message.contains('_')),
                 "the error should name the offending character, got {error}"
             );
-            assert!(validate_new_sandbox_id(CONTROL_PLANE_ID, &driver, &config).is_ok());
+            assert!(validate_new_computer_id(CONTROL_PLANE_ID, &driver, &config).is_ok());
             // Direct mode passes the same `--id`, so it is refused there too.
             config.firecracker.jailer = None;
         }

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -66,9 +66,9 @@ pub use pause::reason as pause_reason;
 pub(crate) use spec::ROOTFS_DISK_ID;
 pub(crate) use types::NetworkAttachment;
 pub use types::{
-    CheckpointInfo, CheckpointSummary, ComputerId, ComputerMountSpec, ComputerNetworkInfo,
-    ComputerNetworkSpec, ComputerSpec, IdleAction, LifecycleUpdate, RestoreComputerSpec,
-    SandboxEvent, SandboxInfo, SandboxState, SandboxSummary, TemplateWarmRef,
+    CheckpointInfo, CheckpointSummary, ComputerEvent, ComputerId, ComputerInfo, ComputerMountSpec,
+    ComputerNetworkInfo, ComputerNetworkSpec, ComputerSpec, ComputerState, ComputerSummary,
+    IdleAction, LifecycleUpdate, RestoreComputerSpec, TemplateWarmRef,
 };
 
 const EVENT_CHANNEL_CAPACITY: usize = 256;
@@ -103,7 +103,7 @@ pub struct SandboxManager {
     /// Template catalog (CORE-107); see `templates.rs` for the manager surface.
     templates: Arc<TemplateCatalog>,
     config: Arc<RuntimeConfig>,
-    events_tx: broadcast::Sender<SandboxEvent>,
+    events_tx: broadcast::Sender<ComputerEvent>,
     cow_manager: Arc<CowManager>,
     /// Pre-warmed restore slots (CORE-78); see `pool.rs`.
     pool: Arc<pool::SlotPool>,
@@ -767,7 +767,7 @@ pub(crate) fn reserve_actor(
     let runtime = Arc::new(Mutex::new(runtime));
     let (snapshot_tx, snapshot) = tokio::sync::watch::channel(ComputerSnapshot::project(
         &runtime.lock().unwrap(),
-        SandboxState::Starting,
+        ComputerState::Starting,
         Deadlines::default(),
     ));
     map.insert(

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -66,9 +66,9 @@ pub use pause::reason as pause_reason;
 pub(crate) use spec::ROOTFS_DISK_ID;
 pub(crate) use types::NetworkAttachment;
 pub use types::{
-    CheckpointInfo, CheckpointSummary, IdleAction, LifecycleUpdate, RestoreSandboxSpec,
-    SandboxEvent, SandboxId, SandboxInfo, SandboxMountSpec, SandboxNetworkInfo, SandboxNetworkSpec,
-    SandboxSpec, SandboxState, SandboxSummary, TemplateWarmRef,
+    CheckpointInfo, CheckpointSummary, ComputerId, ComputerMountSpec, ComputerNetworkInfo,
+    ComputerNetworkSpec, ComputerSpec, IdleAction, LifecycleUpdate, RestoreComputerSpec,
+    SandboxEvent, SandboxInfo, SandboxState, SandboxSummary, TemplateWarmRef,
 };
 
 const EVENT_CHANNEL_CAPACITY: usize = 256;
@@ -89,7 +89,7 @@ pub(crate) struct ComputerRef {
 }
 
 /// The live computers, by id.
-pub(crate) type Computers = Arc<RwLock<HashMap<SandboxId, ComputerRef>>>;
+pub(crate) type Computers = Arc<RwLock<HashMap<ComputerId, ComputerRef>>>;
 
 /// Manages the full lifecycle of multiple sandbox microVMs.
 pub struct SandboxManager {
@@ -333,7 +333,7 @@ impl SandboxManager {
     }
 
     /// This computer's registry entry.
-    pub(super) fn computer(&self, id: &SandboxId) -> Result<ComputerRef> {
+    pub(super) fn computer(&self, id: &ComputerId) -> Result<ComputerRef> {
         self.check_reconcile()?;
         self.computers
             .read()
@@ -344,12 +344,12 @@ impl SandboxManager {
     }
 
     /// This computer's mailbox.
-    pub(super) fn mailbox(&self, id: &SandboxId) -> Result<Mailbox> {
+    pub(super) fn mailbox(&self, id: &ComputerId) -> Result<Mailbox> {
         Ok(self.computer(id)?.mailbox)
     }
 
     /// What a read of this computer sees, without touching its mailbox.
-    pub(super) fn snapshot(&self, id: &SandboxId) -> Result<ComputerSnapshot> {
+    pub(super) fn snapshot(&self, id: &ComputerId) -> Result<ComputerSnapshot> {
         Ok(self.computer(id)?.snapshot.borrow().clone())
     }
 
@@ -475,7 +475,7 @@ impl SandboxManager {
     /// before asking. The gate this used to take could therefore only ever
     /// have fired for a sandbox that has no lease to report anyway, and it
     /// has no non-blocking form on the port.
-    pub fn sandbox_network_identity(&self, id: &str) -> Result<SandboxNetworkIdentity> {
+    pub fn sandbox_network_identity(&self, id: &str) -> Result<ComputerNetworkIdentity> {
         let snapshot = self.snapshot(&id.to_owned())?;
         let lease = snapshot
             .lease
@@ -485,7 +485,7 @@ impl SandboxManager {
                 expected: "sandbox with an active network allocation".into(),
                 actual: snapshot.state.to_string(),
             })?;
-        Ok(SandboxNetworkIdentity {
+        Ok(ComputerNetworkIdentity {
             ip: lease.ipv4()?,
             cleanup_token: lease.cleanup_token.clone(),
             expose: self.services.network.host_ingress(lease)?,
@@ -561,7 +561,7 @@ pub(super) const fn attach_mode(net_invariant: bool) -> AttachMode {
 
 /// A sandbox's network identity as seen by forwarding and DNS consumers.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SandboxNetworkIdentity {
+pub struct ComputerNetworkIdentity {
     /// External pool IP — the address the rest of the system keeps using.
     pub ip: std::net::Ipv4Addr,
     /// Opaque generation token carried through host cleanup finalization.
@@ -755,7 +755,7 @@ pub(super) fn validate_new_sandbox_id(
 /// error path unwinds it.
 pub(crate) fn reserve_actor(
     computers: &Computers,
-    id: &SandboxId,
+    id: &ComputerId,
     runtime: ComputerRuntime,
 ) -> Result<ActorReservation> {
     let mut map = computers.write().unwrap();
@@ -796,7 +796,7 @@ pub(crate) fn reserve_actor(
 /// sender goes with it, so an actor already running would stop too.
 pub(crate) struct ActorReservation {
     computers: Computers,
-    id: SandboxId,
+    id: ComputerId,
     incarnation: Uuid,
     runtime: Runtime,
     mailbox: Mailbox,
@@ -891,7 +891,7 @@ pub(crate) struct ActorSpawn {
 /// needed: a computer removed and re-created under the same id (deterministic
 /// caller-supplied ids make this common) installs a fresh entry, and the
 /// departing actor must not evict it.
-fn forget_computer(computers: &Computers, id: &SandboxId, incarnation: Uuid) {
+fn forget_computer(computers: &Computers, id: &ComputerId, incarnation: Uuid) {
     let mut map = computers.write().unwrap();
     if map
         .get(id)
@@ -910,7 +910,7 @@ mod tests {
     fn placeholder(id: &str) -> ComputerRuntime {
         ComputerRuntime::new(
             id.to_owned(),
-            SandboxSpec::default(),
+            ComputerSpec::default(),
             None,
             PathBuf::from("/tmp/x"),
         )

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -1,4 +1,4 @@
-//! `ComputerManager` — orchestrates sandbox microVM lifecycle.
+//! `ComputerManager` — orchestrates the lifecycle of computer microVMs.
 //!
 //! A sandbox is a short-lived, strongly-isolated microVM decoupled from its
 //! workload: when the initial `cmd` process exits the sandbox transitions back

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -30,7 +30,7 @@ use crate::agent::{ExecInputMsg, ExitStatus, OutputChunk, PortWait, StartCommand
 use crate::agent::{GuestAgent, Readiness};
 use crate::config::RuntimeConfig;
 use crate::environment::NodeEnvironment;
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::lifecycle::actor::{
     Command, ComputerActor, ComputerSeed, ComputerSnapshot, Deadlines, Mailbox, Seeded,
 };
@@ -126,7 +126,7 @@ impl SandboxManager {
     /// Create a new manager from the given configuration, over the
     /// environment-specific components the composer supplies.
     ///
-    /// Fails with [`VmmError::Config`] when the environment's driver lacks a
+    /// Fails with [`ComputerError::Config`] when the environment's driver lacks a
     /// capability every sandbox needs — `Prepare` (the flows spawn the VMM
     /// ahead of the guest), `Staging` (every flow brings its computer's
     /// files into the area the VMM can reach), `Vsock` (the guest agent is
@@ -176,7 +176,7 @@ impl SandboxManager {
             ),
         ] {
             if missing {
-                return Err(VmmError::Config(format!(
+                return Err(ComputerError::Config(format!(
                     "VM driver `{}` has no {capability} capability; {need}",
                     driver.name()
                 )));
@@ -187,7 +187,7 @@ impl SandboxManager {
         ))?);
         drop(records.load_all()?);
         if network.reconcile().is_none() {
-            return Err(VmmError::Config(
+            return Err(ComputerError::Config(
                 "guest network has no reconcile capability; the quarantine ledger is how a host \
                  releases the addresses a previous process held"
                     .into(),
@@ -266,7 +266,7 @@ impl SandboxManager {
                     reconcile::seed_computers(inactive, &computers, &services, &timers_gate);
                     reconcile::finalize_sweep(swept).await?;
                     reconcile_capability(&*network).replay_complete();
-                    Ok::<_, VmmError>(())
+                    Ok::<_, ComputerError>(())
                 }
                 .await
                 .map_err(|error| Arc::<str>::from(error.to_string()));
@@ -340,7 +340,7 @@ impl SandboxManager {
             .unwrap()
             .get(id)
             .cloned()
-            .ok_or_else(|| VmmError::NotFound(id.clone()))
+            .ok_or_else(|| ComputerError::NotFound(id.clone()))
     }
 
     /// This computer's mailbox.
@@ -367,11 +367,13 @@ impl SandboxManager {
         let result = rx
             .wait_for(Option::is_some)
             .await
-            .map_err(|error| VmmError::Other(format!("sandbox reconciliation stopped: {error}")))?
+            .map_err(|error| {
+                ComputerError::Other(format!("sandbox reconciliation stopped: {error}"))
+            })?
             .clone()
             .expect("wait_for returned only after reconciliation completed");
         result.map_err(|error| {
-            VmmError::Other(format!(
+            ComputerError::Other(format!(
                 "sandbox durable-state reconciliation failed: {error}"
             ))
         })
@@ -380,11 +382,11 @@ impl SandboxManager {
     fn check_reconcile(&self) -> Result<()> {
         let result = self.reconcile_done.borrow().clone();
         match result {
-            None => Err(VmmError::Other(
+            None => Err(ComputerError::Other(
                 "sandbox durable-state reconciliation is still running".into(),
             )),
             Some(Ok(())) => Ok(()),
-            Some(Err(error)) => Err(VmmError::Other(format!(
+            Some(Err(error)) => Err(ComputerError::Other(format!(
                 "sandbox durable-state reconciliation failed: {error}"
             ))),
         }
@@ -398,7 +400,7 @@ impl SandboxManager {
             .reconcile_network()
             .pending_cleanups()
             .await
-            .map_err(VmmError::from)?
+            .map_err(ComputerError::from)?
             .into_iter()
             .map(|(vm, token)| (vm.as_str().to_owned(), token))
             .collect())
@@ -478,7 +480,7 @@ impl SandboxManager {
         let lease = snapshot
             .lease
             .as_ref()
-            .ok_or_else(|| VmmError::WrongState {
+            .ok_or_else(|| ComputerError::WrongState {
                 id: id.to_owned(),
                 expected: "sandbox with an active network allocation".into(),
                 actual: snapshot.state.to_string(),
@@ -520,7 +522,7 @@ impl LeaseExt for NetworkLease {
 pub(super) fn ipv4(address: std::net::IpAddr) -> Result<std::net::Ipv4Addr> {
     match address {
         std::net::IpAddr::V4(v4) => Ok(v4),
-        std::net::IpAddr::V6(v6) => Err(VmmError::Network(format!(
+        std::net::IpAddr::V6(v6) => Err(ComputerError::Network(format!(
             "the guest network offered {v6}; this manager's sandboxes are IPv4-only"
         ))),
     }
@@ -644,7 +646,7 @@ pub(crate) fn preserved_cow_file(config: &RuntimeConfig, id: &str) -> PathBuf {
 /// recorded at capture; legacy entries default to the Firecracker format.
 pub(crate) fn catalogued_checkpoint(meta: &SnapshotMeta) -> Result<CheckpointImage> {
     let dir = meta.vmstate_path.parent().ok_or_else(|| {
-        VmmError::Snapshot(format!(
+        ComputerError::Snapshot(format!(
             "checkpoint {} records a vmstate at {}, which is in no directory",
             meta.id,
             meta.vmstate_path.display()
@@ -683,13 +685,13 @@ pub(crate) fn catalogued_checkpoint(meta: &SnapshotMeta) -> Result<CheckpointIma
 /// is exactly what the sweep and the quarantine ledger read back.
 pub(super) fn validate_id(kind: &str, id: &str) -> Result<()> {
     if id.is_empty() {
-        return Err(VmmError::Config(format!("{kind} must not be empty")));
+        return Err(ComputerError::Config(format!("{kind} must not be empty")));
     }
     if !id
         .bytes()
         .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
     {
-        return Err(VmmError::Config(format!(
+        return Err(ComputerError::Config(format!(
             "invalid {kind} {id:?}: only ASCII letters, digits, '-' and '_' are allowed"
         )));
     }
@@ -726,7 +728,7 @@ pub(super) fn validate_new_sandbox_id(
     if let Some(budget) = driver.id_budget(&isolation_spec(config)?)
         && id.len() > budget
     {
-        return Err(VmmError::Config(format!(
+        return Err(ComputerError::Config(format!(
             "invalid sandbox id {id:?}: at most {budget} characters under this \
              driver's layout (its sockets must fit the AF_UNIX path limit)"
         )));
@@ -758,7 +760,7 @@ pub(crate) fn reserve_actor(
 ) -> Result<ActorReservation> {
     let mut map = computers.write().unwrap();
     if map.contains_key(id) {
-        return Err(VmmError::AlreadyExists(id.clone()));
+        return Err(ComputerError::AlreadyExists(id.clone()));
     }
     let incarnation = Uuid::new_v4();
     let (mailbox_tx, commands) = tokio::sync::mpsc::unbounded_channel();
@@ -963,7 +965,7 @@ mod tests {
             let error = SandboxManager::new(config.clone(), environment(driver))
                 .err()
                 .unwrap_or_else(|| panic!("a driver without {name} is refused"));
-            assert!(matches!(error, VmmError::Config(_)), "{error}");
+            assert!(matches!(error, ComputerError::Config(_)), "{error}");
             assert!(error.to_string().contains(name), "{error}");
         }
 
@@ -980,7 +982,7 @@ mod tests {
         // before either touches the per-id resources they both derive.
         assert!(matches!(
             reserve_actor(&computers, &"dup".to_owned(), placeholder("dup")),
-            Err(VmmError::AlreadyExists(_))
+            Err(ComputerError::AlreadyExists(_))
         ));
         drop(first);
         assert!(!computers.read().unwrap().contains_key("dup"));
@@ -1070,7 +1072,7 @@ mod tests {
                 validate_new_sandbox_id(&CONTROL_PLANE_ID.replacen('-', "_", 1), &driver, &config)
                     .expect_err("firecracker would refuse to run under this id");
             assert!(
-                matches!(&error, VmmError::Config(message) if message.contains('_')),
+                matches!(&error, ComputerError::Config(message) if message.contains('_')),
                 "the error should name the offending character, got {error}"
             );
             assert!(validate_new_sandbox_id(CONTROL_PLANE_ID, &driver, &config).is_ok());
@@ -1107,7 +1109,7 @@ mod tests {
 
         assert!(matches!(
             reserve_actor(&computers, &"same".to_owned(), placeholder("same")),
-            Err(VmmError::AlreadyExists(_))
+            Err(ComputerError::AlreadyExists(_))
         ));
         forget_computer(&computers, &"same".to_owned(), incarnation);
         let replacement = reserve_actor(&computers, &"same".to_owned(), placeholder("same"))

--- a/computer/arcbox-computer-runtime/src/sandbox/boot.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/boot.rs
@@ -38,7 +38,7 @@ pub async fn run_ready_probe(
             .await?
         {
             PortWait::Listening => Ok(()),
-            PortWait::Deadline => Err(VmmError::DeadlineExceeded(format!(
+            PortWait::Deadline => Err(ComputerError::DeadlineExceeded(format!(
                 "no listener on port {port} within the ready-probe deadline"
             ))),
         },
@@ -58,7 +58,7 @@ pub async fn run_ready_probe(
                 // this await forever.
                 let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
                 if remaining.is_zero() {
-                    return Err(VmmError::DeadlineExceeded(format!(
+                    return Err(ComputerError::DeadlineExceeded(format!(
                         "ready-probe command did not exit 0 within the deadline ({})",
                         last_status.as_deref().unwrap_or("no attempt completed")
                     )));
@@ -73,14 +73,14 @@ pub async fn run_ready_probe(
                     Ok(Ok(status)) => last_status = Some(format!("last exit: {status:?}")),
                     Ok(Err(error)) => last_status = Some(format!("last error: {error}")),
                     Err(_) => {
-                        return Err(VmmError::DeadlineExceeded(format!(
+                        return Err(ComputerError::DeadlineExceeded(format!(
                             "ready-probe command did not exit within the deadline ({})",
                             last_status.as_deref().unwrap_or("no attempt completed")
                         )));
                     }
                 }
                 if tokio::time::Instant::now() >= deadline {
-                    return Err(VmmError::DeadlineExceeded(format!(
+                    return Err(ComputerError::DeadlineExceeded(format!(
                         "ready-probe command did not exit 0 within the deadline ({})",
                         last_status.as_deref().unwrap_or("no attempt completed")
                     )));
@@ -115,7 +115,7 @@ async fn run_probe_command(
             return Ok(status);
         }
     }
-    Err(VmmError::Vsock(
+    Err(ComputerError::Vsock(
         "probe command stream ended without an exit status".into(),
     ))
 }
@@ -123,7 +123,7 @@ async fn run_probe_command(
 /// A failed restore-staging step, carrying whichever CoW resources were
 /// acquired before the failure so the caller can roll them back.
 pub struct StageError {
-    pub error: VmmError,
+    pub error: ComputerError,
     pub cow_handle: Option<CowHandle>,
 }
 
@@ -158,12 +158,13 @@ pub async fn stage_rootfs_cow_or_copy(
     rootfs: &str,
     journal: &(dyn Fn(Option<&CowHandle>) -> Result<()> + Sync),
 ) -> std::result::Result<StagedRootfs, StageError> {
-    let fail = |error: VmmError, cow_handle: Option<CowHandle>| StageError { error, cow_handle };
+    let fail =
+        |error: ComputerError, cow_handle: Option<CowHandle>| StageError { error, cow_handle };
     let copy = async || {
         staging
             .stage_disk(ROOTFS_DISK_ID, DiskSource::Image(Path::new(rootfs)))
             .await
-            .map_err(VmmError::from)
+            .map_err(ComputerError::from)
     };
     match cow_manager.setup(owner_id, rootfs).await {
         Ok(handle) => {
@@ -222,9 +223,9 @@ pub async fn stage_rootfs_cow_or_copy(
 pub fn create_rootfs_symlink(vm_dir: &Path, dm_device: &str) -> Result<String> {
     let link_path = vm_dir.join("rootfs.link");
     let _ = std::fs::remove_file(&link_path);
-    std::os::unix::fs::symlink(dm_device, &link_path).map_err(VmmError::Io)?;
+    std::os::unix::fs::symlink(dm_device, &link_path).map_err(ComputerError::Io)?;
     link_path
         .to_str()
         .map(str::to_owned)
-        .ok_or_else(|| VmmError::Config(format!("non-UTF-8 path: {}", link_path.display())))
+        .ok_or_else(|| ComputerError::Config(format!("non-UTF-8 path: {}", link_path.display())))
 }

--- a/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
@@ -24,7 +24,7 @@ pub(super) struct RestoreRequest {
     /// `ttl_seconds`) — plus, on the warm-create origin, the initial
     /// workload fields; the boot-recipe fields are ignored — the snapshot
     /// carries the boot state.
-    pub(super) spec: SandboxSpec,
+    pub(super) spec: ComputerSpec,
     /// Which API surface this restore serves; decides the event contract.
     pub(super) origin: RestoreOrigin,
 }
@@ -48,7 +48,7 @@ impl SandboxManager {
     /// Checkpoint a `Ready` sandbox into the snapshot catalog.
     pub async fn checkpoint_sandbox(
         &self,
-        sandbox_id: &SandboxId,
+        sandbox_id: &ComputerId,
         name: String,
         labels: HashMap<String, String>,
     ) -> Result<CheckpointInfo> {
@@ -76,7 +76,7 @@ impl SandboxManager {
     /// exactly what the label guard refuses.
     pub(super) async fn capture_checkpoint(
         &self,
-        sandbox_id: &SandboxId,
+        sandbox_id: &ComputerId,
         name: String,
         labels: HashMap<String, String>,
     ) -> Result<CheckpointInfo> {
@@ -97,7 +97,7 @@ impl SandboxManager {
     /// The restored sandbox starts in `Ready` state immediately.
     ///
     /// Returns `(sandbox_id, ip_address)`.
-    pub async fn restore_sandbox(&self, spec: RestoreSandboxSpec) -> Result<(SandboxId, String)> {
+    pub async fn restore_sandbox(&self, spec: RestoreComputerSpec) -> Result<(ComputerId, String)> {
         self.restore_sandbox_keyed(spec, &Uuid::new_v4().to_string())
             .await
     }
@@ -105,10 +105,10 @@ impl SandboxManager {
     /// Restore with a stable request key for durable replay.
     pub async fn restore_sandbox_keyed(
         &self,
-        spec: RestoreSandboxSpec,
+        spec: RestoreComputerSpec,
         restore_key: &str,
-    ) -> Result<(SandboxId, String)> {
-        let RestoreSandboxSpec {
+    ) -> Result<(ComputerId, String)> {
+        let RestoreComputerSpec {
             id,
             snapshot_id,
             labels,
@@ -119,7 +119,7 @@ impl SandboxManager {
             RestoreRequest {
                 snapshot_id,
                 network_override,
-                spec: SandboxSpec {
+                spec: ComputerSpec {
                     id,
                     labels,
                     ttl_seconds,
@@ -137,7 +137,7 @@ impl SandboxManager {
         &self,
         request: RestoreRequest,
         restore_key: &str,
-    ) -> Result<(SandboxId, String)> {
+    ) -> Result<(ComputerId, String)> {
         // Gate on the startup sweep before touching per-id resources (see
         // create_sandbox / await_reconcile).
         self.await_reconcile().await?;

--- a/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
@@ -1,5 +1,5 @@
 use super::reconcile::JournaledLease;
-use super::record::{ProvisionIntent, SandboxProvisionOutcome};
+use super::record::{ComputerProvisionOutcome, ProvisionIntent};
 use super::*;
 use crate::lifecycle::tasks::CaptureSpec;
 
@@ -278,7 +278,7 @@ impl SandboxManager {
         let mut nic: Option<NicSpec> = None;
         let setup = async {
             super::reconcile::create_runtime_dir(&vm_dir)?;
-            let cleanup_record = super::reconcile::SandboxStateRecord::new(
+            let cleanup_record = super::reconcile::ComputerStateRecord::new(
                 &new_id,
                 None,
                 lease
@@ -348,7 +348,7 @@ impl SandboxManager {
             })),
             seeded: Seeded::Fresh,
         });
-        let outcome = SandboxProvisionOutcome {
+        let outcome = ComputerProvisionOutcome {
             ip_address: ip_address.clone(),
         };
         // A restore's caller waits for READY: that is what makes the sandbox

--- a/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
@@ -48,7 +48,7 @@ impl SandboxManager {
     /// Checkpoint a `Ready` sandbox into the snapshot catalog.
     pub async fn checkpoint_sandbox(
         &self,
-        sandbox_id: &ComputerId,
+        computer_id: &ComputerId,
         name: String,
         labels: HashMap<String, String>,
     ) -> Result<CheckpointInfo> {
@@ -64,7 +64,7 @@ impl SandboxManager {
         // The warm-create cache (CORE-77) trusts its label as the lookup
         // key; a caller must not be able to plant one.
         super::warm::reject_reserved_labels(&labels)?;
-        self.capture_checkpoint(sandbox_id, name, labels).await
+        self.capture_checkpoint(computer_id, name, labels).await
     }
 
     /// [`Self::checkpoint_sandbox`] without the reserved-name and
@@ -76,12 +76,12 @@ impl SandboxManager {
     /// exactly what the label guard refuses.
     pub(super) async fn capture_checkpoint(
         &self,
-        sandbox_id: &ComputerId,
+        computer_id: &ComputerId,
         name: String,
         labels: HashMap<String, String>,
     ) -> Result<CheckpointInfo> {
-        self.mailbox(sandbox_id)?
-            .ask(sandbox_id, |reply| Command::Checkpoint {
+        self.mailbox(computer_id)?
+            .ask(computer_id, |reply| Command::Checkpoint {
                 spec: CaptureSpec { name, labels },
                 reply,
             })
@@ -96,7 +96,7 @@ impl SandboxManager {
     ///
     /// The restored sandbox starts in `Ready` state immediately.
     ///
-    /// Returns `(sandbox_id, ip_address)`.
+    /// Returns `(computer_id, ip_address)`.
     pub async fn restore_sandbox(&self, spec: RestoreComputerSpec) -> Result<(ComputerId, String)> {
         self.restore_sandbox_keyed(spec, &Uuid::new_v4().to_string())
             .await
@@ -374,8 +374,8 @@ impl SandboxManager {
     /// user-owned snapshots, and deleting one would strand a paused sandbox.
     /// Template-owned snapshots (CORE-107) are hidden for the same reason —
     /// they surface via `TemplateService.Get/List`, not as user checkpoints.
-    pub fn list_checkpoints(&self, sandbox_id: Option<&str>) -> Result<Vec<CheckpointSummary>> {
-        let infos = match sandbox_id {
+    pub fn list_checkpoints(&self, computer_id: Option<&str>) -> Result<Vec<CheckpointSummary>> {
+        let infos = match computer_id {
             Some(sid) => self.snapshots.list(sid)?,
             None => self.snapshots.list_all()?,
         };
@@ -388,7 +388,7 @@ impl SandboxManager {
             })
             .map(|s| CheckpointSummary {
                 id: s.id,
-                sandbox_id: s.vm_id,
+                computer_id: s.vm_id,
                 name: s.name.unwrap_or_default(),
                 labels: s.labels,
                 snapshot_dir: s

--- a/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
@@ -56,7 +56,7 @@ impl SandboxManager {
         // The pause machinery owns this name: Remove deletes every snapshot
         // carrying it, so a user checkpoint must not squat on it (CORE-21).
         if name == super::pause::PAUSE_SNAPSHOT_NAME {
-            return Err(VmmError::Config(format!(
+            return Err(ComputerError::Config(format!(
                 "checkpoint name {:?} is reserved for sandbox pause",
                 super::pause::PAUSE_SNAPSHOT_NAME
             )));
@@ -174,14 +174,14 @@ impl SandboxManager {
         // cloning it with a fresh overlay would silently discard that disk
         // state. Resume is the only consumer (CORE-21).
         if snap_meta.name.as_deref() == Some(super::pause::PAUSE_SNAPSHOT_NAME) {
-            return Err(VmmError::WrongState {
+            return Err(ComputerError::WrongState {
                 id: request.snapshot_id.clone(),
                 expected: "a user checkpoint".into(),
                 actual: "the internal pause checkpoint of a paused sandbox".into(),
             });
         }
         if self.config.firecracker.jailer.is_none() {
-            return Err(VmmError::Config(
+            return Err(ComputerError::Config(
                 "checkpoint restore requires jailer isolation; direct mode embeds shared origin \
                  paths"
                     .into(),
@@ -208,16 +208,17 @@ impl SandboxManager {
         {
             ProvisionIntent::Created(record) | ProvisionIntent::Resume(record) => record,
             ProvisionIntent::Replay(record) => {
-                let outcome = record
-                    .provision_outcome
-                    .ok_or_else(|| VmmError::WrongState {
-                        id: new_id.clone(),
-                        expected: "a persisted restore outcome".into(),
-                        actual: "none".into(),
-                    })?;
+                let outcome =
+                    record
+                        .provision_outcome
+                        .ok_or_else(|| ComputerError::WrongState {
+                            id: new_id.clone(),
+                            expected: "a persisted restore outcome".into(),
+                            actual: "none".into(),
+                        })?;
                 return Ok((new_id, outcome.ip_address));
             }
-            ProvisionIntent::Blocked(_) => return Err(VmmError::AlreadyExists(new_id)),
+            ProvisionIntent::Blocked(_) => return Err(ComputerError::AlreadyExists(new_id)),
         };
         let generation = record.generation;
         let deadlines = Deadlines {
@@ -253,7 +254,7 @@ impl SandboxManager {
                 Err(error) => {
                     let abort = self.records.abort_provision(&new_id, generation)?;
                     if let Some(durability_error) = abort.durability_error {
-                        return Err(VmmError::Unavailable(format!(
+                        return Err(ComputerError::Unavailable(format!(
                             "{error}; restore rollback is visible, but durability is unconfirmed: {durability_error}"
                         )));
                     }
@@ -300,7 +301,7 @@ impl SandboxManager {
                         .await?,
                 );
             }
-            Ok::<_, VmmError>(())
+            Ok::<_, ComputerError>(())
         }
         .await;
         if let Err(error) = setup {
@@ -320,7 +321,7 @@ impl SandboxManager {
             if unwound.is_empty() {
                 return Err(error);
             }
-            return Err(VmmError::Unavailable(format!(
+            return Err(ComputerError::Unavailable(format!(
                 "{error}; restore rollback incomplete: {}",
                 unwound.join("; ")
             )));
@@ -414,7 +415,7 @@ impl SandboxManager {
     pub async fn delete_checkpoint(&self, snapshot_id: &str) -> Result<()> {
         let meta = self.snapshots.find_by_id(snapshot_id)?;
         if meta.name.as_deref() == Some(super::pause::PAUSE_SNAPSHOT_NAME) {
-            return Err(VmmError::WrongState {
+            return Err(ComputerError::WrongState {
                 id: snapshot_id.to_owned(),
                 expected: "a user checkpoint".into(),
                 actual: "the internal pause checkpoint of a paused sandbox".into(),
@@ -425,7 +426,7 @@ impl SandboxManager {
         if let Some(owner) = meta.labels.get(crate::template_catalog::TEMPLATE_LABEL)
             && self.templates.references_snapshot(snapshot_id)?
         {
-            return Err(VmmError::FailedPrecondition(format!(
+            return Err(ComputerError::FailedPrecondition(format!(
                 "snapshot {snapshot_id} is owned by template {owner}; delete the template instead"
             )));
         }

--- a/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
@@ -12,7 +12,7 @@ use crate::lifecycle::tasks::CaptureSpec;
 pub(super) const CHECKPOINT_FORMAT: &str = arcbox_vm_driver::testkit::CHECKPOINT_FORMAT;
 
 /// Parameters for the internal restore path
-/// ([`SandboxManager::restore_from_snapshot`]), shared by the Restore RPC
+/// ([`ComputerManager::restore_from_snapshot`]), shared by the Restore RPC
 /// and internal callers.
 pub(super) struct RestoreRequest {
     /// Source checkpoint id.
@@ -29,7 +29,7 @@ pub(super) struct RestoreRequest {
     pub(super) origin: RestoreOrigin,
 }
 
-impl SandboxManager {
+impl ComputerManager {
     /// Rootfs images that existing snapshots or catalog templates need to
     /// stay restorable/bootable.
     ///
@@ -46,7 +46,7 @@ impl SandboxManager {
     }
 
     /// Checkpoint a `Ready` sandbox into the snapshot catalog.
-    pub async fn checkpoint_sandbox(
+    pub async fn checkpoint_computer(
         &self,
         computer_id: &ComputerId,
         name: String,
@@ -67,7 +67,7 @@ impl SandboxManager {
         self.capture_checkpoint(computer_id, name, labels).await
     }
 
-    /// [`Self::checkpoint_sandbox`] without the reserved-name and
+    /// [`Self::checkpoint_computer`] without the reserved-name and
     /// reserved-label guards, for the catalogs that own those names.
     ///
     /// The guards exist to stop a *caller* squatting on the pause
@@ -97,13 +97,16 @@ impl SandboxManager {
     /// The restored sandbox starts in `Ready` state immediately.
     ///
     /// Returns `(computer_id, ip_address)`.
-    pub async fn restore_sandbox(&self, spec: RestoreComputerSpec) -> Result<(ComputerId, String)> {
-        self.restore_sandbox_keyed(spec, &Uuid::new_v4().to_string())
+    pub async fn restore_computer(
+        &self,
+        spec: RestoreComputerSpec,
+    ) -> Result<(ComputerId, String)> {
+        self.restore_computer_keyed(spec, &Uuid::new_v4().to_string())
             .await
     }
 
     /// Restore with a stable request key for durable replay.
-    pub async fn restore_sandbox_keyed(
+    pub async fn restore_computer_keyed(
         &self,
         spec: RestoreComputerSpec,
         restore_key: &str,
@@ -139,7 +142,7 @@ impl SandboxManager {
         restore_key: &str,
     ) -> Result<(ComputerId, String)> {
         // Gate on the startup sweep before touching per-id resources (see
-        // create_sandbox / await_reconcile).
+        // create_computer / await_reconcile).
         self.await_reconcile().await?;
 
         let caller_supplied_id = request.spec.id.as_ref().is_some_and(|id| !id.is_empty());
@@ -150,7 +153,7 @@ impl SandboxManager {
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| Uuid::new_v4().to_string());
 
-        super::validate_new_sandbox_id(&new_id, &*self.services.driver, &self.config)?;
+        super::validate_new_computer_id(&new_id, &*self.services.driver, &self.config)?;
         // The snapshot id is caller-supplied and flows into snapshot dir paths
         // (create_dir_all / copy / remove_dir_all) — validate it too, or a
         // `../` id would traverse out of the snapshots directory.
@@ -246,7 +249,7 @@ impl SandboxManager {
                 .network
                 .reserve(
                     &VmId::new(new_id.as_str())?,
-                    super::sandbox_network_policy(),
+                    super::computer_network_policy(),
                 )
                 .await
             {

--- a/computer/arcbox-computer-runtime/src/sandbox/cleanup.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/cleanup.rs
@@ -66,9 +66,9 @@ mod tests {
         let boot_parked = driver.park_next_boot();
         let (id, _) = manager
             .create_sandbox_keyed(
-                SandboxSpec {
+                ComputerSpec {
                     id: Some("job".into()),
-                    network: SandboxNetworkSpec {
+                    network: ComputerNetworkSpec {
                         mode: "none".into(),
                     },
                     ..Default::default()

--- a/computer/arcbox-computer-runtime/src/sandbox/cleanup.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/cleanup.rs
@@ -1,6 +1,6 @@
 //! What is left of the manager's teardown once the computer's actor owns it.
 //!
-//! `remove_sandbox_impl` and its parts — the busy gate, the bounded wait on a
+//! `remove_computer_impl` and its parts — the busy gate, the bounded wait on a
 //! boot's resource handoff, the epoch-stamped expiry retry, the `Arc::ptr_eq`
 //! generation guard — are the actor's now: `Effect::AbortInflight` plus the
 //! machine's remove arms, tested in `crate::lifecycle::tests`. The release
@@ -46,7 +46,7 @@ mod tests {
             .into_owned();
         let cow_probe = Arc::new(CowTestProbe::default());
         let driver = FakeDriver::new();
-        let manager = SandboxManager::new(
+        let manager = ComputerManager::new(
             config.clone(),
             crate::NodeEnvironment {
                 driver: Arc::new(driver.clone()),
@@ -65,7 +65,7 @@ mod tests {
 
         let boot_parked = driver.park_next_boot();
         let (id, _) = manager
-            .create_sandbox_keyed(
+            .create_computer_keyed(
                 ComputerSpec {
                     id: Some("job".into()),
                     network: ComputerNetworkSpec {
@@ -92,7 +92,7 @@ mod tests {
             serde_json::from_slice(&std::fs::read(vm_dir.join("state.json")).unwrap()).unwrap();
         assert!(state["pid"].as_u64().is_some(), "the vmm pid is journalled");
 
-        tokio::time::timeout(Duration::from_secs(5), manager.remove_sandbox(&id, true))
+        tokio::time::timeout(Duration::from_secs(5), manager.remove_computer(&id, true))
             .await
             .expect("force removal must cancel the parked boot")
             .unwrap();

--- a/computer/arcbox-computer-runtime/src/sandbox/execution.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/execution.rs
@@ -65,7 +65,7 @@ pub struct ExecutionSnapshot {
     /// Execution id, unique within its sandbox.
     pub id: String,
     /// Owning sandbox.
-    pub sandbox_id: SandboxId,
+    pub sandbox_id: ComputerId,
     /// Whether the workload runs on a pseudo-TTY.
     pub tty: bool,
     /// When the workload was dispatched.
@@ -188,7 +188,7 @@ struct ExecState {
 /// A live or recently-exited execution.
 pub(super) struct Execution {
     id: String,
-    sandbox_id: SandboxId,
+    sandbox_id: ComputerId,
     tty: bool,
     started_at: DateTime<Utc>,
     /// The started command, kept to distinguish an idempotent start retry
@@ -207,7 +207,7 @@ pub(super) struct Execution {
 impl Execution {
     fn new(
         id: String,
-        sandbox_id: SandboxId,
+        sandbox_id: ComputerId,
         spec: &ExecutionSpec,
         input_tx: mpsc::Sender<ExecInputMsg>,
     ) -> Self {
@@ -408,7 +408,7 @@ impl Execution {
     }
 }
 
-type ExecKey = (SandboxId, String);
+type ExecKey = (ComputerId, String);
 
 /// Registry of executions, keyed by `(sandbox_id, execution_id)`.
 #[derive(Default)]
@@ -646,7 +646,7 @@ impl SandboxManager {
     /// existing execution instead of dispatching a second process.
     pub async fn start_execution(
         &self,
-        sandbox_id: &SandboxId,
+        sandbox_id: &ComputerId,
         spec: ExecutionSpec,
     ) -> Result<ExecutionSnapshot> {
         let id = match &spec.id {
@@ -829,7 +829,7 @@ impl SandboxManager {
     ///
     /// The sandbox must exist; an unknown id is `NotFound` rather than an
     /// empty list, so a caller can tell "no executions" from a typo.
-    pub fn list_executions(&self, sandbox_id: &SandboxId) -> Result<Vec<ExecutionSnapshot>> {
+    pub fn list_executions(&self, sandbox_id: &ComputerId) -> Result<Vec<ExecutionSnapshot>> {
         self.computer(sandbox_id)?;
         let mut snapshots = self.executions.list(sandbox_id);
         snapshots.sort_by(|a, b| {
@@ -848,7 +848,7 @@ impl SandboxManager {
     /// accepted connections.
     pub async fn wait_sandbox_port(
         &self,
-        id: &SandboxId,
+        id: &ComputerId,
         port: u16,
         timeout: Duration,
     ) -> Result<()> {

--- a/computer/arcbox-computer-runtime/src/sandbox/execution.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/execution.rs
@@ -272,8 +272,8 @@ impl Execution {
     }
 
     /// Error for operations that need the workload alive.
-    fn exited_error(&self) -> VmmError {
-        VmmError::WrongState {
+    fn exited_error(&self) -> ComputerError {
+        ComputerError::WrongState {
             id: format!("execution '{}'", self.id),
             expected: "running".into(),
             actual: "exited".into(),
@@ -301,7 +301,7 @@ impl Execution {
     /// Offset-idempotent stdin write; see [`SandboxManager::write_stdin`].
     async fn write_stdin(&self, offset: u64, data: &[u8], eof: bool) -> Result<StdinState> {
         if eof && self.tty {
-            return Err(VmmError::Config(
+            return Err(ComputerError::Config(
                 "cannot close stdin of a TTY execution; send Ctrl-D (0x04) instead".into(),
             ));
         }
@@ -315,7 +315,7 @@ impl Execution {
                 return Err(self.exited_error());
             }
             if offset > st.stdin_written {
-                return Err(VmmError::StdinGap {
+                return Err(ComputerError::StdinGap {
                     accepted: st.stdin_written,
                     offset,
                 });
@@ -326,7 +326,7 @@ impl Execution {
                 Vec::new()
             } else {
                 if st.stdin_closed {
-                    return Err(VmmError::Config("stdin is already closed".into()));
+                    return Err(ComputerError::Config("stdin is already closed".into()));
                 }
                 #[allow(
                     clippy::cast_possible_truncation,
@@ -360,7 +360,7 @@ impl Execution {
     /// Deliver a POSIX signal to the running workload's process group.
     async fn signal(&self, signal: i32) -> Result<()> {
         if !(1..=64).contains(&signal) {
-            return Err(VmmError::Config(format!("invalid signal {signal}")));
+            return Err(ComputerError::Config(format!("invalid signal {signal}")));
         }
         if self.has_exited() {
             return Err(self.exited_error());
@@ -374,7 +374,9 @@ impl Execution {
     /// Resize the workload's pseudo-TTY.
     async fn resize(&self, width: u16, height: u16) -> Result<()> {
         if !self.tty {
-            return Err(VmmError::Config("execution has no TTY to resize".into()));
+            return Err(ComputerError::Config(
+                "execution has no TTY to resize".into(),
+            ));
         }
         if self.has_exited() {
             return Err(self.exited_error());
@@ -487,7 +489,7 @@ impl ExecutionRegistry {
             if existing.cmd == cmd {
                 return Ok(Reserve::Existing(existing.snapshot()));
             }
-            return Err(VmmError::AlreadyExists(format!(
+            return Err(ComputerError::AlreadyExists(format!(
                 "execution '{}' (id reused for a different command)",
                 key.1
             )));
@@ -499,7 +501,7 @@ impl ExecutionRegistry {
                 // contract only holds once the process is already running.
                 return Ok(Reserve::AwaitPending(pending.done.subscribe()));
             }
-            return Err(VmmError::AlreadyExists(format!(
+            return Err(ComputerError::AlreadyExists(format!(
                 "execution '{}' (id reused for a different command)",
                 key.1
             )));
@@ -526,7 +528,7 @@ impl ExecutionRegistry {
             .get(&(sandbox_id.to_owned(), execution_id.to_owned()))
             .cloned()
             .ok_or_else(|| {
-                VmmError::NotFound(format!(
+                ComputerError::NotFound(format!(
                     "execution '{execution_id}' in sandbox '{sandbox_id}'"
                 ))
             })
@@ -655,7 +657,7 @@ impl SandboxManager {
             _ => Uuid::new_v4().to_string(),
         };
         if spec.cmd.is_empty() {
-            return Err(VmmError::Config(
+            return Err(ComputerError::Config(
                 "execution command must not be empty".into(),
             ));
         }
@@ -681,7 +683,7 @@ impl SandboxManager {
             }
         }
         let Some(reservation) = reservation else {
-            return Err(VmmError::AlreadyExists(format!(
+            return Err(ComputerError::AlreadyExists(format!(
                 "execution '{id}' (concurrent starts did not settle)"
             )));
         };
@@ -839,7 +841,7 @@ impl SandboxManager {
     }
 
     /// Wait until something inside an alive sandbox listens on TCP `port`,
-    /// or fail with [`VmmError::DeadlineExceeded`] once `timeout` elapses.
+    /// or fail with [`ComputerError::DeadlineExceeded`] once `timeout` elapses.
     ///
     /// The vm-agent watches the guest's own listen table in-process — no
     /// connect probes that would perturb the workload with spurious
@@ -853,7 +855,7 @@ impl SandboxManager {
         let agent = self.require_alive_agent(id)?;
         match agent.wait_for_port(port, timeout).await? {
             crate::agent::PortWait::Listening => Ok(()),
-            crate::agent::PortWait::Deadline => Err(VmmError::DeadlineExceeded(format!(
+            crate::agent::PortWait::Deadline => Err(ComputerError::DeadlineExceeded(format!(
                 "no listener on port {port} in sandbox '{id}' within {}s",
                 timeout.as_secs()
             ))),
@@ -994,7 +996,7 @@ mod tests {
 
         // A gap is rejected with the resume point.
         let err = exec.write_stdin(99, b"x", false).await.unwrap_err();
-        assert!(matches!(err, VmmError::StdinGap { accepted: 11, .. }));
+        assert!(matches!(err, ComputerError::StdinGap { accepted: 11, .. }));
 
         // Exactly the deduplicated byte stream reached the process.
         let mut forwarded = Vec::new();
@@ -1018,7 +1020,7 @@ mod tests {
 
         // Further data after EOF is rejected; a pure duplicate is not.
         let err = exec.write_stdin(2, b"more", false).await.unwrap_err();
-        assert!(matches!(err, VmmError::Config(_)));
+        assert!(matches!(err, ComputerError::Config(_)));
         let st = exec.write_stdin(0, b"in", false).await.unwrap();
         assert_eq!(st.bytes_written, 2);
 
@@ -1029,7 +1031,7 @@ mod tests {
         };
         let (tty_exec, _tty_rx) = test_execution(&tty_spec);
         let err = tty_exec.write_stdin(0, b"", true).await.unwrap_err();
-        assert!(matches!(err, VmmError::Config(_)));
+        assert!(matches!(err, ComputerError::Config(_)));
     }
 
     #[tokio::test]
@@ -1100,18 +1102,18 @@ mod tests {
         assert!(matches!(rx.recv().await, Some(ExecInputMsg::Signal(15))));
         assert!(matches!(
             exec.signal(0).await.unwrap_err(),
-            VmmError::Config(_)
+            ComputerError::Config(_)
         ));
         // Non-TTY executions have nothing to resize.
         assert!(matches!(
             exec.resize(80, 24).await.unwrap_err(),
-            VmmError::Config(_)
+            ComputerError::Config(_)
         ));
 
         exec.mark_exited(&Ok(ExitStatus::Code(0)));
         assert!(matches!(
             exec.signal(9).await.unwrap_err(),
-            VmmError::WrongState { .. }
+            ComputerError::WrongState { .. }
         ));
     }
 
@@ -1177,7 +1179,7 @@ mod tests {
         // Different command under the same id → collision.
         assert!(matches!(
             registry.reserve(key, &["other".to_owned()]),
-            Err(VmmError::AlreadyExists(_))
+            Err(ComputerError::AlreadyExists(_))
         ));
 
         // While a start is in flight, a matching retry waits for it instead
@@ -1195,7 +1197,7 @@ mod tests {
             ));
             assert!(matches!(
                 registry.reserve(key2.clone(), &["other".to_owned()]),
-                Err(VmmError::AlreadyExists(_))
+                Err(ComputerError::AlreadyExists(_))
             ));
         }
         // A dropped (uncommitted) reservation frees the slot.

--- a/computer/arcbox-computer-runtime/src/sandbox/execution.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/execution.rs
@@ -65,7 +65,7 @@ pub struct ExecutionSnapshot {
     /// Execution id, unique within its sandbox.
     pub id: String,
     /// Owning sandbox.
-    pub sandbox_id: ComputerId,
+    pub computer_id: ComputerId,
     /// Whether the workload runs on a pseudo-TTY.
     pub tty: bool,
     /// When the workload was dispatched.
@@ -188,7 +188,7 @@ struct ExecState {
 /// A live or recently-exited execution.
 pub(super) struct Execution {
     id: String,
-    sandbox_id: ComputerId,
+    computer_id: ComputerId,
     tty: bool,
     started_at: DateTime<Utc>,
     /// The started command, kept to distinguish an idempotent start retry
@@ -207,13 +207,13 @@ pub(super) struct Execution {
 impl Execution {
     fn new(
         id: String,
-        sandbox_id: ComputerId,
+        computer_id: ComputerId,
         spec: &ExecutionSpec,
         input_tx: mpsc::Sender<ExecInputMsg>,
     ) -> Self {
         Self {
             id,
-            sandbox_id,
+            computer_id,
             tty: spec.tty,
             started_at: Utc::now(),
             cmd: spec.cmd.clone(),
@@ -231,7 +231,7 @@ impl Execution {
         let st = self.state.lock().unwrap();
         ExecutionSnapshot {
             id: self.id.clone(),
-            sandbox_id: self.sandbox_id.clone(),
+            computer_id: self.computer_id.clone(),
             tty: self.tty,
             started_at: self.started_at,
             exited_at: st.exited_at,
@@ -410,7 +410,7 @@ impl Execution {
 
 type ExecKey = (ComputerId, String);
 
-/// Registry of executions, keyed by `(sandbox_id, execution_id)`.
+/// Registry of executions, keyed by `(computer_id, execution_id)`.
 #[derive(Default)]
 pub(super) struct ExecutionRegistry {
     inner: Mutex<RegistryInner>,
@@ -520,36 +520,36 @@ impl ExecutionRegistry {
         }))
     }
 
-    fn get(&self, sandbox_id: &str, execution_id: &str) -> Result<Arc<Execution>> {
+    fn get(&self, computer_id: &str, execution_id: &str) -> Result<Arc<Execution>> {
         self.inner
             .lock()
             .unwrap()
             .live
-            .get(&(sandbox_id.to_owned(), execution_id.to_owned()))
+            .get(&(computer_id.to_owned(), execution_id.to_owned()))
             .cloned()
             .ok_or_else(|| {
                 ComputerError::NotFound(format!(
-                    "execution '{execution_id}' in sandbox '{sandbox_id}'"
+                    "execution '{execution_id}' in sandbox '{computer_id}'"
                 ))
             })
     }
 
     /// Snapshots of every retained execution of one sandbox — running and
     /// exited, until the retention GC drops them.
-    fn list(&self, sandbox_id: &str) -> Vec<ExecutionSnapshot> {
+    fn list(&self, computer_id: &str) -> Vec<ExecutionSnapshot> {
         self.inner
             .lock()
             .unwrap()
             .live
             .iter()
-            .filter(|((sid, _), _)| sid == sandbox_id)
+            .filter(|((sid, _), _)| sid == computer_id)
             .map(|(_, exec)| exec.snapshot())
             .collect()
     }
 
     /// Remove `exec`'s entry if it is still the registered generation.
     fn remove_generation(&self, exec: &Arc<Execution>) {
-        let key = (exec.sandbox_id.clone(), exec.id.clone());
+        let key = (exec.computer_id.clone(), exec.id.clone());
         let mut inner = self.inner.lock().unwrap();
         if inner.live.get(&key).is_some_and(|e| Arc::ptr_eq(e, exec)) {
             inner.live.remove(&key);
@@ -560,13 +560,13 @@ impl ExecutionRegistry {
     /// parked attach/wait subscribers resolve. Entries stay registered —
     /// their buffered output remains readable until the per-execution
     /// retention GC drops them.
-    fn interrupt_sandbox(&self, sandbox_id: &str) {
+    fn interrupt_sandbox(&self, computer_id: &str) {
         let executions: Vec<Arc<Execution>> = {
             let inner = self.inner.lock().unwrap();
             inner
                 .live
                 .iter()
-                .filter(|((sid, _), _)| sid == sandbox_id)
+                .filter(|((sid, _), _)| sid == computer_id)
                 .map(|(_, exec)| Arc::clone(exec))
                 .collect()
         };
@@ -581,13 +581,13 @@ impl ExecutionRegistry {
 /// threading the registry through each of them.
 pub(super) fn spawn_teardown_purge(
     registry: Arc<ExecutionRegistry>,
-    mut events: broadcast::Receiver<SandboxEvent>,
+    mut events: broadcast::Receiver<ComputerEvent>,
 ) {
     tokio::spawn(async move {
         loop {
             match events.recv().await {
                 Ok(ev) if ev.is_terminal() => {
-                    registry.interrupt_sandbox(&ev.sandbox_id);
+                    registry.interrupt_sandbox(&ev.computer_id);
                 }
                 Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {}
                 Err(broadcast::error::RecvError::Closed) => break,
@@ -626,7 +626,7 @@ async fn run_session(
         // drops, so the computer is idle either way — there is just no status
         // to report, only why.
         Err(e) => {
-            warn!(sandbox_id = %exec.sandbox_id, execution_id = %exec.id, error = %e,
+            warn!(computer_id = %exec.computer_id, execution_id = %exec.id, error = %e,
                   "execution session broke before exit");
             slot.exited(WorkloadOutcome::Broke(e.clone()));
         }
@@ -646,7 +646,7 @@ impl SandboxManager {
     /// existing execution instead of dispatching a second process.
     pub async fn start_execution(
         &self,
-        sandbox_id: &ComputerId,
+        computer_id: &ComputerId,
         spec: ExecutionSpec,
     ) -> Result<ExecutionSnapshot> {
         let id = match &spec.id {
@@ -670,7 +670,7 @@ impl SandboxManager {
         for _ in 0..MAX_START_RESERVE_ROUNDS {
             match self
                 .executions
-                .reserve((sandbox_id.clone(), id.clone()), &spec.cmd)?
+                .reserve((computer_id.clone(), id.clone()), &spec.cmd)?
             {
                 Reserve::Existing(snapshot) => return Ok(snapshot),
                 Reserve::Slot(guard) => {
@@ -688,7 +688,7 @@ impl SandboxManager {
             )));
         };
 
-        let agent = self.require_ready_agent(sandbox_id)?;
+        let agent = self.require_ready_agent(computer_id)?;
         let start = StartCommand {
             cmd: spec.cmd.clone(),
             env: spec.env.clone(),
@@ -703,7 +703,7 @@ impl SandboxManager {
         // Claim the computer (Ready → Running) before dispatching, so a
         // losing racer never launches a process (same discipline as
         // workload.rs).
-        let slot = self.workload_slot(sandbox_id)?;
+        let slot = self.workload_slot(computer_id)?;
         slot.claim(WorkloadClaim::Api).await?;
 
         let (input_tx, output_rx) = match agent.exec(start).await {
@@ -721,7 +721,7 @@ impl SandboxManager {
             let _ = input_tx.send(ExecInputMsg::Eof).await;
         }
 
-        let exec = Arc::new(Execution::new(id, sandbox_id.clone(), &spec, input_tx));
+        let exec = Arc::new(Execution::new(id, computer_id.clone(), &spec, input_tx));
         reservation.commit(&exec);
 
         tokio::spawn(run_session(
@@ -743,12 +743,12 @@ impl SandboxManager {
     /// [`SandboxManager::wait_execution`] afterwards.
     pub fn attach_execution(
         &self,
-        sandbox_id: &str,
+        computer_id: &str,
         execution_id: &str,
         stdout_offset: u64,
         stderr_offset: u64,
     ) -> Result<(ExecutionSnapshot, mpsc::Receiver<ExecutionOutput>)> {
-        let exec = self.executions.get(sandbox_id, execution_id)?;
+        let exec = self.executions.get(computer_id, execution_id)?;
         Ok(exec.attach(stdout_offset, stderr_offset))
     }
 
@@ -761,23 +761,23 @@ impl SandboxManager {
     /// the client sends through the stream itself.
     pub async fn write_stdin(
         &self,
-        sandbox_id: &str,
+        computer_id: &str,
         execution_id: &str,
         offset: u64,
         data: &[u8],
         eof: bool,
     ) -> Result<StdinState> {
         self.executions
-            .get(sandbox_id, execution_id)?
+            .get(computer_id, execution_id)?
             .write_stdin(offset, data, eof)
             .await
     }
 
     /// Current stdin acceptance state — the resume point after a lost write.
-    pub fn stdin_status(&self, sandbox_id: &str, execution_id: &str) -> Result<StdinState> {
+    pub fn stdin_status(&self, computer_id: &str, execution_id: &str) -> Result<StdinState> {
         Ok(self
             .executions
-            .get(sandbox_id, execution_id)?
+            .get(computer_id, execution_id)?
             .snapshot()
             .stdin)
     }
@@ -785,12 +785,12 @@ impl SandboxManager {
     /// Deliver a POSIX signal to a running execution's process group.
     pub async fn signal_execution(
         &self,
-        sandbox_id: &str,
+        computer_id: &str,
         execution_id: &str,
         signal: i32,
     ) -> Result<()> {
         self.executions
-            .get(sandbox_id, execution_id)?
+            .get(computer_id, execution_id)?
             .signal(signal)
             .await
     }
@@ -798,13 +798,13 @@ impl SandboxManager {
     /// Resize a running TTY execution's terminal.
     pub async fn resize_execution(
         &self,
-        sandbox_id: &str,
+        computer_id: &str,
         execution_id: &str,
         width: u16,
         height: u16,
     ) -> Result<()> {
         self.executions
-            .get(sandbox_id, execution_id)?
+            .get(computer_id, execution_id)?
             .resize(width, height)
             .await
     }
@@ -813,13 +813,13 @@ impl SandboxManager {
     /// state. A zero timeout polls the current state.
     pub async fn wait_execution(
         &self,
-        sandbox_id: &str,
+        computer_id: &str,
         execution_id: &str,
         timeout: Duration,
     ) -> Result<ExecutionSnapshot> {
         Ok(self
             .executions
-            .get(sandbox_id, execution_id)?
+            .get(computer_id, execution_id)?
             .wait(timeout)
             .await)
     }
@@ -829,9 +829,9 @@ impl SandboxManager {
     ///
     /// The sandbox must exist; an unknown id is `NotFound` rather than an
     /// empty list, so a caller can tell "no executions" from a typo.
-    pub fn list_executions(&self, sandbox_id: &ComputerId) -> Result<Vec<ExecutionSnapshot>> {
-        self.computer(sandbox_id)?;
-        let mut snapshots = self.executions.list(sandbox_id);
+    pub fn list_executions(&self, computer_id: &ComputerId) -> Result<Vec<ExecutionSnapshot>> {
+        self.computer(computer_id)?;
+        let mut snapshots = self.executions.list(computer_id);
         snapshots.sort_by(|a, b| {
             a.started_at
                 .cmp(&b.started_at)

--- a/computer/arcbox-computer-runtime/src/sandbox/execution.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/execution.rs
@@ -54,7 +54,7 @@ pub struct ExecutionSpec {
     pub tty_size: Option<(u16, u16)>,
     /// Kill the process after this many seconds (0 = no timeout).
     pub timeout_seconds: u32,
-    /// Keep stdin open for [`SandboxManager::write_stdin`]. When false the
+    /// Keep stdin open for [`ComputerManager::write_stdin`]. When false the
     /// process starts with stdin already at EOF (run semantics).
     pub stdin: bool,
 }
@@ -298,7 +298,7 @@ impl Execution {
         (snapshot, rx)
     }
 
-    /// Offset-idempotent stdin write; see [`SandboxManager::write_stdin`].
+    /// Offset-idempotent stdin write; see [`ComputerManager::write_stdin`].
     async fn write_stdin(&self, offset: u64, data: &[u8], eof: bool) -> Result<StdinState> {
         if eof && self.tty {
             return Err(ComputerError::Config(
@@ -560,7 +560,7 @@ impl ExecutionRegistry {
     /// parked attach/wait subscribers resolve. Entries stay registered —
     /// their buffered output remains readable until the per-execution
     /// retention GC drops them.
-    fn interrupt_sandbox(&self, computer_id: &str) {
+    fn interrupt_computer(&self, computer_id: &str) {
         let executions: Vec<Arc<Execution>> = {
             let inner = self.inner.lock().unwrap();
             inner
@@ -587,7 +587,7 @@ pub(super) fn spawn_teardown_purge(
         loop {
             match events.recv().await {
                 Ok(ev) if ev.is_terminal() => {
-                    registry.interrupt_sandbox(&ev.computer_id);
+                    registry.interrupt_computer(&ev.computer_id);
                 }
                 Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => {}
                 Err(broadcast::error::RecvError::Closed) => break,
@@ -637,7 +637,7 @@ async fn run_session(
     registry.remove_generation(&exec);
 }
 
-impl SandboxManager {
+impl ComputerManager {
     /// Start an execution inside a `Ready` sandbox.
     ///
     /// The execution id (caller-supplied or generated) addresses the process
@@ -740,7 +740,7 @@ impl SandboxManager {
     /// retained byte if retention already dropped the requested offset), then
     /// live output, and closes once the execution has exited and both
     /// channels are drained. Read the final state with
-    /// [`SandboxManager::wait_execution`] afterwards.
+    /// [`ComputerManager::wait_execution`] afterwards.
     pub fn attach_execution(
         &self,
         computer_id: &str,
@@ -846,7 +846,7 @@ impl SandboxManager {
     /// The vm-agent watches the guest's own listen table in-process — no
     /// connect probes that would perturb the workload with spurious
     /// accepted connections.
-    pub async fn wait_sandbox_port(
+    pub async fn wait_computer_port(
         &self,
         id: &ComputerId,
         port: u16,
@@ -1118,7 +1118,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn interrupt_sandbox_marks_running_executions_but_keeps_them_readable() {
+    async fn interrupt_computer_marks_running_executions_but_keeps_them_readable() {
         let registry = Arc::new(ExecutionRegistry::default());
         let (exec, _rx) = test_execution(&stdin_spec());
         registry
@@ -1128,7 +1128,7 @@ mod tests {
             .live
             .insert(("sandbox-1".into(), "exec-1".into()), Arc::clone(&exec));
 
-        registry.interrupt_sandbox("sandbox-1");
+        registry.interrupt_computer("sandbox-1");
         // Still registered: buffered output stays readable until the
         // retention GC, but the execution is resolved as torn down.
         assert!(registry.get("sandbox-1", "exec-1").is_ok());
@@ -1145,7 +1145,7 @@ mod tests {
             .unwrap()
             .live
             .insert(("sandbox-1".into(), "exec-2".into()), Arc::clone(&done));
-        registry.interrupt_sandbox("sandbox-1");
+        registry.interrupt_computer("sandbox-1");
         assert_eq!(done.snapshot().exit_status, Some(ExitStatus::Code(3)));
     }
 

--- a/computer/arcbox-computer-runtime/src/sandbox/files.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/files.rs
@@ -10,15 +10,15 @@ use super::*;
 use crate::agent::DirWatch;
 use crate::file_proto::FileStatDto;
 
-impl SandboxManager {
+impl ComputerManager {
     /// Read a file from inside an alive sandbox.
-    pub async fn read_sandbox_file(&self, id: &ComputerId, path: &str) -> Result<Vec<u8>> {
+    pub async fn read_computer_file(&self, id: &ComputerId, path: &str) -> Result<Vec<u8>> {
         let agent = self.require_alive_agent(id)?;
         agent.files().read(path).await
     }
 
     /// Write a file into an alive sandbox.
-    pub async fn write_sandbox_file(
+    pub async fn write_computer_file(
         &self,
         id: &ComputerId,
         path: &str,
@@ -31,14 +31,14 @@ impl SandboxManager {
 
     /// Stat one path inside an alive sandbox (symlinks reported, not
     /// followed).
-    pub async fn stat_sandbox_path(&self, id: &ComputerId, path: &str) -> Result<FileStatDto> {
+    pub async fn stat_computer_path(&self, id: &ComputerId, path: &str) -> Result<FileStatDto> {
         let agent = self.require_alive_agent(id)?;
         agent.files().stat(path).await
     }
 
     /// List a directory inside an alive sandbox, non-recursively, with full
     /// per-entry metadata.
-    pub async fn list_sandbox_dir(&self, id: &ComputerId, path: &str) -> Result<Vec<FileStatDto>> {
+    pub async fn list_computer_dir(&self, id: &ComputerId, path: &str) -> Result<Vec<FileStatDto>> {
         let agent = self.require_alive_agent(id)?;
         agent.files().list(path).await
     }
@@ -46,14 +46,14 @@ impl SandboxManager {
     /// Create a directory (and missing parents) inside an alive sandbox.
     /// Succeeds when the directory already exists. `mode` must already be
     /// defaulted by the caller.
-    pub async fn make_sandbox_dir(&self, id: &ComputerId, path: &str, mode: u32) -> Result<()> {
+    pub async fn make_computer_dir(&self, id: &ComputerId, path: &str, mode: u32) -> Result<()> {
         let agent = self.require_alive_agent(id)?;
         agent.files().make_dir(path, mode).await
     }
 
     /// Remove a file, symlink, or directory inside an alive sandbox. A
     /// non-empty directory requires `recursive`.
-    pub async fn remove_sandbox_path(
+    pub async fn remove_computer_path(
         &self,
         id: &ComputerId,
         path: &str,
@@ -64,14 +64,14 @@ impl SandboxManager {
     }
 
     /// Rename / move an entry within an alive sandbox.
-    pub async fn move_sandbox_path(&self, id: &ComputerId, from: &str, to: &str) -> Result<()> {
+    pub async fn move_computer_path(&self, id: &ComputerId, from: &str, to: &str) -> Result<()> {
         let agent = self.require_alive_agent(id)?;
         agent.files().rename(from, to).await
     }
 
     /// Open a directory watch inside an alive sandbox. The returned stream
     /// ends cleanly when the sandbox stops; dropping it cancels the watch.
-    pub async fn watch_sandbox_dir(
+    pub async fn watch_computer_dir(
         &self,
         id: &ComputerId,
         path: &str,

--- a/computer/arcbox-computer-runtime/src/sandbox/files.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/files.rs
@@ -12,7 +12,7 @@ use crate::file_proto::FileStatDto;
 
 impl SandboxManager {
     /// Read a file from inside an alive sandbox.
-    pub async fn read_sandbox_file(&self, id: &SandboxId, path: &str) -> Result<Vec<u8>> {
+    pub async fn read_sandbox_file(&self, id: &ComputerId, path: &str) -> Result<Vec<u8>> {
         let agent = self.require_alive_agent(id)?;
         agent.files().read(path).await
     }
@@ -20,7 +20,7 @@ impl SandboxManager {
     /// Write a file into an alive sandbox.
     pub async fn write_sandbox_file(
         &self,
-        id: &SandboxId,
+        id: &ComputerId,
         path: &str,
         mode: u32,
         data: &[u8],
@@ -31,14 +31,14 @@ impl SandboxManager {
 
     /// Stat one path inside an alive sandbox (symlinks reported, not
     /// followed).
-    pub async fn stat_sandbox_path(&self, id: &SandboxId, path: &str) -> Result<FileStatDto> {
+    pub async fn stat_sandbox_path(&self, id: &ComputerId, path: &str) -> Result<FileStatDto> {
         let agent = self.require_alive_agent(id)?;
         agent.files().stat(path).await
     }
 
     /// List a directory inside an alive sandbox, non-recursively, with full
     /// per-entry metadata.
-    pub async fn list_sandbox_dir(&self, id: &SandboxId, path: &str) -> Result<Vec<FileStatDto>> {
+    pub async fn list_sandbox_dir(&self, id: &ComputerId, path: &str) -> Result<Vec<FileStatDto>> {
         let agent = self.require_alive_agent(id)?;
         agent.files().list(path).await
     }
@@ -46,7 +46,7 @@ impl SandboxManager {
     /// Create a directory (and missing parents) inside an alive sandbox.
     /// Succeeds when the directory already exists. `mode` must already be
     /// defaulted by the caller.
-    pub async fn make_sandbox_dir(&self, id: &SandboxId, path: &str, mode: u32) -> Result<()> {
+    pub async fn make_sandbox_dir(&self, id: &ComputerId, path: &str, mode: u32) -> Result<()> {
         let agent = self.require_alive_agent(id)?;
         agent.files().make_dir(path, mode).await
     }
@@ -55,7 +55,7 @@ impl SandboxManager {
     /// non-empty directory requires `recursive`.
     pub async fn remove_sandbox_path(
         &self,
-        id: &SandboxId,
+        id: &ComputerId,
         path: &str,
         recursive: bool,
     ) -> Result<()> {
@@ -64,7 +64,7 @@ impl SandboxManager {
     }
 
     /// Rename / move an entry within an alive sandbox.
-    pub async fn move_sandbox_path(&self, id: &SandboxId, from: &str, to: &str) -> Result<()> {
+    pub async fn move_sandbox_path(&self, id: &ComputerId, from: &str, to: &str) -> Result<()> {
         let agent = self.require_alive_agent(id)?;
         agent.files().rename(from, to).await
     }
@@ -73,7 +73,7 @@ impl SandboxManager {
     /// ends cleanly when the sandbox stops; dropping it cancels the watch.
     pub async fn watch_sandbox_dir(
         &self,
-        id: &SandboxId,
+        id: &ComputerId,
         path: &str,
         recursive: bool,
     ) -> Result<DirWatch> {

--- a/computer/arcbox-computer-runtime/src/sandbox/files.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/files.rs
@@ -4,7 +4,7 @@
 //! [`GuestFiles`](crate::agent::GuestFiles): each verb verifies the sandbox
 //! is alive (Ready or Running — file I/O works alongside a running
 //! workload) and forwards to the agent. Paused states surface as
-//! [`VmmError::Paused`] so the daemon's transparent auto-resume applies.
+//! [`ComputerError::Paused`] so the daemon's transparent auto-resume applies.
 
 use super::*;
 use crate::agent::DirWatch;

--- a/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
@@ -1,5 +1,5 @@
 use super::reconcile::JournaledLease;
-use super::record::{ProvisionIntent, SandboxProvisionOutcome, SandboxTransition};
+use super::record::{ComputerProvisionOutcome, ComputerTransition, ProvisionIntent};
 use super::*;
 use crate::lifecycle::actor::ComputerSnapshot;
 use crate::sandbox::record::PersistPhase;
@@ -350,7 +350,7 @@ impl SandboxManager {
                 .unwrap_or_default();
 
             super::reconcile::create_runtime_dir(&vm_dir)?;
-            let cleanup_record = super::reconcile::SandboxStateRecord::new(
+            let cleanup_record = super::reconcile::ComputerStateRecord::new(
                 &id,
                 None,
                 lease
@@ -408,7 +408,7 @@ impl SandboxManager {
                         .transition(
                             &id,
                             generation,
-                            SandboxTransition::Failed(error.to_string()),
+                            ComputerTransition::Failed(error.to_string()),
                         )
                         .err()
                         .map(|record_error| format!("record: {record_error}"));
@@ -489,7 +489,7 @@ impl SandboxManager {
             })),
             seeded: Seeded::Fresh,
         });
-        let outcome = SandboxProvisionOutcome {
+        let outcome = ComputerProvisionOutcome {
             ip_address: ip_address.clone(),
         };
         // `AckUnconfirmed` says the `Starting` write is visible but not

--- a/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
@@ -18,14 +18,14 @@ impl SandboxManager {
         &self,
         id: &str,
         request_key: &str,
-    ) -> Result<Option<(SandboxId, String)>> {
+    ) -> Result<Option<(ComputerId, String)>> {
         self.await_reconcile().await?;
         self.records
             .replay_provision(id, request_key)
             .map(|outcome| outcome.map(|outcome| (id.to_owned(), outcome.ip_address)))
     }
 
-    pub async fn create_sandbox(&self, spec: SandboxSpec) -> Result<(SandboxId, String)> {
+    pub async fn create_sandbox(&self, spec: ComputerSpec) -> Result<(ComputerId, String)> {
         self.create_sandbox_keyed(spec, &Uuid::new_v4().to_string())
             .await
     }
@@ -33,9 +33,9 @@ impl SandboxManager {
     /// Create a sandbox with a stable key for durable request replay.
     pub async fn create_sandbox_keyed(
         &self,
-        spec: SandboxSpec,
+        spec: ComputerSpec,
         request_key: &str,
-    ) -> Result<(SandboxId, String)> {
+    ) -> Result<(ComputerId, String)> {
         self.create_sandbox_inner(spec, request_key, WarmPolicy::Auto)
             .await
     }
@@ -49,7 +49,7 @@ impl SandboxManager {
     /// (terminal events prompt it; a 1 s rescan backstops), so this
     /// normally resolves within a second or two. On expiry the fallback
     /// proceeds anyway and `reserve` surfaces the honest UNAVAILABLE.
-    async fn await_network_release(&self, id: &SandboxId) {
+    async fn await_network_release(&self, id: &ComputerId) {
         let deadline = std::time::Instant::now() + Duration::from_secs(10);
         loop {
             match self.reconcile_network().pending_cleanups().await {
@@ -81,10 +81,10 @@ impl SandboxManager {
     /// a duplicate full-memory snapshot).
     pub(super) async fn create_sandbox_inner(
         &self,
-        mut spec: SandboxSpec,
+        mut spec: ComputerSpec,
         request_key: &str,
         warm_policy: WarmPolicy,
-    ) -> Result<(SandboxId, String)> {
+    ) -> Result<(ComputerId, String)> {
         // Do not allocate any per-id resources until the startup orphan sweep
         // has run — otherwise a re-created same-id sandbox races it.
         self.await_reconcile().await?;
@@ -518,7 +518,7 @@ impl SandboxManager {
     /// outlives the remaining budget. All runtime resources (TAP + IP,
     /// dm-snapshot CoW, jailer chroot) are released on `Stopped`; only the
     /// inspectable record and the log directory survive until `Remove`.
-    pub async fn stop_sandbox(&self, id: &SandboxId, timeout_seconds: u32) -> Result<()> {
+    pub async fn stop_sandbox(&self, id: &ComputerId, timeout_seconds: u32) -> Result<()> {
         self.await_reconcile().await?;
         let budget = Duration::from_secs(u64::from(if timeout_seconds > 0 {
             timeout_seconds
@@ -545,7 +545,7 @@ impl SandboxManager {
     /// `Adopt`. The `PreparedVm` a booted sandbox also holds needs no such
     /// step: it kills on drop only while it is still unconsumed.
     pub async fn detach_all(&self) -> Result<()> {
-        let live: Vec<(SandboxId, Arc<dyn VmHandle>)> = self
+        let live: Vec<(ComputerId, Arc<dyn VmHandle>)> = self
             .computers
             .read()
             .unwrap()
@@ -576,7 +576,7 @@ impl SandboxManager {
     }
 
     /// Forcibly destroy a sandbox and release all resources immediately.
-    pub async fn remove_sandbox(&self, id: &SandboxId, force: bool) -> Result<()> {
+    pub async fn remove_sandbox(&self, id: &ComputerId, force: bool) -> Result<()> {
         self.await_reconcile().await?;
         let mailbox = match self.mailbox(id) {
             Ok(mailbox) => mailbox,
@@ -593,7 +593,7 @@ impl SandboxManager {
                     id,
                     ComputerRuntime::new(
                         id.clone(),
-                        SandboxSpec {
+                        ComputerSpec {
                             id: Some(id.clone()),
                             ..Default::default()
                         },
@@ -641,7 +641,7 @@ impl SandboxManager {
     }
 
     /// Return the current state and metadata of a sandbox.
-    pub fn inspect_sandbox(&self, id: &SandboxId) -> Result<SandboxInfo> {
+    pub fn inspect_sandbox(&self, id: &ComputerId) -> Result<SandboxInfo> {
         let snapshot = self.snapshot(id)?;
         // Size the retained artifacts after the read: the sizing stats files
         // and scans the catalog, and the snapshot is a borrow of a `watch`
@@ -666,7 +666,7 @@ impl SandboxManager {
         // per-computer lock is taken at all, so the "never hold the map lock
         // while holding an instance lock" discipline this fold used to need
         // has nothing left to violate.
-        let computers: Vec<(SandboxId, ComputerSnapshot)> = self
+        let computers: Vec<(ComputerId, ComputerSnapshot)> = self
             .computers
             .read()
             .unwrap()
@@ -735,7 +735,7 @@ impl SandboxManager {
     ///
     /// A paused computer answers [`ComputerError::Paused`], not `WrongState`, so
     /// the daemon can resume it transparently and retry (CORE-21).
-    pub(super) fn require_ready_agent(&self, id: &SandboxId) -> Result<Arc<dyn GuestAgent>> {
+    pub(super) fn require_ready_agent(&self, id: &ComputerId) -> Result<Arc<dyn GuestAgent>> {
         self.agent_in(id, &[SandboxState::Ready], "Ready")
     }
 
@@ -744,7 +744,7 @@ impl SandboxManager {
     /// does not block the operation — file I/O works alongside Run/Exec.
     /// Paused states map to [`ComputerError::Paused`] for the daemon's transparent
     /// resume, as above.
-    pub(super) fn require_alive_agent(&self, id: &SandboxId) -> Result<Arc<dyn GuestAgent>> {
+    pub(super) fn require_alive_agent(&self, id: &ComputerId) -> Result<Arc<dyn GuestAgent>> {
         self.agent_in(
             id,
             &[SandboxState::Ready, SandboxState::Running],
@@ -760,7 +760,7 @@ impl SandboxManager {
     /// an exec costs a clone of an `Arc` rather than a scheduling hop.
     fn agent_in(
         &self,
-        id: &SandboxId,
+        id: &ComputerId,
         allowed: &[SandboxState],
         expected: &str,
     ) -> Result<Arc<dyn GuestAgent>> {
@@ -782,14 +782,14 @@ impl SandboxManager {
 }
 
 /// A computer's read snapshot as `Inspect` reports it.
-fn snapshot_to_info(id: &SandboxId, snapshot: &ComputerSnapshot) -> SandboxInfo {
+fn snapshot_to_info(id: &ComputerId, snapshot: &ComputerSnapshot) -> SandboxInfo {
     SandboxInfo {
         id: id.clone(),
         state: snapshot.state,
         labels: snapshot.labels.clone(),
         vcpus: snapshot.vcpus,
         memory_mib: snapshot.memory_mib,
-        network: snapshot.lease.as_ref().map(|lease| SandboxNetworkInfo {
+        network: snapshot.lease.as_ref().map(|lease| ComputerNetworkInfo {
             ip_address: lease.ip.to_string(),
             gateway: lease.gateway.to_string(),
         }),

--- a/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
@@ -59,13 +59,13 @@ impl SandboxManager {
                     // The ledger is what the wait is about, so an unreadable
                     // one is not something to spin on: fall through and let
                     // `reserve` report it.
-                    warn!(sandbox_id = %id, %error, "network cleanup ledger is unreadable");
+                    warn!(computer_id = %id, %error, "network cleanup ledger is unreadable");
                     return;
                 }
             }
             if std::time::Instant::now() > deadline {
                 warn!(
-                    sandbox_id = %id,
+                    computer_id = %id,
                     "network cleanup still awaiting host finalization; cold boot will report it"
                 );
                 return;
@@ -148,7 +148,7 @@ impl SandboxManager {
             )
         {
             info!(
-                sandbox_id = %id,
+                computer_id = %id,
                 snapshot_id = %warm.snapshot_id,
                 "template create: restoring the template's pre-warmed snapshot"
             );
@@ -172,7 +172,7 @@ impl SandboxManager {
                 Err(error @ ComputerError::AckUnconfirmed { .. }) => return Err(error),
                 Err(error) => {
                     warn!(
-                        sandbox_id = %id,
+                        computer_id = %id,
                         snapshot_id = %warm.snapshot_id,
                         %error,
                         "template warm restore failed; cold-booting from the template rootfs"
@@ -197,7 +197,7 @@ impl SandboxManager {
                     Ok(Some(snapshot_id)) => {
                         self.warm.touch(&key);
                         info!(
-                            sandbox_id = %id,
+                            computer_id = %id,
                             snapshot_id,
                             "warm create: restoring cached template snapshot"
                         );
@@ -238,7 +238,7 @@ impl SandboxManager {
                             }
                             Err(error) => {
                                 warn!(
-                                    sandbox_id = %id,
+                                    computer_id = %id,
                                     snapshot_id,
                                     %error,
                                     "warm restore failed; cold-booting instead"
@@ -264,11 +264,11 @@ impl SandboxManager {
                     Err(error) => {
                         // The publish path would scan the same catalog, so a
                         // failed lookup cold-boots without cache interaction.
-                        warn!(sandbox_id = %id, %error, "warm snapshot lookup failed; cold-booting");
+                        warn!(computer_id = %id, %error, "warm snapshot lookup failed; cold-booting");
                     }
                 },
                 Err(error) => {
-                    debug!(sandbox_id = %id, %error, "rootfs fingerprint failed; skipping warm create");
+                    debug!(computer_id = %id, %error, "rootfs fingerprint failed; skipping warm create");
                 }
             }
         }
@@ -381,7 +381,7 @@ impl SandboxManager {
                 // log it here so a create that dies between the network
                 // activation and the Starting journal commit is attributable
                 // from the guest log alone (CORE-82).
-                warn!(sandbox_id = %id, error = %error, "sandbox create setup failed; rolling back");
+                warn!(computer_id = %id, error = %error, "sandbox create setup failed; rolling back");
                 let mut rollback_errors = Vec::new();
                 let mut network_cleanup_failed = false;
                 if let Some(reserved) = lease.clone()
@@ -400,7 +400,7 @@ impl SandboxManager {
                     {
                         let mut creating = arc.lock().unwrap();
                         creating.network = lease;
-                        creating.state = SandboxState::Failed;
+                        creating.state = ComputerState::Failed;
                         creating.error = Some(error.to_string());
                     }
                     let record_error = self
@@ -430,7 +430,7 @@ impl SandboxManager {
                     });
                     let rollback = rollback_errors.join("; ");
                     error!(
-                        sandbox_id = %id,
+                        computer_id = %id,
                         error = %error,
                         rollback = %rollback,
                         "sandbox create rollback incomplete; instance left Failed"
@@ -506,7 +506,7 @@ impl SandboxManager {
                 reply,
             })
             .await?;
-        info!(sandbox_id = %id, "sandbox create requested (async boot started)");
+        info!(computer_id = %id, "sandbox create requested (async boot started)");
         Ok((id, ip_address))
     }
 
@@ -562,7 +562,7 @@ impl SandboxManager {
                 continue;
             };
             match detach.detach().await {
-                Ok(_) => info!(sandbox_id = %id, "handed the sandbox's vm to the next process"),
+                Ok(_) => info!(computer_id = %id, "handed the sandbox's vm to the next process"),
                 Err(error) => failures.push(format!("{id}: {error}")),
             }
         }
@@ -608,7 +608,7 @@ impl SandboxManager {
                                 "sandbox {id} removal is visible, but durability is unconfirmed: {error}"
                             )));
                         }
-                        info!(sandbox_id = %id, "sandbox already removed");
+                        info!(computer_id = %id, "sandbox already removed");
                         return Ok(());
                     }
                     // A create won the race for the id; remove what it made.
@@ -621,7 +621,7 @@ impl SandboxManager {
         mailbox
             .ask(id, |reply| Command::Remove { force, reply })
             .await?;
-        info!(sandbox_id = %id, "sandbox removed");
+        info!(computer_id = %id, "sandbox removed");
         Ok(())
     }
 
@@ -641,12 +641,12 @@ impl SandboxManager {
     }
 
     /// Return the current state and metadata of a sandbox.
-    pub fn inspect_sandbox(&self, id: &ComputerId) -> Result<SandboxInfo> {
+    pub fn inspect_sandbox(&self, id: &ComputerId) -> Result<ComputerInfo> {
         let snapshot = self.snapshot(id)?;
         // Size the retained artifacts after the read: the sizing stats files
         // and scans the catalog, and the snapshot is a borrow of a `watch`
         // the actor writes.
-        let artifacts = (snapshot.state == SandboxState::Paused)
+        let artifacts = (snapshot.state == ComputerState::Paused)
             .then(|| super::pause::paused_artifacts(&self.config, id, &snapshot));
         let mut info = snapshot_to_info(id, &snapshot);
         if let Some(artifacts) = artifacts {
@@ -660,7 +660,7 @@ impl SandboxManager {
         &self,
         state_filter: Option<&str>,
         label_filter: &HashMap<String, String>,
-    ) -> Result<Vec<SandboxSummary>> {
+    ) -> Result<Vec<ComputerSummary>> {
         self.check_reconcile()?;
         // Snapshot every computer's read view under the map read guard. No
         // per-computer lock is taken at all, so the "never hold the map lock
@@ -675,39 +675,40 @@ impl SandboxManager {
             .collect();
         // The second pass pays one catalog listing for the whole response
         // instead of one per paused sandbox.
-        let mut summaries: Vec<(SandboxSummary, Option<super::pause::PausedArtifacts>)> = computers
-            .iter()
-            .filter_map(|(id, snapshot)| {
-                if let Some(sf) = state_filter
-                    && !sf.is_empty()
-                    && snapshot.state.to_string() != sf
-                {
-                    return None;
-                }
-                // Label filter: all supplied key-value pairs must match.
-                for (k, v) in label_filter {
-                    if snapshot.labels.get(k).map(String::as_str) != Some(v.as_str()) {
+        let mut summaries: Vec<(ComputerSummary, Option<super::pause::PausedArtifacts>)> =
+            computers
+                .iter()
+                .filter_map(|(id, snapshot)| {
+                    if let Some(sf) = state_filter
+                        && !sf.is_empty()
+                        && snapshot.state.to_string() != sf
+                    {
                         return None;
                     }
-                }
-                let summary = SandboxSummary {
-                    id: id.clone(),
-                    state: snapshot.state,
-                    labels: snapshot.labels.clone(),
-                    ip_address: snapshot
-                        .lease
-                        .as_ref()
-                        .map(|lease| lease.ip.to_string())
-                        .unwrap_or_default(),
-                    created_at: snapshot.created_at,
-                    paused_at: snapshot.paused_at,
-                    storage_bytes: 0,
-                };
-                let artifacts = (snapshot.state == SandboxState::Paused)
-                    .then(|| super::pause::paused_artifacts(&self.config, id, snapshot));
-                Some((summary, artifacts))
-            })
-            .collect();
+                    // Label filter: all supplied key-value pairs must match.
+                    for (k, v) in label_filter {
+                        if snapshot.labels.get(k).map(String::as_str) != Some(v.as_str()) {
+                            return None;
+                        }
+                    }
+                    let summary = ComputerSummary {
+                        id: id.clone(),
+                        state: snapshot.state,
+                        labels: snapshot.labels.clone(),
+                        ip_address: snapshot
+                            .lease
+                            .as_ref()
+                            .map(|lease| lease.ip.to_string())
+                            .unwrap_or_default(),
+                        created_at: snapshot.created_at,
+                        paused_at: snapshot.paused_at,
+                        storage_bytes: 0,
+                    };
+                    let artifacts = (snapshot.state == ComputerState::Paused)
+                        .then(|| super::pause::paused_artifacts(&self.config, id, snapshot));
+                    Some((summary, artifacts))
+                })
+                .collect();
 
         if summaries.iter().any(|(_, artifacts)| artifacts.is_some()) {
             let catalog = self.snapshots.list_all().unwrap_or_default();
@@ -727,7 +728,7 @@ impl SandboxManager {
     }
 
     /// Subscribe to sandbox lifecycle events.
-    pub fn subscribe_events(&self) -> broadcast::Receiver<SandboxEvent> {
+    pub fn subscribe_events(&self) -> broadcast::Receiver<ComputerEvent> {
         self.events_tx.subscribe()
     }
 
@@ -736,7 +737,7 @@ impl SandboxManager {
     /// A paused computer answers [`ComputerError::Paused`], not `WrongState`, so
     /// the daemon can resume it transparently and retry (CORE-21).
     pub(super) fn require_ready_agent(&self, id: &ComputerId) -> Result<Arc<dyn GuestAgent>> {
-        self.agent_in(id, &[SandboxState::Ready], "Ready")
+        self.agent_in(id, &[ComputerState::Ready], "Ready")
     }
 
     /// Verify the computer is alive (Ready or Running) and return the agent
@@ -747,7 +748,7 @@ impl SandboxManager {
     pub(super) fn require_alive_agent(&self, id: &ComputerId) -> Result<Arc<dyn GuestAgent>> {
         self.agent_in(
             id,
-            &[SandboxState::Ready, SandboxState::Running],
+            &[ComputerState::Ready, ComputerState::Running],
             "Ready or Running",
         )
     }
@@ -761,13 +762,13 @@ impl SandboxManager {
     fn agent_in(
         &self,
         id: &ComputerId,
-        allowed: &[SandboxState],
+        allowed: &[ComputerState],
         expected: &str,
     ) -> Result<Arc<dyn GuestAgent>> {
         let snapshot = self.snapshot(id)?;
         if !allowed.contains(&snapshot.state) {
             return Err(match snapshot.state {
-                SandboxState::Pausing | SandboxState::Paused => ComputerError::Paused(id.clone()),
+                ComputerState::Pausing | ComputerState::Paused => ComputerError::Paused(id.clone()),
                 state => ComputerError::WrongState {
                     id: id.clone(),
                     expected: expected.to_owned(),
@@ -782,8 +783,8 @@ impl SandboxManager {
 }
 
 /// A computer's read snapshot as `Inspect` reports it.
-fn snapshot_to_info(id: &ComputerId, snapshot: &ComputerSnapshot) -> SandboxInfo {
-    SandboxInfo {
+fn snapshot_to_info(id: &ComputerId, snapshot: &ComputerSnapshot) -> ComputerInfo {
+    ComputerInfo {
         id: id.clone(),
         state: snapshot.state,
         labels: snapshot.labels.clone(),

--- a/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
@@ -12,9 +12,9 @@ pub(super) enum WarmPolicy {
     Disabled,
 }
 
-impl SandboxManager {
+impl ComputerManager {
     /// Replay a durable Create outcome without resolving its template again.
-    pub async fn replay_sandbox_create(
+    pub async fn replay_computer_create(
         &self,
         id: &str,
         request_key: &str,
@@ -25,18 +25,18 @@ impl SandboxManager {
             .map(|outcome| outcome.map(|outcome| (id.to_owned(), outcome.ip_address)))
     }
 
-    pub async fn create_sandbox(&self, spec: ComputerSpec) -> Result<(ComputerId, String)> {
-        self.create_sandbox_keyed(spec, &Uuid::new_v4().to_string())
+    pub async fn create_computer(&self, spec: ComputerSpec) -> Result<(ComputerId, String)> {
+        self.create_computer_keyed(spec, &Uuid::new_v4().to_string())
             .await
     }
 
     /// Create a sandbox with a stable key for durable request replay.
-    pub async fn create_sandbox_keyed(
+    pub async fn create_computer_keyed(
         &self,
         spec: ComputerSpec,
         request_key: &str,
     ) -> Result<(ComputerId, String)> {
-        self.create_sandbox_inner(spec, request_key, WarmPolicy::Auto)
+        self.create_computer_inner(spec, request_key, WarmPolicy::Auto)
             .await
     }
 
@@ -74,12 +74,12 @@ impl SandboxManager {
         }
     }
 
-    /// [`Self::create_sandbox_keyed`] with explicit warm behaviour: the
+    /// [`Self::create_computer_keyed`] with explicit warm behaviour: the
     /// prewarm builder (CORE-107) passes [`WarmPolicy::Disabled`] so its own
     /// boot neither restores from a warm source nor publishes into the
     /// warm-cache LRU (which would burn one of the `MAX_WARM_KEYS` slots on
     /// a duplicate full-memory snapshot).
-    pub(super) async fn create_sandbox_inner(
+    pub(super) async fn create_computer_inner(
         &self,
         mut spec: ComputerSpec,
         request_key: &str,
@@ -123,7 +123,7 @@ impl SandboxManager {
         // Hold a caller-supplied id to what the driver can actually run it
         // as — its VM identity and its socket-path budget. Auto-generated
         // UUIDs pass unchanged.
-        super::validate_new_sandbox_id(&id, &*self.services.driver, &self.config)?;
+        super::validate_new_computer_id(&id, &*self.services.driver, &self.config)?;
         spec.id = Some(id.clone());
 
         // Template warm-restore (CORE-107): a catalog template carrying a
@@ -340,7 +340,7 @@ impl SandboxManager {
                 lease = Some(
                     self.services
                         .network
-                        .reserve(&VmId::new(&id)?, super::sandbox_network_policy())
+                        .reserve(&VmId::new(&id)?, super::computer_network_policy())
                         .await?,
                 );
             }
@@ -518,7 +518,7 @@ impl SandboxManager {
     /// outlives the remaining budget. All runtime resources (TAP + IP,
     /// dm-snapshot CoW, jailer chroot) are released on `Stopped`; only the
     /// inspectable record and the log directory survive until `Remove`.
-    pub async fn stop_sandbox(&self, id: &ComputerId, timeout_seconds: u32) -> Result<()> {
+    pub async fn stop_computer(&self, id: &ComputerId, timeout_seconds: u32) -> Result<()> {
         self.await_reconcile().await?;
         let budget = Duration::from_secs(u64::from(if timeout_seconds > 0 {
             timeout_seconds
@@ -576,7 +576,7 @@ impl SandboxManager {
     }
 
     /// Forcibly destroy a sandbox and release all resources immediately.
-    pub async fn remove_sandbox(&self, id: &ComputerId, force: bool) -> Result<()> {
+    pub async fn remove_computer(&self, id: &ComputerId, force: bool) -> Result<()> {
         self.await_reconcile().await?;
         let mailbox = match self.mailbox(id) {
             Ok(mailbox) => mailbox,
@@ -641,7 +641,7 @@ impl SandboxManager {
     }
 
     /// Return the current state and metadata of a sandbox.
-    pub fn inspect_sandbox(&self, id: &ComputerId) -> Result<ComputerInfo> {
+    pub fn inspect_computer(&self, id: &ComputerId) -> Result<ComputerInfo> {
         let snapshot = self.snapshot(id)?;
         // Size the retained artifacts after the read: the sizing stats files
         // and scans the catalog, and the snapshot is a borrow of a `watch`
@@ -656,7 +656,7 @@ impl SandboxManager {
     }
 
     /// List sandboxes, optionally filtered by state string and/or labels.
-    pub fn list_sandboxes(
+    pub fn list_computers(
         &self,
         state_filter: Option<&str>,
         label_filter: &HashMap<String, String>,
@@ -810,7 +810,7 @@ fn snapshot_to_info(id: &ComputerId, snapshot: &ComputerSnapshot) -> ComputerInf
 
 /// Files a listed checkpoint occupies on disk, for storage accounting.
 ///
-/// The listing counterpart of [`SandboxManager::checkpoint_paths`]: it reads
+/// The listing counterpart of [`ComputerManager::checkpoint_paths`]: it reads
 /// an already-loaded [`SnapshotInfo`] so a multi-sandbox response pays one
 /// catalog scan rather than one per paused sandbox.
 fn snapshot_files(info: &crate::snapshot::SnapshotInfo) -> Vec<PathBuf> {
@@ -837,7 +837,7 @@ mod tests {
                 ..arcbox_vm_driver::testkit::FakeDriver::new().capabilities()
             })
             .build();
-        SandboxManager::new(
+        ComputerManager::new(
             config.clone(),
             NodeEnvironment {
                 driver: Arc::new(driver),

--- a/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/lifecycle.rs
@@ -169,7 +169,7 @@ impl SandboxManager {
                 Ok(result) => return Ok(result),
                 // Post-commit ambiguity: the sandbox is running under this
                 // id — cold-booting would recreate a live sandbox.
-                Err(error @ VmmError::AckUnconfirmed { .. }) => return Err(error),
+                Err(error @ ComputerError::AckUnconfirmed { .. }) => return Err(error),
                 Err(error) => {
                     warn!(
                         sandbox_id = %id,
@@ -233,7 +233,7 @@ impl SandboxManager {
                             .await
                         {
                             Ok(result) => return Ok(result),
-                            Err(error @ VmmError::AckUnconfirmed { .. }) => {
+                            Err(error @ ComputerError::AckUnconfirmed { .. }) => {
                                 return Err(error);
                             }
                             Err(error) => {
@@ -289,16 +289,17 @@ impl SandboxManager {
         let record = match self.records.provision_intent(&id, request_key, spec)? {
             ProvisionIntent::Created(record) | ProvisionIntent::Resume(record) => record,
             ProvisionIntent::Replay(record) => {
-                let outcome = record
-                    .provision_outcome
-                    .ok_or_else(|| VmmError::WrongState {
-                        id: id.clone(),
-                        expected: "a persisted create outcome".into(),
-                        actual: "none".into(),
-                    })?;
+                let outcome =
+                    record
+                        .provision_outcome
+                        .ok_or_else(|| ComputerError::WrongState {
+                            id: id.clone(),
+                            expected: "a persisted create outcome".into(),
+                            actual: "none".into(),
+                        })?;
                 return Ok((id, outcome.ip_address));
             }
-            ProvisionIntent::Blocked(_) => return Err(VmmError::AlreadyExists(id)),
+            ProvisionIntent::Blocked(_) => return Err(ComputerError::AlreadyExists(id)),
         };
         let generation = record.generation;
         let deadlines = Deadlines {
@@ -369,7 +370,7 @@ impl SandboxManager {
                 );
             }
 
-            Ok::<_, VmmError>(ip_address)
+            Ok::<_, ComputerError>(ip_address)
         }
         .await;
 
@@ -434,13 +435,13 @@ impl SandboxManager {
                         rollback = %rollback,
                         "sandbox create rollback incomplete; instance left Failed"
                     );
-                    return Err(VmmError::Other(format!(
+                    return Err(ComputerError::Other(format!(
                         "{error}; sandbox rollback is incomplete: {rollback}"
                     )));
                 }
                 let abort = self.records.abort_provision(&id, generation)?;
                 if let Some(durability_error) = abort.durability_error {
-                    return Err(VmmError::Unavailable(format!(
+                    return Err(ComputerError::Unavailable(format!(
                         "{error}; create rollback is visible, but durability is unconfirmed: {durability_error}"
                     )));
                 }
@@ -568,7 +569,7 @@ impl SandboxManager {
         if failures.is_empty() {
             return Ok(());
         }
-        Err(VmmError::Unavailable(format!(
+        Err(ComputerError::Unavailable(format!(
             "some sandboxes could not be handed over and will be killed on exit: {}",
             failures.join("; ")
         )))
@@ -583,7 +584,7 @@ impl SandboxManager {
             // an intent nobody acknowledged, or a tombstone a previous
             // removal did not finish — and the claim is what serializes this
             // against a create of the same id arriving now.
-            Err(VmmError::NotFound(_)) => {
+            Err(ComputerError::NotFound(_)) => {
                 let vm_dir = PathBuf::from(&self.config.firecracker.data_dir)
                     .join("sandboxes")
                     .join(id);
@@ -603,7 +604,7 @@ impl SandboxManager {
                     Ok(_reservation) => {
                         let commit = self.records.cancel_pending_or_missing(id)?;
                         if let Some(error) = commit.durability_error {
-                            return Err(VmmError::Unavailable(format!(
+                            return Err(ComputerError::Unavailable(format!(
                                 "sandbox {id} removal is visible, but durability is unconfirmed: {error}"
                             )));
                         }
@@ -611,7 +612,7 @@ impl SandboxManager {
                         return Ok(());
                     }
                     // A create won the race for the id; remove what it made.
-                    Err(VmmError::AlreadyExists(_)) => self.mailbox(id)?,
+                    Err(ComputerError::AlreadyExists(_)) => self.mailbox(id)?,
                     Err(error) => return Err(error),
                 }
             }
@@ -732,7 +733,7 @@ impl SandboxManager {
 
     /// Verify the computer is `Ready` and return the agent inside it.
     ///
-    /// A paused computer answers [`VmmError::Paused`], not `WrongState`, so
+    /// A paused computer answers [`ComputerError::Paused`], not `WrongState`, so
     /// the daemon can resume it transparently and retry (CORE-21).
     pub(super) fn require_ready_agent(&self, id: &SandboxId) -> Result<Arc<dyn GuestAgent>> {
         self.agent_in(id, &[SandboxState::Ready], "Ready")
@@ -741,7 +742,7 @@ impl SandboxManager {
     /// Verify the computer is alive (Ready or Running) and return the agent
     /// inside it. Unlike [`Self::require_ready_agent`], an in-flight workload
     /// does not block the operation — file I/O works alongside Run/Exec.
-    /// Paused states map to [`VmmError::Paused`] for the daemon's transparent
+    /// Paused states map to [`ComputerError::Paused`] for the daemon's transparent
     /// resume, as above.
     pub(super) fn require_alive_agent(&self, id: &SandboxId) -> Result<Arc<dyn GuestAgent>> {
         self.agent_in(
@@ -766,8 +767,8 @@ impl SandboxManager {
         let snapshot = self.snapshot(id)?;
         if !allowed.contains(&snapshot.state) {
             return Err(match snapshot.state {
-                SandboxState::Pausing | SandboxState::Paused => VmmError::Paused(id.clone()),
-                state => VmmError::WrongState {
+                SandboxState::Pausing | SandboxState::Paused => ComputerError::Paused(id.clone()),
+                state => ComputerError::WrongState {
                     id: id.clone(),
                     expected: expected.to_owned(),
                     actual: state.to_string(),
@@ -776,7 +777,7 @@ impl SandboxManager {
         }
         snapshot
             .agent
-            .ok_or_else(|| VmmError::Vsock(format!("sandbox {id} has no running vm to reach")))
+            .ok_or_else(|| ComputerError::Vsock(format!("sandbox {id} has no running vm to reach")))
     }
 }
 

--- a/computer/arcbox-computer-runtime/src/sandbox/pause.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/pause.rs
@@ -84,7 +84,7 @@ pub struct ResumedRuntime {
 
 /// How a failed resume left the sandbox.
 pub struct ResumeFailure {
-    pub error: VmmError,
+    pub error: ComputerError,
     /// True when every re-created resource was released again and the
     /// retained pause state (checkpoint + disk) is intact — the sandbox can
     /// go back to `Paused` and a retry can succeed.
@@ -121,7 +121,7 @@ impl SandboxManager {
         if computer.snapshot.borrow().state == SandboxState::Ready
             && self.config.firecracker.jailer.is_none()
         {
-            return Err(VmmError::Config(
+            return Err(ComputerError::Config(
                 "sandbox pause requires jailer isolation; direct mode cannot resume".into(),
             ));
         }

--- a/computer/arcbox-computer-runtime/src/sandbox/pause.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/pause.rs
@@ -91,7 +91,7 @@ pub struct ResumeFailure {
     pub unwound: bool,
 }
 
-impl SandboxManager {
+impl ComputerManager {
     /// Pause a `Ready` sandbox: checkpoint it, then release its runtime
     /// resources while keeping the record, checkpoint, and disk overlay
     /// under the same id.
@@ -99,14 +99,14 @@ impl SandboxManager {
     /// Idempotent: pausing a `Paused` sandbox is a no-op. Any other state
     /// answers `WrongState` — an active execution must finish (or be
     /// stopped) first, matching the contract's "requires READY".
-    pub async fn pause_sandbox(&self, id: &ComputerId) -> Result<()> {
-        self.pause_sandbox_with_reason(id, PauseReason::Requested)
+    pub async fn pause_computer(&self, id: &ComputerId) -> Result<()> {
+        self.pause_computer_with_reason(id, PauseReason::Requested)
             .await
     }
 
-    /// [`Self::pause_sandbox`] with an explicit PAUSING-event reason —
+    /// [`Self::pause_computer`] with an explicit PAUSING-event reason —
     /// the idle detector reports `idle_timeout` (see [`reason`]).
-    pub(super) async fn pause_sandbox_with_reason(
+    pub(super) async fn pause_computer_with_reason(
         &self,
         id: &ComputerId,
         reason: PauseReason,
@@ -140,7 +140,7 @@ impl SandboxManager {
     /// "reason" attribute (see [`reason`]).
     ///
     /// Returns the sandbox's (fresh) IP address, empty without networking.
-    pub async fn resume_sandbox(&self, id: &ComputerId, resume_reason: &str) -> Result<String> {
+    pub async fn resume_computer(&self, id: &ComputerId, resume_reason: &str) -> Result<String> {
         self.await_reconcile().await?;
         let computer = self.computer(id)?;
         computer

--- a/computer/arcbox-computer-runtime/src/sandbox/pause.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/pause.rs
@@ -53,16 +53,16 @@ pub mod reason {
     pub const AUTO_RESUME: &str = "auto_resume";
 }
 
-/// Delete every internal pause checkpoint of `sandbox_id`.
+/// Delete every internal pause checkpoint of `computer_id`.
 ///
 /// Scans by the reserved name rather than the recorded snapshot id so a
 /// checkpoint leaked by an interrupted pause (committed to the catalog but
 /// never recorded durably) is cleaned up too.
 pub fn delete_pause_snapshots(
     snapshots: &crate::snapshot::SnapshotCatalog,
-    sandbox_id: &str,
+    computer_id: &str,
 ) -> Result<()> {
-    for info in snapshots.list(sandbox_id)? {
+    for info in snapshots.list(computer_id)? {
         if info.name.as_deref() == Some(PAUSE_SNAPSHOT_NAME) {
             snapshots.delete_by_id(&info.id)?;
         }
@@ -118,7 +118,7 @@ impl SandboxManager {
         // off the snapshot rather than left to the flow, because it is a
         // refusal the caller gets *instead* of the claim: only a computer
         // that would otherwise be paused hears it, exactly as today.
-        if computer.snapshot.borrow().state == SandboxState::Ready
+        if computer.snapshot.borrow().state == ComputerState::Ready
             && self.config.firecracker.jailer.is_none()
         {
             return Err(ComputerError::Config(

--- a/computer/arcbox-computer-runtime/src/sandbox/pause.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/pause.rs
@@ -14,7 +14,7 @@
 //!   writes — which is why restoring *from* a pause checkpoint is refused.
 //!
 //! Resume mirrors the fresh-network restore path: a new TAP + IP is
-//! allocated (`RestoreSandboxSpec::network_override` semantics) and the
+//! allocated (`RestoreComputerSpec::network_override` semantics) and the
 //! sandbox returns to `Ready` under its original id. The old allocation was
 //! quarantined at pause time and its host forwarding state cleaned via the
 //! same durable ticket flow Stop uses. Whether the guest needs re-addressing
@@ -99,7 +99,7 @@ impl SandboxManager {
     /// Idempotent: pausing a `Paused` sandbox is a no-op. Any other state
     /// answers `WrongState` — an active execution must finish (or be
     /// stopped) first, matching the contract's "requires READY".
-    pub async fn pause_sandbox(&self, id: &SandboxId) -> Result<()> {
+    pub async fn pause_sandbox(&self, id: &ComputerId) -> Result<()> {
         self.pause_sandbox_with_reason(id, PauseReason::Requested)
             .await
     }
@@ -108,7 +108,7 @@ impl SandboxManager {
     /// the idle detector reports `idle_timeout` (see [`reason`]).
     pub(super) async fn pause_sandbox_with_reason(
         &self,
-        id: &SandboxId,
+        id: &ComputerId,
         reason: PauseReason,
     ) -> Result<()> {
         self.await_reconcile().await?;
@@ -140,7 +140,7 @@ impl SandboxManager {
     /// "reason" attribute (see [`reason`]).
     ///
     /// Returns the sandbox's (fresh) IP address, empty without networking.
-    pub async fn resume_sandbox(&self, id: &SandboxId, resume_reason: &str) -> Result<String> {
+    pub async fn resume_sandbox(&self, id: &ComputerId, resume_reason: &str) -> Result<String> {
         self.await_reconcile().await?;
         let computer = self.computer(id)?;
         computer
@@ -170,7 +170,7 @@ impl SandboxManager {
 /// borrows the actor's `watch` and the sizing must not.
 pub(super) fn paused_artifacts(
     config: &RuntimeConfig,
-    id: &SandboxId,
+    id: &ComputerId,
     snapshot: &ComputerSnapshot,
 ) -> PausedArtifacts {
     PausedArtifacts {

--- a/computer/arcbox-computer-runtime/src/sandbox/policy/deadlines.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/policy/deadlines.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 
-use crate::sandbox::SandboxState;
+use crate::sandbox::ComputerState;
 
 /// The TTL deadline to arm for a sandbox in `state`, or `None` when its
 /// timer belongs cancelled.
@@ -22,9 +22,9 @@ use crate::sandbox::SandboxState;
 /// resync would re-arm one — recovery restores `ttl_deadline` for every
 /// record regardless of state — so whether a stopped sandbox's record gets
 /// reaped would depend on whether the agent happened to bounce.
-pub fn ttl_due(state: SandboxState, deadline: Option<DateTime<Utc>>) -> Option<DateTime<Utc>> {
+pub fn ttl_due(state: ComputerState, deadline: Option<DateTime<Utc>>) -> Option<DateTime<Utc>> {
     match state {
-        SandboxState::Stopped | SandboxState::Failed => None,
+        ComputerState::Stopped | ComputerState::Failed => None,
         _ => deadline,
     }
 }
@@ -34,8 +34,8 @@ pub fn ttl_due(state: SandboxState, deadline: Option<DateTime<Utc>>) -> Option<D
 ///
 /// Idle detection only makes sense while a sandbox is `Ready`: every other
 /// state either has a workload running or is on its way out.
-pub fn idle_due(state: SandboxState, timeout_seconds: u32) -> Option<Duration> {
-    (state == SandboxState::Ready && timeout_seconds != 0)
+pub fn idle_due(state: ComputerState, timeout_seconds: u32) -> Option<Duration> {
+    (state == ComputerState::Ready && timeout_seconds != 0)
         .then(|| Duration::from_secs(u64::from(timeout_seconds)))
 }
 
@@ -48,15 +48,15 @@ pub fn remaining(deadline: DateTime<Utc>, now: DateTime<Utc>) -> Duration {
 mod tests {
     use super::*;
 
-    const ALL_STATES: [SandboxState; 8] = [
-        SandboxState::Starting,
-        SandboxState::Ready,
-        SandboxState::Running,
-        SandboxState::Stopping,
-        SandboxState::Stopped,
-        SandboxState::Failed,
-        SandboxState::Pausing,
-        SandboxState::Paused,
+    const ALL_STATES: [ComputerState; 8] = [
+        ComputerState::Starting,
+        ComputerState::Ready,
+        ComputerState::Running,
+        ComputerState::Stopping,
+        ComputerState::Stopped,
+        ComputerState::Failed,
+        ComputerState::Pausing,
+        ComputerState::Paused,
     ];
 
     fn at(seconds: i64) -> DateTime<Utc> {
@@ -67,7 +67,7 @@ mod tests {
     fn only_a_terminal_sandbox_drops_its_ttl() {
         let deadline = at(1_700_000_000);
         for state in ALL_STATES {
-            let terminal = matches!(state, SandboxState::Stopped | SandboxState::Failed);
+            let terminal = matches!(state, ComputerState::Stopped | ComputerState::Failed);
             // A paused sandbox still expires: the TTL caps total lifetime
             // regardless of activity.
             assert_eq!(
@@ -82,7 +82,7 @@ mod tests {
     #[test]
     fn only_a_ready_sandbox_with_a_timeout_goes_idle() {
         for state in ALL_STATES {
-            let ready = state == SandboxState::Ready;
+            let ready = state == ComputerState::Ready;
             assert_eq!(
                 idle_due(state, 30),
                 ready.then(|| Duration::from_secs(30)),

--- a/computer/arcbox-computer-runtime/src/sandbox/policy/deadlines.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/policy/deadlines.rs
@@ -64,7 +64,7 @@ mod tests {
     }
 
     #[test]
-    fn only_a_terminal_sandbox_drops_its_ttl() {
+    fn only_a_terminal_computer_drops_its_ttl() {
         let deadline = at(1_700_000_000);
         for state in ALL_STATES {
             let terminal = matches!(state, ComputerState::Stopped | ComputerState::Failed);
@@ -80,7 +80,7 @@ mod tests {
     }
 
     #[test]
-    fn only_a_ready_sandbox_with_a_timeout_goes_idle() {
+    fn only_a_ready_computer_with_a_timeout_goes_idle() {
         for state in ALL_STATES {
             let ready = state == ComputerState::Ready;
             assert_eq!(

--- a/computer/arcbox-computer-runtime/src/sandbox/policy/recovery.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/policy/recovery.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashSet;
 
-use crate::sandbox::SandboxState;
+use crate::sandbox::ComputerState;
 use crate::sandbox::record::PersistPhase;
 
 /// What the orphan sweep established about one sandbox's runtime resources
@@ -38,7 +38,7 @@ pub enum RecoveryAction {
     Fail,
     /// Already inactive before the restart: reconstructed in this state,
     /// without runtime handles.
-    Reinstate(SandboxState),
+    Reinstate(ComputerState),
     /// An interrupted removal: finished as a durable tombstone.
     FinishRemove,
     /// A live phase whose runtime resources were never journaled. The sweep
@@ -74,7 +74,7 @@ pub fn plan(phase: PersistPhase, evidence: JournalEvidence) -> RecoveryAction {
         // workload the previous process was streaming did not survive it,
         // and `Running` is what refuses the next `Run`.
         (PersistPhase::Ready, JournalEvidence::Adopted) => {
-            RecoveryAction::Reinstate(SandboxState::Ready)
+            RecoveryAction::Reinstate(ComputerState::Ready)
         }
         // The sweep adopts a durably `Ready` sandbox and nothing else
         // (`reconcile::adopt_or_kill`), so this pairing is unreachable by
@@ -103,9 +103,9 @@ pub fn plan(phase: PersistPhase, evidence: JournalEvidence) -> RecoveryAction {
         // the sweep preserves durably Paused retained state (clearing any
         // stale journal), so a paused sandbox always survives a restart
         // resumable.
-        (PersistPhase::Paused, _) => RecoveryAction::Reinstate(SandboxState::Paused),
-        (PersistPhase::Stopped, _) => RecoveryAction::Reinstate(SandboxState::Stopped),
-        (PersistPhase::Failed, _) => RecoveryAction::Reinstate(SandboxState::Failed),
+        (PersistPhase::Paused, _) => RecoveryAction::Reinstate(ComputerState::Paused),
+        (PersistPhase::Stopped, _) => RecoveryAction::Reinstate(ComputerState::Stopped),
+        (PersistPhase::Failed, _) => RecoveryAction::Reinstate(ComputerState::Failed),
         (PersistPhase::Removing, _) => RecoveryAction::FinishRemove,
     }
 }
@@ -167,7 +167,7 @@ mod tests {
                 PersistPhase::Ready,
                 RecoveryAction::Fail,
                 RecoveryAction::RefuseUnjournaled,
-                RecoveryAction::Reinstate(SandboxState::Ready),
+                RecoveryAction::Reinstate(ComputerState::Ready),
             ),
             (
                 PersistPhase::Stopping,
@@ -177,14 +177,14 @@ mod tests {
             ),
             (
                 PersistPhase::Stopped,
-                RecoveryAction::Reinstate(SandboxState::Stopped),
-                RecoveryAction::Reinstate(SandboxState::Stopped),
+                RecoveryAction::Reinstate(ComputerState::Stopped),
+                RecoveryAction::Reinstate(ComputerState::Stopped),
                 RecoveryAction::RefuseAdopted,
             ),
             (
                 PersistPhase::Failed,
-                RecoveryAction::Reinstate(SandboxState::Failed),
-                RecoveryAction::Reinstate(SandboxState::Failed),
+                RecoveryAction::Reinstate(ComputerState::Failed),
+                RecoveryAction::Reinstate(ComputerState::Failed),
                 RecoveryAction::RefuseAdopted,
             ),
             (
@@ -201,8 +201,8 @@ mod tests {
             ),
             (
                 PersistPhase::Paused,
-                RecoveryAction::Reinstate(SandboxState::Paused),
-                RecoveryAction::Reinstate(SandboxState::Paused),
+                RecoveryAction::Reinstate(ComputerState::Paused),
+                RecoveryAction::Reinstate(ComputerState::Paused),
                 RecoveryAction::RefuseAdopted,
             ),
             (

--- a/computer/arcbox-computer-runtime/src/sandbox/policy/recovery.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/policy/recovery.rs
@@ -232,7 +232,7 @@ mod tests {
     }
 
     #[test]
-    fn only_a_paused_sandbox_retains_its_disk_state() {
+    fn only_a_paused_computer_retains_its_disk_state() {
         let retained = retained_ids([
             ("paused", PersistPhase::Paused),
             ("ready", PersistPhase::Ready),
@@ -244,7 +244,7 @@ mod tests {
     }
 
     #[test]
-    fn a_retained_sandboxs_journal_is_stale_and_every_other_one_is_an_orphan() {
+    fn a_retained_computers_journal_is_stale_and_every_other_one_is_an_orphan() {
         let retained = HashSet::from(["paused".to_owned()]);
         assert_eq!(
             sweep_action("paused", &retained),

--- a/computer/arcbox-computer-runtime/src/sandbox/policy/warm.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/policy/warm.rs
@@ -14,7 +14,7 @@ use sha2::{Digest, Sha256};
 
 use crate::config::RuntimeConfig;
 use crate::error::{ComputerError, Result};
-use crate::sandbox::SandboxSpec;
+use crate::sandbox::ComputerSpec;
 
 /// Most distinct warm keys cached at once, mirroring the restore pool's
 /// distinct-snapshot cap. Evicting a key deletes its snapshot (and drains
@@ -58,7 +58,7 @@ pub(in crate::sandbox) struct FileFingerprint {
 /// The warm key for an effective (defaults-applied) create spec and the
 /// fingerprints of the boot inputs it resolves to.
 pub(in crate::sandbox) fn warm_key(
-    spec: &SandboxSpec,
+    spec: &ComputerSpec,
     kernel: FileFingerprint,
     rootfs: FileFingerprint,
 ) -> WarmKey {
@@ -96,7 +96,7 @@ pub(in crate::sandbox) fn warm_key(
 /// caller-chosen identity into the snapshot, so it disqualifies too.
 pub(in crate::sandbox) fn warm_eligible(
     config: &RuntimeConfig,
-    spec: &SandboxSpec,
+    spec: &ComputerSpec,
     caller_supplied_boot: bool,
 ) -> bool {
     config.firecracker.warm_create
@@ -206,7 +206,7 @@ impl WarmCache {
 mod tests {
     use super::*;
     use crate::config::JailerConfig;
-    use crate::sandbox::{SandboxMountSpec, SandboxNetworkSpec};
+    use crate::sandbox::{ComputerMountSpec, ComputerNetworkSpec};
 
     fn kernel_fingerprint() -> FileFingerprint {
         FileFingerprint {
@@ -228,14 +228,14 @@ mod tests {
         }
     }
 
-    fn base_spec() -> SandboxSpec {
-        SandboxSpec {
+    fn base_spec() -> ComputerSpec {
+        ComputerSpec {
             kernel: "/run/kernel/vmlinux".into(),
             rootfs: "/data/rootfs.ext4".into(),
             boot_args: "console=ttyS0 quiet".into(),
             vcpus: 2,
             memory_mib: 512,
-            network: SandboxNetworkSpec { mode: "tap".into() },
+            network: ComputerNetworkSpec { mode: "tap".into() },
             ..Default::default()
         }
     }
@@ -262,7 +262,7 @@ mod tests {
         );
     }
 
-    type SpecEdit = Box<dyn Fn(&mut SandboxSpec)>;
+    type SpecEdit = Box<dyn Fn(&mut ComputerSpec)>;
     type FingerprintEdit = Box<dyn Fn(&mut FileFingerprint)>;
 
     #[test]
@@ -362,7 +362,7 @@ mod tests {
         assert!(!warm_eligible(&config, &explicit_ip, false));
 
         let mut mounted = base_spec();
-        mounted.mounts.push(SandboxMountSpec {
+        mounted.mounts.push(ComputerMountSpec {
             source: "/src".into(),
             target: "/dst".into(),
             readonly: true,

--- a/computer/arcbox-computer-runtime/src/sandbox/policy/warm.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/policy/warm.rs
@@ -13,7 +13,7 @@ use chrono::{DateTime, Utc};
 use sha2::{Digest, Sha256};
 
 use crate::config::RuntimeConfig;
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::sandbox::SandboxSpec;
 
 /// Most distinct warm keys cached at once, mirroring the restore pool's
@@ -112,12 +112,12 @@ pub(in crate::sandbox) fn warm_eligible(
 /// the warm-cache key or the template-catalog ownership marker (CORE-107).
 pub(in crate::sandbox) fn reject_reserved_labels(labels: &HashMap<String, String>) -> Result<()> {
     if labels.contains_key(WARM_KEY_LABEL) {
-        return Err(VmmError::Config(format!(
+        return Err(ComputerError::Config(format!(
             "snapshot label {WARM_KEY_LABEL} is reserved for the warm-create cache"
         )));
     }
     if labels.contains_key(crate::template_catalog::TEMPLATE_LABEL) {
-        return Err(VmmError::Config(format!(
+        return Err(ComputerError::Config(format!(
             "snapshot label {} is reserved for the template catalog",
             crate::template_catalog::TEMPLATE_LABEL
         )));

--- a/computer/arcbox-computer-runtime/src/sandbox/pool.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/pool.rs
@@ -14,7 +14,7 @@
 //! network-agnostic (the seam CORE-81 builds on).
 
 use super::boot::{StageError, stage_rootfs_cow_or_copy};
-use super::reconcile::{self, POOL_SLOT_PREFIX, SandboxStateRecord};
+use super::reconcile::{self, ComputerStateRecord, POOL_SLOT_PREFIX};
 use super::*;
 use crate::config::JailerConfig;
 use crate::snapshot::SnapshotMeta;
@@ -78,7 +78,7 @@ pub(super) async fn prepare_slot(
     reconcile::create_runtime_dir(&vm_dir)?;
     reconcile::write_state_record(
         &vm_dir,
-        &SandboxStateRecord::new(&slot_id, None, None, None, config, None)?,
+        &ComputerStateRecord::new(&slot_id, None, None, None, config, None)?,
     )?;
 
     match stage_slot(driver, config, jc, cow_manager, snapshot, &slot_id, &vm_dir).await {
@@ -174,7 +174,7 @@ async fn stage_slot(
     let journal = |cow: Option<&CowHandle>| {
         reconcile::write_state_record(
             vm_dir,
-            &SandboxStateRecord::new(slot_id, pid, None, cow, config, None)?,
+            &ComputerStateRecord::new(slot_id, pid, None, cow, config, None)?,
         )
     };
     let carry = |error: ComputerError, prepared, cow_handle| SlotFailure {

--- a/computer/arcbox-computer-runtime/src/sandbox/pool.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/pool.rs
@@ -371,7 +371,7 @@ pub fn spawn_pool_refill(
     }
 }
 
-impl SandboxManager {
+impl ComputerManager {
     /// Tear down pooled slots: all of them, or those staged from one
     /// snapshot.
     pub(super) async fn drain_pool(&self, snapshot_id: Option<&str>) {

--- a/computer/arcbox-computer-runtime/src/sandbox/pool.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/pool.rs
@@ -56,10 +56,9 @@ pub(super) async fn prepare_slot(
     snapshot: &SnapshotMeta,
 ) -> Result<PreparedSlot> {
     let fc_cfg = &config.firecracker;
-    let jc = fc_cfg
-        .jailer
-        .as_ref()
-        .ok_or_else(|| VmmError::Config("restore slot pooling requires jailer isolation".into()))?;
+    let jc = fc_cfg.jailer.as_ref().ok_or_else(|| {
+        ComputerError::Config("restore slot pooling requires jailer isolation".into())
+    })?;
     // Short suffix on purpose: the slot id becomes a VM identity and must
     // fit the driver's own id budget (`VmDriver::id_budget`) under any
     // configured chroot layout — internal mints bypass the ingress
@@ -129,13 +128,13 @@ pub(super) async fn prepare_slot(
 }
 
 struct SlotFailure {
-    error: VmmError,
+    error: ComputerError,
     prepared: Option<Arc<dyn PreparedVm>>,
     cow_handle: Option<CowHandle>,
 }
 
-impl From<VmmError> for SlotFailure {
-    fn from(error: VmmError) -> Self {
+impl From<ComputerError> for SlotFailure {
+    fn from(error: ComputerError) -> Self {
         Self {
             error,
             prepared: None,
@@ -164,12 +163,12 @@ async fn stage_slot(
     let prepared: Arc<dyn PreparedVm> = Arc::from(
         super::prepare_capability(driver)
             .prepare(
-                &VmId::new(slot_id).map_err(VmmError::from)?,
+                &VmId::new(slot_id).map_err(ComputerError::from)?,
                 &IsolationSpec::try_from(jc)?,
                 vm_dir,
             )
             .await
-            .map_err(VmmError::from)?,
+            .map_err(ComputerError::from)?,
     );
     let pid = super::journaled_pid(&*prepared);
     let journal = |cow: Option<&CowHandle>| {
@@ -178,7 +177,7 @@ async fn stage_slot(
             &SandboxStateRecord::new(slot_id, pid, None, cow, config, None)?,
         )
     };
-    let carry = |error: VmmError, prepared, cow_handle| SlotFailure {
+    let carry = |error: ComputerError, prepared, cow_handle| SlotFailure {
         error,
         prepared,
         cow_handle,
@@ -199,7 +198,7 @@ async fn stage_slot(
 
     let Some(rootfs) = snapshot.rootfs_path.as_deref() else {
         return Err(carry(
-            VmmError::Snapshot(format!(
+            ComputerError::Snapshot(format!(
                 "checkpoint {} records no rootfs template; there is no disk to pre-warm a slot \
                  with",
                 snapshot.id
@@ -271,7 +270,7 @@ pub(super) async fn destroy_slot(cow_manager: &CowManager, mut slot: PreparedSlo
     match tokio::fs::remove_dir_all(&slot.vm_dir).await {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(VmmError::Io(error)),
+        Err(error) => Err(ComputerError::Io(error)),
     }
 }
 

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -24,7 +24,7 @@
 //! - the durable record is `Ready`. `Starting` died with the boot task that
 //!   was driving it and nothing here finishes one; the transitional phases
 //!   died between resource states;
-//! - the journal says how its lease attaches ([`SandboxStateRecord::attach_mode`]),
+//! - the journal says how its lease attaches ([`ComputerStateRecord::attach_mode`]),
 //!   and the guest network takes that lease back under exactly that mode;
 //! - the CoW manager re-registers the dm-snapshot the guest is running on.
 //!
@@ -52,7 +52,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
 use super::policy::recovery::{self, JournalEvidence, RecoveryAction, SweepAction};
-use super::record::{PersistPhase, SandboxRecord, SandboxRecordStore, SandboxTransition};
+use super::record::{ComputerRecord, ComputerRecordStore, ComputerTransition, PersistPhase};
 use super::{ComputerState, LeaseExt};
 use crate::config::RuntimeConfig;
 use crate::error::{ComputerError, Result};
@@ -133,7 +133,7 @@ impl CowRecord {
 /// the daemon stages the agent it shipped with, so an old agent only ever sees
 /// new records across a daemon downgrade.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct SandboxStateRecord {
+pub struct ComputerStateRecord {
     /// Sandbox ID (also the directory name).
     pub id: String,
     /// The VMM's PID at boot time.
@@ -151,7 +151,7 @@ pub struct SandboxStateRecord {
     /// by [`tap_name_for`], the same rule [`validate_state_record`]
     /// enforces, and the resolvers from the network config the pool was
     /// built with — and neither is read back:
-    /// [`SandboxStateRecord::lease`] is what the sweep uses.
+    /// [`ComputerStateRecord::lease`] is what the sweep uses.
     #[serde(default)]
     pub network: Option<JournaledAllocation>,
     /// dm-snapshot CoW resources to tear down.
@@ -323,7 +323,7 @@ const fn default_prefix_len() -> u8 {
     16
 }
 
-impl SandboxStateRecord {
+impl ComputerStateRecord {
     /// Assemble a record from boot/restore results.
     pub fn new(
         id: &str,
@@ -388,7 +388,7 @@ impl SandboxStateRecord {
 /// `lease` in the journal's legacy allocation shape.
 ///
 /// `tap_name` and `dns_servers` are the two fields a lease does not carry;
-/// see [`SandboxStateRecord::network`] for why they are written anyway.
+/// see [`ComputerStateRecord::network`] for why they are written anyway.
 fn legacy_allocation(lease: &NetworkLease, dns: &[String]) -> Result<JournaledAllocation> {
     let ip = lease.ipv4()?;
     Ok(JournaledAllocation {
@@ -403,7 +403,7 @@ fn legacy_allocation(lease: &NetworkLease, dns: &[String]) -> Result<JournaledAl
 }
 
 /// Atomically persist crash-recovery metadata before resources are exposed.
-pub fn write_state_record(vm_dir: &Path, record: &SandboxStateRecord) -> Result<()> {
+pub fn write_state_record(vm_dir: &Path, record: &ComputerStateRecord) -> Result<()> {
     let bytes = serde_json::to_vec_pretty(record)?;
     arcbox_atomic_file::write(&vm_dir.join(STATE_FILE), &bytes)?;
     Ok(())
@@ -445,7 +445,7 @@ pub fn clear_state_record(vm_dir: &Path) -> Result<()> {
 
 /// One sandbox whose VM outlived the process that booted it, with every
 /// runtime resource the sweep took back for it.
-pub(super) struct AdoptedSandbox {
+pub(super) struct AdoptedComputer {
     handle: Arc<dyn VmHandle>,
     lease: Option<NetworkLease>,
     identity: Option<NetworkIdentity>,
@@ -477,13 +477,13 @@ impl SkippedJournals {
     /// The durable key is the directory alone. The resource names are
     /// every spelling the record offers — the directory it sat in, the id
     /// it claims, the pool slot it says its dm/CoW resources are keyed by
-    /// ([`SandboxStateRecord::resource_owner`]), and the owners its
+    /// ([`ComputerStateRecord::resource_owner`]), and the owners its
     /// journaled CoW names spell out. One reason a journal is unreadable
     /// is that those disagree, so holding a name that turns out to be
     /// nobody's costs a leaked device this sweep would have reaped, while
     /// missing the real one aborts the whole reconciliation on a device a
     /// live VMM still pins.
-    fn hold(&mut self, dir: &Path, record: &SandboxStateRecord) {
+    fn hold(&mut self, dir: &Path, record: &ComputerStateRecord) {
         if let Some(name) = dir.file_name().and_then(|name| name.to_str()) {
             self.ids.insert(name.to_owned());
             self.owners.insert(name.to_owned());
@@ -527,7 +527,7 @@ pub(super) struct OrphanSweep {
     ids: HashSet<String>,
     /// Sandboxes reclaimed alive, by id. Their journals stay on disk — they
     /// are live state again, not debris — and so do their runtime dirs.
-    adopted: HashMap<String, AdoptedSandbox>,
+    adopted: HashMap<String, AdoptedComputer>,
     /// Sandboxes whose journal this process could not read: the name of
     /// the directory each was found in, never the id it claimed.
     skipped: HashSet<String>,
@@ -582,7 +582,7 @@ pub(super) async fn sweep_orphans(
     network: &dyn GuestNetwork,
     cow_manager: &CowManager,
     snapshots: &crate::snapshot::SnapshotCatalog,
-    store: &SandboxRecordStore,
+    store: &ComputerRecordStore,
 ) -> Result<OrphanSweep> {
     // Snapshots staged by a checkpoint that died mid-flight: unfinished by
     // definition, and each can hold a full memory dump.
@@ -605,7 +605,7 @@ pub(super) async fn sweep_orphans(
             continue;
         }
         let state_path = dir.join(STATE_FILE);
-        let record: SandboxStateRecord = match std::fs::read(&state_path) {
+        let record: ComputerStateRecord = match std::fs::read(&state_path) {
             Ok(bytes) => serde_json::from_slice(&bytes)?,
             // No record: either never booted or cleanly stopped.
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
@@ -642,7 +642,7 @@ pub(super) async fn sweep_orphans(
         // snapshot and execution ids that never become a VM identity, and
         // is deliberately permissive for exactly this reason — so the id a
         // driver will be handed is parsed here, letting `adopt_or_kill` and
-        // [`SandboxStateRecord::lease`] rely on it downstream.
+        // [`ComputerStateRecord::lease`] rely on it downstream.
         let usable = validate_state_record(config, &sandboxes_dir, &dir, &record)
             .and_then(|()| VmId::new(record.id.as_str()).map_err(ComputerError::from))
             .and_then(|_| VmId::new(record.resource_owner()).map_err(ComputerError::from));
@@ -725,8 +725,8 @@ pub(super) async fn sweep_orphans(
     reason = "the sweep's whole resource set, threaded rather than re-derived"
 )]
 async fn reap_orphans(
-    records: &[(PathBuf, SandboxStateRecord)],
-    adopted: &mut HashMap<String, AdoptedSandbox>,
+    records: &[(PathBuf, ComputerStateRecord)],
+    adopted: &mut HashMap<String, AdoptedComputer>,
     retained: &HashSet<String>,
     held: &HashSet<String>,
     phases: &HashMap<&str, super::record::PersistPhase>,
@@ -854,7 +854,7 @@ pub(super) async fn finalize_sweep(sweep: OrphanSweep) -> Result<()> {
 /// carries are needed afterwards, by [`finalize_sweep`].
 pub(super) struct SweptRuntime {
     swept: HashSet<String>,
-    adopted: HashMap<String, AdoptedSandbox>,
+    adopted: HashMap<String, AdoptedComputer>,
     skipped: HashSet<String>,
 }
 
@@ -873,7 +873,7 @@ pub(super) struct SweptRuntime {
 /// the only handle keeping its guest alive, so dropping either here would
 /// kill that guest with its lease and template refcount still held.
 pub(super) fn normalize_durable_records(
-    store: &SandboxRecordStore,
+    store: &ComputerRecordStore,
     data_dir: &Path,
     sweep: Option<&mut SweptRuntime>,
     built: &mut Vec<RecoveredComputer>,
@@ -922,7 +922,7 @@ pub(super) fn normalize_durable_records(
                     .transition(
                         &record.id,
                         record.generation,
-                        SandboxTransition::Failed(AGENT_RESTART_ERROR.into()),
+                        ComputerTransition::Failed(AGENT_RESTART_ERROR.into()),
                     )?
                     .confirmed("sandbox restart normalization")?;
                 inactive.push(RecoveredComputer::reinstated(inactive_instance(
@@ -990,7 +990,7 @@ pub(super) async fn release_unclaimed(
 /// Best-effort per resource: it runs while an error is already on its way
 /// out, and every sandbox's journal survives to be swept again.
 async fn release_reclaimed(
-    adopted: &mut HashMap<String, AdoptedSandbox>,
+    adopted: &mut HashMap<String, AdoptedComputer>,
     network: &dyn GuestNetwork,
     cow_manager: &CowManager,
 ) {
@@ -1167,7 +1167,7 @@ pub(super) fn seed_computers(
 }
 
 fn inactive_instance(
-    record: SandboxRecord,
+    record: ComputerRecord,
     state: ComputerState,
     data_dir: &Path,
 ) -> ComputerRuntime {
@@ -1203,12 +1203,12 @@ fn inactive_instance(
 /// is not journaled, so it stays `None` rather than being invented from this
 /// restart's clock.
 fn adopted_instance(
-    record: SandboxRecord,
+    record: ComputerRecord,
     state: ComputerState,
     data_dir: &Path,
-    adopted: AdoptedSandbox,
+    adopted: AdoptedComputer,
 ) -> ComputerRuntime {
-    let AdoptedSandbox {
+    let AdoptedComputer {
         handle,
         lease,
         identity,
@@ -1246,9 +1246,9 @@ async fn adopt_or_kill(
     network: &dyn GuestNetwork,
     cow_manager: &CowManager,
     runtime_dir: &Path,
-    record: &SandboxStateRecord,
+    record: &ComputerStateRecord,
     phase: Option<super::record::PersistPhase>,
-) -> Result<Option<AdoptedSandbox>> {
+) -> Result<Option<AdoptedComputer>> {
     let Some(adopt) = driver.adopt() else {
         return Ok(None);
     };
@@ -1301,7 +1301,7 @@ async fn adopt_or_kill(
 fn vm_record(
     driver: &dyn VmDriver,
     runtime_dir: &Path,
-    record: &SandboxStateRecord,
+    record: &ComputerStateRecord,
 ) -> Result<VmRecord> {
     Ok(VmRecord {
         id: VmId::new(record.resource_owner())?,
@@ -1329,10 +1329,10 @@ fn vm_record(
 async fn reclaim(
     network: &dyn GuestNetwork,
     cow_manager: &CowManager,
-    record: &SandboxStateRecord,
+    record: &ComputerStateRecord,
     phase: Option<super::record::PersistPhase>,
     handle: &Arc<dyn VmHandle>,
-) -> std::result::Result<AdoptedSandbox, String> {
+) -> std::result::Result<AdoptedComputer, String> {
     // A guest that is quiesced (a checkpoint that died between the pause and
     // the resume) or gone answers nothing; only a running one is usable.
     match handle.state() {
@@ -1389,7 +1389,7 @@ async fn reclaim(
             .map_err(|error| format!("its disk overlay could not be re-registered: {error}"))?;
     }
 
-    Ok(AdoptedSandbox {
+    Ok(AdoptedComputer {
         handle: Arc::clone(handle),
         lease,
         identity,
@@ -1411,7 +1411,7 @@ fn validate_state_record(
     config: &RuntimeConfig,
     sandboxes_dir: &Path,
     directory: &Path,
-    record: &SandboxStateRecord,
+    record: &ComputerStateRecord,
 ) -> Result<()> {
     super::validate_id("sandbox id", &record.id)?;
     if directory.file_name().and_then(|name| name.to_str()) != Some(record.id.as_str()) {
@@ -1474,7 +1474,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::super::ComputerSpec;
-    use super::super::record::{PersistPhase, ProvisionIntent, SandboxProvisionOutcome};
+    use super::super::record::{ComputerProvisionOutcome, PersistPhase, ProvisionIntent};
     use super::*;
 
     /// `state.json` written before the guest-network port existed, verbatim.
@@ -1503,7 +1503,7 @@ mod tests {
 
     #[test]
     fn a_pre_port_journal_loads_and_is_written_back_unchanged() {
-        let record: SandboxStateRecord = serde_json::from_str(LEGACY_RECORD).unwrap();
+        let record: ComputerStateRecord = serde_json::from_str(LEGACY_RECORD).unwrap();
         let lease = record.lease().unwrap().expect("the record holds a lease");
         assert_eq!(lease.vm.as_str(), "box");
         assert_eq!(lease.ip, "172.20.0.7".parse::<std::net::IpAddr>().unwrap());
@@ -1530,7 +1530,7 @@ mod tests {
             cgroup_version: None,
             parent_cgroup: None,
         });
-        let written = SandboxStateRecord::new(
+        let written = ComputerStateRecord::new(
             "box",
             Some(4242),
             Some(JournaledLease::cold_boot(&lease, true)),
@@ -1575,7 +1575,7 @@ mod tests {
           },
           "jailer": true
         }"#;
-        let record: SandboxStateRecord = serde_json::from_str(OLDEST_RECORD).unwrap();
+        let record: ComputerStateRecord = serde_json::from_str(OLDEST_RECORD).unwrap();
         let network = record.network.as_ref().expect("the record holds a network");
         assert_eq!(network.prefix_len, 16);
         assert_eq!(network.cleanup_token, "");
@@ -1590,7 +1590,7 @@ mod tests {
     /// datapath.
     #[test]
     fn a_journal_without_an_attach_mode_loads_as_not_adoptable() {
-        let record: SandboxStateRecord = serde_json::from_str(LEGACY_RECORD).unwrap();
+        let record: ComputerStateRecord = serde_json::from_str(LEGACY_RECORD).unwrap();
         assert_eq!(record.attach_mode, None);
         assert!(!record.net_invariant);
     }
@@ -1609,7 +1609,7 @@ mod tests {
         };
         let config = RuntimeConfig::default();
         for baked in [true, false] {
-            let record = SandboxStateRecord::new(
+            let record = ComputerStateRecord::new(
                 "box",
                 None,
                 Some(JournaledLease::cold_boot(&lease, baked)),
@@ -1623,7 +1623,7 @@ mod tests {
         }
         // A restore or resume is the only thing that varies the mode, and
         // both halves come from the snapshot's flag there.
-        let legacy = SandboxStateRecord::new(
+        let legacy = ComputerStateRecord::new(
             "box",
             None,
             Some(JournaledLease::from_snapshot(&lease, false)),
@@ -1639,7 +1639,11 @@ mod tests {
         assert!(!legacy.net_invariant);
     }
 
-    fn record_in_phase(store: &SandboxRecordStore, id: &str, phase: PersistPhase) -> SandboxRecord {
+    fn record_in_phase(
+        store: &ComputerRecordStore,
+        id: &str,
+        phase: PersistPhase,
+    ) -> ComputerRecord {
         let spec = ComputerSpec {
             id: Some(id.into()),
             ..ComputerSpec::default()
@@ -1657,7 +1661,7 @@ mod tests {
                     .transition(
                         id,
                         generation,
-                        SandboxTransition::Failed("original failure".into()),
+                        ComputerTransition::Failed("original failure".into()),
                     )
                     .unwrap();
             }
@@ -1666,13 +1670,13 @@ mod tests {
                     .transition(
                         id,
                         generation,
-                        SandboxTransition::Starting(SandboxProvisionOutcome {
+                        ComputerTransition::Starting(ComputerProvisionOutcome {
                             ip_address: "192.0.2.2".into(),
                         }),
                     )
                     .unwrap();
                 store
-                    .transition(id, generation, SandboxTransition::Removing)
+                    .transition(id, generation, ComputerTransition::Removing)
                     .unwrap();
             }
             phase => {
@@ -1680,7 +1684,7 @@ mod tests {
                     .transition(
                         id,
                         generation,
-                        SandboxTransition::Starting(SandboxProvisionOutcome {
+                        ComputerTransition::Starting(ComputerProvisionOutcome {
                             ip_address: "192.0.2.2".into(),
                         }),
                     )
@@ -1689,32 +1693,32 @@ mod tests {
                     PersistPhase::Starting => {}
                     PersistPhase::Ready => {
                         store
-                            .transition(id, generation, SandboxTransition::Ready)
+                            .transition(id, generation, ComputerTransition::Ready)
                             .unwrap();
                     }
                     PersistPhase::Stopping | PersistPhase::Stopped => {
                         store
-                            .transition(id, generation, SandboxTransition::Stopping)
+                            .transition(id, generation, ComputerTransition::Stopping)
                             .unwrap();
                         if phase == PersistPhase::Stopped {
                             store
-                                .transition(id, generation, SandboxTransition::Stopped)
+                                .transition(id, generation, ComputerTransition::Stopped)
                                 .unwrap();
                         }
                     }
                     PersistPhase::Pausing | PersistPhase::Paused | PersistPhase::Resuming => {
                         store
-                            .transition(id, generation, SandboxTransition::Ready)
+                            .transition(id, generation, ComputerTransition::Ready)
                             .unwrap();
                         store
-                            .transition(id, generation, SandboxTransition::Pausing)
+                            .transition(id, generation, ComputerTransition::Pausing)
                             .unwrap();
                         if phase != PersistPhase::Pausing {
                             store
                                 .transition(
                                     id,
                                     generation,
-                                    SandboxTransition::Paused {
+                                    ComputerTransition::Paused {
                                         snapshot_id: "snap".into(),
                                     },
                                 )
@@ -1722,7 +1726,7 @@ mod tests {
                         }
                         if phase == PersistPhase::Resuming {
                             store
-                                .transition(id, generation, SandboxTransition::Resuming)
+                                .transition(id, generation, ComputerTransition::Resuming)
                                 .unwrap();
                         }
                     }
@@ -1736,7 +1740,7 @@ mod tests {
 
     #[test]
     fn state_record_roundtrips_through_json() {
-        let record = SandboxStateRecord {
+        let record = ComputerStateRecord {
             id: "sb-1".into(),
             pid: Some(42),
             network: None,
@@ -1754,7 +1758,7 @@ mod tests {
             net_invariant: true,
         };
         let bytes = serde_json::to_vec(&record).unwrap();
-        let parsed: SandboxStateRecord = serde_json::from_slice(&bytes).unwrap();
+        let parsed: ComputerStateRecord = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(parsed.id, "sb-1");
         assert_eq!(parsed.pid, Some(42));
         assert!(parsed.jailer);
@@ -1778,7 +1782,7 @@ mod tests {
                 .join(format!("arcbox-cow-{owner}.img")),
             template_path: "/var/lib/arcbox/sandbox/rootfs.ext4".into(),
         };
-        let record = |slot: Option<&str>, cow_owner: &str| SandboxStateRecord {
+        let record = |slot: Option<&str>, cow_owner: &str| ComputerStateRecord {
             id: "sb-1".into(),
             pid: None,
             network: None,
@@ -1836,7 +1840,7 @@ mod tests {
     #[test]
     fn startup_normalizes_crash_phases_and_restores_inactive_records() {
         let data_dir = tempfile::tempdir().unwrap();
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         for (id, phase) in [
             ("creating", PersistPhase::Creating),
             ("starting", PersistPhase::Starting),
@@ -1888,7 +1892,7 @@ mod tests {
     #[test]
     fn paused_records_survive_restart_while_interrupted_transitions_fail() {
         let data_dir = tempfile::tempdir().unwrap();
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         record_in_phase(&store, "clean", PersistPhase::Paused);
         record_in_phase(&store, "mid-pause", PersistPhase::Pausing);
         record_in_phase(&store, "mid-resume", PersistPhase::Resuming);
@@ -1933,7 +1937,7 @@ mod tests {
     #[tokio::test]
     async fn stale_pause_journal_is_dropped_and_retained_state_survives() {
         let data_dir = tempfile::tempdir().unwrap();
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         record_in_phase(&store, "napper", PersistPhase::Paused);
 
         let vm_dir = data_dir.path().join("sandboxes").join("napper");
@@ -2006,7 +2010,7 @@ mod tests {
         config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
         write_state_record(
             &vm_dir,
-            &SandboxStateRecord::new(
+            &ComputerStateRecord::new(
                 "orphan",
                 Some(i32::try_from(pid).unwrap()),
                 None,
@@ -2167,7 +2171,7 @@ mod tests {
 
         let mut config = RuntimeConfig::default();
         config.firecracker.data_dir = data_dir.to_string_lossy().into_owned();
-        let store = SandboxRecordStore::new(data_dir).unwrap();
+        let store = ComputerRecordStore::new(data_dir).unwrap();
         record_in_phase(&store, "keeper", case.phase);
         // Durable records with no journal at all, which is what makes
         // recovery refuse to normalize and fails the whole reconciliation.
@@ -2184,7 +2188,7 @@ mod tests {
             mac: "02:fc:00:00:00:09".parse().unwrap(),
             cleanup_token: "gen-1".into(),
         };
-        let mut record = SandboxStateRecord::new(
+        let mut record = ComputerStateRecord::new(
             "keeper",
             Some(i32::try_from(pid).unwrap()),
             Some(JournaledLease::cold_boot(&lease, true)),
@@ -2271,10 +2275,11 @@ mod tests {
         // nothing this crate does produces one.
         let broken_dir = data_dir.path().join("sandboxes").join("broken");
         std::fs::create_dir_all(&broken_dir).unwrap();
-        let stray = SandboxStateRecord::new("not-broken", None, None, None, &config, None).unwrap();
+        let stray =
+            ComputerStateRecord::new("not-broken", None, None, None, &config, None).unwrap();
         write_state_record(&broken_dir, &stray).unwrap();
 
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         record_in_phase(&store, "broken", PersistPhase::Ready);
         drop(store);
 
@@ -2323,10 +2328,10 @@ mod tests {
         let legacy = "inst_7f3a";
         let legacy_dir = data_dir.path().join("sandboxes").join(legacy);
         std::fs::create_dir_all(&legacy_dir).unwrap();
-        let record = SandboxStateRecord::new(legacy, None, None, None, &config, None).unwrap();
+        let record = ComputerStateRecord::new(legacy, None, None, None, &config, None).unwrap();
         write_state_record(&legacy_dir, &record).unwrap();
 
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         record_in_phase(&store, legacy, PersistPhase::Ready);
         drop(store);
 
@@ -2376,7 +2381,7 @@ mod tests {
         };
         let broken_dir = data_dir.path().join("sandboxes").join("broken");
         std::fs::create_dir_all(&broken_dir).unwrap();
-        let mut stray = SandboxStateRecord::new(
+        let mut stray = ComputerStateRecord::new(
             "not-broken",
             None,
             Some(JournaledLease::cold_boot(&lease, true)),
@@ -2454,7 +2459,7 @@ mod tests {
         // that makes a journal unreadable in the first place.
         let broken_dir = data_dir.path().join("sandboxes").join("broken");
         std::fs::create_dir_all(&broken_dir).unwrap();
-        let stray = SandboxStateRecord::new("ghost", None, None, None, &config, None).unwrap();
+        let stray = ComputerStateRecord::new("ghost", None, None, None, &config, None).unwrap();
         write_state_record(&broken_dir, &stray).unwrap();
 
         // A real `ghost`: durably `Ready`, with no journal of its own. Its
@@ -2510,7 +2515,7 @@ mod tests {
         };
         write_state_record(
             &keeper_dir,
-            &SandboxStateRecord::new(
+            &ComputerStateRecord::new(
                 "keeper",
                 keeper
                     .record()
@@ -2531,11 +2536,11 @@ mod tests {
         let _broken = boot_previous_vm(&driver, &broken_dir, "zzz-broken", true, false).await;
         write_state_record(
             &broken_dir,
-            &SandboxStateRecord::new("zzz-broken", None, None, None, &config, None).unwrap(),
+            &ComputerStateRecord::new("zzz-broken", None, None, None, &config, None).unwrap(),
         )
         .unwrap();
 
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         record_in_phase(&store, "keeper", PersistPhase::Ready);
         drop(store);
 
@@ -2642,7 +2647,7 @@ mod tests {
         let mut adopted = HashMap::new();
         adopted.insert(
             "stuck".to_owned(),
-            AdoptedSandbox {
+            AdoptedComputer {
                 handle: Arc::new(RefusesShutdown(Arc::from(vm))),
                 lease: Some(lease),
                 identity: None,
@@ -2818,7 +2823,7 @@ mod tests {
             let goner_dir = data_dir.path().join("sandboxes").join("goner");
             let goner = boot_previous_vm(&driver, &goner_dir, "goner", false, true).await;
             let mut journal =
-                SandboxStateRecord::new("goner", None, None, None, &config, None).unwrap();
+                ComputerStateRecord::new("goner", None, None, None, &config, None).unwrap();
             journal.jailer = journaled_jailer;
             write_state_record(&goner_dir, &journal).unwrap();
 
@@ -2827,7 +2832,7 @@ mod tests {
             let keeper = boot_previous_vm(&driver, &keeper_dir, "keeper", true, true).await;
             write_state_record(
                 &keeper_dir,
-                &SandboxStateRecord::new("keeper", None, None, None, &config, None).unwrap(),
+                &ComputerStateRecord::new("keeper", None, None, None, &config, None).unwrap(),
             )
             .unwrap();
 
@@ -2837,11 +2842,11 @@ mod tests {
             let _odd = boot_previous_vm(&driver, &odd_dir, "zzz-odd", true, true).await;
             write_state_record(
                 &odd_dir,
-                &SandboxStateRecord::new("someone-else", None, None, None, &config, None).unwrap(),
+                &ComputerStateRecord::new("someone-else", None, None, None, &config, None).unwrap(),
             )
             .unwrap();
 
-            let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+            let store = ComputerRecordStore::new(data_dir.path()).unwrap();
             record_in_phase(&store, "goner", PersistPhase::Ready);
             record_in_phase(&store, "keeper", PersistPhase::Ready);
             let cow_manager =
@@ -2869,7 +2874,7 @@ mod tests {
     #[test]
     fn active_record_without_cleanup_journal_blocks_normalization() {
         let data_dir = tempfile::tempdir().unwrap();
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         record_in_phase(&store, "starting", PersistPhase::Starting);
 
         assert!(matches!(

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -1473,7 +1473,7 @@ fn validate_state_record(
 mod tests {
     use std::collections::HashMap;
 
-    use super::super::SandboxSpec;
+    use super::super::ComputerSpec;
     use super::super::record::{PersistPhase, ProvisionIntent, SandboxProvisionOutcome};
     use super::*;
 
@@ -1640,9 +1640,9 @@ mod tests {
     }
 
     fn record_in_phase(store: &SandboxRecordStore, id: &str, phase: PersistPhase) -> SandboxRecord {
-        let spec = SandboxSpec {
+        let spec = ComputerSpec {
             id: Some(id.into()),
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         };
         let record = match store.provision_intent(id, "create-key", spec).unwrap() {
             ProvisionIntent::Created(record) => record,

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -1,6 +1,6 @@
 //! Crash-recovery reconciliation for sandbox runtime state.
 //!
-//! `SandboxManager` state is in-memory; if the agent restarts (crash,
+//! `ComputerManager` state is in-memory; if the agent restarts (crash,
 //! supervision respawn) the VMM processes, TAP devices, dm-snapshot
 //! devices, and jailer chroots of running sandboxes are left with no owner,
 //! and fresh IP allocations can collide with orphaned TAPs. To recover,
@@ -1954,7 +1954,7 @@ mod tests {
         let mut config = RuntimeConfig::default();
         config.firecracker.data_dir = data_dir.path().to_string_lossy().into_owned();
         let environment = crate::testkit::fake_environment(&config).unwrap();
-        let manager = super::super::SandboxManager::new(config, environment).unwrap();
+        let manager = super::super::ComputerManager::new(config, environment).unwrap();
         manager.await_reconcile().await.unwrap();
 
         assert!(!vm_dir.join(STATE_FILE).exists());
@@ -2021,7 +2021,7 @@ mod tests {
             .unwrap(),
         )
         .unwrap();
-        let manager = super::super::SandboxManager::new(
+        let manager = super::super::ComputerManager::new(
             config.clone(),
             crate::NodeEnvironment {
                 driver: std::sync::Arc::new(driver),
@@ -2157,7 +2157,7 @@ mod tests {
         unjournaled: &[(&str, PersistPhase)],
     ) -> (
         Box<dyn VmHandle>,
-        super::super::SandboxManager,
+        super::super::ComputerManager,
         std::sync::Arc<arcbox_vm_driver::testkit::FakeNetwork>,
         Result<()>,
     ) {
@@ -2206,7 +2206,7 @@ mod tests {
         if !case.network_adopts {
             network.fail_adopt_once();
         }
-        let manager = super::super::SandboxManager::new(
+        let manager = super::super::ComputerManager::new(
             config.clone(),
             crate::NodeEnvironment {
                 driver: std::sync::Arc::new(driver),
@@ -2222,7 +2222,7 @@ mod tests {
     /// The payload: a `Ready` sandbox whose VM outlived its agent comes back
     /// with everything it was running on, and its journal stays where it is.
     #[tokio::test]
-    async fn a_live_ready_sandbox_is_reclaimed_rather_than_killed() {
+    async fn a_live_ready_computer_is_reclaimed_rather_than_killed() {
         let data_dir = tempfile::tempdir().unwrap();
         let (vm, manager, network, reconciled) =
             sweep_one(data_dir.path(), &AdoptionCase::live(), &[]).await;
@@ -2544,7 +2544,7 @@ mod tests {
         record_in_phase(&store, "keeper", PersistPhase::Ready);
         drop(store);
 
-        let manager = super::super::SandboxManager::new(
+        let manager = super::super::ComputerManager::new(
             config.clone(),
             crate::NodeEnvironment {
                 driver: std::sync::Arc::new(driver),
@@ -2637,7 +2637,7 @@ mod tests {
         let lease = network
             .reserve(
                 &VmId::new("stuck").unwrap(),
-                super::super::sandbox_network_policy(),
+                super::super::computer_network_policy(),
             )
             .await
             .unwrap();

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -53,7 +53,7 @@ use tracing::{info, warn};
 
 use super::policy::recovery::{self, JournalEvidence, RecoveryAction, SweepAction};
 use super::record::{PersistPhase, SandboxRecord, SandboxRecordStore, SandboxTransition};
-use super::{LeaseExt, SandboxState};
+use super::{ComputerState, LeaseExt};
 use crate::config::RuntimeConfig;
 use crate::error::{ComputerError, Result};
 use crate::lifecycle::actor::{Deadlines, Seeded};
@@ -648,7 +648,7 @@ pub(super) async fn sweep_orphans(
             .and_then(|_| VmId::new(record.resource_owner()).map_err(ComputerError::from));
         if let Err(error) = usable {
             warn!(
-                sandbox_id = %record.id,
+                computer_id = %record.id,
                 path = %dir.display(),
                 %error,
                 "skipping an unusable crash journal: its VM is left alone and every \
@@ -795,11 +795,11 @@ async fn reap_orphans(
             continue;
         }
         if recovery::sweep_action(&record.id, retained) == SweepAction::DropStaleJournal {
-            info!(sandbox_id = %record.id, "dropping stale pause journal, keeping retained state");
+            info!(computer_id = %record.id, "dropping stale pause journal, keeping retained state");
             clear_state_record(dir)?;
             continue;
         }
-        info!(sandbox_id = %record.id, "reconciling orphaned sandbox");
+        info!(computer_id = %record.id, "reconciling orphaned sandbox");
 
         if let Some(cow) = &record.cow {
             cow_manager.teardown_checked(&cow.to_handle()).await?;
@@ -927,7 +927,7 @@ pub(super) fn normalize_durable_records(
                     .confirmed("sandbox restart normalization")?;
                 inactive.push(RecoveredComputer::reinstated(inactive_instance(
                     record,
-                    SandboxState::Failed,
+                    ComputerState::Failed,
                     data_dir,
                 )));
             }
@@ -1055,7 +1055,7 @@ async fn kill_or_hand_over(id: &str, handle: &Arc<dyn VmHandle>) -> Result<()> {
     if let Some(detach) = handle.detach()
         && let Err(error) = detach.detach().await
     {
-        warn!(sandbox_id = %id, %error, "handing the vmm over failed; dropping it kills it");
+        warn!(computer_id = %id, %error, "handing the vmm over failed; dropping it kills it");
     }
     Err(error.into())
 }
@@ -1078,10 +1078,10 @@ async fn release_one(
     network: &dyn GuestNetwork,
     cow_manager: &CowManager,
 ) {
-    warn!(sandbox_id = %id, "releasing a reclaimed sandbox that recovery did not take");
+    warn!(computer_id = %id, "releasing a reclaimed sandbox that recovery did not take");
     if let Err(error) = kill_or_hand_over(id, handle).await {
         warn!(
-            sandbox_id = %id, %error,
+            computer_id = %id, %error,
             "killing the reclaimed vmm failed; leaving it, its disk and its address for the next sweep"
         );
         return;
@@ -1089,12 +1089,12 @@ async fn release_one(
     if let Some(cow_handle) = cow_handle
         && let Err(error) = cow_manager.teardown_checked(cow_handle).await
     {
-        warn!(sandbox_id = %id, %error, "releasing the reclaimed disk overlay failed");
+        warn!(computer_id = %id, %error, "releasing the reclaimed disk overlay failed");
     }
     if let Some(lease) = lease
         && let Err(error) = network.quarantine(lease).await
     {
-        warn!(sandbox_id = %id, %error, "quarantining the reclaimed lease failed");
+        warn!(computer_id = %id, %error, "quarantining the reclaimed lease failed");
     }
 }
 
@@ -1119,10 +1119,10 @@ impl RecoveredComputer {
 /// what it left rather than a decision: `plan` only ever reinstates the three
 /// inactive phases, and the `Fail` verdict writes `Failed` before it gets
 /// here.
-const fn phase_of(state: SandboxState) -> PersistPhase {
+const fn phase_of(state: ComputerState) -> PersistPhase {
     match state {
-        SandboxState::Paused | SandboxState::Pausing => PersistPhase::Paused,
-        SandboxState::Stopped | SandboxState::Stopping => PersistPhase::Stopped,
+        ComputerState::Paused | ComputerState::Pausing => PersistPhase::Paused,
+        ComputerState::Stopped | ComputerState::Stopping => PersistPhase::Stopped,
         _ => PersistPhase::Failed,
     }
 }
@@ -1160,7 +1160,7 @@ pub(super) fn seed_computers(
             // Unreachable: the sweep runs before any create can claim an id,
             // and every record it reads is distinct.
             Err(error) => {
-                warn!(sandbox_id = %id, %error, "a recovered computer's id was already claimed");
+                warn!(computer_id = %id, %error, "a recovered computer's id was already claimed");
             }
         }
     }
@@ -1168,7 +1168,7 @@ pub(super) fn seed_computers(
 
 fn inactive_instance(
     record: SandboxRecord,
-    state: SandboxState,
+    state: ComputerState,
     data_dir: &Path,
 ) -> ComputerRuntime {
     let vm_dir = data_dir.join("sandboxes").join(&record.id);
@@ -1185,7 +1185,7 @@ fn inactive_instance(
     // The TTL cap survives restarts: a reloaded paused sandbox still
     // expires (the lifecycle monitor re-arms the timer after reconcile).
     instance.ttl_deadline = record.ttl_deadline;
-    if state == SandboxState::Paused {
+    if state == ComputerState::Paused {
         instance.pause_snapshot_id = record.pause_snapshot_id;
         instance.paused_at = record.paused_at;
     }
@@ -1204,7 +1204,7 @@ fn inactive_instance(
 /// restart's clock.
 fn adopted_instance(
     record: SandboxRecord,
-    state: SandboxState,
+    state: ComputerState,
     data_dir: &Path,
     adopted: AdoptedSandbox,
 ) -> ComputerRuntime {
@@ -1269,12 +1269,12 @@ async fn adopt_or_kill(
 
     match reclaim(network, cow_manager, record, phase, &handle).await {
         Ok(reclaimed) => {
-            info!(sandbox_id = %record.id, vm = %vm_record.id, "reclaimed a sandbox whose vm outlived its agent");
+            info!(computer_id = %record.id, vm = %vm_record.id, "reclaimed a sandbox whose vm outlived its agent");
             Ok(Some(reclaimed))
         }
         Err(reason) => {
             info!(
-                sandbox_id = %record.id, vm = %vm_record.id, %reason,
+                computer_id = %record.id, vm = %vm_record.id, %reason,
                 "killing the orphaned vmm"
             );
             // A kill that fails leaves the VM alive and still pinning its dm
@@ -1863,7 +1863,7 @@ mod tests {
             assert_eq!(record.error.as_deref(), Some(AGENT_RESTART_ERROR));
 
             let instance = &inactive[id];
-            assert_eq!(instance.runtime.state, SandboxState::Failed);
+            assert_eq!(instance.runtime.state, ComputerState::Failed);
             assert_eq!(instance.runtime.error.as_deref(), Some(AGENT_RESTART_ERROR));
             assert_eq!(instance.runtime.record_generation, Some(record.generation));
             assert!(instance.runtime.prepared.is_none());
@@ -1871,8 +1871,8 @@ mod tests {
             assert!(instance.runtime.network.is_none());
         }
 
-        assert_eq!(inactive["stopped"].runtime.state, SandboxState::Stopped);
-        assert_eq!(inactive["failed"].runtime.state, SandboxState::Failed);
+        assert_eq!(inactive["stopped"].runtime.state, ComputerState::Stopped);
+        assert_eq!(inactive["failed"].runtime.state, ComputerState::Failed);
         assert_eq!(
             inactive["failed"].runtime.error.as_deref(),
             Some("original failure")
@@ -1907,7 +1907,7 @@ mod tests {
             .collect();
 
         let clean = &inactive["clean"].runtime;
-        assert_eq!(clean.state, SandboxState::Paused);
+        assert_eq!(clean.state, ComputerState::Paused);
         assert_eq!(clean.pause_snapshot_id.as_deref(), Some("snap"));
         assert!(clean.paused_at.is_some());
         assert_eq!(
@@ -1918,7 +1918,7 @@ mod tests {
         // An interrupted pause/resume never reached a durable Paused commit;
         // its resources were swept, so it degrades honestly.
         for id in ["mid-pause", "mid-resume"] {
-            assert_eq!(inactive[id].runtime.state, SandboxState::Failed, "{id}");
+            assert_eq!(inactive[id].runtime.state, ComputerState::Failed, "{id}");
             assert_eq!(
                 store.load(id).unwrap().unwrap().phase,
                 PersistPhase::Failed,
@@ -1957,7 +1957,7 @@ mod tests {
         assert!(parked_rootfs.exists());
         assert!(cow_file.exists());
         let napper = manager.snapshot(&"napper".to_owned()).unwrap();
-        assert_eq!(napper.state, SandboxState::Paused);
+        assert_eq!(napper.state, ComputerState::Paused);
         assert_eq!(napper.pause_snapshot_id.as_deref(), Some("snap"));
     }
 
@@ -2228,7 +2228,7 @@ mod tests {
         let keeper = manager.snapshot(&"keeper".to_owned()).unwrap();
         // `Ready`, not `Running`: the workload the previous process was
         // streaming did not survive it, and `Running` refuses the next `Run`.
-        assert_eq!(keeper.state, SandboxState::Ready);
+        assert_eq!(keeper.state, ComputerState::Ready);
         assert!(keeper.handle.is_some(), "the VM's handle came back");
         assert_eq!(
             keeper.lease.as_ref().map(|lease| lease.ip.to_string()),
@@ -2289,13 +2289,13 @@ mod tests {
         );
         assert_eq!(
             manager.snapshot(&"keeper".to_owned()).unwrap().state,
-            SandboxState::Ready
+            ComputerState::Ready
         );
         // Inspectable rather than fatal. `Unjournaled` would have refused a
         // live phase here, which is the abort the skip exists to avoid.
         assert_eq!(
             manager.snapshot(&"broken".to_owned()).unwrap().state,
-            SandboxState::Failed,
+            ComputerState::Failed,
             "the unreadable one is reported, not reconciled"
         );
         assert!(
@@ -2341,7 +2341,7 @@ mod tests {
         );
         assert_eq!(
             manager.snapshot(&legacy.to_owned()).unwrap().state,
-            SandboxState::Failed,
+            ComputerState::Failed,
             "the one it could not is reported, not reconciled"
         );
         assert!(
@@ -2774,7 +2774,7 @@ mod tests {
                 "{what}: the journal is cleared"
             );
             let keeper = manager.snapshot(&"keeper".to_owned()).unwrap();
-            assert_eq!(keeper.state, SandboxState::Failed, "{what}");
+            assert_eq!(keeper.state, ComputerState::Failed, "{what}");
             assert!(keeper.handle.is_none(), "{what}");
         }
     }

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -55,7 +55,7 @@ use super::policy::recovery::{self, JournalEvidence, RecoveryAction, SweepAction
 use super::record::{PersistPhase, SandboxRecord, SandboxRecordStore, SandboxTransition};
 use super::{LeaseExt, SandboxState};
 use crate::config::RuntimeConfig;
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::lifecycle::actor::{Deadlines, Seeded};
 use crate::lifecycle::runtime::ComputerRuntime;
 use crate::snapshot_cow::{
@@ -360,7 +360,10 @@ impl SandboxStateRecord {
                     ip: allocation.ip_address.into(),
                     prefix_len: allocation.prefix_len,
                     gateway: allocation.gateway.into(),
-                    mac: allocation.mac_address.parse().map_err(VmmError::from)?,
+                    mac: allocation
+                        .mac_address
+                        .parse()
+                        .map_err(ComputerError::from)?,
                     cleanup_token: allocation.cleanup_token.clone(),
                 })
             })
@@ -409,13 +412,13 @@ pub fn write_state_record(vm_dir: &Path, record: &SandboxStateRecord) -> Result<
 /// Creates a runtime directory and durably links it from its parent.
 pub(super) fn create_runtime_dir(vm_dir: &Path) -> Result<()> {
     let parent = vm_dir.parent().ok_or_else(|| {
-        crate::error::VmmError::Config(format!(
+        crate::error::ComputerError::Config(format!(
             "sandbox runtime directory has no parent: {}",
             vm_dir.display()
         ))
     })?;
     let data_dir = parent.parent().ok_or_else(|| {
-        crate::error::VmmError::Config(format!(
+        crate::error::ComputerError::Config(format!(
             "sandbox runtime parent has no parent: {}",
             parent.display()
         ))
@@ -641,8 +644,8 @@ pub(super) async fn sweep_orphans(
         // driver will be handed is parsed here, letting `adopt_or_kill` and
         // [`SandboxStateRecord::lease`] rely on it downstream.
         let usable = validate_state_record(config, &sandboxes_dir, &dir, &record)
-            .and_then(|()| VmId::new(record.id.as_str()).map_err(VmmError::from))
-            .and_then(|_| VmId::new(record.resource_owner()).map_err(VmmError::from));
+            .and_then(|()| VmId::new(record.id.as_str()).map_err(ComputerError::from))
+            .and_then(|_| VmId::new(record.resource_owner()).map_err(ComputerError::from));
         if let Err(error) = usable {
             warn!(
                 sandbox_id = %record.id,
@@ -803,7 +806,10 @@ async fn reap_orphans(
         }
 
         if let Some(lease) = record.lease()? {
-            network.quarantine(lease).await.map_err(VmmError::from)?;
+            network
+                .quarantine(lease)
+                .await
+                .map_err(ComputerError::from)?;
         }
 
         // The VM's own area — under the jailer, a whole chroot holding the
@@ -898,14 +904,14 @@ pub(super) fn normalize_durable_records(
         match recovery::plan(record.phase, evidence) {
             RecoveryAction::LeaveResumable => {}
             RecoveryAction::RefuseUnjournaled => {
-                return Err(crate::error::VmmError::Unavailable(format!(
+                return Err(crate::error::ComputerError::Unavailable(format!(
                     "sandbox {} is {} but has no cleanup journal",
                     record.id,
                     record.phase.as_str()
                 )));
             }
             RecoveryAction::RefuseAdopted => {
-                return Err(crate::error::VmmError::Unavailable(format!(
+                return Err(crate::error::ComputerError::Unavailable(format!(
                     "sandbox {} is {}, a phase the startup sweep must not adopt",
                     record.id,
                     record.phase.as_str()
@@ -1250,7 +1256,7 @@ async fn adopt_or_kill(
     let adopted = tokio::time::timeout(ADOPT_TIMEOUT, adopt.adopt(&vm_record))
         .await
         .map_err(|_| {
-            VmmError::Process(format!(
+            ComputerError::Process(format!(
                 "sandbox {}: the driver did not find or reconnect to its vmm within {}s",
                 record.id,
                 ADOPT_TIMEOUT.as_secs()
@@ -1409,7 +1415,7 @@ fn validate_state_record(
 ) -> Result<()> {
     super::validate_id("sandbox id", &record.id)?;
     if directory.file_name().and_then(|name| name.to_str()) != Some(record.id.as_str()) {
-        return Err(crate::error::VmmError::Config(format!(
+        return Err(crate::error::ComputerError::Config(format!(
             "sandbox cleanup record id {} does not match directory {}",
             record.id,
             directory.display()
@@ -1418,7 +1424,7 @@ fn validate_state_record(
     if let Some(network) = &record.network {
         let expected = tap_name_for(network.ip_address);
         if network.tap_name != expected {
-            return Err(crate::error::VmmError::Config(format!(
+            return Err(crate::error::ComputerError::Config(format!(
                 "sandbox {} cleanup record has unexpected TAP {}",
                 record.id, network.tap_name
             )));
@@ -1427,7 +1433,7 @@ fn validate_state_record(
     if let Some(slot_id) = &record.pool_slot_id {
         super::validate_id("pool slot id", slot_id)?;
         if !slot_id.starts_with(POOL_SLOT_PREFIX) {
-            return Err(crate::error::VmmError::Config(format!(
+            return Err(crate::error::ComputerError::Config(format!(
                 "sandbox {} cleanup record has non-pool slot id {slot_id}",
                 record.id
             )));
@@ -1443,7 +1449,7 @@ fn validate_state_record(
             || cow.dm_device != format!("/dev/mapper/{expected_name}")
             || cow.cow_file != expected_file
         {
-            return Err(crate::error::VmmError::Config(format!(
+            return Err(crate::error::ComputerError::Config(format!(
                 "sandbox {} cleanup record has invalid CoW resources",
                 record.id
             )));
@@ -1452,7 +1458,7 @@ fn validate_state_record(
     if let Some(origin) = &record.restore_origin_dir {
         let origin_id = origin.file_name().and_then(|name| name.to_str());
         if origin.parent() != Some(sandboxes_dir) || origin_id.is_none() {
-            return Err(crate::error::VmmError::Config(format!(
+            return Err(crate::error::ComputerError::Config(format!(
                 "sandbox {} restore origin escapes {}",
                 record.id,
                 sandboxes_dir.display()
@@ -2873,7 +2879,7 @@ mod tests {
                 Some(&mut SweptRuntime::nothing_kept()),
                 &mut Vec::new()
             ),
-            Err(crate::error::VmmError::Unavailable(_))
+            Err(crate::error::ComputerError::Unavailable(_))
         ));
         assert_eq!(
             store.load("starting").unwrap().unwrap().phase,

--- a/computer/arcbox-computer-runtime/src/sandbox/record.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/record.rs
@@ -14,10 +14,10 @@
 mod phase;
 mod store;
 
+pub use phase::ComputerRecord;
 pub use phase::PersistPhase;
 pub use phase::ProvisionIntent;
-pub use phase::SandboxRecord;
 /// Crate-visible, like [`PersistPhase`]: `crate::lifecycle`'s actor is what
 /// executes the durable writes the machine asks for.
-pub use phase::{SandboxProvisionOutcome, SandboxTransition};
-pub use store::SandboxRecordStore;
+pub use phase::{ComputerProvisionOutcome, ComputerTransition};
+pub use store::ComputerRecordStore;

--- a/computer/arcbox-computer-runtime/src/sandbox/record/phase.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/record/phase.rs
@@ -38,7 +38,7 @@ pub enum SandboxPhase {
 }
 
 /// The durable phase under the name R3's lifecycle HSM uses for it: what a
-/// crash-restart reads back, as opposed to the in-memory `SandboxState` a
+/// crash-restart reads back, as opposed to the in-memory `ComputerState` a
 /// caller sees.
 ///
 /// The module boundary is where the two names meet: inside `record` the

--- a/computer/arcbox-computer-runtime/src/sandbox/record/phase.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/record/phase.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::sandbox::{SandboxId, SandboxSpec, validate_id};
 
 pub(super) const RECORD_VERSION: u32 = 1;
@@ -153,7 +153,7 @@ impl SandboxRecord {
         let atomic_ready = matches!(&transition, SandboxTransition::ReadyWithOutcome(_))
             && self.phase == SandboxPhase::Creating;
         if !atomic_ready && !self.phase.can_transition_to(next) {
-            return Err(VmmError::WrongState {
+            return Err(ComputerError::WrongState {
                 id: self.id.clone(),
                 expected: format!("a valid transition from {}", self.phase.as_str()),
                 actual: next.as_str().to_owned(),
@@ -165,7 +165,7 @@ impl SandboxRecord {
                 if let Some(existing) = &self.provision_outcome
                     && existing != &outcome
                 {
-                    return Err(VmmError::WrongState {
+                    return Err(ComputerError::WrongState {
                         id: self.id.clone(),
                         expected: format!("provision outcome {existing:?}"),
                         actual: format!("provision outcome {outcome:?}"),
@@ -179,7 +179,7 @@ impl SandboxRecord {
                 if let Some(existing) = &self.provision_outcome
                     && existing != &outcome
                 {
-                    return Err(VmmError::WrongState {
+                    return Err(ComputerError::WrongState {
                         id: self.id.clone(),
                         expected: format!("provision outcome {existing:?}"),
                         actual: format!("provision outcome {outcome:?}"),
@@ -309,7 +309,7 @@ pub(super) fn classify_existing_provision(
     request_key: &str,
 ) -> Result<ExistingProvision> {
     if record.request_key != request_key {
-        return Err(VmmError::AlreadyExists(record.id.clone()));
+        return Err(ComputerError::AlreadyExists(record.id.clone()));
     }
     Ok(match record.phase {
         SandboxPhase::Creating => ExistingProvision::Pending,
@@ -329,29 +329,29 @@ pub(super) fn classify_existing_provision(
 pub(super) fn validate_record(id: &str, record: &SandboxRecord) -> Result<()> {
     validate_id("sandbox id", id)?;
     if record.version != RECORD_VERSION {
-        return Err(VmmError::Config(format!(
+        return Err(ComputerError::Config(format!(
             "unsupported sandbox record version {} for {id}",
             record.version
         )));
     }
     if record.id != id {
-        return Err(VmmError::Config(format!(
+        return Err(ComputerError::Config(format!(
             "sandbox record id mismatch: expected {id}, got {}",
             record.id
         )));
     }
     if record.effective_spec.id.as_deref() != Some(id) {
-        return Err(VmmError::Config(format!(
+        return Err(ComputerError::Config(format!(
             "sandbox record spec id mismatch for {id}"
         )));
     }
     if record.request_key.is_empty() {
-        return Err(VmmError::Config(format!(
+        return Err(ComputerError::Config(format!(
             "sandbox record provision request key is empty for {id}"
         )));
     }
     if record.phase == SandboxPhase::Creating && record.provision_outcome.is_some() {
-        return Err(VmmError::Config(format!(
+        return Err(ComputerError::Config(format!(
             "creating sandbox record unexpectedly has a provision outcome for {id}"
         )));
     }
@@ -366,7 +366,7 @@ pub(super) fn validate_record(id: &str, record: &SandboxRecord) -> Result<()> {
             | SandboxPhase::Resuming
     ) && record.provision_outcome.is_none()
     {
-        return Err(VmmError::Config(format!(
+        return Err(ComputerError::Config(format!(
             "sandbox record has no provision outcome in phase {} for {id}",
             record.phase.as_str()
         )));
@@ -374,7 +374,7 @@ pub(super) fn validate_record(id: &str, record: &SandboxRecord) -> Result<()> {
     if matches!(record.phase, SandboxPhase::Paused | SandboxPhase::Resuming)
         && record.pause_snapshot_id.is_none()
     {
-        return Err(VmmError::Config(format!(
+        return Err(ComputerError::Config(format!(
             "sandbox record has no pause snapshot in phase {} for {id}",
             record.phase.as_str()
         )));

--- a/computer/arcbox-computer-runtime/src/sandbox/record/phase.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/record/phase.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::error::{ComputerError, Result};
-use crate::sandbox::{SandboxId, SandboxSpec, validate_id};
+use crate::sandbox::{ComputerId, ComputerSpec, validate_id};
 
 pub(super) const RECORD_VERSION: u32 = 1;
 
@@ -62,10 +62,10 @@ pub struct SandboxProvisionOutcome {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SandboxRecord {
     pub(super) version: u32,
-    pub(in crate::sandbox) id: SandboxId,
+    pub(in crate::sandbox) id: ComputerId,
     pub(crate) generation: Uuid,
     pub(in crate::sandbox) request_key: String,
-    pub(in crate::sandbox) effective_spec: SandboxSpec,
+    pub(in crate::sandbox) effective_spec: ComputerSpec,
     pub(in crate::sandbox) phase: SandboxPhase,
     pub(in crate::sandbox) provision_outcome: Option<SandboxProvisionOutcome>,
     pub(in crate::sandbox) created_at: DateTime<Utc>,
@@ -127,7 +127,7 @@ impl SandboxTransition {
 }
 
 impl SandboxRecord {
-    pub(super) fn new(id: &str, request_key: &str, effective_spec: SandboxSpec) -> Self {
+    pub(super) fn new(id: &str, request_key: &str, effective_spec: ComputerSpec) -> Self {
         let created_at = Utc::now();
         let ttl_deadline = (effective_spec.ttl_seconds > 0)
             .then(|| created_at + chrono::Duration::seconds(i64::from(effective_spec.ttl_seconds)));
@@ -430,9 +430,9 @@ mod tests {
         SandboxRecord::new(
             id,
             "key",
-            SandboxSpec {
+            ComputerSpec {
                 id: Some(id.to_owned()),
-                ..SandboxSpec::default()
+                ..ComputerSpec::default()
             },
         )
     }

--- a/computer/arcbox-computer-runtime/src/sandbox/record/phase.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/record/phase.rs
@@ -19,7 +19,7 @@ pub(super) const RECORD_VERSION: u32 = 1;
 /// phase at `Ready`, avoiding record writes on the execution hot path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum SandboxPhase {
+pub enum ComputerPhase {
     Creating,
     Starting,
     Ready,
@@ -42,32 +42,31 @@ pub enum SandboxPhase {
 /// caller sees.
 ///
 /// The module boundary is where the two names meet: inside `record` the
-/// enum is `SandboxPhase`, and this alias — the only one of the two
-/// [`super`] re-exports — is what every other module says. R3's rename
-/// then has one module to touch.
+/// enum is `ComputerPhase`, and this alias — the only one of the two
+/// [`super`] re-exports — is what every other module says.
 ///
 /// Crate-visible rather than `pub(in crate::sandbox)`: `crate::lifecycle`'s
 /// state machine projects onto these phases and its table test is written
-/// against [`SandboxPhase::can_transition_to`], so the durable vocabulary
+/// against [`ComputerPhase::can_transition_to`], so the durable vocabulary
 /// has to reach one module outside `sandbox`.
-pub type PersistPhase = SandboxPhase;
+pub type PersistPhase = ComputerPhase;
 
 /// The stable result returned once a provisioning request has been accepted.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SandboxProvisionOutcome {
+pub struct ComputerProvisionOutcome {
     pub ip_address: String,
 }
 
 /// Versioned durable state for one sandbox generation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SandboxRecord {
+pub struct ComputerRecord {
     pub(super) version: u32,
     pub(in crate::sandbox) id: ComputerId,
     pub(crate) generation: Uuid,
     pub(in crate::sandbox) request_key: String,
     pub(in crate::sandbox) effective_spec: ComputerSpec,
-    pub(in crate::sandbox) phase: SandboxPhase,
-    pub(in crate::sandbox) provision_outcome: Option<SandboxProvisionOutcome>,
+    pub(in crate::sandbox) phase: ComputerPhase,
+    pub(in crate::sandbox) provision_outcome: Option<ComputerProvisionOutcome>,
     pub(in crate::sandbox) created_at: DateTime<Utc>,
     pub(in crate::sandbox) error: Option<String>,
     /// Catalog id of the internal pause checkpoint. Set while the record is
@@ -89,17 +88,17 @@ pub struct SandboxRecord {
 /// Result of reserving a durable provisioning intent.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProvisionIntent {
-    Created(SandboxRecord),
-    Resume(SandboxRecord),
-    Replay(SandboxRecord),
-    Blocked(SandboxRecord),
+    Created(ComputerRecord),
+    Resume(ComputerRecord),
+    Replay(ComputerRecord),
+    Blocked(ComputerRecord),
 }
 
 /// Generation-checked lifecycle update.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SandboxTransition {
-    Starting(SandboxProvisionOutcome),
-    ReadyWithOutcome(SandboxProvisionOutcome),
+pub enum ComputerTransition {
+    Starting(ComputerProvisionOutcome),
+    ReadyWithOutcome(ComputerProvisionOutcome),
     Ready,
     Stopping,
     Stopped,
@@ -110,23 +109,23 @@ pub enum SandboxTransition {
     Resuming,
 }
 
-impl SandboxTransition {
-    fn phase(&self) -> SandboxPhase {
+impl ComputerTransition {
+    fn phase(&self) -> ComputerPhase {
         match self {
-            Self::Starting(_) => SandboxPhase::Starting,
-            Self::ReadyWithOutcome(_) | Self::Ready => SandboxPhase::Ready,
-            Self::Stopping => SandboxPhase::Stopping,
-            Self::Stopped => SandboxPhase::Stopped,
-            Self::Failed(_) => SandboxPhase::Failed,
-            Self::Removing => SandboxPhase::Removing,
-            Self::Pausing => SandboxPhase::Pausing,
-            Self::Paused { .. } => SandboxPhase::Paused,
-            Self::Resuming => SandboxPhase::Resuming,
+            Self::Starting(_) => ComputerPhase::Starting,
+            Self::ReadyWithOutcome(_) | Self::Ready => ComputerPhase::Ready,
+            Self::Stopping => ComputerPhase::Stopping,
+            Self::Stopped => ComputerPhase::Stopped,
+            Self::Failed(_) => ComputerPhase::Failed,
+            Self::Removing => ComputerPhase::Removing,
+            Self::Pausing => ComputerPhase::Pausing,
+            Self::Paused { .. } => ComputerPhase::Paused,
+            Self::Resuming => ComputerPhase::Resuming,
         }
     }
 }
 
-impl SandboxRecord {
+impl ComputerRecord {
     pub(super) fn new(id: &str, request_key: &str, effective_spec: ComputerSpec) -> Self {
         let created_at = Utc::now();
         let ttl_deadline = (effective_spec.ttl_seconds > 0)
@@ -138,7 +137,7 @@ impl SandboxRecord {
             generation: Uuid::new_v4(),
             request_key: request_key.to_owned(),
             effective_spec,
-            phase: SandboxPhase::Creating,
+            phase: ComputerPhase::Creating,
             provision_outcome: None,
             created_at,
             error: None,
@@ -148,10 +147,10 @@ impl SandboxRecord {
         }
     }
 
-    pub(super) fn apply(&mut self, transition: SandboxTransition) -> Result<()> {
+    pub(super) fn apply(&mut self, transition: ComputerTransition) -> Result<()> {
         let next = transition.phase();
-        let atomic_ready = matches!(&transition, SandboxTransition::ReadyWithOutcome(_))
-            && self.phase == SandboxPhase::Creating;
+        let atomic_ready = matches!(&transition, ComputerTransition::ReadyWithOutcome(_))
+            && self.phase == ComputerPhase::Creating;
         if !atomic_ready && !self.phase.can_transition_to(next) {
             return Err(ComputerError::WrongState {
                 id: self.id.clone(),
@@ -161,7 +160,7 @@ impl SandboxRecord {
         }
 
         match transition {
-            SandboxTransition::Starting(outcome) => {
+            ComputerTransition::Starting(outcome) => {
                 if let Some(existing) = &self.provision_outcome
                     && existing != &outcome
                 {
@@ -171,11 +170,11 @@ impl SandboxRecord {
                         actual: format!("provision outcome {outcome:?}"),
                     });
                 }
-                self.phase = SandboxPhase::Starting;
+                self.phase = ComputerPhase::Starting;
                 self.provision_outcome = Some(outcome);
                 self.error = None;
             }
-            SandboxTransition::ReadyWithOutcome(outcome) => {
+            ComputerTransition::ReadyWithOutcome(outcome) => {
                 if let Some(existing) = &self.provision_outcome
                     && existing != &outcome
                 {
@@ -185,42 +184,42 @@ impl SandboxRecord {
                         actual: format!("provision outcome {outcome:?}"),
                     });
                 }
-                self.phase = SandboxPhase::Ready;
+                self.phase = ComputerPhase::Ready;
                 self.provision_outcome = Some(outcome);
                 self.error = None;
                 self.redact_runtime_inputs();
             }
-            SandboxTransition::Ready => {
-                self.phase = SandboxPhase::Ready;
+            ComputerTransition::Ready => {
+                self.phase = ComputerPhase::Ready;
                 self.error = None;
                 self.pause_snapshot_id = None;
                 self.paused_at = None;
                 self.redact_runtime_inputs();
             }
-            SandboxTransition::Stopping => {
-                self.phase = SandboxPhase::Stopping;
+            ComputerTransition::Stopping => {
+                self.phase = ComputerPhase::Stopping;
                 self.error = None;
                 self.redact_runtime_inputs();
             }
-            SandboxTransition::Stopped => {
-                self.phase = SandboxPhase::Stopped;
+            ComputerTransition::Stopped => {
+                self.phase = ComputerPhase::Stopped;
                 self.error = None;
             }
-            SandboxTransition::Failed(error) => {
-                self.phase = SandboxPhase::Failed;
+            ComputerTransition::Failed(error) => {
+                self.phase = ComputerPhase::Failed;
                 self.error = Some(error);
                 self.redact_runtime_inputs();
             }
-            SandboxTransition::Removing => {
-                self.phase = SandboxPhase::Removing;
+            ComputerTransition::Removing => {
+                self.phase = ComputerPhase::Removing;
                 self.redact_runtime_inputs();
             }
-            SandboxTransition::Pausing => {
-                self.phase = SandboxPhase::Pausing;
+            ComputerTransition::Pausing => {
+                self.phase = ComputerPhase::Pausing;
                 self.error = None;
             }
-            SandboxTransition::Paused { snapshot_id } => {
-                self.phase = SandboxPhase::Paused;
+            ComputerTransition::Paused { snapshot_id } => {
+                self.phase = ComputerPhase::Paused;
                 self.pause_snapshot_id = Some(snapshot_id);
                 // Stamped once per pause, not once per transition: a failed
                 // resume parks the record back at `Paused`, and overwriting
@@ -230,8 +229,8 @@ impl SandboxRecord {
                 self.paused_at.get_or_insert_with(Utc::now);
                 self.error = None;
             }
-            SandboxTransition::Resuming => {
-                self.phase = SandboxPhase::Resuming;
+            ComputerTransition::Resuming => {
+                self.phase = ComputerPhase::Resuming;
                 self.error = None;
             }
         }
@@ -252,7 +251,7 @@ impl SandboxRecord {
     }
 }
 
-impl SandboxPhase {
+impl ComputerPhase {
     pub fn can_transition_to(self, next: Self) -> bool {
         self == next
             || matches!(
@@ -305,28 +304,28 @@ pub(super) enum ExistingProvision {
 }
 
 pub(super) fn classify_existing_provision(
-    record: &SandboxRecord,
+    record: &ComputerRecord,
     request_key: &str,
 ) -> Result<ExistingProvision> {
     if record.request_key != request_key {
         return Err(ComputerError::AlreadyExists(record.id.clone()));
     }
     Ok(match record.phase {
-        SandboxPhase::Creating => ExistingProvision::Pending,
-        SandboxPhase::Starting | SandboxPhase::Ready => ExistingProvision::Replay,
+        ComputerPhase::Creating => ExistingProvision::Pending,
+        ComputerPhase::Starting | ComputerPhase::Ready => ExistingProvision::Replay,
         // A paused sandbox's provision outcome names a released IP, so a
         // same-key create retry must not replay it as live.
-        SandboxPhase::Stopping
-        | SandboxPhase::Stopped
-        | SandboxPhase::Failed
-        | SandboxPhase::Removing
-        | SandboxPhase::Pausing
-        | SandboxPhase::Paused
-        | SandboxPhase::Resuming => ExistingProvision::Blocked,
+        ComputerPhase::Stopping
+        | ComputerPhase::Stopped
+        | ComputerPhase::Failed
+        | ComputerPhase::Removing
+        | ComputerPhase::Pausing
+        | ComputerPhase::Paused
+        | ComputerPhase::Resuming => ExistingProvision::Blocked,
     })
 }
 
-pub(super) fn validate_record(id: &str, record: &SandboxRecord) -> Result<()> {
+pub(super) fn validate_record(id: &str, record: &ComputerRecord) -> Result<()> {
     validate_id("sandbox id", id)?;
     if record.version != RECORD_VERSION {
         return Err(ComputerError::Config(format!(
@@ -350,20 +349,20 @@ pub(super) fn validate_record(id: &str, record: &SandboxRecord) -> Result<()> {
             "sandbox record provision request key is empty for {id}"
         )));
     }
-    if record.phase == SandboxPhase::Creating && record.provision_outcome.is_some() {
+    if record.phase == ComputerPhase::Creating && record.provision_outcome.is_some() {
         return Err(ComputerError::Config(format!(
             "creating sandbox record unexpectedly has a provision outcome for {id}"
         )));
     }
     if matches!(
         record.phase,
-        SandboxPhase::Starting
-            | SandboxPhase::Ready
-            | SandboxPhase::Stopping
-            | SandboxPhase::Stopped
-            | SandboxPhase::Pausing
-            | SandboxPhase::Paused
-            | SandboxPhase::Resuming
+        ComputerPhase::Starting
+            | ComputerPhase::Ready
+            | ComputerPhase::Stopping
+            | ComputerPhase::Stopped
+            | ComputerPhase::Pausing
+            | ComputerPhase::Paused
+            | ComputerPhase::Resuming
     ) && record.provision_outcome.is_none()
     {
         return Err(ComputerError::Config(format!(
@@ -371,8 +370,10 @@ pub(super) fn validate_record(id: &str, record: &SandboxRecord) -> Result<()> {
             record.phase.as_str()
         )));
     }
-    if matches!(record.phase, SandboxPhase::Paused | SandboxPhase::Resuming)
-        && record.pause_snapshot_id.is_none()
+    if matches!(
+        record.phase,
+        ComputerPhase::Paused | ComputerPhase::Resuming
+    ) && record.pause_snapshot_id.is_none()
     {
         return Err(ComputerError::Config(format!(
             "sandbox record has no pause snapshot in phase {} for {id}",
@@ -384,14 +385,14 @@ pub(super) fn validate_record(id: &str, record: &SandboxRecord) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::SandboxPhase::*;
+    use super::ComputerPhase::*;
     use super::*;
 
     /// Every durable phase, in declaration order. Both axes of the edge
     /// table below iterate this, so a phase missing here is a pair nobody
     /// checks — [`targets_of`]'s exhaustive match is what stops a new
     /// variant from being added without a row.
-    const ALL_PHASES: [SandboxPhase; 10] = [
+    const ALL_PHASES: [ComputerPhase; 10] = [
         Creating, Starting, Ready, Stopping, Stopped, Failed, Removing, Pausing, Paused, Resuming,
     ];
 
@@ -402,7 +403,7 @@ mod tests {
     /// `can_transition_to`, which is why the test below asserts it over all
     /// `(from, to)` pairs instead of sampling: an edge missing here becomes
     /// a wrong state machine there.
-    fn targets_of(from: SandboxPhase) -> &'static [SandboxPhase] {
+    fn targets_of(from: ComputerPhase) -> &'static [ComputerPhase] {
         match from {
             Creating => &[Starting, Failed, Removing],
             Starting => &[Ready, Stopping, Failed, Removing],
@@ -420,14 +421,14 @@ mod tests {
         }
     }
 
-    fn outcome() -> SandboxProvisionOutcome {
-        SandboxProvisionOutcome {
+    fn outcome() -> ComputerProvisionOutcome {
+        ComputerProvisionOutcome {
             ip_address: "192.0.2.2".into(),
         }
     }
 
-    fn creating(id: &str) -> SandboxRecord {
-        SandboxRecord::new(
+    fn creating(id: &str) -> ComputerRecord {
+        ComputerRecord::new(
             id,
             "key",
             ComputerSpec {
@@ -457,25 +458,25 @@ mod tests {
 
     #[test]
     fn every_transition_projects_onto_one_phase() {
-        // `SandboxTransition::phase`'s own match is exhaustive, so a new
+        // `ComputerTransition::phase`'s own match is exhaustive, so a new
         // transition cannot skip this list without failing to compile there
         // first.
-        let projections: [(SandboxTransition, SandboxPhase); 10] = [
-            (SandboxTransition::Starting(outcome()), Starting),
-            (SandboxTransition::ReadyWithOutcome(outcome()), Ready),
-            (SandboxTransition::Ready, Ready),
-            (SandboxTransition::Stopping, Stopping),
-            (SandboxTransition::Stopped, Stopped),
-            (SandboxTransition::Failed("boom".into()), Failed),
-            (SandboxTransition::Removing, Removing),
-            (SandboxTransition::Pausing, Pausing),
+        let projections: [(ComputerTransition, ComputerPhase); 10] = [
+            (ComputerTransition::Starting(outcome()), Starting),
+            (ComputerTransition::ReadyWithOutcome(outcome()), Ready),
+            (ComputerTransition::Ready, Ready),
+            (ComputerTransition::Stopping, Stopping),
+            (ComputerTransition::Stopped, Stopped),
+            (ComputerTransition::Failed("boom".into()), Failed),
+            (ComputerTransition::Removing, Removing),
+            (ComputerTransition::Pausing, Pausing),
             (
-                SandboxTransition::Paused {
+                ComputerTransition::Paused {
                     snapshot_id: "snap".into(),
                 },
                 Paused,
             ),
-            (SandboxTransition::Resuming, Resuming),
+            (ComputerTransition::Resuming, Resuming),
         ];
 
         for (transition, phase) in projections {
@@ -487,24 +488,24 @@ mod tests {
     fn only_a_restore_may_commit_ready_straight_from_creating() {
         // `Creating -> Ready` is not an edge...
         let mut record = creating("box");
-        assert!(record.apply(SandboxTransition::Ready).is_err());
+        assert!(record.apply(ComputerTransition::Ready).is_err());
         assert_eq!(record.phase, Creating);
 
         // ...except for the restore path's single-hop commit, which carries
         // the outcome the skipped `Starting` write would have persisted.
         record
-            .apply(SandboxTransition::ReadyWithOutcome(outcome()))
+            .apply(ComputerTransition::ReadyWithOutcome(outcome()))
             .unwrap();
         assert_eq!(record.phase, Ready);
         assert_eq!(record.provision_outcome, Some(outcome()));
 
         // The exception is keyed on `Creating`: from anywhere else the edge
         // set rules, so a stopped record cannot be revived by it.
-        record.apply(SandboxTransition::Stopping).unwrap();
-        record.apply(SandboxTransition::Stopped).unwrap();
+        record.apply(ComputerTransition::Stopping).unwrap();
+        record.apply(ComputerTransition::Stopped).unwrap();
         assert!(
             record
-                .apply(SandboxTransition::ReadyWithOutcome(outcome()))
+                .apply(ComputerTransition::ReadyWithOutcome(outcome()))
                 .is_err()
         );
         assert_eq!(record.phase, Stopped);

--- a/computer/arcbox-computer-runtime/src/sandbox/record/store.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/record/store.rs
@@ -23,7 +23,7 @@ use super::phase::{
     ExistingProvision, ProvisionIntent, RECORD_VERSION, SandboxPhase, SandboxProvisionOutcome,
     SandboxRecord, SandboxTransition, classify_existing_provision, validate_record,
 };
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::sandbox::types::IdleAction;
 use crate::sandbox::{SandboxSpec, validate_id};
 
@@ -40,7 +40,7 @@ pub struct DurableCommit<T> {
 impl<T> DurableCommit<T> {
     pub fn confirmed(self, operation: &str) -> Result<T> {
         match self.durability_error {
-            Some(error) => Err(VmmError::Unavailable(format!(
+            Some(error) => Err(ComputerError::Unavailable(format!(
                 "{operation} is visible but its durability is unconfirmed: {error}"
             ))),
             None => Ok(self.value),
@@ -88,19 +88,19 @@ impl SandboxRecordStore {
             .filter(|path| path.extension() == Some(OsStr::new("json")))
             .map(|path| {
                 if !fs::symlink_metadata(&path)?.file_type().is_file() {
-                    return Err(VmmError::Config(format!(
+                    return Err(ComputerError::Config(format!(
                         "sandbox record is not a regular file: {}",
                         path.display()
                     )));
                 }
                 let id = path.file_stem().and_then(OsStr::to_str).ok_or_else(|| {
-                    VmmError::Config(format!(
+                    ComputerError::Config(format!(
                         "sandbox record has an invalid file name: {}",
                         path.display()
                     ))
                 })?;
                 self.load_unlocked(id)?.ok_or_else(|| {
-                    VmmError::Other(format!(
+                    ComputerError::Other(format!(
                         "sandbox record disappeared while loading: {}",
                         path.display()
                     ))
@@ -132,7 +132,7 @@ impl SandboxRecordStore {
             }
             ExistingProvision::Blocked => {
                 self.confirm_root_unlocked("provision collision")?;
-                Err(VmmError::AlreadyExists(id.to_owned()))
+                Err(ComputerError::AlreadyExists(id.to_owned()))
             }
         }
     }
@@ -181,7 +181,7 @@ impl SandboxRecordStore {
         let _guard = self.lock()?;
         let mut record = self
             .load_unlocked(id)?
-            .ok_or_else(|| VmmError::NotFound(id.to_owned()))?;
+            .ok_or_else(|| ComputerError::NotFound(id.to_owned()))?;
         if record.generation != generation {
             return Err(generation_mismatch(id, record.generation, generation));
         }
@@ -209,7 +209,7 @@ impl SandboxRecordStore {
         let _guard = self.lock()?;
         let mut record = self
             .load_unlocked(id)?
-            .ok_or_else(|| VmmError::NotFound(id.to_owned()))?;
+            .ok_or_else(|| ComputerError::NotFound(id.to_owned()))?;
         if record.generation != generation {
             return Err(generation_mismatch(id, record.generation, generation));
         }
@@ -243,7 +243,7 @@ impl SandboxRecordStore {
             return Ok(self.confirm_absence_unlocked());
         };
         if record.phase != SandboxPhase::Creating || record.provision_outcome.is_some() {
-            return Err(VmmError::AlreadyExists(id.to_owned()));
+            return Err(ComputerError::AlreadyExists(id.to_owned()));
         }
         self.delete_unlocked(id)
     }
@@ -251,7 +251,7 @@ impl SandboxRecordStore {
     fn lock(&self) -> Result<MutexGuard<'_, ()>> {
         self.lock
             .lock()
-            .map_err(|_| VmmError::Other("sandbox record store mutex poisoned".into()))
+            .map_err(|_| ComputerError::Other("sandbox record store mutex poisoned".into()))
     }
 
     fn load_unlocked(&self, id: &str) -> Result<Option<SandboxRecord>> {
@@ -263,7 +263,7 @@ impl SandboxRecordStore {
             Err(error) => return Err(error.into()),
         };
         if !metadata.file_type().is_file() {
-            return Err(VmmError::Config(format!(
+            return Err(ComputerError::Config(format!(
                 "sandbox record is not a regular file: {}",
                 path.display()
             )));
@@ -282,7 +282,7 @@ impl SandboxRecordStore {
         }
         let header: RecordHeader = serde_json::from_slice(&bytes)?;
         if header.version != RECORD_VERSION {
-            return Err(VmmError::Config(format!(
+            return Err(ComputerError::Config(format!(
                 "unsupported sandbox record version {} for {id}",
                 header.version
             )));
@@ -325,7 +325,7 @@ impl SandboxRecordStore {
             return Err(generation_mismatch(id, record.generation, generation));
         }
         if record.phase != expected_phase {
-            return Err(VmmError::WrongState {
+            return Err(ComputerError::WrongState {
                 id: id.to_owned(),
                 expected: expected_phase.as_str().into(),
                 actual: record.phase.as_str().into(),
@@ -352,7 +352,7 @@ impl SandboxRecordStore {
 
     fn confirm_root_unlocked(&self, operation: &str) -> Result<()> {
         self.sync_root_unlocked().map_err(|error| {
-            VmmError::Unavailable(format!(
+            ComputerError::Unavailable(format!(
                 "{operation} durability could not be confirmed: {error}"
             ))
         })
@@ -372,15 +372,15 @@ impl SandboxRecordStore {
 fn validate_provision_input(id: &str, request_key: &str) -> Result<()> {
     validate_id("sandbox id", id)?;
     if request_key.is_empty() {
-        return Err(VmmError::Config(
+        return Err(ComputerError::Config(
             "sandbox provision request key must not be empty".into(),
         ));
     }
     Ok(())
 }
 
-fn generation_mismatch(id: &str, expected: Uuid, actual: Uuid) -> VmmError {
-    VmmError::WrongState {
+fn generation_mismatch(id: &str, expected: Uuid, actual: Uuid) -> ComputerError {
+    ComputerError::WrongState {
         id: id.to_owned(),
         expected: format!("generation {expected}"),
         actual: format!("generation {actual}"),
@@ -461,7 +461,7 @@ mod tests {
         );
         assert!(matches!(
             reopened.replay_provision("restored", "different-restore-key"),
-            Err(VmmError::AlreadyExists(id)) if id == "restored"
+            Err(ComputerError::AlreadyExists(id)) if id == "restored"
         ));
     }
 
@@ -473,13 +473,13 @@ mod tests {
         let path = store.record_path("box");
 
         fs::write(&path, b"{").unwrap();
-        assert!(matches!(store.load_all(), Err(VmmError::Json(_))));
+        assert!(matches!(store.load_all(), Err(ComputerError::Json(_))));
 
         record.version = RECORD_VERSION + 1;
         fs::write(&path, serde_json::to_vec(&record).unwrap()).unwrap();
         assert!(matches!(
             store.load_all(),
-            Err(VmmError::Config(message))
+            Err(ComputerError::Config(message))
                 if message.contains("unsupported sandbox record version")
         ));
     }
@@ -504,11 +504,11 @@ mod tests {
         ));
         assert!(matches!(
             store.provision_intent("box", "other", spec("box")),
-            Err(VmmError::AlreadyExists(id)) if id == "box"
+            Err(ComputerError::AlreadyExists(id)) if id == "box"
         ));
         assert!(matches!(
             store.replay_provision("box", "other"),
-            Err(VmmError::AlreadyExists(id)) if id == "box"
+            Err(ComputerError::AlreadyExists(id)) if id == "box"
         ));
 
         let mut with_secret = spec("box");
@@ -569,7 +569,7 @@ mod tests {
             .unwrap();
         assert!(matches!(
             store.replay_provision("box", "key"),
-            Err(VmmError::AlreadyExists(id)) if id == "box"
+            Err(ComputerError::AlreadyExists(id)) if id == "box"
         ));
         assert!(matches!(
             store.provision_intent("box", "key", spec("box")).unwrap(),
@@ -616,14 +616,14 @@ mod tests {
             .unwrap();
         assert!(matches!(
             store.replay_provision("box", "key"),
-            Err(VmmError::AlreadyExists(id)) if id == "box"
+            Err(ComputerError::AlreadyExists(id)) if id == "box"
         ));
         store
             .transition("box", record.generation, SandboxTransition::Stopped)
             .unwrap();
         assert!(matches!(
             store.replay_provision("box", "key"),
-            Err(VmmError::AlreadyExists(id)) if id == "box"
+            Err(ComputerError::AlreadyExists(id)) if id == "box"
         ));
         store
             .transition("box", record.generation, SandboxTransition::Stopped)
@@ -635,7 +635,7 @@ mod tests {
             .unwrap();
         assert!(matches!(
             store.replay_provision("box", "key"),
-            Err(VmmError::AlreadyExists(id)) if id == "box"
+            Err(ComputerError::AlreadyExists(id)) if id == "box"
         ));
         store.finish_remove("box", record.generation).unwrap();
         assert_eq!(store.load("box").unwrap(), None);
@@ -661,7 +661,7 @@ mod tests {
             .unwrap();
         assert!(matches!(
             store.replay_provision("failed", "key"),
-            Err(VmmError::AlreadyExists(id)) if id == "failed"
+            Err(ComputerError::AlreadyExists(id)) if id == "failed"
         ));
     }
 
@@ -716,7 +716,7 @@ mod tests {
         // A paused id must not replay its (released) provision outcome.
         assert!(matches!(
             store.replay_provision("box", "key"),
-            Err(VmmError::AlreadyExists(_))
+            Err(ComputerError::AlreadyExists(_))
         ));
 
         // Resume keeps the snapshot until Ready clears it.

--- a/computer/arcbox-computer-runtime/src/sandbox/record/store.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/record/store.rs
@@ -25,7 +25,7 @@ use super::phase::{
 };
 use crate::error::{ComputerError, Result};
 use crate::sandbox::types::IdleAction;
-use crate::sandbox::{SandboxSpec, validate_id};
+use crate::sandbox::{ComputerSpec, validate_id};
 
 const RECORDS_DIR: &str = "sandbox-records";
 
@@ -142,7 +142,7 @@ impl SandboxRecordStore {
         &self,
         id: &str,
         request_key: &str,
-        effective_spec: SandboxSpec,
+        effective_spec: ComputerSpec,
     ) -> Result<ProvisionIntent> {
         validate_provision_input(id, request_key)?;
 
@@ -391,11 +391,11 @@ fn generation_mismatch(id: &str, expected: Uuid, actual: Uuid) -> ComputerError 
 mod tests {
     use super::*;
 
-    fn spec(id: &str) -> SandboxSpec {
-        SandboxSpec {
+    fn spec(id: &str) -> ComputerSpec {
+        ComputerSpec {
             id: Some(id.to_owned()),
             ttl_seconds: 60,
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         }
     }
 

--- a/computer/arcbox-computer-runtime/src/sandbox/record/store.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/record/store.rs
@@ -1,4 +1,4 @@
-//! The file-backed record store: how a [`super::phase::SandboxRecord`]
+//! The file-backed record store: how a [`super::phase::ComputerRecord`]
 //! reaches the disk, and what "durable" means for each write.
 //!
 //! Every mutation is generation-checked, serialized by a process-local
@@ -20,8 +20,8 @@ use uuid::Uuid;
 use arcbox_atomic_file::AtomicWriteError;
 
 use super::phase::{
-    ExistingProvision, ProvisionIntent, RECORD_VERSION, SandboxPhase, SandboxProvisionOutcome,
-    SandboxRecord, SandboxTransition, classify_existing_provision, validate_record,
+    ComputerPhase, ComputerProvisionOutcome, ComputerRecord, ComputerTransition, ExistingProvision,
+    ProvisionIntent, RECORD_VERSION, classify_existing_provision, validate_record,
 };
 use crate::error::{ComputerError, Result};
 use crate::sandbox::types::IdleAction;
@@ -49,12 +49,12 @@ impl<T> DurableCommit<T> {
 }
 
 /// File-backed sandbox record store serialized by a process-local mutex.
-pub struct SandboxRecordStore {
+pub struct ComputerRecordStore {
     root: PathBuf,
     lock: Mutex<()>,
 }
 
-impl SandboxRecordStore {
+impl ComputerRecordStore {
     /// Opens the durable store beside, rather than inside, runtime sandboxes.
     pub fn new(data_dir: &Path) -> Result<Self> {
         let root = data_dir.join(RECORDS_DIR);
@@ -70,13 +70,13 @@ impl SandboxRecordStore {
 
     /// Loads the current record for `id`.
     #[cfg(test)]
-    pub(in crate::sandbox) fn load(&self, id: &str) -> Result<Option<SandboxRecord>> {
+    pub(in crate::sandbox) fn load(&self, id: &str) -> Result<Option<ComputerRecord>> {
         let _guard = self.lock()?;
         self.load_unlocked(id)
     }
 
     /// Loads every durable record, rejecting any malformed record file.
-    pub(in crate::sandbox) fn load_all(&self) -> Result<Vec<SandboxRecord>> {
+    pub(in crate::sandbox) fn load_all(&self) -> Result<Vec<ComputerRecord>> {
         let _guard = self.lock()?;
         let mut paths = fs::read_dir(&self.root)?
             .map(|entry| entry.map(|entry| entry.path()))
@@ -117,7 +117,7 @@ impl SandboxRecordStore {
         &self,
         id: &str,
         request_key: &str,
-    ) -> Result<Option<SandboxProvisionOutcome>> {
+    ) -> Result<Option<ComputerProvisionOutcome>> {
         validate_provision_input(id, request_key)?;
         let _guard = self.lock()?;
         let Some(record) = self.load_unlocked(id)? else {
@@ -161,7 +161,7 @@ impl SandboxRecordStore {
             });
         }
 
-        let record = SandboxRecord::new(id, request_key, effective_spec);
+        let record = ComputerRecord::new(id, request_key, effective_spec);
         if let Some(error) = self.save_unlocked(&record)? {
             warn!(
                 computer_id = id,
@@ -176,8 +176,8 @@ impl SandboxRecordStore {
         &self,
         id: &str,
         generation: Uuid,
-        transition: SandboxTransition,
-    ) -> Result<DurableCommit<SandboxRecord>> {
+        transition: ComputerTransition,
+    ) -> Result<DurableCommit<ComputerRecord>> {
         let _guard = self.lock()?;
         let mut record = self
             .load_unlocked(id)?
@@ -225,12 +225,12 @@ impl SandboxRecordStore {
 
     /// Removes a known pre-ACK provision intent after side effects rolled back.
     pub fn abort_provision(&self, id: &str, generation: Uuid) -> Result<DurableCommit<()>> {
-        self.delete_record(id, generation, SandboxPhase::Creating)
+        self.delete_record(id, generation, ComputerPhase::Creating)
     }
 
     /// Releases an ID only after removal and resource cleanup completed.
     pub fn finish_remove(&self, id: &str, generation: Uuid) -> Result<DurableCommit<()>> {
-        self.delete_record(id, generation, SandboxPhase::Removing)
+        self.delete_record(id, generation, ComputerPhase::Removing)
     }
 
     /// Cancels a pre-ACK intent, or confirms that an already-removed ID is free.
@@ -242,7 +242,7 @@ impl SandboxRecordStore {
         let Some(record) = self.load_unlocked(id)? else {
             return Ok(self.confirm_absence_unlocked());
         };
-        if record.phase != SandboxPhase::Creating || record.provision_outcome.is_some() {
+        if record.phase != ComputerPhase::Creating || record.provision_outcome.is_some() {
             return Err(ComputerError::AlreadyExists(id.to_owned()));
         }
         self.delete_unlocked(id)
@@ -254,7 +254,7 @@ impl SandboxRecordStore {
             .map_err(|_| ComputerError::Other("sandbox record store mutex poisoned".into()))
     }
 
-    fn load_unlocked(&self, id: &str) -> Result<Option<SandboxRecord>> {
+    fn load_unlocked(&self, id: &str) -> Result<Option<ComputerRecord>> {
         validate_id("sandbox id", id)?;
         let path = self.record_path(id);
         let metadata = match fs::symlink_metadata(&path) {
@@ -287,12 +287,12 @@ impl SandboxRecordStore {
                 header.version
             )));
         }
-        let record: SandboxRecord = serde_json::from_slice(&bytes)?;
+        let record: ComputerRecord = serde_json::from_slice(&bytes)?;
         validate_record(id, &record)?;
         Ok(Some(record))
     }
 
-    fn save_unlocked(&self, record: &SandboxRecord) -> Result<Option<String>> {
+    fn save_unlocked(&self, record: &ComputerRecord) -> Result<Option<String>> {
         validate_record(&record.id, record)?;
         let bytes = serde_json::to_vec_pretty(record)?;
         // A record that reached the filesystem but whose rename is not
@@ -315,7 +315,7 @@ impl SandboxRecordStore {
         &self,
         id: &str,
         generation: Uuid,
-        expected_phase: SandboxPhase,
+        expected_phase: ComputerPhase,
     ) -> Result<DurableCommit<()>> {
         let _guard = self.lock()?;
         let Some(record) = self.load_unlocked(id)? else {
@@ -399,7 +399,7 @@ mod tests {
         }
     }
 
-    fn created(intent: ProvisionIntent) -> SandboxRecord {
+    fn created(intent: ProvisionIntent) -> ComputerRecord {
         match intent {
             ProvisionIntent::Created(record) => record,
             other => panic!("expected created intent, got {other:?}"),
@@ -409,11 +409,11 @@ mod tests {
     #[test]
     fn records_survive_reopen_and_ignore_truncated_temporary_files() {
         let data_dir = tempfile::tempdir().unwrap();
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         let record = created(store.provision_intent("box", "key", spec("box")).unwrap());
 
         fs::write(store.root.join(".box.interrupted.tmp"), b"{").unwrap();
-        let reopened = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let reopened = ComputerRecordStore::new(data_dir.path()).unwrap();
 
         assert_eq!(reopened.load("box").unwrap(), Some(record));
         assert_eq!(reopened.load("other").unwrap(), None);
@@ -435,24 +435,24 @@ mod tests {
     #[test]
     fn ready_restore_outcome_replays_after_store_reopen() {
         let data_dir = tempfile::tempdir().unwrap();
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         let record = created(
             store
                 .provision_intent("restored", "restore-key", spec("restored"))
                 .unwrap(),
         );
-        let outcome = SandboxProvisionOutcome {
+        let outcome = ComputerProvisionOutcome {
             ip_address: "192.0.2.8".into(),
         };
         store
             .transition(
                 "restored",
                 record.generation,
-                SandboxTransition::ReadyWithOutcome(outcome.clone()),
+                ComputerTransition::ReadyWithOutcome(outcome.clone()),
             )
             .unwrap();
 
-        let reopened = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let reopened = ComputerRecordStore::new(data_dir.path()).unwrap();
         assert_eq!(
             reopened
                 .replay_provision("restored", "restore-key")
@@ -468,7 +468,7 @@ mod tests {
     #[test]
     fn load_all_rejects_corrupt_and_unsupported_records() {
         let data_dir = tempfile::tempdir().unwrap();
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         let mut record = created(store.provision_intent("box", "key", spec("box")).unwrap());
         let path = store.record_path("box");
 
@@ -487,7 +487,7 @@ mod tests {
     #[test]
     fn matching_intent_resumes_then_replays_but_a_different_key_collides() {
         let data_dir = tempfile::tempdir().unwrap();
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         assert_eq!(store.replay_provision("missing", "key").unwrap(), None);
         let mut original = spec("box");
         original.rootfs = "/first/rootfs.ext4".into();
@@ -513,7 +513,7 @@ mod tests {
 
         let mut with_secret = spec("box");
         with_secret.env.insert("TOKEN".into(), "secret".into());
-        let store2 = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store2 = ComputerRecordStore::new(data_dir.path()).unwrap();
         store2
             .provision_intent("secret-box", "secret-key", {
                 with_secret.id = Some("secret-box".into());
@@ -525,7 +525,7 @@ mod tests {
             .transition(
                 "secret-box",
                 secret_record.generation,
-                SandboxTransition::Failed("boot failed".into()),
+                ComputerTransition::Failed("boot failed".into()),
             )
             .unwrap();
         assert!(
@@ -542,21 +542,21 @@ mod tests {
             .transition(
                 "box",
                 record.generation,
-                SandboxTransition::Starting(SandboxProvisionOutcome {
+                ComputerTransition::Starting(ComputerProvisionOutcome {
                     ip_address: "192.0.2.2".into(),
                 }),
             )
             .unwrap();
         assert_eq!(
             store.replay_provision("box", "key").unwrap(),
-            Some(SandboxProvisionOutcome {
+            Some(ComputerProvisionOutcome {
                 ip_address: "192.0.2.2".into()
             })
         );
         assert!(matches!(
             store.provision_intent("box", "key", spec("box")).unwrap(),
             ProvisionIntent::Replay(found)
-                if found.provision_outcome == Some(SandboxProvisionOutcome {
+                if found.provision_outcome == Some(ComputerProvisionOutcome {
                     ip_address: "192.0.2.2".into()
                 })
         ));
@@ -564,7 +564,7 @@ mod tests {
             .transition(
                 "box",
                 record.generation,
-                SandboxTransition::Failed("boot failed".into()),
+                ComputerTransition::Failed("boot failed".into()),
             )
             .unwrap();
         assert!(matches!(
@@ -573,65 +573,65 @@ mod tests {
         ));
         assert!(matches!(
             store.provision_intent("box", "key", spec("box")).unwrap(),
-            ProvisionIntent::Blocked(found) if found.phase == SandboxPhase::Failed
+            ProvisionIntent::Blocked(found) if found.phase == ComputerPhase::Failed
         ));
     }
 
     #[test]
     fn transitions_enforce_generation_and_lifecycle_edges() {
         let data_dir = tempfile::tempdir().unwrap();
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         let record = created(store.provision_intent("box", "key", spec("box")).unwrap());
 
         assert!(
             store
-                .transition("box", Uuid::new_v4(), SandboxTransition::Ready)
+                .transition("box", Uuid::new_v4(), ComputerTransition::Ready)
                 .is_err()
         );
         assert!(
             store
-                .transition("box", record.generation, SandboxTransition::Ready)
+                .transition("box", record.generation, ComputerTransition::Ready)
                 .is_err()
         );
         assert_eq!(
             store.load("box").unwrap().unwrap().phase,
-            SandboxPhase::Creating
+            ComputerPhase::Creating
         );
 
         store
             .transition(
                 "box",
                 record.generation,
-                SandboxTransition::Starting(SandboxProvisionOutcome {
+                ComputerTransition::Starting(ComputerProvisionOutcome {
                     ip_address: String::new(),
                 }),
             )
             .unwrap();
         store
-            .transition("box", record.generation, SandboxTransition::Ready)
+            .transition("box", record.generation, ComputerTransition::Ready)
             .unwrap();
         assert!(store.replay_provision("box", "key").unwrap().is_some());
         store
-            .transition("box", record.generation, SandboxTransition::Stopping)
+            .transition("box", record.generation, ComputerTransition::Stopping)
             .unwrap();
         assert!(matches!(
             store.replay_provision("box", "key"),
             Err(ComputerError::AlreadyExists(id)) if id == "box"
         ));
         store
-            .transition("box", record.generation, SandboxTransition::Stopped)
+            .transition("box", record.generation, ComputerTransition::Stopped)
             .unwrap();
         assert!(matches!(
             store.replay_provision("box", "key"),
             Err(ComputerError::AlreadyExists(id)) if id == "box"
         ));
         store
-            .transition("box", record.generation, SandboxTransition::Stopped)
+            .transition("box", record.generation, ComputerTransition::Stopped)
             .unwrap()
             .confirmed("idempotent stopped retry")
             .unwrap();
         store
-            .transition("box", record.generation, SandboxTransition::Removing)
+            .transition("box", record.generation, ComputerTransition::Removing)
             .unwrap();
         assert!(matches!(
             store.replay_provision("box", "key"),
@@ -656,7 +656,7 @@ mod tests {
             .transition(
                 "failed",
                 failed.generation,
-                SandboxTransition::Failed("interrupted".into()),
+                ComputerTransition::Failed("interrupted".into()),
             )
             .unwrap();
         assert!(matches!(
@@ -668,20 +668,20 @@ mod tests {
     #[test]
     fn pause_resume_transitions_carry_the_snapshot_and_paused_at() {
         let data_dir = tempfile::tempdir().unwrap();
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         let record = created(store.provision_intent("box", "key", spec("box")).unwrap());
         let generation = record.generation;
         store
             .transition(
                 "box",
                 generation,
-                SandboxTransition::Starting(SandboxProvisionOutcome {
+                ComputerTransition::Starting(ComputerProvisionOutcome {
                     ip_address: "192.0.2.2".into(),
                 }),
             )
             .unwrap();
         store
-            .transition("box", generation, SandboxTransition::Ready)
+            .transition("box", generation, ComputerTransition::Ready)
             .unwrap();
 
         // Pausing may not jump straight to Paused-from-Ready.
@@ -690,26 +690,26 @@ mod tests {
                 .transition(
                     "box",
                     generation,
-                    SandboxTransition::Paused {
+                    ComputerTransition::Paused {
                         snapshot_id: "snap".into()
                     }
                 )
                 .is_err()
         );
         store
-            .transition("box", generation, SandboxTransition::Pausing)
+            .transition("box", generation, ComputerTransition::Pausing)
             .unwrap();
         let paused = store
             .transition(
                 "box",
                 generation,
-                SandboxTransition::Paused {
+                ComputerTransition::Paused {
                     snapshot_id: "snap".into(),
                 },
             )
             .unwrap()
             .value;
-        assert_eq!(paused.phase, SandboxPhase::Paused);
+        assert_eq!(paused.phase, ComputerPhase::Paused);
         assert_eq!(paused.pause_snapshot_id.as_deref(), Some("snap"));
         assert!(paused.paused_at.is_some());
 
@@ -721,7 +721,7 @@ mod tests {
 
         // Resume keeps the snapshot until Ready clears it.
         let resuming = store
-            .transition("box", generation, SandboxTransition::Resuming)
+            .transition("box", generation, ComputerTransition::Resuming)
             .unwrap()
             .value;
         assert_eq!(resuming.pause_snapshot_id.as_deref(), Some("snap"));
@@ -732,7 +732,7 @@ mod tests {
             .transition(
                 "box",
                 generation,
-                SandboxTransition::Paused {
+                ComputerTransition::Paused {
                     snapshot_id: "snap".into(),
                 },
             )
@@ -741,25 +741,25 @@ mod tests {
         assert_eq!(reverted.paused_at, paused.paused_at);
         // …and a successful one lands Ready with the pause state cleared.
         store
-            .transition("box", generation, SandboxTransition::Resuming)
+            .transition("box", generation, ComputerTransition::Resuming)
             .unwrap();
         let ready = store
-            .transition("box", generation, SandboxTransition::Ready)
+            .transition("box", generation, ComputerTransition::Ready)
             .unwrap()
             .value;
-        assert_eq!(ready.phase, SandboxPhase::Ready);
+        assert_eq!(ready.phase, ComputerPhase::Ready);
         assert_eq!(ready.pause_snapshot_id, None);
         assert_eq!(ready.paused_at, None);
 
         // A genuine re-pause after Ready gets a fresh stamp.
         store
-            .transition("box", generation, SandboxTransition::Pausing)
+            .transition("box", generation, ComputerTransition::Pausing)
             .unwrap();
         let repaused = store
             .transition(
                 "box",
                 generation,
-                SandboxTransition::Paused {
+                ComputerTransition::Paused {
                     snapshot_id: "snap2".into(),
                 },
             )
@@ -772,36 +772,36 @@ mod tests {
     #[test]
     fn failed_pause_reverts_to_ready_and_paused_cannot_stop() {
         let data_dir = tempfile::tempdir().unwrap();
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         let record = created(store.provision_intent("box", "key", spec("box")).unwrap());
         let generation = record.generation;
         store
             .transition(
                 "box",
                 generation,
-                SandboxTransition::Starting(SandboxProvisionOutcome {
+                ComputerTransition::Starting(ComputerProvisionOutcome {
                     ip_address: String::new(),
                 }),
             )
             .unwrap();
         store
-            .transition("box", generation, SandboxTransition::Ready)
+            .transition("box", generation, ComputerTransition::Ready)
             .unwrap();
         store
-            .transition("box", generation, SandboxTransition::Pausing)
+            .transition("box", generation, ComputerTransition::Pausing)
             .unwrap();
         store
-            .transition("box", generation, SandboxTransition::Ready)
+            .transition("box", generation, ComputerTransition::Ready)
             .unwrap();
 
         store
-            .transition("box", generation, SandboxTransition::Pausing)
+            .transition("box", generation, ComputerTransition::Pausing)
             .unwrap();
         store
             .transition(
                 "box",
                 generation,
-                SandboxTransition::Paused {
+                ComputerTransition::Paused {
                     snapshot_id: "snap".into(),
                 },
             )
@@ -809,11 +809,11 @@ mod tests {
         // Paused has no VM to drain: only Resume, Failed, or Removing apply.
         assert!(
             store
-                .transition("box", generation, SandboxTransition::Stopping)
+                .transition("box", generation, ComputerTransition::Stopping)
                 .is_err()
         );
         store
-            .transition("box", generation, SandboxTransition::Removing)
+            .transition("box", generation, ComputerTransition::Removing)
             .unwrap();
         store.finish_remove("box", generation).unwrap();
     }
@@ -821,7 +821,7 @@ mod tests {
     #[test]
     fn pre_ack_abort_releases_only_the_expected_generation() {
         let data_dir = tempfile::tempdir().unwrap();
-        let store = SandboxRecordStore::new(data_dir.path()).unwrap();
+        let store = ComputerRecordStore::new(data_dir.path()).unwrap();
         let record = created(store.provision_intent("box", "key", spec("box")).unwrap());
 
         assert!(store.abort_provision("box", Uuid::new_v4()).is_err());

--- a/computer/arcbox-computer-runtime/src/sandbox/record/store.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/record/store.rs
@@ -164,7 +164,7 @@ impl SandboxRecordStore {
         let record = SandboxRecord::new(id, request_key, effective_spec);
         if let Some(error) = self.save_unlocked(&record)? {
             warn!(
-                sandbox_id = id,
+                computer_id = id,
                 error, "provision intent is visible but directory fsync failed"
             );
         }

--- a/computer/arcbox-computer-runtime/src/sandbox/spec.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/spec.rs
@@ -13,7 +13,7 @@ use arcbox_vm_driver::{
 };
 
 use crate::boot_proto::KernelIpParam;
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::sandbox::{NetworkAttachment, SandboxSpec, ipv4, netmask};
 
 /// The boot recipe as the driver port sees it.
@@ -56,7 +56,7 @@ pub fn build_vm_spec(
         id: VmId::new(id)?,
         cpus: spec.vcpus.max(1),
         memory_mib: u32::try_from(spec.memory_mib).map_err(|_| {
-            VmmError::Config(format!(
+            ComputerError::Config(format!(
                 "memory_mib {} exceeds what a VM spec can carry",
                 spec.memory_mib
             ))

--- a/computer/arcbox-computer-runtime/src/sandbox/spec.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/spec.rs
@@ -14,7 +14,7 @@ use arcbox_vm_driver::{
 
 use crate::boot_proto::KernelIpParam;
 use crate::error::{ComputerError, Result};
-use crate::sandbox::{NetworkAttachment, SandboxSpec, ipv4, netmask};
+use crate::sandbox::{ComputerSpec, NetworkAttachment, ipv4, netmask};
 
 /// The boot recipe as the driver port sees it.
 ///
@@ -35,7 +35,7 @@ use crate::sandbox::{NetworkAttachment, SandboxSpec, ipv4, netmask};
 /// `KernelIpParam::from_str` to derive the DNS nameserver.
 pub fn build_vm_spec(
     id: &str,
-    spec: &SandboxSpec,
+    spec: &ComputerSpec,
     net: Option<&NetworkAttachment>,
     kernel: PathBuf,
     rootfs: PathBuf,
@@ -179,11 +179,11 @@ mod tests {
     /// CID 3, dirty tracking on — and nothing the sandbox never had.
     #[test]
     fn boot_spec_bakes_the_invariant_identity_and_the_fixed_devices() {
-        let spec = SandboxSpec {
+        let spec = ComputerSpec {
             boot_args: "console=ttyS0".into(),
             vcpus: 0,
             memory_mib: 512,
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         };
         let vm = build_vm_spec(
             "box",
@@ -226,7 +226,7 @@ mod tests {
 
         // A caller-pinned `ip=` is kept verbatim; no network means no NIC
         // and no `ip=` at all.
-        let pinned = SandboxSpec {
+        let pinned = ComputerSpec {
             boot_args: "ip=10.0.0.2::10.0.0.1:255.255.255.0".into(),
             ..spec.clone()
         };

--- a/computer/arcbox-computer-runtime/src/sandbox/templates.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/templates.rs
@@ -1,4 +1,4 @@
-//! Template-catalog surface on [`SandboxManager`] (CORE-107).
+//! Template-catalog surface on [`ComputerManager`] (CORE-107).
 //!
 //! Thin delegation to [`TemplateCatalog`](crate::template_catalog::TemplateCatalog)
 //! plus the artifact side effects the catalog itself never performs: draining
@@ -6,7 +6,7 @@
 //! Build orchestration (rootfs conversion, prewarm) lives in the guest agent
 //! and lands its results here via [`register_template_draft`].
 //!
-//! [`register_template_draft`]: SandboxManager::register_template_draft
+//! [`register_template_draft`]: ComputerManager::register_template_draft
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -14,7 +14,7 @@ use std::path::Path;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use super::SandboxManager;
+use super::ComputerManager;
 use super::types::{ComputerId, ComputerSpec, ComputerState};
 use crate::error::{ComputerError, Result};
 use crate::snapshot::{SnapshotDraft, SnapshotGeometry};
@@ -39,7 +39,7 @@ pub struct PromotedSnapshot {
     pub artifact_bytes: u64,
 }
 
-impl SandboxManager {
+impl ComputerManager {
     /// Resolve a `name[:version]` catalog reference.
     pub fn get_template(&self, reference: &str) -> Result<ResolvedTemplate> {
         self.templates.resolve(reference).map_err(Into::into)
@@ -176,7 +176,7 @@ impl SandboxManager {
             self.config.defaults.memory_mib
         };
         // Short id on purpose: it must fit the driver's own id budget
-        // (`VmDriver::id_budget`, enforced by `validate_new_sandbox_id`) —
+        // (`VmDriver::id_budget`, enforced by `validate_new_computer_id`) —
         // `template-build-<full uuid>` was 51 chars and overflowed AF_UNIX's
         // `sun_path`, failing the builder boot as an opaque socket timeout.
         // 16 hex chars keep collisions out of reach for an ephemeral,
@@ -195,7 +195,7 @@ impl SandboxManager {
             ..Default::default()
         };
         let (id, _ip) = self
-            .create_sandbox_inner(
+            .create_computer_inner(
                 spec,
                 &Uuid::new_v4().to_string(),
                 super::lifecycle::WarmPolicy::Disabled,
@@ -208,7 +208,7 @@ impl SandboxManager {
         // vCPUs/memory allocated. The fresh snapshot is dropped too — no
         // record references it yet — and the error names the builder id so
         // the operator can remove it and retry.
-        if let Err(remove_error) = self.remove_sandbox(&id, true).await {
+        if let Err(remove_error) = self.remove_computer(&id, true).await {
             if let Ok((snapshot_id, _)) = &checkpoint {
                 self.discard_promoted_snapshot(snapshot_id).await;
             }
@@ -237,7 +237,7 @@ impl SandboxManager {
         let deadline =
             tokio::time::Instant::now() + std::time::Duration::from_secs(READY_TIMEOUT_SECS);
         loop {
-            let info = self.inspect_sandbox(id)?;
+            let info = self.inspect_computer(id)?;
             match info.state {
                 ComputerState::Ready => break,
                 ComputerState::Failed => {
@@ -395,17 +395,17 @@ mod tests {
     use std::path::Path;
 
     use crate::config::RuntimeConfig;
-    use crate::sandbox::SandboxManager;
+    use crate::sandbox::ComputerManager;
     use crate::snapshot::{SnapshotCatalog, SnapshotDraft};
     use crate::template_catalog::{
         TEMPLATE_LABEL, TemplateDefaultsSpec, TemplateEntry, WarmArtifact,
     };
 
-    async fn manager(data_dir: &Path) -> SandboxManager {
+    async fn manager(data_dir: &Path) -> ComputerManager {
         let mut config = RuntimeConfig::default();
         config.firecracker.data_dir = data_dir.to_string_lossy().into_owned();
         let environment = crate::testkit::fake_environment(&config).unwrap();
-        let manager = SandboxManager::new(config, environment).unwrap();
+        let manager = ComputerManager::new(config, environment).unwrap();
         manager.await_reconcile().await.unwrap();
         manager
     }

--- a/computer/arcbox-computer-runtime/src/sandbox/templates.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/templates.rs
@@ -15,7 +15,7 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use super::SandboxManager;
-use super::types::{ComputerId, ComputerSpec, SandboxState};
+use super::types::{ComputerId, ComputerSpec, ComputerState};
 use crate::error::{ComputerError, Result};
 use crate::snapshot::{SnapshotDraft, SnapshotGeometry};
 use crate::template_catalog::{
@@ -239,8 +239,8 @@ impl SandboxManager {
         loop {
             let info = self.inspect_sandbox(id)?;
             match info.state {
-                SandboxState::Ready => break,
-                SandboxState::Failed => {
+                ComputerState::Ready => break,
+                ComputerState::Failed => {
                     return Err(ComputerError::FailedPrecondition(format!(
                         "prewarm boot failed: {}",
                         info.error.unwrap_or_else(|| "unknown boot failure".into())

--- a/computer/arcbox-computer-runtime/src/sandbox/templates.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/templates.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 use super::SandboxManager;
 use super::types::{SandboxId, SandboxSpec, SandboxState};
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::snapshot::{SnapshotDraft, SnapshotGeometry};
 use crate::template_catalog::{
     ReleasedArtifacts, ResolvedTemplate, TEMPLATE_LABEL, TemplateDefaultsSpec, TemplateEntry,
@@ -99,19 +99,19 @@ impl SandboxManager {
         crate::template_catalog::validate_template_name(template_name)?;
         let source = self.snapshots.find_by_id(source_snapshot_id)?;
         if source.name.as_deref() == Some(super::pause::PAUSE_SNAPSHOT_NAME) {
-            return Err(VmmError::FailedPrecondition(format!(
+            return Err(ComputerError::FailedPrecondition(format!(
                 "snapshot {source_snapshot_id} is the internal pause checkpoint of a \
                  paused sandbox; checkpoint the sandbox instead"
             )));
         }
         let geometry = source.geometry.ok_or_else(|| {
-            VmmError::FailedPrecondition(format!(
+            ComputerError::FailedPrecondition(format!(
                 "snapshot {source_snapshot_id} predates geometry recording; \
                  re-checkpoint the sandbox with this agent and promote the new snapshot"
             ))
         })?;
         let rootfs_path = source.rootfs_path.clone().ok_or_else(|| {
-            VmmError::FailedPrecondition(format!(
+            ComputerError::FailedPrecondition(format!(
                 "snapshot {source_snapshot_id} records no rootfs path; \
                  re-checkpoint the sandbox and promote the new snapshot"
             ))
@@ -161,7 +161,7 @@ impl SandboxManager {
         defaults: &TemplateDefaultsSpec,
     ) -> Result<PrewarmOutcome> {
         if self.config.firecracker.jailer.is_none() {
-            return Err(VmmError::FailedPrecondition(
+            return Err(ComputerError::FailedPrecondition(
                 "prewarm requires jailer mode (snapshot restore does)".into(),
             ));
         }
@@ -212,7 +212,7 @@ impl SandboxManager {
             if let Ok((snapshot_id, _)) = &checkpoint {
                 self.discard_promoted_snapshot(snapshot_id).await;
             }
-            return Err(VmmError::Unavailable(format!(
+            return Err(ComputerError::Unavailable(format!(
                 "prewarm builder sandbox {id} could not be removed ({remove_error}); \
                  remove it manually and retry the build"
             )));
@@ -241,13 +241,13 @@ impl SandboxManager {
             match info.state {
                 SandboxState::Ready => break,
                 SandboxState::Failed => {
-                    return Err(VmmError::FailedPrecondition(format!(
+                    return Err(ComputerError::FailedPrecondition(format!(
                         "prewarm boot failed: {}",
                         info.error.unwrap_or_else(|| "unknown boot failure".into())
                     )));
                 }
                 _ if tokio::time::Instant::now() >= deadline => {
-                    return Err(VmmError::DeadlineExceeded(format!(
+                    return Err(ComputerError::DeadlineExceeded(format!(
                         "prewarm builder did not reach READY within {READY_TIMEOUT_SECS}s"
                     )));
                 }
@@ -359,33 +359,33 @@ fn clone_or_copy(src: &Path, dst: &Path) -> Result<u64> {
     {
         use std::os::fd::AsRawFd as _;
         use std::os::unix::fs::OpenOptionsExt as _;
-        let source = std::fs::File::open(src).map_err(VmmError::Io)?;
+        let source = std::fs::File::open(src).map_err(ComputerError::Io)?;
         let dest = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
             .mode(0o600)
             .open(dst)
-            .map_err(VmmError::Io)?;
+            .map_err(ComputerError::Io)?;
         // SAFETY: both fds are open for the duration of the call; FICLONE
         // only clones extents from the source fd into the destination fd.
         let rc = unsafe { libc::ioctl(dest.as_raw_fd(), libc::FICLONE as _, source.as_raw_fd()) };
         if rc == 0 {
-            dest.sync_all().map_err(VmmError::Io)?;
-            return Ok(source.metadata().map_err(VmmError::Io)?.len());
+            dest.sync_all().map_err(ComputerError::Io)?;
+            return Ok(source.metadata().map_err(ComputerError::Io)?.len());
         }
         // Reflink unsupported here (non-Btrfs staging, cross-subvolume
         // boundary) — fall back to a plain copy below.
         drop(dest);
         let _ = std::fs::remove_file(dst);
     }
-    let bytes = std::fs::copy(src, dst).map_err(VmmError::Io)?;
-    let dest = std::fs::File::open(dst).map_err(VmmError::Io)?;
+    let bytes = std::fs::copy(src, dst).map_err(ComputerError::Io)?;
+    let dest = std::fs::File::open(dst).map_err(ComputerError::Io)?;
     std::fs::set_permissions(dst, {
         use std::os::unix::fs::PermissionsExt as _;
         std::fs::Permissions::from_mode(0o600)
     })
-    .map_err(VmmError::Io)?;
-    dest.sync_all().map_err(VmmError::Io)?;
+    .map_err(ComputerError::Io)?;
+    dest.sync_all().map_err(ComputerError::Io)?;
     Ok(bytes)
 }
 

--- a/computer/arcbox-computer-runtime/src/sandbox/templates.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/templates.rs
@@ -15,7 +15,7 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use super::SandboxManager;
-use super::types::{SandboxId, SandboxSpec, SandboxState};
+use super::types::{ComputerId, ComputerSpec, SandboxState};
 use crate::error::{ComputerError, Result};
 use crate::snapshot::{SnapshotDraft, SnapshotGeometry};
 use crate::template_catalog::{
@@ -184,7 +184,7 @@ impl SandboxManager {
         let mut suffix = Uuid::new_v4().simple().to_string();
         suffix.truncate(16);
         let builder_id = format!("tpl-build-{suffix}");
-        let spec = SandboxSpec {
+        let spec = ComputerSpec {
             id: Some(builder_id.clone()),
             rootfs: rootfs_path.to_owned(),
             vcpus,
@@ -231,7 +231,7 @@ impl SandboxManager {
     /// Wait for the builder to reach READY, then checkpoint it under the
     /// template label. Polled rather than event-driven: a lagged broadcast
     /// receiver would miss the READY edge, while polling cannot.
-    async fn prewarm_checkpoint(&self, id: &SandboxId, template: &str) -> Result<(String, u64)> {
+    async fn prewarm_checkpoint(&self, id: &ComputerId, template: &str) -> Result<(String, u64)> {
         const READY_POLL_MS: u64 = 250;
         const READY_TIMEOUT_SECS: u64 = 180;
         let deadline =
@@ -338,7 +338,7 @@ pub struct PrewarmOutcome {
 /// the template.
 pub(super) fn template_restore_eligible(
     config: &crate::config::RuntimeConfig,
-    spec: &SandboxSpec,
+    spec: &ComputerSpec,
     caller_supplied_boot: bool,
     warm: &crate::sandbox::TemplateWarmRef,
 ) -> bool {

--- a/computer/arcbox-computer-runtime/src/sandbox/timers.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/timers.rs
@@ -50,7 +50,7 @@ impl SandboxManager {
             .await?;
         let deadlines = computer.snapshot.borrow().deadlines;
         info!(
-            sandbox_id = %id,
+            computer_id = %id,
             ttl_deadline = ?deadlines.ttl,
             idle_timeout_seconds = deadlines.idle_timeout_seconds,
             on_idle = ?deadlines.on_idle,

--- a/computer/arcbox-computer-runtime/src/sandbox/timers.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/timers.rs
@@ -24,7 +24,7 @@
 
 use super::*;
 
-impl SandboxManager {
+impl ComputerManager {
     /// Replace a computer's lifecycle deadlines (CORE-60).
     ///
     /// `ttl_seconds` re-arms the hard cap from *now* (0 removes it);
@@ -32,7 +32,7 @@ impl SandboxManager {
     /// timer; `on_idle` replaces the policy. `None` fields are unchanged.
     /// Allowed in any non-terminal state — a paused computer keeps honoring
     /// its (re-armed) TTL, and new idle knobs apply on the next `Ready`.
-    pub async fn set_sandbox_lifecycle(
+    pub async fn set_computer_lifecycle(
         &self,
         id: &ComputerId,
         update: LifecycleUpdate,

--- a/computer/arcbox-computer-runtime/src/sandbox/timers.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/timers.rs
@@ -34,7 +34,7 @@ impl SandboxManager {
     /// its (re-armed) TTL, and new idle knobs apply on the next `Ready`.
     pub async fn set_sandbox_lifecycle(
         &self,
-        id: &SandboxId,
+        id: &ComputerId,
         update: LifecycleUpdate,
     ) -> Result<()> {
         self.await_reconcile().await?;

--- a/computer/arcbox-computer-runtime/src/sandbox/types.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/types.rs
@@ -80,7 +80,7 @@ impl std::fmt::Display for ComputerState {
     }
 }
 
-// Spec types (input to SandboxManager methods)
+// Spec types (input to ComputerManager methods)
 
 /// What happens when a sandbox's idle timeout expires (CORE-21).
 ///
@@ -340,4 +340,4 @@ pub struct CheckpointSummary {
     pub created_at: String,
 }
 
-// SandboxManager
+// ComputerManager

--- a/computer/arcbox-computer-runtime/src/sandbox/types.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/types.rs
@@ -1,7 +1,7 @@
 use super::*;
 use serde::{Deserialize, Serialize};
 
-pub type SandboxId = String;
+pub type ComputerId = String;
 
 /// A sandbox's network as the boot flow carries it: the lease the guest
 /// network reserved, the NIC it returned when it activated that lease, and
@@ -114,14 +114,14 @@ pub struct LifecycleUpdate {
 
 /// Network configuration supplied at sandbox creation time.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SandboxNetworkSpec {
+pub struct ComputerNetworkSpec {
     /// `"tap"` (default) or `"none"`.
     pub mode: String,
 }
 
 /// A single bind-mount into the sandbox.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SandboxMountSpec {
+pub struct ComputerMountSpec {
     pub source: String,
     pub target: String,
     pub readonly: bool,
@@ -136,7 +136,7 @@ pub struct SandboxMountSpec {
 /// boundary (see the guest agent's `SandboxService::create`).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
-pub struct SandboxSpec {
+pub struct ComputerSpec {
     /// Caller-supplied ID; auto-generated (UUID) when `None` or empty.
     pub id: Option<String>,
     /// Arbitrary key-value metadata (filtering, listing).
@@ -160,9 +160,9 @@ pub struct SandboxSpec {
     /// User to run the initial command as.
     pub user: String,
     /// Bind mounts into the sandbox.
-    pub mounts: Vec<SandboxMountSpec>,
+    pub mounts: Vec<ComputerMountSpec>,
     /// Network configuration.
-    pub network: SandboxNetworkSpec,
+    pub network: ComputerNetworkSpec,
     /// Auto-destroy TTL in seconds (0 = no limit).
     pub ttl_seconds: u32,
     /// SSH public key injected via MMDS (None = no SSH setup).
@@ -186,7 +186,7 @@ pub struct SandboxSpec {
 }
 
 /// A template's pre-warmed boot-to-ready snapshot, threaded through
-/// [`SandboxSpec`] (CORE-107).
+/// [`ComputerSpec`] (CORE-107).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TemplateWarmRef {
     /// Snapshot id in the snapshot catalog.
@@ -198,7 +198,7 @@ pub struct TemplateWarmRef {
 
 /// Parameters to restore a sandbox from a checkpoint.
 #[derive(Debug, Clone, Default)]
-pub struct RestoreSandboxSpec {
+pub struct RestoreComputerSpec {
     /// Caller-supplied ID (None = auto-generate).
     pub id: Option<String>,
     /// Source checkpoint/snapshot ID.
@@ -215,7 +215,7 @@ pub struct RestoreSandboxSpec {
 
 /// Lightweight summary for `List` operations.
 pub struct SandboxSummary {
-    pub id: SandboxId,
+    pub id: ComputerId,
     pub state: SandboxState,
     pub labels: HashMap<String, String>,
     /// Allocated IP address (empty when network mode is `"none"`).
@@ -229,12 +229,12 @@ pub struct SandboxSummary {
 
 /// Detailed sandbox state for `Inspect`.
 pub struct SandboxInfo {
-    pub id: SandboxId,
+    pub id: ComputerId,
     pub state: SandboxState,
     pub labels: HashMap<String, String>,
     pub vcpus: u32,
     pub memory_mib: u64,
-    pub network: Option<SandboxNetworkInfo>,
+    pub network: Option<ComputerNetworkInfo>,
     pub created_at: DateTime<Utc>,
     pub ready_at: Option<DateTime<Utc>>,
     pub last_exited_at: Option<DateTime<Utc>>,
@@ -253,7 +253,7 @@ pub struct SandboxInfo {
 }
 
 /// Network details within `SandboxInfo`.
-pub struct SandboxNetworkInfo {
+pub struct ComputerNetworkInfo {
     pub ip_address: String,
     pub gateway: String,
 }
@@ -283,7 +283,7 @@ pub mod action {
 /// A sandbox lifecycle event broadcast to subscribers.
 #[derive(Debug, Clone)]
 pub struct SandboxEvent {
-    pub sandbox_id: SandboxId,
+    pub sandbox_id: ComputerId,
     /// One of the [`action`] constants.
     pub action: String,
     /// Unix nanoseconds.

--- a/computer/arcbox-computer-runtime/src/sandbox/types.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/types.rs
@@ -44,7 +44,7 @@ impl NetworkAttachment {
 
 /// Lifecycle state of a sandbox.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SandboxState {
+pub enum ComputerState {
     /// VMM prepared; VM still booting.
     Starting,
     /// VM booted and ready to accept workloads (or last workload exited).
@@ -65,7 +65,7 @@ pub enum SandboxState {
     Paused,
 }
 
-impl std::fmt::Display for SandboxState {
+impl std::fmt::Display for ComputerState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Starting => write!(f, "starting"),
@@ -214,9 +214,9 @@ pub struct RestoreComputerSpec {
 // Public output types (returned to callers / gRPC layer)
 
 /// Lightweight summary for `List` operations.
-pub struct SandboxSummary {
+pub struct ComputerSummary {
     pub id: ComputerId,
-    pub state: SandboxState,
+    pub state: ComputerState,
     pub labels: HashMap<String, String>,
     /// Allocated IP address (empty when network mode is `"none"`).
     pub ip_address: String,
@@ -228,9 +228,9 @@ pub struct SandboxSummary {
 }
 
 /// Detailed sandbox state for `Inspect`.
-pub struct SandboxInfo {
+pub struct ComputerInfo {
     pub id: ComputerId,
-    pub state: SandboxState,
+    pub state: ComputerState,
     pub labels: HashMap<String, String>,
     pub vcpus: u32,
     pub memory_mib: u64,
@@ -252,7 +252,7 @@ pub struct SandboxInfo {
     pub on_idle: IdleAction,
 }
 
-/// Network details within `SandboxInfo`.
+/// Network details within `ComputerInfo`.
 pub struct ComputerNetworkInfo {
     pub ip_address: String,
     pub gateway: String,
@@ -260,7 +260,7 @@ pub struct ComputerNetworkInfo {
 
 // Events
 
-/// The `action` values a [`SandboxEvent`] carries, in lifecycle order.
+/// The `action` values a [`ComputerEvent`] carries, in lifecycle order.
 ///
 /// `action` stays a `String` on the event (it crosses the API as one), but
 /// every emit site and match in this crate goes through these constants, so
@@ -282,8 +282,8 @@ pub mod action {
 
 /// A sandbox lifecycle event broadcast to subscribers.
 #[derive(Debug, Clone)]
-pub struct SandboxEvent {
-    pub sandbox_id: ComputerId,
+pub struct ComputerEvent {
+    pub computer_id: ComputerId,
     /// One of the [`action`] constants.
     pub action: String,
     /// Unix nanoseconds.
@@ -292,10 +292,10 @@ pub struct SandboxEvent {
     pub attributes: HashMap<String, String>,
 }
 
-impl SandboxEvent {
-    pub fn new(sandbox_id: &str, action: &str) -> Self {
+impl ComputerEvent {
+    pub fn new(computer_id: &str, action: &str) -> Self {
         Self {
-            sandbox_id: sandbox_id.to_owned(),
+            computer_id: computer_id.to_owned(),
             action: action.to_owned(),
             timestamp_ns: Utc::now().timestamp_nanos_opt().unwrap_or(0),
             attributes: HashMap::new(),
@@ -333,7 +333,7 @@ pub struct CheckpointInfo {
 pub struct CheckpointSummary {
     pub id: String,
     /// ID of the sandbox that was checkpointed.
-    pub sandbox_id: String,
+    pub computer_id: String,
     pub name: String,
     pub labels: HashMap<String, String>,
     pub snapshot_dir: String,

--- a/computer/arcbox-computer-runtime/src/sandbox/warm.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/warm.rs
@@ -151,12 +151,12 @@ pub async fn publish_after_boot(
 /// its guest is frozen and the boot must fail (see
 /// [`CheckpointFailure`](crate::lifecycle::tasks::checkpoint::CheckpointFailure)).
 enum PublishFailure {
-    Recoverable(VmmError),
-    Frozen(VmmError),
+    Recoverable(ComputerError),
+    Frozen(ComputerError),
 }
 
-impl From<VmmError> for PublishFailure {
-    fn from(error: VmmError) -> Self {
+impl From<ComputerError> for PublishFailure {
+    fn from(error: ComputerError) -> Self {
         Self::Recoverable(error)
     }
 }

--- a/computer/arcbox-computer-runtime/src/sandbox/warm.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/warm.rs
@@ -41,7 +41,7 @@ fn fingerprint(path: &Path) -> std::io::Result<FileFingerprint> {
 
 /// Derive the warm key for an effective (defaults-applied) create spec,
 /// fingerprinting the kernel and rootfs files on disk.
-pub(super) fn derive_warm_key(spec: &SandboxSpec) -> std::io::Result<WarmKey> {
+pub(super) fn derive_warm_key(spec: &ComputerSpec) -> std::io::Result<WarmKey> {
     Ok(warm_key(
         spec,
         fingerprint(Path::new(&spec.kernel))?,
@@ -108,7 +108,7 @@ pub struct WarmPublishTicket {
 /// a cmd-less boot, `Starting` when the tail is still holding the workload
 /// slot for the initial cmd.
 pub async fn publish_after_boot(
-    sandbox_id: &SandboxId,
+    sandbox_id: &ComputerId,
     ticket: &WarmPublishTicket,
     computer: &Arc<Mutex<ComputerRuntime>>,
     cow_manager: &CowManager,
@@ -176,7 +176,7 @@ impl From<crate::lifecycle::tasks::checkpoint::CheckpointFailure> for PublishFai
 /// (see [`super::policy::warm`]).
 /// Returns `None` when the key was already cached by a concurrent create.
 async fn publish_warm_snapshot(
-    sandbox_id: &SandboxId,
+    sandbox_id: &ComputerId,
     ticket: &WarmPublishTicket,
     computer: &Arc<Mutex<ComputerRuntime>>,
     cow_manager: &CowManager,
@@ -256,14 +256,14 @@ mod tests {
         warm_key(&base_spec(), fingerprint_of(7), fingerprint_of(42))
     }
 
-    fn base_spec() -> SandboxSpec {
-        SandboxSpec {
+    fn base_spec() -> ComputerSpec {
+        ComputerSpec {
             kernel: "/run/kernel/vmlinux".into(),
             rootfs: "/data/rootfs.ext4".into(),
             boot_args: "console=ttyS0 quiet".into(),
             vcpus: 2,
             memory_mib: 512,
-            network: SandboxNetworkSpec { mode: "tap".into() },
+            network: ComputerNetworkSpec { mode: "tap".into() },
             ..Default::default()
         }
     }

--- a/computer/arcbox-computer-runtime/src/sandbox/warm.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/warm.rs
@@ -108,28 +108,28 @@ pub struct WarmPublishTicket {
 /// a cmd-less boot, `Starting` when the tail is still holding the workload
 /// slot for the initial cmd.
 pub async fn publish_after_boot(
-    sandbox_id: &ComputerId,
+    computer_id: &ComputerId,
     ticket: &WarmPublishTicket,
     computer: &Arc<Mutex<ComputerRuntime>>,
     cow_manager: &CowManager,
-    expected_state: SandboxState,
+    expected_state: ComputerState,
 ) -> Result<()> {
     if !ticket.cache.begin_publish(&ticket.key) {
         debug!(
-            sandbox_id,
+            computer_id,
             "a warm snapshot publish for this key is already in flight"
         );
         return Ok(());
     }
     let started = std::time::Instant::now();
     let published =
-        publish_warm_snapshot(sandbox_id, ticket, computer, cow_manager, expected_state).await;
+        publish_warm_snapshot(computer_id, ticket, computer, cow_manager, expected_state).await;
     ticket.cache.end_publish(&ticket.key);
     match published {
         Ok(Some(snapshot_id)) => {
             let checkpoint_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
             info!(
-                sandbox_id,
+                computer_id,
                 snapshot_id, checkpoint_ms, "warm template snapshot published"
             );
             Ok(())
@@ -138,7 +138,7 @@ pub async fn publish_after_boot(
         Err(PublishFailure::Frozen(error)) => Err(error),
         Err(PublishFailure::Recoverable(error)) => {
             warn!(
-                sandbox_id,
+                computer_id,
                 %error,
                 "warm snapshot publish failed; later creates keep cold-booting"
             );
@@ -176,11 +176,11 @@ impl From<crate::lifecycle::tasks::checkpoint::CheckpointFailure> for PublishFai
 /// (see [`super::policy::warm`]).
 /// Returns `None` when the key was already cached by a concurrent create.
 async fn publish_warm_snapshot(
-    sandbox_id: &ComputerId,
+    computer_id: &ComputerId,
     ticket: &WarmPublishTicket,
     computer: &Arc<Mutex<ComputerRuntime>>,
     cow_manager: &CowManager,
-    expected_state: SandboxState,
+    expected_state: ComputerState,
 ) -> std::result::Result<Option<String>, PublishFailure> {
     // A concurrent first-create may have published while this guest booted.
     if warm_entries(&ticket.snapshots)?
@@ -195,7 +195,7 @@ async fn publish_warm_snapshot(
     let info = crate::lifecycle::tasks::checkpoint::checkpoint_impl(
         computer,
         &ticket.snapshots,
-        sandbox_id,
+        computer_id,
         crate::lifecycle::tasks::checkpoint::CheckpointRequest {
             name,
             labels,

--- a/computer/arcbox-computer-runtime/src/sandbox/workload.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/workload.rs
@@ -94,7 +94,7 @@ pub async fn start_run_workload(
 
 impl SandboxManager {
     /// This computer's workload slot: its actor, behind the seam.
-    pub(super) fn workload_slot(&self, id: &SandboxId) -> Result<Arc<dyn WorkloadSlot>> {
+    pub(super) fn workload_slot(&self, id: &ComputerId) -> Result<Arc<dyn WorkloadSlot>> {
         Ok(Arc::new(crate::lifecycle::flows::ActorSlot {
             id: id.clone(),
             mailbox: self.mailbox(id)?,
@@ -107,7 +107,7 @@ impl SandboxManager {
     )]
     pub async fn run_in_sandbox(
         &self,
-        id: &SandboxId,
+        id: &ComputerId,
         cmd: Vec<String>,
         env: HashMap<String, String>,
         working_dir: String,

--- a/computer/arcbox-computer-runtime/src/sandbox/workload.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/workload.rs
@@ -92,7 +92,7 @@ pub async fn start_run_workload(
     Ok(spawn_exit_watcher(inner_rx, slot))
 }
 
-impl SandboxManager {
+impl ComputerManager {
     /// This computer's workload slot: its actor, behind the seam.
     pub(super) fn workload_slot(&self, id: &ComputerId) -> Result<Arc<dyn WorkloadSlot>> {
         Ok(Arc::new(crate::lifecycle::flows::ActorSlot {
@@ -105,7 +105,7 @@ impl SandboxManager {
         clippy::too_many_arguments,
         reason = "public API mirrors workload request"
     )]
-    pub async fn run_in_sandbox(
+    pub async fn run_in_computer(
         &self,
         id: &ComputerId,
         cmd: Vec<String>,

--- a/computer/arcbox-computer-runtime/src/testkit/agent.rs
+++ b/computer/arcbox-computer-runtime/src/testkit/agent.rs
@@ -27,7 +27,7 @@ use crate::agent::{
     StartCommand,
 };
 use crate::boot_proto::NetReconfigCommand;
-use crate::error::{Result, VmmError};
+use crate::error::{ComputerError, Result};
 use crate::file_proto::{FileStatDto, FsEventDto, KIND_DIR, KIND_FILE};
 
 /// What the guest does when it is asked to start a command.
@@ -234,7 +234,7 @@ impl FakeAgent {
             .unwrap_or_else(Reply::ok);
         let (tx, rx) = mpsc::channel(16);
         match reply {
-            Reply::Fails(message) => return Err(VmmError::Vsock(message)),
+            Reply::Fails(message) => return Err(ComputerError::Vsock(message)),
             Reply::NeverExits => lock(&self.shared.open).push(Box::new(tx)),
             Reply::Exits { stdout, status } => {
                 tokio::spawn(async move {
@@ -330,8 +330,8 @@ impl GuestFiles for FakeAgent {
     async fn read(&self, path: &str) -> Result<Vec<u8>> {
         match lock(&self.shared.files).get(path) {
             Some(Entry::File { data, .. }) => Ok(data.clone()),
-            Some(Entry::Dir { .. }) => Err(VmmError::Vsock(format!("{path} is a directory"))),
-            None => Err(VmmError::PathNotFound(path.to_owned())),
+            Some(Entry::Dir { .. }) => Err(ComputerError::Vsock(format!("{path} is a directory"))),
+            None => Err(ComputerError::PathNotFound(path.to_owned())),
         }
     }
 
@@ -350,7 +350,7 @@ impl GuestFiles for FakeAgent {
         lock(&self.shared.files)
             .get(path)
             .map(|entry| stat_of(path, entry))
-            .ok_or_else(|| VmmError::PathNotFound(path.to_owned()))
+            .ok_or_else(|| ComputerError::PathNotFound(path.to_owned()))
     }
 
     async fn list(&self, path: &str) -> Result<Vec<FileStatDto>> {
@@ -360,8 +360,8 @@ impl GuestFiles for FakeAgent {
                 .into_iter()
                 .map(|(child, entry)| stat_of(child, entry))
                 .collect()),
-            Some(Entry::File { .. }) => Err(VmmError::NotADirectory(path.to_owned())),
-            None => Err(VmmError::PathNotFound(path.to_owned())),
+            Some(Entry::File { .. }) => Err(ComputerError::NotADirectory(path.to_owned())),
+            None => Err(ComputerError::PathNotFound(path.to_owned())),
         }
     }
 
@@ -379,7 +379,7 @@ impl GuestFiles for FakeAgent {
     async fn remove(&self, path: &str, recursive: bool) -> Result<()> {
         let mut files = lock(&self.shared.files);
         if !files.contains_key(path) {
-            return Err(VmmError::PathNotFound(path.to_owned()));
+            return Err(ComputerError::PathNotFound(path.to_owned()));
         }
         let descendants: Vec<String> = files
             .keys()
@@ -387,7 +387,7 @@ impl GuestFiles for FakeAgent {
             .cloned()
             .collect();
         if !descendants.is_empty() && !recursive {
-            return Err(VmmError::DirectoryNotEmpty(path.to_owned()));
+            return Err(ComputerError::DirectoryNotEmpty(path.to_owned()));
         }
         for key in descendants {
             files.remove(&key);
@@ -400,7 +400,7 @@ impl GuestFiles for FakeAgent {
         let mut files = lock(&self.shared.files);
         let entry = files
             .remove(from)
-            .ok_or_else(|| VmmError::PathNotFound(from.to_owned()))?;
+            .ok_or_else(|| ComputerError::PathNotFound(from.to_owned()))?;
         let moved: Vec<String> = files
             .keys()
             .filter(|key| key.starts_with(&format!("{from}/")))
@@ -416,7 +416,7 @@ impl GuestFiles for FakeAgent {
 
     async fn watch(&self, path: &str, _recursive: bool) -> Result<DirWatch> {
         if !lock(&self.shared.files).contains_key(path) {
-            return Err(VmmError::PathNotFound(path.to_owned()));
+            return Err(ComputerError::PathNotFound(path.to_owned()));
         }
         let (tx, events) = mpsc::unbounded_channel();
         lock(&self.shared.watchers).push(tx);

--- a/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
+++ b/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
@@ -1,6 +1,6 @@
 //! The manager's own flows, driven end to end over the fakes.
 //!
-//! One computer per test, created through `create_sandbox` and reached
+//! One computer per test, created through `create_computer` and reached
 //! only through the public API — so what these assert is what a caller
 //! gets, and no test can reach a state a real flow does not produce.
 //!
@@ -42,7 +42,7 @@ async fn a_create_boots_to_ready_and_serves_exec_and_files() {
 
     let (id, ip) = fixture
         .manager
-        .create_sandbox(ComputerSpec {
+        .create_computer(ComputerSpec {
             id: Some("booted".into()),
             cmd: vec!["/bin/hello".into()],
             ..ComputerSpec::default()
@@ -84,24 +84,24 @@ async fn a_create_boots_to_ready_and_serves_exec_and_files() {
     // The file verbs reach the guest through the port.
     fixture
         .manager
-        .write_sandbox_file(&id, "/tmp/note", 0o644, b"written")
+        .write_computer_file(&id, "/tmp/note", 0o644, b"written")
         .await
         .unwrap();
     assert_eq!(
         fixture
             .manager
-            .read_sandbox_file(&id, "/tmp/note")
+            .read_computer_file(&id, "/tmp/note")
             .await
             .unwrap(),
         b"written"
     );
     fixture
         .manager
-        .move_sandbox_path(&id, "/tmp/note", "/tmp/moved")
+        .move_computer_path(&id, "/tmp/note", "/tmp/moved")
         .await
         .unwrap();
     assert!(matches!(
-        fixture.manager.stat_sandbox_path(&id, "/tmp/note").await,
+        fixture.manager.stat_computer_path(&id, "/tmp/note").await,
         Err(ComputerError::PathNotFound(_))
     ));
 
@@ -109,7 +109,7 @@ async fn a_create_boots_to_ready_and_serves_exec_and_files() {
     // guest side emits arrives through it whatever the transport.
     let mut watch = fixture
         .manager
-        .watch_sandbox_dir(&id, "/tmp/moved", false)
+        .watch_computer_dir(&id, "/tmp/moved", false)
         .await
         .unwrap();
     fixture
@@ -143,7 +143,7 @@ async fn a_cmd_carrying_boot_announces_its_workload_around_ready() {
 
     let (id, _ip) = fixture
         .manager
-        .create_sandbox(ComputerSpec {
+        .create_computer(ComputerSpec {
             id: Some("noisy".into()),
             cmd: vec!["/bin/hello".into()],
             ..ComputerSpec::default()
@@ -184,7 +184,7 @@ async fn a_ready_probe_command_that_never_exits_fails_the_boot() {
 
     let (id, _ip) = fixture
         .manager
-        .create_sandbox(ComputerSpec {
+        .create_computer(ComputerSpec {
             id: Some("wedged".into()),
             ready_probe: Some(
                 arcbox_computer_runtime::template_catalog::ReadyProbeSpec::Command {
@@ -218,7 +218,7 @@ async fn a_boot_whose_cmd_exits_while_the_gate_runs_still_reaches_ready() {
 
     let (id, _ip) = fixture
         .manager
-        .create_sandbox(ComputerSpec {
+        .create_computer(ComputerSpec {
             id: Some("gated".into()),
             cmd: vec!["/bin/cmd".into()],
             ready_probe: Some(
@@ -262,7 +262,7 @@ async fn a_boot_the_driver_refuses_fails_and_releases_the_computer() {
 
     let (id, _ip) = fixture
         .manager
-        .create_sandbox(ComputerSpec {
+        .create_computer(ComputerSpec {
             id: Some("doomed".into()),
             ..ComputerSpec::default()
         })
@@ -293,7 +293,7 @@ async fn a_create_that_fails_before_activation_hands_the_address_back() {
 
     fixture
         .manager
-        .create_sandbox(ComputerSpec {
+        .create_computer(ComputerSpec {
             id: Some("doomed".into()),
             ..ComputerSpec::default()
         })
@@ -313,7 +313,7 @@ async fn a_create_that_fails_before_activation_hands_the_address_back() {
     );
     let (_id, reused) = fixture
         .manager
-        .create_sandbox(ComputerSpec {
+        .create_computer(ComputerSpec {
             id: Some("next".into()),
             ..ComputerSpec::default()
         })
@@ -374,7 +374,7 @@ async fn an_idle_computer_pauses_and_says_the_timer_did_it() {
     );
     fixture.await_state(&id, ComputerState::Paused).await;
     assert!(
-        fixture.manager.inspect_sandbox(&id).is_ok(),
+        fixture.manager.inspect_computer(&id).is_ok(),
         "the PAUSE policy never removes the computer"
     );
 }
@@ -393,7 +393,7 @@ async fn a_ttl_expiry_removes_even_a_busy_computer() {
     // the boot: under a paused clock every await advances virtual time.
     fixture
         .manager
-        .set_sandbox_lifecycle(
+        .set_computer_lifecycle(
             &id,
             LifecycleUpdate {
                 ttl_seconds: Some(2),
@@ -418,7 +418,7 @@ async fn set_lifecycle_rearms_the_ttl_and_replaces_only_what_it_names() {
     let before = chrono::Utc::now();
     fixture
         .manager
-        .set_sandbox_lifecycle(
+        .set_computer_lifecycle(
             &id,
             LifecycleUpdate {
                 ttl_seconds: Some(600),
@@ -429,7 +429,7 @@ async fn set_lifecycle_rearms_the_ttl_and_replaces_only_what_it_names() {
         .await
         .unwrap();
 
-    let info = fixture.manager.inspect_sandbox(&id).unwrap();
+    let info = fixture.manager.inspect_computer(&id).unwrap();
     let deadline = info.ttl_deadline.expect("ttl deadline armed");
     assert!(deadline >= before + chrono::Duration::seconds(600));
     assert!(deadline <= chrono::Utc::now() + chrono::Duration::seconds(600));
@@ -439,7 +439,7 @@ async fn set_lifecycle_rearms_the_ttl_and_replaces_only_what_it_names() {
     // Absent fields are unchanged; ttl 0 removes the cap.
     fixture
         .manager
-        .set_sandbox_lifecycle(
+        .set_computer_lifecycle(
             &id,
             LifecycleUpdate {
                 ttl_seconds: Some(0),
@@ -448,7 +448,7 @@ async fn set_lifecycle_rearms_the_ttl_and_replaces_only_what_it_names() {
         )
         .await
         .unwrap();
-    let info = fixture.manager.inspect_sandbox(&id).unwrap();
+    let info = fixture.manager.inspect_computer(&id).unwrap();
     assert_eq!(info.ttl_deadline, None);
     assert_eq!(info.idle_timeout_seconds, 30);
     assert_eq!(info.on_idle, IdleAction::Pause);
@@ -461,31 +461,31 @@ async fn set_lifecycle_rejects_terminal_states_and_missing_ids() {
     assert!(matches!(
         fixture
             .manager
-            .set_sandbox_lifecycle(&"ghost".to_owned(), LifecycleUpdate::default())
+            .set_computer_lifecycle(&"ghost".to_owned(), LifecycleUpdate::default())
             .await,
         Err(ComputerError::NotFound(_))
     ));
 
     let stopped = fixture.ready("halted").await;
     let mut events = fixture.manager.subscribe_events();
-    fixture.manager.stop_sandbox(&stopped, 1).await.unwrap();
+    fixture.manager.stop_computer(&stopped, 1).await.unwrap();
     await_action(&mut events, &stopped, action::STOPPED).await;
     fixture.await_state(&stopped, ComputerState::Stopped).await;
     assert!(matches!(
         fixture
             .manager
-            .set_sandbox_lifecycle(&stopped, LifecycleUpdate::default())
+            .set_computer_lifecycle(&stopped, LifecycleUpdate::default())
             .await,
         Err(ComputerError::WrongState { .. })
     ));
 
     // Paused computers accept updates: the TTL keeps applying to them.
     let paused = fixture.ready("asleep").await;
-    fixture.manager.pause_sandbox(&paused).await.unwrap();
+    fixture.manager.pause_computer(&paused).await.unwrap();
     fixture.await_state(&paused, ComputerState::Paused).await;
     fixture
         .manager
-        .set_sandbox_lifecycle(
+        .set_computer_lifecycle(
             &paused,
             LifecycleUpdate {
                 ttl_seconds: Some(120),
@@ -510,7 +510,7 @@ async fn a_pause_records_what_it_retained_and_a_resume_uses_it() {
     let id = fixture.ready("nap").await;
     let mut events = fixture.manager.subscribe_events();
 
-    fixture.manager.pause_sandbox(&id).await.unwrap();
+    fixture.manager.pause_computer(&id).await.unwrap();
     fixture.await_state(&id, ComputerState::Paused).await;
     let pausing = await_action(&mut events, &id, action::PAUSING).await;
     assert_eq!(
@@ -519,7 +519,7 @@ async fn a_pause_records_what_it_retained_and_a_resume_uses_it() {
     );
     await_action(&mut events, &id, action::PAUSED).await;
 
-    let info = fixture.manager.inspect_sandbox(&id).unwrap();
+    let info = fixture.manager.inspect_computer(&id).unwrap();
     assert!(info.paused_at.is_some(), "the pause records when it froze");
     assert!(
         info.storage_bytes > 0,
@@ -527,7 +527,7 @@ async fn a_pause_records_what_it_retained_and_a_resume_uses_it() {
     );
     let listed = fixture
         .manager
-        .list_sandboxes(None, &HashMap::new())
+        .list_computers(None, &HashMap::new())
         .unwrap();
     let summary = listed.iter().find(|entry| entry.id == id).unwrap();
     assert_eq!(
@@ -549,7 +549,7 @@ async fn a_pause_records_what_it_retained_and_a_resume_uses_it() {
     fixture.settle_network_cleanups().await;
     let ip = fixture
         .manager
-        .resume_sandbox(&id, pause_reason::RESUME)
+        .resume_computer(&id, pause_reason::RESUME)
         .await
         .unwrap();
     assert!(!ip.is_empty(), "a resume answers with its fresh address");
@@ -573,23 +573,23 @@ async fn pause_is_idempotent_and_gates_on_state() {
     fixture.agent().on(&["/bin/wedged"], Reply::NeverExits);
 
     assert!(matches!(
-        fixture.manager.pause_sandbox(&"missing".to_owned()).await,
+        fixture.manager.pause_computer(&"missing".to_owned()).await,
         Err(ComputerError::NotFound(_))
     ));
 
     let asleep = fixture.ready("asleep").await;
-    fixture.manager.pause_sandbox(&asleep).await.unwrap();
+    fixture.manager.pause_computer(&asleep).await.unwrap();
     fixture.await_state(&asleep, ComputerState::Paused).await;
     fixture
         .manager
-        .pause_sandbox(&asleep)
+        .pause_computer(&asleep)
         .await
         .expect("pausing a paused computer is a no-op");
 
     let busy = fixture.booted(never_exits("busy")).await;
     fixture.await_state(&busy, ComputerState::Running).await;
     assert!(matches!(
-        fixture.manager.pause_sandbox(&busy).await,
+        fixture.manager.pause_computer(&busy).await,
         Err(ComputerError::WrongState { .. })
     ));
 }
@@ -601,11 +601,11 @@ async fn a_direct_mode_pause_is_refused_before_it_freezes_anything() {
     let fixture = Fixture::direct().await;
     let id = fixture.ready("plain").await;
 
-    let error = fixture.manager.pause_sandbox(&id).await.unwrap_err();
+    let error = fixture.manager.pause_computer(&id).await.unwrap_err();
     assert!(matches!(error, ComputerError::Config(_)), "{error}");
     assert!(error.to_string().contains("jailer"), "{error}");
     assert_eq!(
-        fixture.manager.inspect_sandbox(&id).unwrap().state,
+        fixture.manager.inspect_computer(&id).unwrap().state,
         ComputerState::Ready,
         "the refused pause left the computer alone"
     );
@@ -621,7 +621,7 @@ async fn resume_is_a_noop_on_live_states_and_refuses_terminal_ones() {
     let ready = fixture.ready("awake").await;
     let address = fixture
         .manager
-        .inspect_sandbox(&ready)
+        .inspect_computer(&ready)
         .unwrap()
         .network
         .expect("a networked computer")
@@ -629,7 +629,7 @@ async fn resume_is_a_noop_on_live_states_and_refuses_terminal_ones() {
     assert_eq!(
         fixture
             .manager
-            .resume_sandbox(&ready, pause_reason::RESUME)
+            .resume_computer(&ready, pause_reason::RESUME)
             .await
             .unwrap(),
         address,
@@ -640,17 +640,17 @@ async fn resume_is_a_noop_on_live_states_and_refuses_terminal_ones() {
     fixture.await_state(&running, ComputerState::Running).await;
     fixture
         .manager
-        .resume_sandbox(&running, pause_reason::RESUME)
+        .resume_computer(&running, pause_reason::RESUME)
         .await
         .expect("resuming a busy computer is a no-op");
 
     let stopped = fixture.ready("halted").await;
-    fixture.manager.stop_sandbox(&stopped, 1).await.unwrap();
+    fixture.manager.stop_computer(&stopped, 1).await.unwrap();
     fixture.await_state(&stopped, ComputerState::Stopped).await;
     assert!(matches!(
         fixture
             .manager
-            .resume_sandbox(&stopped, pause_reason::RESUME)
+            .resume_computer(&stopped, pause_reason::RESUME)
             .await,
         Err(ComputerError::WrongState { .. })
     ));
@@ -666,7 +666,7 @@ async fn a_pause_that_leaves_the_guest_frozen_fails_and_releases_the_computer() 
     fixture.driver().freeze_next_checkpoint();
     let mut events = fixture.manager.subscribe_events();
 
-    let error = fixture.manager.pause_sandbox(&id).await.unwrap_err();
+    let error = fixture.manager.pause_computer(&id).await.unwrap_err();
     assert!(
         !matches!(error, ComputerError::WrongState { .. }),
         "the capture failure is the reported error: {error}"
@@ -685,7 +685,7 @@ async fn a_pause_that_leaves_the_guest_frozen_fails_and_releases_the_computer() 
     assert!(matches!(
         fixture
             .manager
-            .resume_sandbox(&id, pause_reason::RESUME)
+            .resume_computer(&id, pause_reason::RESUME)
             .await,
         Err(ComputerError::WrongState { .. })
     ));
@@ -698,17 +698,17 @@ async fn a_pause_that_leaves_the_guest_frozen_fails_and_releases_the_computer() 
 async fn the_data_plane_reports_a_paused_computer_readably() {
     let fixture = Fixture::jailed().await;
     let id = fixture.ready("asleep").await;
-    fixture.manager.pause_sandbox(&id).await.unwrap();
+    fixture.manager.pause_computer(&id).await.unwrap();
     fixture.await_state(&id, ComputerState::Paused).await;
 
     assert!(matches!(
-        fixture.manager.read_sandbox_file(&id, "/tmp/x").await,
+        fixture.manager.read_computer_file(&id, "/tmp/x").await,
         Err(ComputerError::Paused(paused)) if paused == id
     ));
     assert!(matches!(
         fixture
             .manager
-            .run_in_sandbox(
+            .run_in_computer(
                 &id,
                 vec!["/bin/anything".into()],
                 HashMap::new(),
@@ -738,7 +738,7 @@ async fn a_checkpoint_restores_onto_a_fresh_address() {
 
     let checkpoint = fixture
         .manager
-        .checkpoint_sandbox(&id, "user".into(), HashMap::new())
+        .checkpoint_computer(&id, "user".into(), HashMap::new())
         .await
         .unwrap();
     assert_eq!(
@@ -752,14 +752,14 @@ async fn a_checkpoint_restores_onto_a_fresh_address() {
         vec![checkpoint.snapshot_id.clone()]
     );
     assert_eq!(
-        fixture.manager.inspect_sandbox(&id).unwrap().state,
+        fixture.manager.inspect_computer(&id).unwrap().state,
         ComputerState::Ready,
         "the origin keeps running: the capture resumed it"
     );
 
     let (clone, clone_ip) = fixture
         .manager
-        .restore_sandbox(RestoreComputerSpec {
+        .restore_computer(RestoreComputerSpec {
             id: Some("clone".into()),
             snapshot_id: checkpoint.snapshot_id.clone(),
             network_override: true,
@@ -777,7 +777,7 @@ async fn a_checkpoint_restores_onto_a_fresh_address() {
         clone_ip,
         fixture
             .manager
-            .inspect_sandbox(&id)
+            .inspect_computer(&id)
             .unwrap()
             .network
             .unwrap()
@@ -797,12 +797,12 @@ async fn a_recoverable_checkpoint_failure_leaves_the_computer_ready() {
 
     fixture
         .manager
-        .checkpoint_sandbox(&id, "user".into(), HashMap::new())
+        .checkpoint_computer(&id, "user".into(), HashMap::new())
         .await
         .expect_err("a capture the driver refused");
 
     assert_eq!(
-        fixture.manager.inspect_sandbox(&id).unwrap().state,
+        fixture.manager.inspect_computer(&id).unwrap().state,
         ComputerState::Ready
     );
     assert!(
@@ -834,7 +834,7 @@ async fn a_checkpoint_that_leaves_the_guest_frozen_fails_and_releases_the_comput
 
     let error = fixture
         .manager
-        .checkpoint_sandbox(&id, "user".into(), HashMap::new())
+        .checkpoint_computer(&id, "user".into(), HashMap::new())
         .await
         .expect_err("a capture that froze the guest");
     assert!(
@@ -856,14 +856,14 @@ async fn a_failed_restore_frees_its_id_before_it_answers() {
     let origin = fixture.ready("origin").await;
     let checkpoint = fixture
         .manager
-        .checkpoint_sandbox(&origin, "user".into(), HashMap::new())
+        .checkpoint_computer(&origin, "user".into(), HashMap::new())
         .await
         .unwrap();
 
     fixture.driver().fail_next_boot();
     fixture
         .manager
-        .restore_sandbox(RestoreComputerSpec {
+        .restore_computer(RestoreComputerSpec {
             id: Some("second".into()),
             snapshot_id: checkpoint.snapshot_id.clone(),
             network_override: true,
@@ -877,7 +877,7 @@ async fn a_failed_restore_frees_its_id_before_it_answers() {
     fixture.settle_network_cleanups().await;
     let (again, _ip) = fixture
         .manager
-        .restore_sandbox(RestoreComputerSpec {
+        .restore_computer(RestoreComputerSpec {
             id: Some("second".into()),
             snapshot_id: checkpoint.snapshot_id,
             network_override: true,
@@ -909,7 +909,7 @@ async fn a_caller_cannot_squat_on_the_reserved_checkpoint_name_or_labels() {
     ] {
         let error = fixture
             .manager
-            .checkpoint_sandbox(&id, name.to_owned(), labels)
+            .checkpoint_computer(&id, name.to_owned(), labels)
             .await
             .expect_err("a reserved name or label is refused");
         assert!(matches!(error, ComputerError::Config(_)), "{error}");
@@ -928,14 +928,14 @@ async fn removing_a_paused_computer_takes_its_retained_checkpoint() {
         "nothing is pinned before there is a checkpoint"
     );
 
-    fixture.manager.pause_sandbox(&id).await.unwrap();
+    fixture.manager.pause_computer(&id).await.unwrap();
     fixture.await_state(&id, ComputerState::Paused).await;
     assert!(
         !fixture.manager.pinned_rootfs_paths().unwrap().is_empty(),
         "the pause checkpoint pins the rootfs it was captured from"
     );
 
-    fixture.manager.remove_sandbox(&id, false).await.unwrap();
+    fixture.manager.remove_computer(&id, false).await.unwrap();
     fixture.await_gone(&id).await;
     assert!(
         fixture.manager.pinned_rootfs_paths().unwrap().is_empty(),
@@ -986,7 +986,7 @@ async fn a_boot_whose_warm_publish_freezes_the_guest_fails() {
 
     let (id, _ip) = fixture
         .manager
-        .create_sandbox(ComputerSpec {
+        .create_computer(ComputerSpec {
             id: Some("chilled".into()),
             ..ComputerSpec::default()
         })
@@ -1015,7 +1015,7 @@ async fn a_forced_remove_preempts_a_boot_in_flight() {
 
     let (id, _ip) = fixture
         .manager
-        .create_sandbox(ComputerSpec {
+        .create_computer(ComputerSpec {
             id: Some("wedged".into()),
             ready_probe: Some(
                 arcbox_computer_runtime::template_catalog::ReadyProbeSpec::Command {
@@ -1034,7 +1034,7 @@ async fn a_forced_remove_preempts_a_boot_in_flight() {
 
     tokio::time::timeout(
         std::time::Duration::from_secs(10),
-        fixture.manager.remove_sandbox(&id, true),
+        fixture.manager.remove_computer(&id, true),
     )
     .await
     .expect("a forced remove must preempt the gate")
@@ -1056,10 +1056,10 @@ async fn remove_refuses_a_busy_computer_unless_forced() {
     let mut events = fixture.manager.subscribe_events();
 
     assert!(matches!(
-        fixture.manager.remove_sandbox(&id, false).await,
+        fixture.manager.remove_computer(&id, false).await,
         Err(ComputerError::WrongState { .. })
     ));
-    fixture.manager.remove_sandbox(&id, true).await.unwrap();
+    fixture.manager.remove_computer(&id, true).await.unwrap();
     await_action(&mut events, &id, action::REMOVED).await;
     fixture.await_gone(&id).await;
 }
@@ -1094,7 +1094,7 @@ async fn a_detached_computer_is_adopted_by_the_next_process_and_serves_an_exec()
     // running, after which the overlay and TAP are torn out from under a
     // live guest.
     let vm = arcbox_vm_driver::VmId::new(&id).unwrap();
-    fixture.manager.remove_sandbox(&id, false).await.unwrap();
+    fixture.manager.remove_computer(&id, false).await.unwrap();
     fixture.await_gone(&id).await;
     assert_eq!(
         fixture.driver().shutdowns(&vm),
@@ -1135,7 +1135,7 @@ async fn an_adopted_computer_on_a_copied_rootfs_pauses_and_keeps_its_disk() {
     fixture = fixture.restart().await;
     fixture.await_state(&id, ComputerState::Ready).await;
 
-    fixture.manager.pause_sandbox(&id).await.unwrap();
+    fixture.manager.pause_computer(&id).await.unwrap();
     fixture.await_state(&id, ComputerState::Paused).await;
     // The frozen on-disk name a resume reattaches from.
     let parked = fixture.vm_dir(&id).join("paused-rootfs.ext4");
@@ -1147,7 +1147,7 @@ async fn an_adopted_computer_on_a_copied_rootfs_pauses_and_keeps_its_disk() {
     fixture.settle_network_cleanups().await;
     let error = fixture
         .manager
-        .resume_sandbox(&id, pause_reason::RESUME)
+        .resume_computer(&id, pause_reason::RESUME)
         .await
         .expect_err("an adopted computer's checkpoint records no kernel to stage");
     assert!(
@@ -1178,10 +1178,10 @@ async fn a_computer_whose_vm_died_comes_back_failed() {
 
     let info = fixture
         .manager
-        .inspect_sandbox(&id)
+        .inspect_computer(&id)
         .expect("the sweep reinstated the computer");
     assert_eq!(info.state, ComputerState::Failed);
-    fixture.manager.remove_sandbox(&id, false).await.unwrap();
+    fixture.manager.remove_computer(&id, false).await.unwrap();
     fixture.await_gone(&id).await;
 }
 
@@ -1193,7 +1193,7 @@ async fn a_computer_whose_vm_died_comes_back_failed() {
 /// rather than building a second computer — the durable half of an
 /// at-least-once RPC.
 ///
-/// The replay is its own verb, and has to be: `create_sandbox_keyed`
+/// The replay is its own verb, and has to be: `create_computer_keyed`
 /// claims the id in memory *before* it consults the durable record, so
 /// while the computer is live the claim answers first. A caller that
 /// retries has to ask the record.
@@ -1206,7 +1206,7 @@ async fn a_create_replays_its_recorded_outcome_rather_than_building_a_second_com
     };
     let (id, ip) = fixture
         .manager
-        .create_sandbox_keyed(spec.clone(), "one-key")
+        .create_computer_keyed(spec.clone(), "one-key")
         .await
         .unwrap();
     fixture.await_state(&id, ComputerState::Ready).await;
@@ -1214,7 +1214,7 @@ async fn a_create_replays_its_recorded_outcome_rather_than_building_a_second_com
     assert_eq!(
         fixture
             .manager
-            .replay_sandbox_create(&id, "one-key")
+            .replay_computer_create(&id, "one-key")
             .await
             .unwrap(),
         Some((id.clone(), ip)),
@@ -1223,7 +1223,7 @@ async fn a_create_replays_its_recorded_outcome_rather_than_building_a_second_com
     assert_eq!(
         fixture
             .manager
-            .replay_sandbox_create("nobody", "one-key")
+            .replay_computer_create("nobody", "one-key")
             .await
             .unwrap(),
         None,
@@ -1233,20 +1233,20 @@ async fn a_create_replays_its_recorded_outcome_rather_than_building_a_second_com
         matches!(
             fixture
                 .manager
-                .replay_sandbox_create(&id, "another-key")
+                .replay_computer_create(&id, "another-key")
                 .await,
             Err(ComputerError::AlreadyExists(_))
         ),
         "the key that made the record owns it"
     );
     assert!(matches!(
-        fixture.manager.create_sandbox_keyed(spec, "one-key").await,
+        fixture.manager.create_computer_keyed(spec, "one-key").await,
         Err(ComputerError::AlreadyExists(_))
     ));
     assert_eq!(
         fixture
             .manager
-            .list_sandboxes(None, &HashMap::new())
+            .list_computers(None, &HashMap::new())
             .unwrap()
             .len(),
         1,
@@ -1265,22 +1265,22 @@ async fn a_create_of_a_live_id_under_another_key_is_refused() {
     };
     let (id, _ip) = fixture
         .manager
-        .create_sandbox_keyed(spec(), "mine")
+        .create_computer_keyed(spec(), "mine")
         .await
         .unwrap();
     fixture.await_state(&id, ComputerState::Ready).await;
 
     assert!(matches!(
-        fixture.manager.create_sandbox_keyed(spec(), "yours").await,
+        fixture.manager.create_computer_keyed(spec(), "yours").await,
         Err(ComputerError::AlreadyExists(_))
     ));
 
     // And a same-key retry after the computer has left its live phases is
     // refused too: its recorded outcome names an address it no longer has.
-    fixture.manager.stop_sandbox(&id, 1).await.unwrap();
+    fixture.manager.stop_computer(&id, 1).await.unwrap();
     fixture.await_state(&id, ComputerState::Stopped).await;
     assert!(matches!(
-        fixture.manager.create_sandbox_keyed(spec(), "mine").await,
+        fixture.manager.create_computer_keyed(spec(), "mine").await,
         Err(ComputerError::AlreadyExists(_))
     ));
 }

--- a/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
+++ b/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 
 use arcbox_computer_runtime::testkit::agent::Reply;
 use arcbox_computer_runtime::{
-    ComputerError, IdleAction, LifecycleUpdate, RestoreSandboxSpec, SandboxSpec, SandboxState,
+    ComputerError, ComputerSpec, IdleAction, LifecycleUpdate, RestoreComputerSpec, SandboxState,
     pause_reason,
 };
 use support::{Fixture, Setup, action, await_action, drain_actions, never_exits};
@@ -42,10 +42,10 @@ async fn a_create_boots_to_ready_and_serves_exec_and_files() {
 
     let (id, ip) = fixture
         .manager
-        .create_sandbox(SandboxSpec {
+        .create_sandbox(ComputerSpec {
             id: Some("booted".into()),
             cmd: vec!["/bin/hello".into()],
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         })
         .await
         .unwrap();
@@ -143,10 +143,10 @@ async fn a_cmd_carrying_boot_announces_its_workload_around_ready() {
 
     let (id, _ip) = fixture
         .manager
-        .create_sandbox(SandboxSpec {
+        .create_sandbox(ComputerSpec {
             id: Some("noisy".into()),
             cmd: vec!["/bin/hello".into()],
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         })
         .await
         .unwrap();
@@ -184,7 +184,7 @@ async fn a_ready_probe_command_that_never_exits_fails_the_boot() {
 
     let (id, _ip) = fixture
         .manager
-        .create_sandbox(SandboxSpec {
+        .create_sandbox(ComputerSpec {
             id: Some("wedged".into()),
             ready_probe: Some(
                 arcbox_computer_runtime::template_catalog::ReadyProbeSpec::Command {
@@ -192,7 +192,7 @@ async fn a_ready_probe_command_that_never_exits_fails_the_boot() {
                     timeout_seconds: 1,
                 },
             ),
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         })
         .await
         .unwrap();
@@ -218,7 +218,7 @@ async fn a_boot_whose_cmd_exits_while_the_gate_runs_still_reaches_ready() {
 
     let (id, _ip) = fixture
         .manager
-        .create_sandbox(SandboxSpec {
+        .create_sandbox(ComputerSpec {
             id: Some("gated".into()),
             cmd: vec!["/bin/cmd".into()],
             ready_probe: Some(
@@ -227,7 +227,7 @@ async fn a_boot_whose_cmd_exits_while_the_gate_runs_still_reaches_ready() {
                     timeout_seconds: 30,
                 },
             ),
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         })
         .await
         .unwrap();
@@ -262,9 +262,9 @@ async fn a_boot_the_driver_refuses_fails_and_releases_the_computer() {
 
     let (id, _ip) = fixture
         .manager
-        .create_sandbox(SandboxSpec {
+        .create_sandbox(ComputerSpec {
             id: Some("doomed".into()),
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         })
         .await
         .unwrap();
@@ -293,9 +293,9 @@ async fn a_create_that_fails_before_activation_hands_the_address_back() {
 
     fixture
         .manager
-        .create_sandbox(SandboxSpec {
+        .create_sandbox(ComputerSpec {
             id: Some("doomed".into()),
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         })
         .await
         .expect_err("the journal write cannot succeed against a directory");
@@ -313,9 +313,9 @@ async fn a_create_that_fails_before_activation_hands_the_address_back() {
     );
     let (_id, reused) = fixture
         .manager
-        .create_sandbox(SandboxSpec {
+        .create_sandbox(ComputerSpec {
             id: Some("next".into()),
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         })
         .await
         .unwrap();
@@ -336,11 +336,11 @@ async fn an_idle_computer_is_removed_when_its_policy_says_kill() {
     let fixture = Fixture::jailed().await;
     let mut events = fixture.manager.subscribe_events();
     let id = fixture
-        .booted(SandboxSpec {
+        .booted(ComputerSpec {
             id: Some("bored".into()),
             idle_timeout_seconds: 2,
             on_idle: IdleAction::Kill,
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         })
         .await;
 
@@ -357,11 +357,11 @@ async fn an_idle_computer_pauses_and_says_the_timer_did_it() {
     let fixture = Fixture::jailed().await;
     let mut events = fixture.manager.subscribe_events();
     let id = fixture
-        .booted(SandboxSpec {
+        .booted(ComputerSpec {
             id: Some("napper".into()),
             idle_timeout_seconds: 2,
             on_idle: IdleAction::Pause,
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         })
         .await;
 
@@ -759,11 +759,11 @@ async fn a_checkpoint_restores_onto_a_fresh_address() {
 
     let (clone, clone_ip) = fixture
         .manager
-        .restore_sandbox(RestoreSandboxSpec {
+        .restore_sandbox(RestoreComputerSpec {
             id: Some("clone".into()),
             snapshot_id: checkpoint.snapshot_id.clone(),
             network_override: true,
-            ..RestoreSandboxSpec::default()
+            ..RestoreComputerSpec::default()
         })
         .await
         .unwrap();
@@ -863,11 +863,11 @@ async fn a_failed_restore_frees_its_id_before_it_answers() {
     fixture.driver().fail_next_boot();
     fixture
         .manager
-        .restore_sandbox(RestoreSandboxSpec {
+        .restore_sandbox(RestoreComputerSpec {
             id: Some("second".into()),
             snapshot_id: checkpoint.snapshot_id.clone(),
             network_override: true,
-            ..RestoreSandboxSpec::default()
+            ..RestoreComputerSpec::default()
         })
         .await
         .expect_err("the driver refused the restore");
@@ -877,11 +877,11 @@ async fn a_failed_restore_frees_its_id_before_it_answers() {
     fixture.settle_network_cleanups().await;
     let (again, _ip) = fixture
         .manager
-        .restore_sandbox(RestoreSandboxSpec {
+        .restore_sandbox(RestoreComputerSpec {
             id: Some("second".into()),
             snapshot_id: checkpoint.snapshot_id,
             network_override: true,
-            ..RestoreSandboxSpec::default()
+            ..RestoreComputerSpec::default()
         })
         .await
         .expect("the failed restore left nothing owning the id");
@@ -986,9 +986,9 @@ async fn a_boot_whose_warm_publish_freezes_the_guest_fails() {
 
     let (id, _ip) = fixture
         .manager
-        .create_sandbox(SandboxSpec {
+        .create_sandbox(ComputerSpec {
             id: Some("chilled".into()),
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         })
         .await
         .unwrap();
@@ -1015,7 +1015,7 @@ async fn a_forced_remove_preempts_a_boot_in_flight() {
 
     let (id, _ip) = fixture
         .manager
-        .create_sandbox(SandboxSpec {
+        .create_sandbox(ComputerSpec {
             id: Some("wedged".into()),
             ready_probe: Some(
                 arcbox_computer_runtime::template_catalog::ReadyProbeSpec::Command {
@@ -1025,7 +1025,7 @@ async fn a_forced_remove_preempts_a_boot_in_flight() {
                     timeout_seconds: 600,
                 },
             ),
-            ..SandboxSpec::default()
+            ..ComputerSpec::default()
         })
         .await
         .unwrap();
@@ -1200,9 +1200,9 @@ async fn a_computer_whose_vm_died_comes_back_failed() {
 #[tokio::test]
 async fn a_create_replays_its_recorded_outcome_rather_than_building_a_second_computer() {
     let fixture = Fixture::jailed().await;
-    let spec = SandboxSpec {
+    let spec = ComputerSpec {
         id: Some("twice".into()),
-        ..SandboxSpec::default()
+        ..ComputerSpec::default()
     };
     let (id, ip) = fixture
         .manager
@@ -1259,9 +1259,9 @@ async fn a_create_replays_its_recorded_outcome_rather_than_building_a_second_com
 #[tokio::test]
 async fn a_create_of_a_live_id_under_another_key_is_refused() {
     let fixture = Fixture::jailed().await;
-    let spec = || SandboxSpec {
+    let spec = || ComputerSpec {
         id: Some("taken".into()),
-        ..SandboxSpec::default()
+        ..ComputerSpec::default()
     };
     let (id, _ip) = fixture
         .manager

--- a/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
+++ b/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 
 use arcbox_computer_runtime::testkit::agent::Reply;
 use arcbox_computer_runtime::{
-    ComputerError, ComputerSpec, IdleAction, LifecycleUpdate, RestoreComputerSpec, SandboxState,
+    ComputerError, ComputerSpec, ComputerState, IdleAction, LifecycleUpdate, RestoreComputerSpec,
     pause_reason,
 };
 use support::{Fixture, Setup, action, await_action, drain_actions, never_exits};
@@ -125,7 +125,7 @@ async fn a_create_boots_to_ready_and_serves_exec_and_files() {
     );
 
     // And so does a workload, once the initial cmd has released the slot.
-    fixture.await_state(&id, SandboxState::Ready).await;
+    fixture.await_state(&id, ComputerState::Ready).await;
     assert_eq!(fixture.run(&id, &["/bin/hello"]).await, b"hi");
 }
 
@@ -150,7 +150,7 @@ async fn a_cmd_carrying_boot_announces_its_workload_around_ready() {
         })
         .await
         .unwrap();
-    fixture.await_state(&id, SandboxState::Ready).await;
+    fixture.await_state(&id, ComputerState::Ready).await;
 
     let actions = drain_actions(&mut events, &id);
     assert!(
@@ -247,7 +247,7 @@ async fn a_boot_whose_cmd_exits_while_the_gate_runs_still_reaches_ready() {
     fixture.agent().on(&["/bin/probe"], Reply::ok());
 
     await_action(&mut events, &id, action::READY).await;
-    fixture.await_state(&id, SandboxState::Ready).await;
+    fixture.await_state(&id, ComputerState::Ready).await;
     assert_eq!(fixture.run(&id, &["/bin/cmd"]).await, Vec::<u8>::new());
 }
 
@@ -372,7 +372,7 @@ async fn an_idle_computer_pauses_and_says_the_timer_did_it() {
         Some(pause_reason::IDLE_TIMEOUT),
         "the PAUSING event names the idle timer, not a caller"
     );
-    fixture.await_state(&id, SandboxState::Paused).await;
+    fixture.await_state(&id, ComputerState::Paused).await;
     assert!(
         fixture.manager.inspect_sandbox(&id).is_ok(),
         "the PAUSE policy never removes the computer"
@@ -387,7 +387,7 @@ async fn a_ttl_expiry_removes_even_a_busy_computer() {
     let fixture = Fixture::jailed().await;
     fixture.agent().on(&["/bin/wedged"], Reply::NeverExits);
     let id = fixture.booted(never_exits("capped")).await;
-    fixture.await_state(&id, SandboxState::Running).await;
+    fixture.await_state(&id, ComputerState::Running).await;
 
     // Armed once the workload is running, so the cap cannot be spent on
     // the boot: under a paused clock every await advances virtual time.
@@ -470,7 +470,7 @@ async fn set_lifecycle_rejects_terminal_states_and_missing_ids() {
     let mut events = fixture.manager.subscribe_events();
     fixture.manager.stop_sandbox(&stopped, 1).await.unwrap();
     await_action(&mut events, &stopped, action::STOPPED).await;
-    fixture.await_state(&stopped, SandboxState::Stopped).await;
+    fixture.await_state(&stopped, ComputerState::Stopped).await;
     assert!(matches!(
         fixture
             .manager
@@ -482,7 +482,7 @@ async fn set_lifecycle_rejects_terminal_states_and_missing_ids() {
     // Paused computers accept updates: the TTL keeps applying to them.
     let paused = fixture.ready("asleep").await;
     fixture.manager.pause_sandbox(&paused).await.unwrap();
-    fixture.await_state(&paused, SandboxState::Paused).await;
+    fixture.await_state(&paused, ComputerState::Paused).await;
     fixture
         .manager
         .set_sandbox_lifecycle(
@@ -511,7 +511,7 @@ async fn a_pause_records_what_it_retained_and_a_resume_uses_it() {
     let mut events = fixture.manager.subscribe_events();
 
     fixture.manager.pause_sandbox(&id).await.unwrap();
-    fixture.await_state(&id, SandboxState::Paused).await;
+    fixture.await_state(&id, ComputerState::Paused).await;
     let pausing = await_action(&mut events, &id, action::PAUSING).await;
     assert_eq!(
         pausing.attributes.get("reason").map(String::as_str),
@@ -558,7 +558,7 @@ async fn a_pause_records_what_it_retained_and_a_resume_uses_it() {
         resumed.attributes.get("reason").map(String::as_str),
         Some(pause_reason::RESUME)
     );
-    fixture.await_state(&id, SandboxState::Ready).await;
+    fixture.await_state(&id, ComputerState::Ready).await;
     assert_eq!(
         fixture.run(&id, &["/bin/hello"]).await,
         b"hi",
@@ -579,7 +579,7 @@ async fn pause_is_idempotent_and_gates_on_state() {
 
     let asleep = fixture.ready("asleep").await;
     fixture.manager.pause_sandbox(&asleep).await.unwrap();
-    fixture.await_state(&asleep, SandboxState::Paused).await;
+    fixture.await_state(&asleep, ComputerState::Paused).await;
     fixture
         .manager
         .pause_sandbox(&asleep)
@@ -587,7 +587,7 @@ async fn pause_is_idempotent_and_gates_on_state() {
         .expect("pausing a paused computer is a no-op");
 
     let busy = fixture.booted(never_exits("busy")).await;
-    fixture.await_state(&busy, SandboxState::Running).await;
+    fixture.await_state(&busy, ComputerState::Running).await;
     assert!(matches!(
         fixture.manager.pause_sandbox(&busy).await,
         Err(ComputerError::WrongState { .. })
@@ -606,7 +606,7 @@ async fn a_direct_mode_pause_is_refused_before_it_freezes_anything() {
     assert!(error.to_string().contains("jailer"), "{error}");
     assert_eq!(
         fixture.manager.inspect_sandbox(&id).unwrap().state,
-        SandboxState::Ready,
+        ComputerState::Ready,
         "the refused pause left the computer alone"
     );
 }
@@ -637,7 +637,7 @@ async fn resume_is_a_noop_on_live_states_and_refuses_terminal_ones() {
     );
 
     let running = fixture.booted(never_exits("busy")).await;
-    fixture.await_state(&running, SandboxState::Running).await;
+    fixture.await_state(&running, ComputerState::Running).await;
     fixture
         .manager
         .resume_sandbox(&running, pause_reason::RESUME)
@@ -646,7 +646,7 @@ async fn resume_is_a_noop_on_live_states_and_refuses_terminal_ones() {
 
     let stopped = fixture.ready("halted").await;
     fixture.manager.stop_sandbox(&stopped, 1).await.unwrap();
-    fixture.await_state(&stopped, SandboxState::Stopped).await;
+    fixture.await_state(&stopped, ComputerState::Stopped).await;
     assert!(matches!(
         fixture
             .manager
@@ -699,7 +699,7 @@ async fn the_data_plane_reports_a_paused_computer_readably() {
     let fixture = Fixture::jailed().await;
     let id = fixture.ready("asleep").await;
     fixture.manager.pause_sandbox(&id).await.unwrap();
-    fixture.await_state(&id, SandboxState::Paused).await;
+    fixture.await_state(&id, ComputerState::Paused).await;
 
     assert!(matches!(
         fixture.manager.read_sandbox_file(&id, "/tmp/x").await,
@@ -753,7 +753,7 @@ async fn a_checkpoint_restores_onto_a_fresh_address() {
     );
     assert_eq!(
         fixture.manager.inspect_sandbox(&id).unwrap().state,
-        SandboxState::Ready,
+        ComputerState::Ready,
         "the origin keeps running: the capture resumed it"
     );
 
@@ -767,7 +767,7 @@ async fn a_checkpoint_restores_onto_a_fresh_address() {
         })
         .await
         .unwrap();
-    fixture.await_state(&clone, SandboxState::Ready).await;
+    fixture.await_state(&clone, ComputerState::Ready).await;
     assert_eq!(
         fixture.driver().restored_vms(),
         vec![arcbox_vm_driver::VmId::new(&clone).unwrap()],
@@ -803,7 +803,7 @@ async fn a_recoverable_checkpoint_failure_leaves_the_computer_ready() {
 
     assert_eq!(
         fixture.manager.inspect_sandbox(&id).unwrap().state,
-        SandboxState::Ready
+        ComputerState::Ready
     );
     assert!(
         fixture
@@ -885,7 +885,7 @@ async fn a_failed_restore_frees_its_id_before_it_answers() {
         })
         .await
         .expect("the failed restore left nothing owning the id");
-    fixture.await_state(&again, SandboxState::Ready).await;
+    fixture.await_state(&again, ComputerState::Ready).await;
 }
 
 /// The names and labels the lifecycle machinery owns are not a caller's to
@@ -929,7 +929,7 @@ async fn removing_a_paused_computer_takes_its_retained_checkpoint() {
     );
 
     fixture.manager.pause_sandbox(&id).await.unwrap();
-    fixture.await_state(&id, SandboxState::Paused).await;
+    fixture.await_state(&id, ComputerState::Paused).await;
     assert!(
         !fixture.manager.pinned_rootfs_paths().unwrap().is_empty(),
         "the pause checkpoint pins the rootfs it was captured from"
@@ -1030,7 +1030,7 @@ async fn a_forced_remove_preempts_a_boot_in_flight() {
         .await
         .unwrap();
     await_action(&mut events, &id, action::CREATED).await;
-    fixture.await_state(&id, SandboxState::Starting).await;
+    fixture.await_state(&id, ComputerState::Starting).await;
 
     tokio::time::timeout(
         std::time::Duration::from_secs(10),
@@ -1052,7 +1052,7 @@ async fn remove_refuses_a_busy_computer_unless_forced() {
     let fixture = Fixture::jailed().await;
     fixture.agent().on(&["/bin/wedged"], Reply::NeverExits);
     let id = fixture.booted(never_exits("busy")).await;
-    fixture.await_state(&id, SandboxState::Running).await;
+    fixture.await_state(&id, ComputerState::Running).await;
     let mut events = fixture.manager.subscribe_events();
 
     assert!(matches!(
@@ -1081,7 +1081,7 @@ async fn a_detached_computer_is_adopted_by_the_next_process_and_serves_an_exec()
     fixture.manager.detach_all().await.unwrap();
     fixture = fixture.restart().await;
 
-    fixture.await_state(&id, SandboxState::Ready).await;
+    fixture.await_state(&id, ComputerState::Ready).await;
     assert_eq!(
         fixture.run(&id, &["echo", "still here"]).await,
         b"still here",
@@ -1133,10 +1133,10 @@ async fn an_adopted_computer_on_a_copied_rootfs_pauses_and_keeps_its_disk() {
 
     fixture.manager.detach_all().await.unwrap();
     fixture = fixture.restart().await;
-    fixture.await_state(&id, SandboxState::Ready).await;
+    fixture.await_state(&id, ComputerState::Ready).await;
 
     fixture.manager.pause_sandbox(&id).await.unwrap();
-    fixture.await_state(&id, SandboxState::Paused).await;
+    fixture.await_state(&id, ComputerState::Paused).await;
     // The frozen on-disk name a resume reattaches from.
     let parked = fixture.vm_dir(&id).join("paused-rootfs.ext4");
     assert!(
@@ -1154,7 +1154,7 @@ async fn an_adopted_computer_on_a_copied_rootfs_pauses_and_keeps_its_disk() {
         matches!(&error, ComputerError::Io(io) if io.kind() == std::io::ErrorKind::NotFound),
         "the kernel path the checkpoint recorded is empty, so staging it is ENOENT: {error}"
     );
-    fixture.await_state(&id, SandboxState::Paused).await;
+    fixture.await_state(&id, ComputerState::Paused).await;
     assert!(parked.exists(), "a failed resume leaves the disk parked");
 }
 
@@ -1180,7 +1180,7 @@ async fn a_computer_whose_vm_died_comes_back_failed() {
         .manager
         .inspect_sandbox(&id)
         .expect("the sweep reinstated the computer");
-    assert_eq!(info.state, SandboxState::Failed);
+    assert_eq!(info.state, ComputerState::Failed);
     fixture.manager.remove_sandbox(&id, false).await.unwrap();
     fixture.await_gone(&id).await;
 }
@@ -1209,7 +1209,7 @@ async fn a_create_replays_its_recorded_outcome_rather_than_building_a_second_com
         .create_sandbox_keyed(spec.clone(), "one-key")
         .await
         .unwrap();
-    fixture.await_state(&id, SandboxState::Ready).await;
+    fixture.await_state(&id, ComputerState::Ready).await;
 
     assert_eq!(
         fixture
@@ -1268,7 +1268,7 @@ async fn a_create_of_a_live_id_under_another_key_is_refused() {
         .create_sandbox_keyed(spec(), "mine")
         .await
         .unwrap();
-    fixture.await_state(&id, SandboxState::Ready).await;
+    fixture.await_state(&id, ComputerState::Ready).await;
 
     assert!(matches!(
         fixture.manager.create_sandbox_keyed(spec(), "yours").await,
@@ -1278,7 +1278,7 @@ async fn a_create_of_a_live_id_under_another_key_is_refused() {
     // And a same-key retry after the computer has left its live phases is
     // refused too: its recorded outcome names an address it no longer has.
     fixture.manager.stop_sandbox(&id, 1).await.unwrap();
-    fixture.await_state(&id, SandboxState::Stopped).await;
+    fixture.await_state(&id, ComputerState::Stopped).await;
     assert!(matches!(
         fixture.manager.create_sandbox_keyed(spec(), "mine").await,
         Err(ComputerError::AlreadyExists(_))

--- a/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
+++ b/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 
 use arcbox_computer_runtime::testkit::agent::Reply;
 use arcbox_computer_runtime::{
-    IdleAction, LifecycleUpdate, RestoreSandboxSpec, SandboxSpec, SandboxState, VmmError,
+    ComputerError, IdleAction, LifecycleUpdate, RestoreSandboxSpec, SandboxSpec, SandboxState,
     pause_reason,
 };
 use support::{Fixture, Setup, action, await_action, drain_actions, never_exits};
@@ -102,7 +102,7 @@ async fn a_create_boots_to_ready_and_serves_exec_and_files() {
         .unwrap();
     assert!(matches!(
         fixture.manager.stat_sandbox_path(&id, "/tmp/note").await,
-        Err(VmmError::PathNotFound(_))
+        Err(ComputerError::PathNotFound(_))
     ));
 
     // A watch is a stream the port owns rather than a socket, so what the
@@ -463,7 +463,7 @@ async fn set_lifecycle_rejects_terminal_states_and_missing_ids() {
             .manager
             .set_sandbox_lifecycle(&"ghost".to_owned(), LifecycleUpdate::default())
             .await,
-        Err(VmmError::NotFound(_))
+        Err(ComputerError::NotFound(_))
     ));
 
     let stopped = fixture.ready("halted").await;
@@ -476,7 +476,7 @@ async fn set_lifecycle_rejects_terminal_states_and_missing_ids() {
             .manager
             .set_sandbox_lifecycle(&stopped, LifecycleUpdate::default())
             .await,
-        Err(VmmError::WrongState { .. })
+        Err(ComputerError::WrongState { .. })
     ));
 
     // Paused computers accept updates: the TTL keeps applying to them.
@@ -574,7 +574,7 @@ async fn pause_is_idempotent_and_gates_on_state() {
 
     assert!(matches!(
         fixture.manager.pause_sandbox(&"missing".to_owned()).await,
-        Err(VmmError::NotFound(_))
+        Err(ComputerError::NotFound(_))
     ));
 
     let asleep = fixture.ready("asleep").await;
@@ -590,7 +590,7 @@ async fn pause_is_idempotent_and_gates_on_state() {
     fixture.await_state(&busy, SandboxState::Running).await;
     assert!(matches!(
         fixture.manager.pause_sandbox(&busy).await,
-        Err(VmmError::WrongState { .. })
+        Err(ComputerError::WrongState { .. })
     ));
 }
 
@@ -602,7 +602,7 @@ async fn a_direct_mode_pause_is_refused_before_it_freezes_anything() {
     let id = fixture.ready("plain").await;
 
     let error = fixture.manager.pause_sandbox(&id).await.unwrap_err();
-    assert!(matches!(error, VmmError::Config(_)), "{error}");
+    assert!(matches!(error, ComputerError::Config(_)), "{error}");
     assert!(error.to_string().contains("jailer"), "{error}");
     assert_eq!(
         fixture.manager.inspect_sandbox(&id).unwrap().state,
@@ -652,7 +652,7 @@ async fn resume_is_a_noop_on_live_states_and_refuses_terminal_ones() {
             .manager
             .resume_sandbox(&stopped, pause_reason::RESUME)
             .await,
-        Err(VmmError::WrongState { .. })
+        Err(ComputerError::WrongState { .. })
     ));
 }
 
@@ -668,7 +668,7 @@ async fn a_pause_that_leaves_the_guest_frozen_fails_and_releases_the_computer() 
 
     let error = fixture.manager.pause_sandbox(&id).await.unwrap_err();
     assert!(
-        !matches!(error, VmmError::WrongState { .. }),
+        !matches!(error, ComputerError::WrongState { .. }),
         "the capture failure is the reported error: {error}"
     );
     fixture.await_released(&id).await;
@@ -687,7 +687,7 @@ async fn a_pause_that_leaves_the_guest_frozen_fails_and_releases_the_computer() 
             .manager
             .resume_sandbox(&id, pause_reason::RESUME)
             .await,
-        Err(VmmError::WrongState { .. })
+        Err(ComputerError::WrongState { .. })
     ));
 }
 
@@ -703,7 +703,7 @@ async fn the_data_plane_reports_a_paused_computer_readably() {
 
     assert!(matches!(
         fixture.manager.read_sandbox_file(&id, "/tmp/x").await,
-        Err(VmmError::Paused(paused)) if paused == id
+        Err(ComputerError::Paused(paused)) if paused == id
     ));
     assert!(matches!(
         fixture
@@ -720,7 +720,7 @@ async fn the_data_plane_reports_a_paused_computer_readably() {
             )
             .await
             .err(),
-        Some(VmmError::Paused(paused)) if paused == id
+        Some(ComputerError::Paused(paused)) if paused == id
     ));
 }
 
@@ -912,7 +912,7 @@ async fn a_caller_cannot_squat_on_the_reserved_checkpoint_name_or_labels() {
             .checkpoint_sandbox(&id, name.to_owned(), labels)
             .await
             .expect_err("a reserved name or label is refused");
-        assert!(matches!(error, VmmError::Config(_)), "{error}");
+        assert!(matches!(error, ComputerError::Config(_)), "{error}");
     }
 }
 
@@ -1057,7 +1057,7 @@ async fn remove_refuses_a_busy_computer_unless_forced() {
 
     assert!(matches!(
         fixture.manager.remove_sandbox(&id, false).await,
-        Err(VmmError::WrongState { .. })
+        Err(ComputerError::WrongState { .. })
     ));
     fixture.manager.remove_sandbox(&id, true).await.unwrap();
     await_action(&mut events, &id, action::REMOVED).await;
@@ -1151,7 +1151,7 @@ async fn an_adopted_computer_on_a_copied_rootfs_pauses_and_keeps_its_disk() {
         .await
         .expect_err("an adopted computer's checkpoint records no kernel to stage");
     assert!(
-        matches!(&error, VmmError::Io(io) if io.kind() == std::io::ErrorKind::NotFound),
+        matches!(&error, ComputerError::Io(io) if io.kind() == std::io::ErrorKind::NotFound),
         "the kernel path the checkpoint recorded is empty, so staging it is ENOENT: {error}"
     );
     fixture.await_state(&id, SandboxState::Paused).await;
@@ -1235,13 +1235,13 @@ async fn a_create_replays_its_recorded_outcome_rather_than_building_a_second_com
                 .manager
                 .replay_sandbox_create(&id, "another-key")
                 .await,
-            Err(VmmError::AlreadyExists(_))
+            Err(ComputerError::AlreadyExists(_))
         ),
         "the key that made the record owns it"
     );
     assert!(matches!(
         fixture.manager.create_sandbox_keyed(spec, "one-key").await,
-        Err(VmmError::AlreadyExists(_))
+        Err(ComputerError::AlreadyExists(_))
     ));
     assert_eq!(
         fixture
@@ -1272,7 +1272,7 @@ async fn a_create_of_a_live_id_under_another_key_is_refused() {
 
     assert!(matches!(
         fixture.manager.create_sandbox_keyed(spec(), "yours").await,
-        Err(VmmError::AlreadyExists(_))
+        Err(ComputerError::AlreadyExists(_))
     ));
 
     // And a same-key retry after the computer has left its live phases is
@@ -1281,6 +1281,6 @@ async fn a_create_of_a_live_id_under_another_key_is_refused() {
     fixture.await_state(&id, SandboxState::Stopped).await;
     assert!(matches!(
         fixture.manager.create_sandbox_keyed(spec(), "mine").await,
-        Err(VmmError::AlreadyExists(_))
+        Err(ComputerError::AlreadyExists(_))
     ));
 }

--- a/computer/arcbox-computer-runtime/tests/support/mod.rs
+++ b/computer/arcbox-computer-runtime/tests/support/mod.rs
@@ -22,8 +22,8 @@ use arcbox_computer_runtime::config::{JailerConfig, RuntimeConfig};
 use arcbox_computer_runtime::testkit::agent::FakeAgentFactory;
 use arcbox_computer_runtime::testkit::fake_environment;
 use arcbox_computer_runtime::{
-    ComputerEvent, ComputerId, ComputerSpec, ComputerState, NodeEnvironment, OutputChunk,
-    SandboxManager,
+    ComputerEvent, ComputerId, ComputerManager, ComputerSpec, ComputerState, NodeEnvironment,
+    OutputChunk,
 };
 use arcbox_vm_driver::testkit::{FakeDriver, FakeNetwork};
 use tokio::sync::broadcast;
@@ -37,7 +37,7 @@ const DEADLINE: Duration = Duration::from_secs(10);
 /// tidiness. A sandbox id has to fit what AF_UNIX leaves of the jail's
 /// socket paths, and macOS's per-user `$TMPDIR` (`/var/folders/../T/`)
 /// spends ~50 bytes of that on its own — enough to take the budget to
-/// zero, so every `create_sandbox` would be refused at id validation
+/// zero, so every `create_computer` would be refused at id validation
 /// before reaching anything it meant to exercise. A short root is also
 /// what a real node's jail base is.
 ///
@@ -151,8 +151,8 @@ struct Ports {
 }
 
 impl Ports {
-    async fn manager(&self, config: &RuntimeConfig) -> Arc<SandboxManager> {
-        let manager = SandboxManager::new(
+    async fn manager(&self, config: &RuntimeConfig) -> Arc<ComputerManager> {
+        let manager = ComputerManager::new(
             config.clone(),
             NodeEnvironment {
                 // The fixture's own clones, so a restart hands its
@@ -186,7 +186,7 @@ impl Ports {
 /// A manager over the fakes, with the handles a test scripts and asserts
 /// through.
 pub struct Fixture {
-    pub manager: Arc<SandboxManager>,
+    pub manager: Arc<ComputerManager>,
     ports: Ports,
     config: RuntimeConfig,
     /// The data dir, kept alive for the fixture's life.
@@ -280,7 +280,7 @@ impl Fixture {
         let mut events = self.manager.subscribe_events();
         let (id, _ip) = self
             .manager
-            .create_sandbox(spec)
+            .create_computer(spec)
             .await
             .expect("the create is accepted");
         await_action(&mut events, &id, action::READY).await;
@@ -295,7 +295,7 @@ impl Fixture {
     pub async fn await_state(&self, id: &ComputerId, state: ComputerState) {
         let deadline = tokio::time::Instant::now() + DEADLINE;
         loop {
-            let seen = self.manager.inspect_sandbox(id);
+            let seen = self.manager.inspect_computer(id);
             match &seen {
                 Ok(info) if info.state == state => return,
                 _ if tokio::time::Instant::now() >= deadline => panic!(
@@ -313,7 +313,7 @@ impl Fixture {
     /// Wait until `id` is no longer registered, or fail the test.
     pub async fn await_gone(&self, id: &ComputerId) {
         let deadline = tokio::time::Instant::now() + DEADLINE;
-        while self.manager.inspect_sandbox(id).is_ok() {
+        while self.manager.inspect_computer(id).is_ok() {
             assert!(
                 tokio::time::Instant::now() < deadline,
                 "{id} is still registered"
@@ -354,7 +354,7 @@ impl Fixture {
     pub async fn run(&self, id: &ComputerId, cmd: &[&str]) -> Vec<u8> {
         let mut output = self
             .manager
-            .run_in_sandbox(
+            .run_in_computer(
                 id,
                 cmd.iter().map(|arg| (*arg).to_owned()).collect(),
                 HashMap::new(),
@@ -378,7 +378,7 @@ impl Fixture {
 
 /// Play the host's half of the network-cleanup ticket protocol for every
 /// quarantined address, and answer with the ids it settled.
-pub async fn settle_network_cleanups(manager: &SandboxManager) -> Vec<String> {
+pub async fn settle_network_cleanups(manager: &ComputerManager) -> Vec<String> {
     let pending = manager.pending_network_cleanups().await.unwrap();
     for (id, token) in &pending {
         manager

--- a/computer/arcbox-computer-runtime/tests/support/mod.rs
+++ b/computer/arcbox-computer-runtime/tests/support/mod.rs
@@ -22,7 +22,7 @@ use arcbox_computer_runtime::config::{JailerConfig, RuntimeConfig};
 use arcbox_computer_runtime::testkit::agent::FakeAgentFactory;
 use arcbox_computer_runtime::testkit::fake_environment;
 use arcbox_computer_runtime::{
-    NodeEnvironment, OutputChunk, SandboxEvent, SandboxId, SandboxManager, SandboxSpec,
+    ComputerId, ComputerSpec, NodeEnvironment, OutputChunk, SandboxEvent, SandboxManager,
     SandboxState,
 };
 use arcbox_vm_driver::testkit::{FakeDriver, FakeNetwork};
@@ -260,11 +260,11 @@ impl Fixture {
 
     /// Create a computer and wait until it is `Ready` — the state every
     /// data-plane and lifecycle verb is specified against.
-    pub async fn ready(&self, id: &str) -> SandboxId {
+    pub async fn ready(&self, id: &str) -> ComputerId {
         let id = self
-            .booted(SandboxSpec {
+            .booted(ComputerSpec {
                 id: Some(id.to_owned()),
-                ..SandboxSpec::default()
+                ..ComputerSpec::default()
             })
             .await;
         self.await_state(&id, SandboxState::Ready).await;
@@ -276,7 +276,7 @@ impl Fixture {
     /// Not the same as [`Self::ready`]: a spec carrying an initial `cmd`
     /// publishes READY and RUNNING in the same breath, so a computer whose
     /// cmd does not exit is announced ready and observed `Running`.
-    pub async fn booted(&self, spec: SandboxSpec) -> SandboxId {
+    pub async fn booted(&self, spec: ComputerSpec) -> ComputerId {
         let mut events = self.manager.subscribe_events();
         let (id, _ip) = self
             .manager
@@ -292,7 +292,7 @@ impl Fixture {
     /// Every verb answers from the computer's actor and several of them
     /// leave work running behind the answer, so a read taken right after
     /// one can still see the state it started from.
-    pub async fn await_state(&self, id: &SandboxId, state: SandboxState) {
+    pub async fn await_state(&self, id: &ComputerId, state: SandboxState) {
         let deadline = tokio::time::Instant::now() + DEADLINE;
         loop {
             let seen = self.manager.inspect_sandbox(id);
@@ -311,7 +311,7 @@ impl Fixture {
     }
 
     /// Wait until `id` is no longer registered, or fail the test.
-    pub async fn await_gone(&self, id: &SandboxId) {
+    pub async fn await_gone(&self, id: &ComputerId) {
         let deadline = tokio::time::Instant::now() + DEADLINE;
         while self.manager.inspect_sandbox(id).is_ok() {
             assert!(
@@ -337,7 +337,7 @@ impl Fixture {
     /// Wait until `id` is `Failed` with its crash journal cleared, which
     /// is the last thing a release does and therefore the one observation
     /// that covers the whole of it.
-    pub async fn await_released(&self, id: &SandboxId) {
+    pub async fn await_released(&self, id: &ComputerId) {
         self.await_state(id, SandboxState::Failed).await;
         let journal = self.vm_dir(id).join("state.json");
         let deadline = tokio::time::Instant::now() + DEADLINE;
@@ -351,7 +351,7 @@ impl Fixture {
     }
 
     /// Run `cmd` in `id` and collect everything the guest wrote to stdout.
-    pub async fn run(&self, id: &SandboxId, cmd: &[&str]) -> Vec<u8> {
+    pub async fn run(&self, id: &ComputerId, cmd: &[&str]) -> Vec<u8> {
         let mut output = self
             .manager
             .run_in_sandbox(
@@ -449,10 +449,10 @@ pub fn drain_actions(events: &mut broadcast::Receiver<SandboxEvent>, id: &str) -
 
 /// A spec whose initial command never exits, so the computer stays busy
 /// until something tears it down.
-pub fn never_exits(id: &str) -> SandboxSpec {
-    SandboxSpec {
+pub fn never_exits(id: &str) -> ComputerSpec {
+    ComputerSpec {
         id: Some(id.to_owned()),
         cmd: vec!["/bin/wedged".into()],
-        ..SandboxSpec::default()
+        ..ComputerSpec::default()
     }
 }

--- a/computer/arcbox-computer-runtime/tests/support/mod.rs
+++ b/computer/arcbox-computer-runtime/tests/support/mod.rs
@@ -22,8 +22,8 @@ use arcbox_computer_runtime::config::{JailerConfig, RuntimeConfig};
 use arcbox_computer_runtime::testkit::agent::FakeAgentFactory;
 use arcbox_computer_runtime::testkit::fake_environment;
 use arcbox_computer_runtime::{
-    ComputerId, ComputerSpec, NodeEnvironment, OutputChunk, SandboxEvent, SandboxManager,
-    SandboxState,
+    ComputerEvent, ComputerId, ComputerSpec, ComputerState, NodeEnvironment, OutputChunk,
+    SandboxManager,
 };
 use arcbox_vm_driver::testkit::{FakeDriver, FakeNetwork};
 use tokio::sync::broadcast;
@@ -267,7 +267,7 @@ impl Fixture {
                 ..ComputerSpec::default()
             })
             .await;
-        self.await_state(&id, SandboxState::Ready).await;
+        self.await_state(&id, ComputerState::Ready).await;
         id
     }
 
@@ -292,7 +292,7 @@ impl Fixture {
     /// Every verb answers from the computer's actor and several of them
     /// leave work running behind the answer, so a read taken right after
     /// one can still see the state it started from.
-    pub async fn await_state(&self, id: &ComputerId, state: SandboxState) {
+    pub async fn await_state(&self, id: &ComputerId, state: ComputerState) {
         let deadline = tokio::time::Instant::now() + DEADLINE;
         loop {
             let seen = self.manager.inspect_sandbox(id);
@@ -338,7 +338,7 @@ impl Fixture {
     /// is the last thing a release does and therefore the one observation
     /// that covers the whole of it.
     pub async fn await_released(&self, id: &ComputerId) {
-        self.await_state(id, SandboxState::Failed).await;
+        self.await_state(id, ComputerState::Failed).await;
         let journal = self.vm_dir(id).join("state.json");
         let deadline = tokio::time::Instant::now() + DEADLINE;
         while journal.exists() {
@@ -393,7 +393,7 @@ pub async fn settle_network_cleanups(manager: &SandboxManager) -> Vec<String> {
     pending.into_iter().map(|(id, _)| id).collect()
 }
 
-/// The `action` values [`SandboxEvent`] carries, as the wire spells them.
+/// The `action` values [`ComputerEvent`] carries, as the wire spells them.
 ///
 /// Spelled out rather than imported: the constants they mirror are
 /// crate-private, and it is the *strings* an out-of-crate consumer matches
@@ -414,21 +414,21 @@ pub mod action {
 /// Wait for `action` on `id`, or fail the test — reporting a failure on
 /// the same computer immediately rather than waiting out the deadline.
 pub async fn await_action(
-    events: &mut broadcast::Receiver<SandboxEvent>,
+    events: &mut broadcast::Receiver<ComputerEvent>,
     id: &str,
     action: &str,
-) -> SandboxEvent {
+) -> ComputerEvent {
     let deadline = tokio::time::Instant::now() + DEADLINE;
     loop {
         let event = tokio::time::timeout_at(deadline, events.recv())
             .await
             .unwrap_or_else(|_| panic!("no {action} for {id} within the deadline"))
             .expect("the event stream stays open");
-        if event.sandbox_id == id && event.action == action {
+        if event.computer_id == id && event.action == action {
             return event;
         }
         assert_ne!(
-            (event.action.as_str(), event.sandbox_id.as_str()),
+            (event.action.as_str(), event.computer_id.as_str()),
             (self::action::FAILED, id),
             "{id} failed instead of reaching {action}: {:?}",
             event.attributes
@@ -437,10 +437,10 @@ pub async fn await_action(
 }
 
 /// Every `action` seen for `id` so far, in order.
-pub fn drain_actions(events: &mut broadcast::Receiver<SandboxEvent>, id: &str) -> Vec<String> {
+pub fn drain_actions(events: &mut broadcast::Receiver<ComputerEvent>, id: &str) -> Vec<String> {
     let mut actions = Vec::new();
     while let Ok(event) = events.try_recv() {
-        if event.sandbox_id == id {
+        if event.computer_id == id {
             actions.push(event.action);
         }
     }

--- a/engine/arcbox-snapshot/src/template_catalog.rs
+++ b/engine/arcbox-snapshot/src/template_catalog.rs
@@ -190,7 +190,7 @@ pub struct PublishOutcome {
 /// Snapshot ids released by a catalog mutation.
 ///
 /// Owned by removed entries and referenced by no remaining entry anywhere in
-/// the catalog. The caller (`SandboxManager`) deletes them from the snapshot
+/// the catalog. The caller (`ComputerManager`) deletes them from the snapshot
 /// catalog — the catalog itself never touches artifacts.
 #[derive(Debug, Default)]
 pub struct ReleasedArtifacts {

--- a/guest/arcbox-agent/examples/sandbox-manager-smoke.rs
+++ b/guest/arcbox-agent/examples/sandbox-manager-smoke.rs
@@ -1,4 +1,4 @@
-//! End-to-end smoke test for [`SandboxManager`], over the environment this
+//! End-to-end smoke test for [`ComputerManager`], over the environment this
 //! crate composes for the System VM.
 //!
 //! ## Usage
@@ -42,7 +42,7 @@ use std::time::Instant;
 
 use anyhow::{Context, bail};
 use arcbox_computer_runtime::{
-    ComputerEvent, ComputerSpec, ComputerState, RestoreComputerSpec, SandboxManager,
+    ComputerEvent, ComputerManager, ComputerSpec, ComputerState, RestoreComputerSpec,
 };
 use tokio::sync::broadcast;
 use tokio::time::timeout;
@@ -82,7 +82,7 @@ async fn main() -> anyhow::Result<()> {
     let environment =
         arcbox_agent::sandbox::node_environment(&config, arcbox_agent::sandbox::block_tools())?;
     let manager =
-        SandboxManager::new(config.runtime, environment).context("SandboxManager::new")?;
+        ComputerManager::new(config.runtime, environment).context("ComputerManager::new")?;
 
     // Phase 1 — Core lifecycle
     println!("\n=== Phase 1: Core lifecycle ===");
@@ -91,18 +91,18 @@ async fn main() -> anyhow::Result<()> {
 
     let t0 = Instant::now();
     let (id, ip) = manager
-        .create_sandbox(ComputerSpec {
+        .create_computer(ComputerSpec {
             id: Some("smoke-1".into()),
             ..Default::default()
         })
         .await
-        .context("create_sandbox")?;
+        .context("create_computer")?;
     println!("  [create]  id={id} ip={ip}");
 
     wait_for_ready(&manager, &id, &mut events, 60).await?;
     println!("  [ready]   boot={}ms", t0.elapsed().as_millis());
 
-    let info = manager.inspect_sandbox(&id).context("inspect_sandbox")?;
+    let info = manager.inspect_computer(&id).context("inspect_computer")?;
     println!(
         "  [inspect] state={} vcpus={} mem={}MiB ip={}",
         info.state,
@@ -112,7 +112,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let list = manager
-        .list_sandboxes(None, &HashMap::new())
+        .list_computers(None, &HashMap::new())
         .context("list sandboxes")?;
     println!("  [list]    {} sandbox(es):", list.len());
     for s in &list {
@@ -157,7 +157,7 @@ async fn main() -> anyhow::Result<()> {
     {
         let mut events_n = manager.subscribe_events();
         let (id2, ip2) = manager
-            .create_sandbox(ComputerSpec {
+            .create_computer(ComputerSpec {
                 id: Some("smoke-net-2".into()),
                 ..Default::default()
             })
@@ -167,7 +167,7 @@ async fn main() -> anyhow::Result<()> {
 
         if ip == ip2 {
             // Clean up before bailing.
-            let _ = manager.remove_sandbox(&id2, true).await;
+            let _ = manager.remove_computer(&id2, true).await;
             bail!("duplicate IP {ip2} assigned to two concurrent sandboxes");
         }
         println!("  [net.3]  IPs are distinct ({ip} ≠ {ip2}) ✓");
@@ -176,17 +176,17 @@ async fn main() -> anyhow::Result<()> {
 
         // Capture TAP name before destroying the sandbox.
         let tap2 = manager
-            .inspect_sandbox(&id2)
+            .inspect_computer(&id2)
             .ok()
             .and_then(|i| i.network)
             .and_then(|n| tap_name_for(&n.ip_address));
 
         manager
-            .stop_sandbox(&id2, 10)
+            .stop_computer(&id2, 10)
             .await
             .context("stop smoke-net-2")?;
         manager
-            .remove_sandbox(&id2, false)
+            .remove_computer(&id2, false)
             .await
             .context("remove smoke-net-2")?;
         println!("  [net.3]  smoke-net-2 removed");
@@ -281,9 +281,9 @@ async fn main() -> anyhow::Result<()> {
     let snapshot_id_opt: Option<String> = if run_phase3 {
         println!("\n=== Phase 3: Checkpoint ===");
         let ck = manager
-            .checkpoint_sandbox(&id, "smoke-test".into(), HashMap::new())
+            .checkpoint_computer(&id, "smoke-test".into(), HashMap::new())
             .await
-            .context("checkpoint_sandbox")?;
+            .context("checkpoint_computer")?;
         println!("  [checkpoint] snapshot_id={}", ck.snapshot_id);
         println!("               dir={}", ck.snapshot_dir);
         Some(ck.snapshot_id)
@@ -293,14 +293,14 @@ async fn main() -> anyhow::Result<()> {
 
     // Phase 1 cleanup
     manager
-        .stop_sandbox(&id, 30)
+        .stop_computer(&id, 30)
         .await
-        .context("stop_sandbox")?;
+        .context("stop_computer")?;
     println!("\n  [stop]   done");
     manager
-        .remove_sandbox(&id, false)
+        .remove_computer(&id, false)
         .await
-        .context("remove_sandbox")?;
+        .context("remove_computer")?;
     println!("  [remove] done");
 
     // Phase 3 (cont) — Restore
@@ -309,7 +309,7 @@ async fn main() -> anyhow::Result<()> {
 
         let mut events2 = manager.subscribe_events();
         let (rid, rip) = manager
-            .restore_sandbox(RestoreComputerSpec {
+            .restore_computer(RestoreComputerSpec {
                 id: Some("smoke-restored".into()),
                 snapshot_id,
                 labels: HashMap::new(),
@@ -317,12 +317,12 @@ async fn main() -> anyhow::Result<()> {
                 ttl_seconds: 0,
             })
             .await
-            .context("restore_sandbox")?;
+            .context("restore_computer")?;
         println!("  [restore] id={rid} ip={rip}");
 
         wait_for_ready(&manager, &rid, &mut events2, 30).await?;
 
-        let rinfo = manager.inspect_sandbox(&rid).context("inspect restored")?;
+        let rinfo = manager.inspect_computer(&rid).context("inspect restored")?;
         println!(
             "  [inspect] state={} ip={}",
             rinfo.state,
@@ -333,11 +333,11 @@ async fn main() -> anyhow::Result<()> {
         );
 
         manager
-            .stop_sandbox(&rid, 30)
+            .stop_computer(&rid, 30)
             .await
             .context("stop restored")?;
         manager
-            .remove_sandbox(&rid, false)
+            .remove_computer(&rid, false)
             .await
             .context("remove restored")?;
         println!("  [cleanup] restored sandbox removed");
@@ -353,14 +353,14 @@ async fn main() -> anyhow::Result<()> {
 ///
 /// Prints a one-line summary with exit code and trimmed output.
 async fn run_cmd(
-    manager: &SandboxManager,
+    manager: &ComputerManager,
     id: &str,
     cmd: &[&str],
     timeout_secs: u32,
 ) -> anyhow::Result<String> {
     let label = cmd.join(" ");
     let mut rx = manager
-        .run_in_sandbox(
+        .run_in_computer(
             &id.to_owned(),
             cmd.iter().map(|s| s.to_string()).collect(),
             HashMap::new(),
@@ -371,7 +371,7 @@ async fn run_cmd(
             timeout_secs,
         )
         .await
-        .with_context(|| format!("run_in_sandbox: {label}"))?;
+        .with_context(|| format!("run_in_computer: {label}"))?;
 
     let mut stdout = Vec::new();
     let mut exit_code = 0;
@@ -401,12 +401,12 @@ async fn run_cmd(
 /// Checks current state first (fast path for snapshot restores that complete
 /// synchronously), then falls back to watching the event broadcast channel.
 async fn wait_for_ready(
-    manager: &SandboxManager,
+    manager: &ComputerManager,
     id: &str,
     events: &mut broadcast::Receiver<ComputerEvent>,
     timeout_secs: u64,
 ) -> anyhow::Result<()> {
-    if let Ok(info) = manager.inspect_sandbox(&id.to_string()) {
+    if let Ok(info) = manager.inspect_computer(&id.to_string()) {
         match info.state {
             ComputerState::Ready => return Ok(()),
             ComputerState::Failed => bail!(

--- a/guest/arcbox-agent/examples/sandbox-manager-smoke.rs
+++ b/guest/arcbox-agent/examples/sandbox-manager-smoke.rs
@@ -42,7 +42,7 @@ use std::time::Instant;
 
 use anyhow::{Context, bail};
 use arcbox_computer_runtime::{
-    RestoreSandboxSpec, SandboxEvent, SandboxManager, SandboxSpec, SandboxState,
+    ComputerSpec, RestoreComputerSpec, SandboxEvent, SandboxManager, SandboxState,
 };
 use tokio::sync::broadcast;
 use tokio::time::timeout;
@@ -91,7 +91,7 @@ async fn main() -> anyhow::Result<()> {
 
     let t0 = Instant::now();
     let (id, ip) = manager
-        .create_sandbox(SandboxSpec {
+        .create_sandbox(ComputerSpec {
             id: Some("smoke-1".into()),
             ..Default::default()
         })
@@ -157,7 +157,7 @@ async fn main() -> anyhow::Result<()> {
     {
         let mut events_n = manager.subscribe_events();
         let (id2, ip2) = manager
-            .create_sandbox(SandboxSpec {
+            .create_sandbox(ComputerSpec {
                 id: Some("smoke-net-2".into()),
                 ..Default::default()
             })
@@ -309,7 +309,7 @@ async fn main() -> anyhow::Result<()> {
 
         let mut events2 = manager.subscribe_events();
         let (rid, rip) = manager
-            .restore_sandbox(RestoreSandboxSpec {
+            .restore_sandbox(RestoreComputerSpec {
                 id: Some("smoke-restored".into()),
                 snapshot_id,
                 labels: HashMap::new(),

--- a/guest/arcbox-agent/examples/sandbox-manager-smoke.rs
+++ b/guest/arcbox-agent/examples/sandbox-manager-smoke.rs
@@ -42,7 +42,7 @@ use std::time::Instant;
 
 use anyhow::{Context, bail};
 use arcbox_computer_runtime::{
-    ComputerSpec, RestoreComputerSpec, SandboxEvent, SandboxManager, SandboxState,
+    ComputerEvent, ComputerSpec, ComputerState, RestoreComputerSpec, SandboxManager,
 };
 use tokio::sync::broadcast;
 use tokio::time::timeout;
@@ -403,13 +403,13 @@ async fn run_cmd(
 async fn wait_for_ready(
     manager: &SandboxManager,
     id: &str,
-    events: &mut broadcast::Receiver<SandboxEvent>,
+    events: &mut broadcast::Receiver<ComputerEvent>,
     timeout_secs: u64,
 ) -> anyhow::Result<()> {
     if let Ok(info) = manager.inspect_sandbox(&id.to_string()) {
         match info.state {
-            SandboxState::Ready => return Ok(()),
-            SandboxState::Failed => bail!(
+            ComputerState::Ready => return Ok(()),
+            ComputerState::Failed => bail!(
                 "sandbox {id} failed: {}",
                 info.error.unwrap_or_else(|| "unknown".into())
             ),
@@ -421,8 +421,8 @@ async fn wait_for_ready(
     timeout(std::time::Duration::from_secs(timeout_secs), async {
         loop {
             match events.recv().await {
-                Ok(ev) if ev.sandbox_id == id && ev.action == "ready" => return Ok(()),
-                Ok(ev) if ev.sandbox_id == id && ev.action == "failed" => {
+                Ok(ev) if ev.computer_id == id && ev.action == "ready" => return Ok(()),
+                Ok(ev) if ev.computer_id == id && ev.action == "failed" => {
                     let err = ev
                         .attributes
                         .get("error")

--- a/guest/arcbox-agent/src/agent/linux/port_forward.rs
+++ b/guest/arcbox-agent/src/agent/linux/port_forward.rs
@@ -32,7 +32,7 @@ use std::net::Ipv4Addr;
 use std::process::Output;
 
 use anyhow::{Context, Result, bail};
-use arcbox_computer_runtime::SandboxNetworkIdentity;
+use arcbox_computer_runtime::ComputerNetworkIdentity;
 use arcbox_tap_net::ExposeTarget;
 use arcbox_tap_net::invariant;
 use tokio::process::Command;
@@ -103,7 +103,7 @@ impl PortForwardManager {
     pub async fn forward(
         &mut self,
         sandbox_id: &str,
-        identity: &SandboxNetworkIdentity,
+        identity: &ComputerNetworkIdentity,
         sandbox_port: u16,
         protocol: Protocol,
     ) -> Result<u16> {
@@ -314,7 +314,7 @@ impl PortForwardManager {
 /// composed over, and installing the wrong DNAT would strand the mapping
 /// silently.
 fn expose_rule_specs(
-    identity: &SandboxNetworkIdentity,
+    identity: &ComputerNetworkIdentity,
     guest_port: u16,
     sandbox_port: u16,
     protocol: Protocol,
@@ -648,8 +648,8 @@ mod tests {
         assert_eq!(args[..8], dnat[..8]);
     }
 
-    fn identity(expose: HostIngress) -> SandboxNetworkIdentity {
-        SandboxNetworkIdentity {
+    fn identity(expose: HostIngress) -> ComputerNetworkIdentity {
+        ComputerNetworkIdentity {
             ip: "172.20.0.2".parse().unwrap(),
             cleanup_token: "generation".into(),
             expose,

--- a/guest/arcbox-agent/src/config/mod.rs
+++ b/guest/arcbox-agent/src/config/mod.rs
@@ -1,7 +1,7 @@
 //! VMM configuration loading for the guest agent.
 //!
 //! One TOML file, read into the two halves that consume it: the
-//! [`RuntimeConfig`] the embedded [`SandboxManager`] runs on, and the
+//! [`RuntimeConfig`] the embedded [`ComputerManager`] runs on, and the
 //! [`AdapterConfig`] this crate builds the VMM driver and the sandbox
 //! network from. The load priority is:
 //!

--- a/guest/arcbox-agent/src/config/mod.rs
+++ b/guest/arcbox-agent/src/config/mod.rs
@@ -15,7 +15,7 @@ pub use adapters::{AdapterConfig, JailerProcess};
 
 use arcbox_computer_runtime::RuntimeConfig;
 use arcbox_computer_runtime::config::{
-    DefaultVmConfig, FirecrackerConfig, GrpcConfig, JailerConfig, NetworkConfig,
+    ComputerConfig, DefaultVmConfig, GrpcConfig, JailerConfig, NetworkConfig,
 };
 use arcbox_constants::paths::{ARCBOX_RUNTIME_BIN_DIR, ARCBOX_RUNTIME_DIR, JAILER_CHROOT_BASE};
 
@@ -77,7 +77,7 @@ fn guest_defaults() -> GuestConfig {
     let runtime_bin = std::path::Path::new(ARCBOX_RUNTIME_BIN_DIR);
     let runtime_root = std::path::Path::new(ARCBOX_RUNTIME_DIR);
     let runtime = RuntimeConfig {
-        firecracker: FirecrackerConfig {
+        firecracker: ComputerConfig {
             jailer: Some(JailerConfig {
                 uid: 0,
                 gid: 0,

--- a/guest/arcbox-agent/src/error.rs
+++ b/guest/arcbox-agent/src/error.rs
@@ -88,40 +88,40 @@ impl SandboxError {
 /// construction.
 impl From<arcbox_snapshot::SnapshotError> for SandboxError {
     fn from(e: arcbox_snapshot::SnapshotError) -> Self {
-        Self::from(arcbox_computer_runtime::VmmError::from(e))
+        Self::from(arcbox_computer_runtime::ComputerError::from(e))
     }
 }
 
-impl From<arcbox_computer_runtime::VmmError> for SandboxError {
-    fn from(e: arcbox_computer_runtime::VmmError) -> Self {
-        use arcbox_computer_runtime::VmmError;
+impl From<arcbox_computer_runtime::ComputerError> for SandboxError {
+    fn from(e: arcbox_computer_runtime::ComputerError) -> Self {
+        use arcbox_computer_runtime::ComputerError;
         match &e {
             // A missing sandbox path keeps its typed "path not found:"
             // message: the daemon's classifier maps the 404 onto the
             // FILE_NOT_FOUND registry code by that prefix.
             // A missing template keeps its typed "template not found:"
             // message for the same reason (TEMPLATE_NOT_FOUND, CORE-107).
-            VmmError::NotFound(_) | VmmError::PathNotFound(_) | VmmError::TemplateNotFound(_) => {
-                Self::NotFound(e.to_string())
-            }
-            VmmError::AlreadyExists(_) | VmmError::TemplateVersionExists(_) => {
+            ComputerError::NotFound(_)
+            | ComputerError::PathNotFound(_)
+            | ComputerError::TemplateNotFound(_) => Self::NotFound(e.to_string()),
+            ComputerError::AlreadyExists(_) | ComputerError::TemplateVersionExists(_) => {
                 Self::AlreadyExists(e.to_string())
             }
             // A non-empty directory is a precondition failure (412), like a
             // wrong sandbox state: retrying without `recursive` never helps.
-            VmmError::WrongState { .. }
-            | VmmError::DirectoryNotEmpty(_)
-            | VmmError::FailedPrecondition(_) => Self::WrongState(e.to_string()),
-            VmmError::Paused(_) => Self::SandboxPaused(e.to_string()),
-            VmmError::StdinGap { .. } => Self::StdinGap(e.to_string()),
-            VmmError::DeadlineExceeded(_) => Self::Deadline(e.to_string()),
-            VmmError::Unavailable(_) | VmmError::AckUnconfirmed { .. } => {
+            ComputerError::WrongState { .. }
+            | ComputerError::DirectoryNotEmpty(_)
+            | ComputerError::FailedPrecondition(_) => Self::WrongState(e.to_string()),
+            ComputerError::Paused(_) => Self::SandboxPaused(e.to_string()),
+            ComputerError::StdinGap { .. } => Self::StdinGap(e.to_string()),
+            ComputerError::DeadlineExceeded(_) => Self::Deadline(e.to_string()),
+            ComputerError::Unavailable(_) | ComputerError::AckUnconfirmed { .. } => {
                 Self::Unavailable(e.to_string())
             }
             // Invalid caller input (e.g. a rejected sandbox id, or a
             // directory verb aimed at a non-directory) is a 400, not a
             // 500 — otherwise a bad request surfaces as INTERNAL.
-            VmmError::Config(_) | VmmError::NotADirectory(_) => {
+            ComputerError::Config(_) | ComputerError::NotADirectory(_) => {
                 Self::InvalidArgument(e.to_string())
             }
             _ => Self::Internal(e.to_string()),
@@ -135,20 +135,22 @@ mod tests {
 
     #[test]
     fn invalid_config_maps_to_400_not_500() {
-        let err = SandboxError::from(arcbox_computer_runtime::VmmError::Config("bad id".into()));
+        let err = SandboxError::from(arcbox_computer_runtime::ComputerError::Config(
+            "bad id".into(),
+        ));
         assert!(matches!(err, SandboxError::InvalidArgument(_)));
         assert_eq!(err.status_code(), 400);
     }
 
     #[test]
     fn runtime_errors_stay_500() {
-        let err = SandboxError::from(arcbox_computer_runtime::VmmError::Vsock("boom".into()));
+        let err = SandboxError::from(arcbox_computer_runtime::ComputerError::Vsock("boom".into()));
         assert_eq!(err.status_code(), 500);
     }
 
     #[test]
     fn stdin_gap_maps_to_416() {
-        let err = SandboxError::from(arcbox_computer_runtime::VmmError::StdinGap {
+        let err = SandboxError::from(arcbox_computer_runtime::ComputerError::StdinGap {
             accepted: 7,
             offset: 9,
         });
@@ -158,14 +160,14 @@ mod tests {
 
     #[test]
     fn paused_maps_to_423_for_the_daemon_auto_resume() {
-        let err = SandboxError::from(arcbox_computer_runtime::VmmError::Paused("box".into()));
+        let err = SandboxError::from(arcbox_computer_runtime::ComputerError::Paused("box".into()));
         assert!(matches!(err, SandboxError::SandboxPaused(_)));
         assert_eq!(err.status_code(), 423);
     }
 
     #[test]
     fn path_not_found_maps_to_404_with_the_classifier_prefix() {
-        let err = SandboxError::from(arcbox_computer_runtime::VmmError::PathNotFound(
+        let err = SandboxError::from(arcbox_computer_runtime::ComputerError::PathNotFound(
             "/a/b".into(),
         ));
         assert!(matches!(err, SandboxError::NotFound(_)));
@@ -176,7 +178,7 @@ mod tests {
 
     #[test]
     fn template_errors_keep_their_classifier_prefixes_and_codes() {
-        let err = SandboxError::from(arcbox_computer_runtime::VmmError::TemplateNotFound(
+        let err = SandboxError::from(arcbox_computer_runtime::ComputerError::TemplateNotFound(
             "code:9.9".into(),
         ));
         assert!(matches!(err, SandboxError::NotFound(_)));
@@ -184,12 +186,12 @@ mod tests {
         // The daemon classifier keys on this exact prefix (TEMPLATE_NOT_FOUND).
         assert_eq!(err.to_string(), "template not found: code:9.9");
 
-        let err = SandboxError::from(arcbox_computer_runtime::VmmError::TemplateVersionExists(
-            "x".into(),
-        ));
+        let err = SandboxError::from(
+            arcbox_computer_runtime::ComputerError::TemplateVersionExists("x".into()),
+        );
         assert_eq!(err.status_code(), 409);
 
-        let err = SandboxError::from(arcbox_computer_runtime::VmmError::FailedPrecondition(
+        let err = SandboxError::from(arcbox_computer_runtime::ComputerError::FailedPrecondition(
             "no draft".into(),
         ));
         assert_eq!(err.status_code(), 412);
@@ -197,7 +199,7 @@ mod tests {
 
     #[test]
     fn directory_not_empty_maps_to_412() {
-        let err = SandboxError::from(arcbox_computer_runtime::VmmError::DirectoryNotEmpty(
+        let err = SandboxError::from(arcbox_computer_runtime::ComputerError::DirectoryNotEmpty(
             "/full".into(),
         ));
         assert_eq!(err.status_code(), 412);
@@ -205,7 +207,7 @@ mod tests {
 
     #[test]
     fn not_a_directory_maps_to_400() {
-        let err = SandboxError::from(arcbox_computer_runtime::VmmError::NotADirectory(
+        let err = SandboxError::from(arcbox_computer_runtime::ComputerError::NotADirectory(
             "/a/file".into(),
         ));
         assert_eq!(err.status_code(), 400);
@@ -213,7 +215,7 @@ mod tests {
 
     #[test]
     fn deadline_maps_to_504_for_the_daemon_deadline_code() {
-        let err = SandboxError::from(arcbox_computer_runtime::VmmError::DeadlineExceeded(
+        let err = SandboxError::from(arcbox_computer_runtime::ComputerError::DeadlineExceeded(
             "no listener on port 8080".into(),
         ));
         assert!(matches!(err, SandboxError::Deadline(_)));
@@ -222,7 +224,7 @@ mod tests {
 
     #[test]
     fn durability_uncertainty_maps_to_503() {
-        let err = SandboxError::from(arcbox_computer_runtime::VmmError::Unavailable(
+        let err = SandboxError::from(arcbox_computer_runtime::ComputerError::Unavailable(
             "record fsync failed".into(),
         ));
         assert!(matches!(err, SandboxError::Unavailable(_)));

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -1,6 +1,6 @@
 //! Sandbox service for the guest agent.
 //!
-//! Wraps [`SandboxManager`] from `arcbox-computer-runtime` and translates
+//! Wraps [`ComputerManager`] from `arcbox-computer-runtime` and translates
 //! between the `sandbox_v1` protobuf types (from `arcbox-connect`) and the
 //! native Rust types used by `arcbox-computer-runtime`. Lifecycle CRUD
 //! lives here; executions, events, file I/O, and snapshots live in the
@@ -19,8 +19,8 @@ use std::sync::{Arc, Mutex, Weak};
 
 use arcbox_computer_runtime::agent::VmProtoAgentFactory;
 use arcbox_computer_runtime::{
-    ComputerError, ComputerMountSpec, ComputerNetworkSpec, ComputerSpec, ComputerState,
-    NodeEnvironment, RootfsBuilder, RootfsPaths, SandboxManager,
+    ComputerError, ComputerManager, ComputerMountSpec, ComputerNetworkSpec, ComputerSpec,
+    ComputerState, NodeEnvironment, RootfsBuilder, RootfsPaths,
 };
 use arcbox_connect::sandbox_v1;
 use arcbox_fc_driver::{FcDriver, FcDriverConfig};
@@ -61,9 +61,9 @@ pub fn probe_kvm() -> Result<(), String> {
     }
 }
 
-/// Thin wrapper around [`SandboxManager`] for use in the agent's RPC layer.
+/// Thin wrapper around [`ComputerManager`] for use in the agent's RPC layer.
 pub struct SandboxService {
-    manager: Arc<SandboxManager>,
+    manager: Arc<ComputerManager>,
     creates: Arc<CreateRegistry>,
     operations: SandboxOperationLocks,
     /// Template names with a Build in flight; a second Build on a busy name
@@ -112,7 +112,7 @@ pub fn rootfs_builder(block_tools: Arc<dyn BlockTools>) -> RootfsBuilder {
 }
 
 /// The environment-specific components the sandbox stack runs on inside
-/// the System VM. This is where they are built: `SandboxManager::new`
+/// the System VM. This is where they are built: `ComputerManager::new`
 /// builds none of them, so the choice of VMM is made here.
 ///
 /// Four components, out of the two halves of `config`:
@@ -186,7 +186,7 @@ impl SandboxService {
     }
 
     pub(crate) fn is_terminal_or_absent(&self, id: &str) -> bool {
-        match self.manager.inspect_sandbox(&id.to_owned()) {
+        match self.manager.inspect_computer(&id.to_owned()) {
             Ok(info) => matches!(info.state, ComputerState::Stopped | ComputerState::Failed),
             Err(ComputerError::NotFound(_)) => true,
             Err(_) => false,
@@ -203,7 +203,7 @@ impl SandboxService {
         let environment = node_environment(&config, block_tools)?;
         // `into_shared` starts the lifecycle monitor driving the idle/TTL
         // expiry timers (CORE-21/60).
-        let manager = SandboxManager::new(config.runtime, environment)
+        let manager = ComputerManager::new(config.runtime, environment)
             .map_err(|e| anyhow::anyhow!("{e}"))?
             .into_shared();
         let creates = Arc::new(CreateRegistry::default());
@@ -305,7 +305,7 @@ impl SandboxService {
         if !request.id.is_empty()
             && let Some((id, ip_address)) = self
                 .manager
-                .replay_sandbox_create(&request.id, create_key)
+                .replay_computer_create(&request.id, create_key)
                 .await
                 .map_err(SandboxError::from)?
         {
@@ -355,7 +355,7 @@ impl SandboxService {
 
         let (id, ip_address) = self
             .manager
-            .create_sandbox_keyed(spec, create_key)
+            .create_computer_keyed(spec, create_key)
             .await
             .map_err(SandboxError::from)?;
         register_sandbox_dns(&id, &ip_address);
@@ -436,7 +436,7 @@ impl SandboxService {
         req: sandbox_v1::StopSandboxRequest,
     ) -> Result<(), SandboxError> {
         self.manager
-            .stop_sandbox(&req.id, req.timeout_seconds)
+            .stop_computer(&req.id, req.timeout_seconds)
             .await
             .map_err(SandboxError::from)?;
         deregister_sandbox_dns(&req.id);
@@ -451,7 +451,7 @@ impl SandboxService {
         req: sandbox_v1::PauseSandboxRequest,
     ) -> Result<(), SandboxError> {
         self.manager
-            .pause_sandbox(&req.id)
+            .pause_computer(&req.id)
             .await
             .map_err(SandboxError::from)?;
         deregister_sandbox_dns(&req.id);
@@ -474,7 +474,7 @@ impl SandboxService {
         };
         let ip_address = self
             .manager
-            .resume_sandbox(&req.id, reason)
+            .resume_computer(&req.id, reason)
             .await
             .map_err(SandboxError::from)?;
         if !ip_address.is_empty() {
@@ -501,7 +501,7 @@ impl SandboxService {
                 .map(|value| idle_action_to_spec(value.as_known().unwrap_or_default())),
         };
         self.manager
-            .set_sandbox_lifecycle(&req.id, update)
+            .set_computer_lifecycle(&req.id, update)
             .await
             .map_err(SandboxError::from)
     }
@@ -519,7 +519,7 @@ impl SandboxService {
         req: sandbox_v1::RemoveSandboxRequest,
     ) -> Result<(), SandboxError> {
         self.manager
-            .remove_sandbox(&req.id, req.force)
+            .remove_computer(&req.id, req.force)
             .await
             .map_err(SandboxError::from)?;
         deregister_sandbox_dns(&req.id);
@@ -533,7 +533,7 @@ impl SandboxService {
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
         let info = self
             .manager
-            .inspect_sandbox(&req.id)
+            .inspect_computer(&req.id)
             .map_err(SandboxError::from)?;
         Ok(convert::info_to_proto(info))
     }
@@ -546,7 +546,7 @@ impl SandboxService {
         let labels: std::collections::HashMap<String, String> = req.labels.into_iter().collect();
         let summaries = self
             .manager
-            .list_sandboxes(state_filter, &labels)
+            .list_computers(state_filter, &labels)
             .map_err(SandboxError::from)?;
         let (page, next_page_token) =
             convert::paginate(summaries, |s| &s.id, req.page_size, &req.page_token);
@@ -564,7 +564,7 @@ impl SandboxService {
         sandbox_id: &str,
     ) -> Result<arcbox_computer_runtime::ComputerNetworkIdentity, SandboxError> {
         self.manager
-            .sandbox_network_identity(sandbox_id)
+            .computer_network_identity(sandbox_id)
             .map_err(SandboxError::from)
     }
 
@@ -692,7 +692,7 @@ impl SandboxService {
         self.creates.clear_completed_if(id, || {
             completed_create_is_stale(
                 self.manager
-                    .inspect_sandbox(&id.to_owned())
+                    .inspect_computer(&id.to_owned())
                     .map(|info| info.state),
             )
         });

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -19,8 +19,8 @@ use std::sync::{Arc, Mutex, Weak};
 
 use arcbox_computer_runtime::agent::VmProtoAgentFactory;
 use arcbox_computer_runtime::{
-    NodeEnvironment, RootfsBuilder, RootfsPaths, SandboxManager, SandboxMountSpec,
-    SandboxNetworkSpec, SandboxSpec, SandboxState, VmmError,
+    ComputerError, NodeEnvironment, RootfsBuilder, RootfsPaths, SandboxManager, SandboxMountSpec,
+    SandboxNetworkSpec, SandboxSpec, SandboxState,
 };
 use arcbox_connect::sandbox_v1;
 use arcbox_fc_driver::{FcDriver, FcDriverConfig};
@@ -188,7 +188,7 @@ impl SandboxService {
     pub(crate) fn is_terminal_or_absent(&self, id: &str) -> bool {
         match self.manager.inspect_sandbox(&id.to_owned()) {
             Ok(info) => matches!(info.state, SandboxState::Stopped | SandboxState::Failed),
-            Err(VmmError::NotFound(_)) => true,
+            Err(ComputerError::NotFound(_)) => true,
             Err(_) => false,
         }
     }
@@ -406,8 +406,8 @@ impl SandboxService {
                     // reclaimed it — from genuine pin corruption. Neither is
                     // a rebuild trigger.
                     return Err(match self.manager.get_template(&resolved.name) {
-                        Err(VmmError::TemplateNotFound(_)) => {
-                            SandboxError::from(VmmError::TemplateNotFound(format!(
+                        Err(ComputerError::TemplateNotFound(_)) => {
+                            SandboxError::from(ComputerError::TemplateNotFound(format!(
                                 "{} (deleted while this create was resolving it)",
                                 resolved.name
                             )))
@@ -699,9 +699,9 @@ impl SandboxService {
     }
 }
 
-fn completed_create_is_stale(state: Result<SandboxState, VmmError>) -> bool {
+fn completed_create_is_stale(state: Result<SandboxState, ComputerError>) -> bool {
     match state {
-        Ok(SandboxState::Stopped | SandboxState::Failed) | Err(VmmError::NotFound(_)) => true,
+        Ok(SandboxState::Stopped | SandboxState::Failed) | Err(ComputerError::NotFound(_)) => true,
         // A paused sandbox is logically alive: the same-id create replay
         // must keep answering until it is actually removed.
         Ok(
@@ -835,10 +835,10 @@ mod tests {
         for state in [SandboxState::Stopped, SandboxState::Failed] {
             assert!(completed_create_is_stale(Ok(state)));
         }
-        assert!(completed_create_is_stale(Err(VmmError::NotFound(
+        assert!(completed_create_is_stale(Err(ComputerError::NotFound(
             "removed".into()
         ))));
-        assert!(!completed_create_is_stale(Err(VmmError::Config(
+        assert!(!completed_create_is_stale(Err(ComputerError::Config(
             "inspect failed".into()
         ))));
     }

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -19,8 +19,8 @@ use std::sync::{Arc, Mutex, Weak};
 
 use arcbox_computer_runtime::agent::VmProtoAgentFactory;
 use arcbox_computer_runtime::{
-    ComputerError, NodeEnvironment, RootfsBuilder, RootfsPaths, SandboxManager, SandboxMountSpec,
-    SandboxNetworkSpec, SandboxSpec, SandboxState,
+    ComputerError, ComputerMountSpec, ComputerNetworkSpec, ComputerSpec, NodeEnvironment,
+    RootfsBuilder, RootfsPaths, SandboxManager, SandboxState,
 };
 use arcbox_connect::sandbox_v1;
 use arcbox_fc_driver::{FcDriver, FcDriverConfig};
@@ -562,7 +562,7 @@ impl SandboxService {
     pub(crate) fn sandbox_network_identity(
         &self,
         sandbox_id: &str,
-    ) -> Result<arcbox_computer_runtime::SandboxNetworkIdentity, SandboxError> {
+    ) -> Result<arcbox_computer_runtime::ComputerNetworkIdentity, SandboxError> {
         self.manager
             .sandbox_network_identity(sandbox_id)
             .map_err(SandboxError::from)
@@ -736,8 +736,8 @@ fn deregister_sandbox_dns(id: &str) {
     }
 }
 
-/// Convert a `CreateSandboxRequest` proto to a [`SandboxSpec`].
-fn proto_to_spec(req: sandbox_v1::CreateSandboxRequest) -> SandboxSpec {
+/// Convert a `CreateSandboxRequest` proto to a [`ComputerSpec`].
+fn proto_to_spec(req: sandbox_v1::CreateSandboxRequest) -> ComputerSpec {
     // An unset `limits`/`network` field derefs to the default instance, and
     // an unknown wire value falls back to UNSPECIFIED — the proto3 defaults.
     let (vcpus, memory_mib) = (req.limits.vcpus, req.limits.memory_mib);
@@ -746,7 +746,7 @@ fn proto_to_spec(req: sandbox_v1::CreateSandboxRequest) -> SandboxSpec {
         // UNSPECIFIED defaults to a networked sandbox.
         sandbox_v1::NetworkMode::Enabled | sandbox_v1::NetworkMode::Unspecified => "tap",
     };
-    SandboxSpec {
+    ComputerSpec {
         id: if req.id.is_empty() {
             None
         } else {
@@ -767,13 +767,13 @@ fn proto_to_spec(req: sandbox_v1::CreateSandboxRequest) -> SandboxSpec {
         mounts: req
             .mounts
             .into_iter()
-            .map(|m| SandboxMountSpec {
+            .map(|m| ComputerMountSpec {
                 source: m.source,
                 target: m.target,
                 readonly: m.readonly,
             })
             .collect(),
-        network: SandboxNetworkSpec { mode: mode.into() },
+        network: ComputerNetworkSpec { mode: mode.into() },
         ttl_seconds: req.ttl_seconds,
         ssh_public_key: req.ssh_public_key,
         idle_timeout_seconds: req.idle_timeout_seconds,

--- a/guest/arcbox-agent/src/sandbox.rs
+++ b/guest/arcbox-agent/src/sandbox.rs
@@ -19,8 +19,8 @@ use std::sync::{Arc, Mutex, Weak};
 
 use arcbox_computer_runtime::agent::VmProtoAgentFactory;
 use arcbox_computer_runtime::{
-    ComputerError, ComputerMountSpec, ComputerNetworkSpec, ComputerSpec, NodeEnvironment,
-    RootfsBuilder, RootfsPaths, SandboxManager, SandboxState,
+    ComputerError, ComputerMountSpec, ComputerNetworkSpec, ComputerSpec, ComputerState,
+    NodeEnvironment, RootfsBuilder, RootfsPaths, SandboxManager,
 };
 use arcbox_connect::sandbox_v1;
 use arcbox_fc_driver::{FcDriver, FcDriverConfig};
@@ -187,7 +187,7 @@ impl SandboxService {
 
     pub(crate) fn is_terminal_or_absent(&self, id: &str) -> bool {
         match self.manager.inspect_sandbox(&id.to_owned()) {
-            Ok(info) => matches!(info.state, SandboxState::Stopped | SandboxState::Failed),
+            Ok(info) => matches!(info.state, ComputerState::Stopped | ComputerState::Failed),
             Err(ComputerError::NotFound(_)) => true,
             Err(_) => false,
         }
@@ -699,18 +699,20 @@ impl SandboxService {
     }
 }
 
-fn completed_create_is_stale(state: Result<SandboxState, ComputerError>) -> bool {
+fn completed_create_is_stale(state: Result<ComputerState, ComputerError>) -> bool {
     match state {
-        Ok(SandboxState::Stopped | SandboxState::Failed) | Err(ComputerError::NotFound(_)) => true,
+        Ok(ComputerState::Stopped | ComputerState::Failed) | Err(ComputerError::NotFound(_)) => {
+            true
+        }
         // A paused sandbox is logically alive: the same-id create replay
         // must keep answering until it is actually removed.
         Ok(
-            SandboxState::Starting
-            | SandboxState::Ready
-            | SandboxState::Running
-            | SandboxState::Stopping
-            | SandboxState::Pausing
-            | SandboxState::Paused,
+            ComputerState::Starting
+            | ComputerState::Ready
+            | ComputerState::Running
+            | ComputerState::Stopping
+            | ComputerState::Pausing
+            | ComputerState::Paused,
         )
         | Err(_) => false,
     }
@@ -825,14 +827,14 @@ mod tests {
     #[test]
     fn completed_create_is_stale_only_after_terminal_or_removed_state() {
         for state in [
-            SandboxState::Starting,
-            SandboxState::Ready,
-            SandboxState::Running,
-            SandboxState::Stopping,
+            ComputerState::Starting,
+            ComputerState::Ready,
+            ComputerState::Running,
+            ComputerState::Stopping,
         ] {
             assert!(!completed_create_is_stale(Ok(state)));
         }
-        for state in [SandboxState::Stopped, SandboxState::Failed] {
+        for state in [ComputerState::Stopped, ComputerState::Failed] {
             assert!(completed_create_is_stale(Ok(state)));
         }
         assert!(completed_create_is_stale(Err(ComputerError::NotFound(

--- a/guest/arcbox-agent/src/sandbox/convert.rs
+++ b/guest/arcbox-agent/src/sandbox/convert.rs
@@ -6,8 +6,8 @@ use arcbox_computer_runtime::template_catalog::{
     ReadyProbeSpec, TemplateDefaultsSpec, TemplateEntry,
 };
 use arcbox_computer_runtime::{
-    CheckpointInfo, CheckpointSummary, ExecutionChannel, ExecutionSnapshot, ExitStatus, IdleAction,
-    SandboxEvent as VmSandboxEvent, SandboxInfo, SandboxState, SandboxSummary, StdinState,
+    CheckpointInfo, CheckpointSummary, ComputerEvent, ComputerInfo, ComputerState, ComputerSummary,
+    ExecutionChannel, ExecutionSnapshot, ExitStatus, IdleAction, StdinState,
 };
 use arcbox_connect::sandbox_v1;
 use buffa_types::google::protobuf::Timestamp;
@@ -69,7 +69,7 @@ pub(super) fn execution_to_proto(snap: &ExecutionSnapshot) -> sandbox_v1::Execut
     };
     sandbox_v1::Execution {
         id: snap.id.clone(),
-        sandbox_id: snap.sandbox_id.clone(),
+        sandbox_id: snap.computer_id.clone(),
         state: state.into(),
         tty: snap.tty,
         started_at: timestamp(snap.started_at).into(),
@@ -140,16 +140,16 @@ pub(super) fn channel_to_proto(channel: ExecutionChannel, tty: bool) -> sandbox_
     }
 }
 
-pub(super) fn state_to_proto(state: SandboxState) -> sandbox_v1::SandboxState {
+pub(super) fn state_to_proto(state: ComputerState) -> sandbox_v1::SandboxState {
     match state {
-        SandboxState::Starting => sandbox_v1::SandboxState::Starting,
-        SandboxState::Ready => sandbox_v1::SandboxState::Ready,
-        SandboxState::Running => sandbox_v1::SandboxState::Running,
-        SandboxState::Stopping => sandbox_v1::SandboxState::Stopping,
-        SandboxState::Stopped => sandbox_v1::SandboxState::Stopped,
-        SandboxState::Failed => sandbox_v1::SandboxState::Failed,
-        SandboxState::Pausing => sandbox_v1::SandboxState::Pausing,
-        SandboxState::Paused => sandbox_v1::SandboxState::Paused,
+        ComputerState::Starting => sandbox_v1::SandboxState::Starting,
+        ComputerState::Ready => sandbox_v1::SandboxState::Ready,
+        ComputerState::Running => sandbox_v1::SandboxState::Running,
+        ComputerState::Stopping => sandbox_v1::SandboxState::Stopping,
+        ComputerState::Stopped => sandbox_v1::SandboxState::Stopped,
+        ComputerState::Failed => sandbox_v1::SandboxState::Failed,
+        ComputerState::Pausing => sandbox_v1::SandboxState::Pausing,
+        ComputerState::Paused => sandbox_v1::SandboxState::Paused,
     }
 }
 
@@ -187,9 +187,9 @@ pub(super) fn event_kind(action: &str) -> sandbox_v1::SandboxEventKind {
     }
 }
 
-pub(super) fn vm_event_to_proto(e: VmSandboxEvent) -> sandbox_v1::SandboxEvent {
+pub(super) fn vm_event_to_proto(e: ComputerEvent) -> sandbox_v1::SandboxEvent {
     sandbox_v1::SandboxEvent {
-        sandbox_id: e.sandbox_id,
+        sandbox_id: e.computer_id,
         kind: event_kind(&e.action).into(),
         time: timestamp_from_unix_nanos(e.timestamp_ns).into(),
         attributes: e.attributes.into_iter().collect(),
@@ -197,7 +197,7 @@ pub(super) fn vm_event_to_proto(e: VmSandboxEvent) -> sandbox_v1::SandboxEvent {
     }
 }
 
-pub(super) fn info_to_proto(info: SandboxInfo) -> sandbox_v1::SandboxInfo {
+pub(super) fn info_to_proto(info: ComputerInfo) -> sandbox_v1::SandboxInfo {
     // The host TAP name is deliberately not exposed (CORE-54): it is a host
     // interface a tenant can neither see nor use.
     let network = info.network.map(|n| sandbox_v1::SandboxNetwork {
@@ -238,7 +238,7 @@ pub(super) fn idle_action_to_proto(action: IdleAction) -> sandbox_v1::IdleAction
     }
 }
 
-pub(super) fn summary_to_proto(s: SandboxSummary) -> sandbox_v1::SandboxSummary {
+pub(super) fn summary_to_proto(s: ComputerSummary) -> sandbox_v1::SandboxSummary {
     sandbox_v1::SandboxSummary {
         id: s.id,
         state: state_to_proto(s.state).into(),
@@ -265,7 +265,7 @@ pub(super) fn checkpoint_to_proto(info: CheckpointInfo) -> sandbox_v1::Checkpoin
 pub(super) fn checkpoint_summary_to_proto(s: CheckpointSummary) -> sandbox_v1::SnapshotSummary {
     sandbox_v1::SnapshotSummary {
         id: s.id,
-        sandbox_id: s.sandbox_id,
+        sandbox_id: s.computer_id,
         name: s.name,
         labels: s.labels.into_iter().collect(),
         created_at: timestamp_from_rfc3339(&s.created_at).into(),

--- a/guest/arcbox-agent/src/sandbox/events.rs
+++ b/guest/arcbox-agent/src/sandbox/events.rs
@@ -66,7 +66,7 @@ impl SandboxService {
                     // waiting for the 1 s rescan below.
                     Ok(event) if event.is_terminal() || event.action == "paused" => {
                         if let Some(ticket) = self
-                            .pending_cleanup_ticket(&event.sandbox_id)
+                            .pending_cleanup_ticket(&event.computer_id)
                             .await
                             .map_err(|error| anyhow::anyhow!(error.to_string()))?
                         {
@@ -152,7 +152,7 @@ impl SandboxService {
                 match bcast_rx.recv().await {
                     Ok(event) => {
                         // Apply filters.
-                        if !filter_id.is_empty() && event.sandbox_id != filter_id {
+                        if !filter_id.is_empty() && event.computer_id != filter_id {
                             continue;
                         }
                         if filter_kind != sandbox_v1::SandboxEventKind::Unspecified

--- a/guest/arcbox-agent/src/sandbox/execution.rs
+++ b/guest/arcbox-agent/src/sandbox/execution.rs
@@ -271,7 +271,7 @@ impl SandboxService {
             .filter(|p| *p != 0)
             .ok_or_else(|| SandboxError::InvalidArgument(format!("invalid port {}", req.port)))?;
         self.manager
-            .wait_sandbox_port(
+            .wait_computer_port(
                 &req.sandbox_id,
                 port,
                 Duration::from_secs(u64::from(req.timeout_seconds)),

--- a/guest/arcbox-agent/src/sandbox/files.rs
+++ b/guest/arcbox-agent/src/sandbox/files.rs
@@ -38,7 +38,7 @@ impl SandboxService {
             }
         };
 
-        let data = match self.manager.read_sandbox_file(&req.id, &req.path).await {
+        let data = match self.manager.read_computer_file(&req.id, &req.path).await {
             Ok(d) => d,
             Err(e) => {
                 let e = SandboxError::from(e);
@@ -144,7 +144,7 @@ impl SandboxService {
         let mode = if open.mode == 0 { 0o644 } else { open.mode };
         match self
             .manager
-            .write_sandbox_file(&open.id, &open.path, mode, &data)
+            .write_computer_file(&open.id, &open.path, mode, &data)
             .await
         {
             Ok(()) => {
@@ -165,7 +165,7 @@ impl SandboxService {
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
         let dto = self
             .manager
-            .stat_sandbox_path(&req.id, &req.path)
+            .stat_computer_path(&req.id, &req.path)
             .await
             .map_err(SandboxError::from)?;
         Ok(convert::file_stat_to_proto(&dto))
@@ -180,7 +180,7 @@ impl SandboxService {
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
         let entries = self
             .manager
-            .list_sandbox_dir(&req.id, &req.path)
+            .list_computer_dir(&req.id, &req.path)
             .await
             .map_err(SandboxError::from)?;
         Ok(sandbox_v1::ListDirResponse {
@@ -195,7 +195,7 @@ impl SandboxService {
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
         let mode = if req.mode == 0 { 0o755 } else { req.mode };
         self.manager
-            .make_sandbox_dir(&req.id, &req.path, mode)
+            .make_computer_dir(&req.id, &req.path, mode)
             .await
             .map_err(SandboxError::from)
     }
@@ -205,7 +205,7 @@ impl SandboxService {
         let req = sandbox_v1::RemoveEntryRequest::decode_from_slice(payload)
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
         self.manager
-            .remove_sandbox_path(&req.id, &req.path, req.recursive)
+            .remove_computer_path(&req.id, &req.path, req.recursive)
             .await
             .map_err(SandboxError::from)
     }
@@ -215,7 +215,7 @@ impl SandboxService {
         let req = sandbox_v1::MoveEntryRequest::decode_from_slice(payload)
             .map_err(|e| SandboxError::Decode(e.to_string()))?;
         self.manager
-            .move_sandbox_path(&req.id, &req.from_path, &req.to_path)
+            .move_computer_path(&req.id, &req.from_path, &req.to_path)
             .await
             .map_err(SandboxError::from)
     }
@@ -249,7 +249,7 @@ impl SandboxService {
 
         let mut watch = match self
             .manager
-            .watch_sandbox_dir(&req.id, &req.path, req.recursive)
+            .watch_computer_dir(&req.id, &req.path, req.recursive)
             .await
         {
             Ok(watch) => watch,

--- a/guest/arcbox-agent/src/sandbox/snapshots.rs
+++ b/guest/arcbox-agent/src/sandbox/snapshots.rs
@@ -18,7 +18,7 @@ impl SandboxService {
         let _operation = self.operations.lock(&req.sandbox_id).await;
         let info = self
             .manager
-            .checkpoint_sandbox(&req.sandbox_id, req.name, req.labels.into_iter().collect())
+            .checkpoint_computer(&req.sandbox_id, req.name, req.labels.into_iter().collect())
             .await
             .map_err(SandboxError::from)?;
         Ok(convert::checkpoint_to_proto(info))
@@ -50,10 +50,10 @@ impl SandboxService {
         };
         let (id, ip_address) = self
             .manager
-            .restore_sandbox_keyed(spec, &restore_key)
+            .restore_computer_keyed(spec, &restore_key)
             .await
             .map_err(SandboxError::from)?;
-        let live = self.manager.inspect_sandbox(&id).is_ok_and(|info| {
+        let live = self.manager.inspect_computer(&id).is_ok_and(|info| {
             matches!(
                 info.state,
                 ComputerState::Starting | ComputerState::Ready | ComputerState::Running

--- a/guest/arcbox-agent/src/sandbox/snapshots.rs
+++ b/guest/arcbox-agent/src/sandbox/snapshots.rs
@@ -1,6 +1,6 @@
 //! Sandbox checkpoint / restore handlers.
 
-use arcbox_computer_runtime::{RestoreSandboxSpec, SandboxState};
+use arcbox_computer_runtime::{RestoreComputerSpec, SandboxState};
 use arcbox_connect::sandbox_v1;
 use buffa::Message;
 
@@ -37,7 +37,7 @@ impl SandboxService {
         if !req.id.is_empty() {
             self.clear_stale_completed_create(&req.id);
         }
-        let spec = RestoreSandboxSpec {
+        let spec = RestoreComputerSpec {
             id: if req.id.is_empty() {
                 None
             } else {

--- a/guest/arcbox-agent/src/sandbox/snapshots.rs
+++ b/guest/arcbox-agent/src/sandbox/snapshots.rs
@@ -1,6 +1,6 @@
 //! Sandbox checkpoint / restore handlers.
 
-use arcbox_computer_runtime::{RestoreComputerSpec, SandboxState};
+use arcbox_computer_runtime::{ComputerState, RestoreComputerSpec};
 use arcbox_connect::sandbox_v1;
 use buffa::Message;
 
@@ -56,7 +56,7 @@ impl SandboxService {
         let live = self.manager.inspect_sandbox(&id).is_ok_and(|info| {
             matches!(
                 info.state,
-                SandboxState::Starting | SandboxState::Ready | SandboxState::Running
+                ComputerState::Starting | ComputerState::Ready | ComputerState::Running
             ) && info
                 .network
                 .is_some_and(|network| network.ip_address == ip_address)

--- a/guest/arcbox-agent/src/sandbox/templates.rs
+++ b/guest/arcbox-agent/src/sandbox/templates.rs
@@ -1,7 +1,7 @@
 //! Template catalog handlers (CORE-107).
 //!
 //! Decode → manager → encode glue over the catalog surface on
-//! [`SandboxManager`](arcbox_computer_runtime::SandboxManager), plus the Build
+//! [`ComputerManager`](arcbox_computer_runtime::ComputerManager), plus the Build
 //! orchestrator, which drives the existing rootfs pipeline (`template.rs`
 //! export + `RootfsBuilder` conversion) and registers the result as the
 //! catalog draft. `template.rs` (singular) is the

--- a/guest/arcbox-agent/src/sandbox/templates.rs
+++ b/guest/arcbox-agent/src/sandbox/templates.rs
@@ -228,7 +228,7 @@ impl SandboxService {
             // whose warm restore points at missing artifacts. Leave the
             // copy; the error is retryable and the referenced-or-orphan
             // outcome is safe either way.
-            Err(error @ arcbox_computer_runtime::VmmError::Unavailable(_)) => {
+            Err(error @ arcbox_computer_runtime::ComputerError::Unavailable(_)) => {
                 Err(SandboxError::from(error))
             }
             Err(error) => {

--- a/guest/arcbox-agent/tests/sandbox_manager_e2e.rs
+++ b/guest/arcbox-agent/tests/sandbox_manager_e2e.rs
@@ -46,8 +46,8 @@ use std::time::Duration;
 use arcbox_agent::config::{AdapterConfig, GuestConfig};
 use arcbox_agent::sandbox::{block_tools, node_environment};
 use arcbox_computer_runtime::{
-    DefaultVmConfig, FirecrackerConfig, GrpcConfig, NetworkConfig, RuntimeConfig, SandboxEvent,
-    SandboxManager, SandboxNetworkSpec, SandboxSpec, SandboxState,
+    ComputerNetworkSpec, ComputerSpec, DefaultVmConfig, FirecrackerConfig, GrpcConfig,
+    NetworkConfig, RuntimeConfig, SandboxEvent, SandboxManager, SandboxState,
 };
 
 // ---------------------------------------------------------------------------
@@ -104,10 +104,10 @@ fn try_config(data_dir: &str) -> Option<GuestConfig> {
     })
 }
 
-/// Return a SandboxSpec with networking disabled (no TAP, no root required).
-fn no_tap() -> SandboxSpec {
-    SandboxSpec {
-        network: SandboxNetworkSpec {
+/// Return a ComputerSpec with networking disabled (no TAP, no root required).
+fn no_tap() -> ComputerSpec {
+    ComputerSpec {
+        network: ComputerNetworkSpec {
             mode: "none".into(),
         },
         ..Default::default()
@@ -454,7 +454,7 @@ async fn e2e_sandbox_outlives_its_manager_and_is_adopted() {
         let mgr = manager(cfg);
         finalize_startup_cleanup(&mgr).await;
         let mut events = mgr.subscribe_events();
-        let (id, ip) = mgr.create_sandbox(SandboxSpec::default()).await.unwrap();
+        let (id, ip) = mgr.create_sandbox(ComputerSpec::default()).await.unwrap();
         assert!(
             wait_for_event(&mut events, &id, "ready").await,
             "sandbox did not reach ready"

--- a/guest/arcbox-agent/tests/sandbox_manager_e2e.rs
+++ b/guest/arcbox-agent/tests/sandbox_manager_e2e.rs
@@ -46,8 +46,8 @@ use std::time::Duration;
 use arcbox_agent::config::{AdapterConfig, GuestConfig};
 use arcbox_agent::sandbox::{block_tools, node_environment};
 use arcbox_computer_runtime::{
-    ComputerEvent, ComputerNetworkSpec, ComputerSpec, ComputerState, DefaultVmConfig,
-    FirecrackerConfig, GrpcConfig, NetworkConfig, RuntimeConfig, SandboxManager,
+    ComputerEvent, ComputerManager, ComputerNetworkSpec, ComputerSpec, ComputerState,
+    DefaultVmConfig, FirecrackerConfig, GrpcConfig, NetworkConfig, RuntimeConfig,
 };
 
 // ---------------------------------------------------------------------------
@@ -116,14 +116,14 @@ fn no_tap() -> ComputerSpec {
 
 /// A manager over the environment `SandboxService::new` composes: this
 /// suite exercises the real composition rather than one of its own.
-fn manager(cfg: GuestConfig) -> SandboxManager {
+fn manager(cfg: GuestConfig) -> ComputerManager {
     let environment = node_environment(&cfg, block_tools()).unwrap();
-    SandboxManager::new(cfg.runtime, environment).unwrap()
+    ComputerManager::new(cfg.runtime, environment).unwrap()
 }
 
 /// Complete the startup cleanup handshake for a manager backed by a fresh
 /// test directory, where no stale host resources exist.
-async fn finalize_startup_cleanup(mgr: &SandboxManager) {
+async fn finalize_startup_cleanup(mgr: &ComputerManager) {
     let token = mgr
         .startup_cleanup_token()
         .await
@@ -181,22 +181,22 @@ async fn e2e_sandbox_basic_lifecycle() {
     let mgr = manager(cfg);
     let mut events = mgr.subscribe_events();
 
-    let (id, _ip) = mgr.create_sandbox(no_tap()).await.unwrap();
+    let (id, _ip) = mgr.create_computer(no_tap()).await.unwrap();
     assert!(
         wait_for_event(&mut events, &id, "ready").await,
         "sandbox did not reach ready state"
     );
 
-    let info = mgr.inspect_sandbox(&id).unwrap();
+    let info = mgr.inspect_computer(&id).unwrap();
     assert_eq!(info.state, ComputerState::Ready);
 
-    mgr.stop_sandbox(&id, 5).await.unwrap();
-    let info = mgr.inspect_sandbox(&id).unwrap();
+    mgr.stop_computer(&id, 5).await.unwrap();
+    let info = mgr.inspect_computer(&id).unwrap();
     assert_eq!(info.state, ComputerState::Stopped);
 
-    mgr.remove_sandbox(&id, true).await.unwrap();
+    mgr.remove_computer(&id, true).await.unwrap();
     assert!(
-        mgr.inspect_sandbox(&id).is_err(),
+        mgr.inspect_computer(&id).is_err(),
         "sandbox should be gone after remove"
     );
 }
@@ -215,13 +215,13 @@ async fn e2e_event_broadcast_ready() {
     let mgr = manager(cfg);
     let mut events = mgr.subscribe_events();
 
-    let (id, _) = mgr.create_sandbox(no_tap()).await.unwrap();
+    let (id, _) = mgr.create_computer(no_tap()).await.unwrap();
     assert!(
         wait_for_event(&mut events, &id, "ready").await,
         "expected ready event for sandbox {id}"
     );
 
-    mgr.remove_sandbox(&id, true).await.unwrap();
+    mgr.remove_computer(&id, true).await.unwrap();
 }
 
 /// Create two sandboxes with TAP networking and verify they receive distinct
@@ -247,8 +247,8 @@ async fn e2e_two_sandboxes_distinct_ips() {
     let mut ev1 = mgr.subscribe_events();
     let mut ev2 = mgr.subscribe_events();
 
-    let (id1, ip1) = mgr.create_sandbox(Default::default()).await.unwrap();
-    let (id2, ip2) = mgr.create_sandbox(Default::default()).await.unwrap();
+    let (id1, ip1) = mgr.create_computer(Default::default()).await.unwrap();
+    let (id2, ip2) = mgr.create_computer(Default::default()).await.unwrap();
 
     assert_ne!(ip1, ip2, "sandboxes must receive distinct IP addresses");
 
@@ -261,12 +261,12 @@ async fn e2e_two_sandboxes_distinct_ips() {
         "sandbox 2 did not reach ready"
     );
 
-    mgr.remove_sandbox(&id1, true).await.unwrap();
-    mgr.remove_sandbox(&id2, true).await.unwrap();
+    mgr.remove_computer(&id1, true).await.unwrap();
+    mgr.remove_computer(&id2, true).await.unwrap();
 }
 
 /// Create a sandbox with TAP networking, verify the TAP interface exists while
-/// it is running, then verify it is removed after `remove_sandbox`.
+/// it is running, then verify it is removed after `remove_computer`.
 /// Requires root.
 #[tokio::test]
 #[ignore = "requires FC_BINARY/FC_KERNEL/FC_ROOTFS environment variables and root"]
@@ -286,7 +286,7 @@ async fn e2e_sandbox_with_tap_network() {
     finalize_startup_cleanup(&mgr).await;
     let mut events = mgr.subscribe_events();
 
-    let (id, ip) = mgr.create_sandbox(Default::default()).await.unwrap();
+    let (id, ip) = mgr.create_computer(Default::default()).await.unwrap();
     assert!(!ip.is_empty(), "tap mode should assign an IP address");
     assert!(
         wait_for_event(&mut events, &id, "ready").await,
@@ -294,7 +294,7 @@ async fn e2e_sandbox_with_tap_network() {
     );
 
     let tap_name = {
-        let info = mgr.inspect_sandbox(&id).unwrap();
+        let info = mgr.inspect_computer(&id).unwrap();
         let net = info.network.expect("tap mode should populate network info");
         // The host interface is deliberately not part of the sandbox API
         // (CORE-54); this test owns the host, so it derives the name the
@@ -312,7 +312,7 @@ async fn e2e_sandbox_with_tap_network() {
         tap_name
     };
 
-    mgr.remove_sandbox(&id, true).await.unwrap();
+    mgr.remove_computer(&id, true).await.unwrap();
 
     assert!(
         !common::iface_exists(&tap_name),
@@ -336,14 +336,14 @@ async fn e2e_run_command() {
     let mgr = manager(cfg);
     let mut events = mgr.subscribe_events();
 
-    let (id, _) = mgr.create_sandbox(no_tap()).await.unwrap();
+    let (id, _) = mgr.create_computer(no_tap()).await.unwrap();
     assert!(
         wait_for_event(&mut events, &id, "ready").await,
         "sandbox did not reach ready"
     );
 
     let mut rx = mgr
-        .run_in_sandbox(
+        .run_in_computer(
             &id,
             vec!["echo".into(), "hello from vm".into()],
             HashMap::new(),
@@ -377,7 +377,7 @@ async fn e2e_run_command() {
     );
     assert_eq!(exit_code, 0, "echo should exit with code 0");
 
-    mgr.remove_sandbox(&id, true).await.unwrap();
+    mgr.remove_computer(&id, true).await.unwrap();
 }
 
 /// The VMM pid the sandbox's crash journal names, so the test can prove a
@@ -454,7 +454,7 @@ async fn e2e_sandbox_outlives_its_manager_and_is_adopted() {
         let mgr = manager(cfg);
         finalize_startup_cleanup(&mgr).await;
         let mut events = mgr.subscribe_events();
-        let (id, ip) = mgr.create_sandbox(ComputerSpec::default()).await.unwrap();
+        let (id, ip) = mgr.create_computer(ComputerSpec::default()).await.unwrap();
         assert!(
             wait_for_event(&mut events, &id, "ready").await,
             "sandbox did not reach ready"
@@ -487,7 +487,7 @@ async fn e2e_sandbox_outlives_its_manager_and_is_adopted() {
         mgr.finalize_startup_cleanup(&token).await.unwrap();
     }
 
-    let info = mgr.inspect_sandbox(&id).unwrap();
+    let info = mgr.inspect_computer(&id).unwrap();
     assert_eq!(
         info.state,
         ComputerState::Ready,
@@ -507,7 +507,7 @@ async fn e2e_sandbox_outlives_its_manager_and_is_adopted() {
     // An exec proves the vsock path was re-established, not just that the
     // process is alive: this agent was built from the adopted handle.
     let mut rx = mgr
-        .run_in_sandbox(
+        .run_in_computer(
             &id,
             vec!["echo".into(), "still here".into()],
             HashMap::new(),
@@ -540,8 +540,8 @@ async fn e2e_sandbox_outlives_its_manager_and_is_adopted() {
 
     // And the adopted sandbox is still removable — through the handle, since
     // no PreparedVm crosses a restart.
-    mgr.remove_sandbox(&id, true).await.unwrap();
-    assert!(mgr.inspect_sandbox(&id).is_err());
+    mgr.remove_computer(&id, true).await.unwrap();
+    assert!(mgr.inspect_computer(&id).is_err());
     {
         assert!(!firecracker_alive(pid), "remove left a firecracker behind");
         assert!(

--- a/guest/arcbox-agent/tests/sandbox_manager_e2e.rs
+++ b/guest/arcbox-agent/tests/sandbox_manager_e2e.rs
@@ -46,8 +46,8 @@ use std::time::Duration;
 use arcbox_agent::config::{AdapterConfig, GuestConfig};
 use arcbox_agent::sandbox::{block_tools, node_environment};
 use arcbox_computer_runtime::{
-    ComputerEvent, ComputerManager, ComputerNetworkSpec, ComputerSpec, ComputerState,
-    DefaultVmConfig, FirecrackerConfig, GrpcConfig, NetworkConfig, RuntimeConfig,
+    ComputerConfig, ComputerEvent, ComputerManager, ComputerNetworkSpec, ComputerSpec,
+    ComputerState, DefaultVmConfig, GrpcConfig, NetworkConfig, RuntimeConfig,
 };
 
 // ---------------------------------------------------------------------------
@@ -60,7 +60,7 @@ fn try_config(data_dir: &str) -> Option<GuestConfig> {
     let kernel = std::env::var("FC_KERNEL").ok()?;
     let rootfs = std::env::var("FC_ROOTFS").ok()?;
     let runtime = RuntimeConfig {
-        firecracker: FirecrackerConfig {
+        firecracker: ComputerConfig {
             jailer: None,
             data_dir: data_dir.to_owned(),
             // Direct mode cannot restore (and so never pools); keep the

--- a/guest/arcbox-agent/tests/sandbox_manager_e2e.rs
+++ b/guest/arcbox-agent/tests/sandbox_manager_e2e.rs
@@ -46,8 +46,8 @@ use std::time::Duration;
 use arcbox_agent::config::{AdapterConfig, GuestConfig};
 use arcbox_agent::sandbox::{block_tools, node_environment};
 use arcbox_computer_runtime::{
-    ComputerNetworkSpec, ComputerSpec, DefaultVmConfig, FirecrackerConfig, GrpcConfig,
-    NetworkConfig, RuntimeConfig, SandboxEvent, SandboxManager, SandboxState,
+    ComputerEvent, ComputerNetworkSpec, ComputerSpec, ComputerState, DefaultVmConfig,
+    FirecrackerConfig, GrpcConfig, NetworkConfig, RuntimeConfig, SandboxManager,
 };
 
 // ---------------------------------------------------------------------------
@@ -136,14 +136,14 @@ async fn finalize_startup_cleanup(mgr: &SandboxManager) {
 /// or until a `"failed"` event for `id` is received, or a 30-second timeout
 /// expires.  Returns `true` on success.
 async fn wait_for_event(
-    rx: &mut tokio::sync::broadcast::Receiver<SandboxEvent>,
+    rx: &mut tokio::sync::broadcast::Receiver<ComputerEvent>,
     id: &str,
     action: &str,
 ) -> bool {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     loop {
         match tokio::time::timeout_at(deadline, rx.recv()).await {
-            Ok(Ok(ev)) if ev.sandbox_id == id => {
+            Ok(Ok(ev)) if ev.computer_id == id => {
                 if ev.action == action {
                     return true;
                 }
@@ -188,11 +188,11 @@ async fn e2e_sandbox_basic_lifecycle() {
     );
 
     let info = mgr.inspect_sandbox(&id).unwrap();
-    assert_eq!(info.state, SandboxState::Ready);
+    assert_eq!(info.state, ComputerState::Ready);
 
     mgr.stop_sandbox(&id, 5).await.unwrap();
     let info = mgr.inspect_sandbox(&id).unwrap();
-    assert_eq!(info.state, SandboxState::Stopped);
+    assert_eq!(info.state, ComputerState::Stopped);
 
     mgr.remove_sandbox(&id, true).await.unwrap();
     assert!(
@@ -490,7 +490,7 @@ async fn e2e_sandbox_outlives_its_manager_and_is_adopted() {
     let info = mgr.inspect_sandbox(&id).unwrap();
     assert_eq!(
         info.state,
-        SandboxState::Ready,
+        ComputerState::Ready,
         "the sandbox is usable again, not failed"
     );
     assert_eq!(

--- a/guest/arcbox-agent/tests/sandbox_service_manager.rs
+++ b/guest/arcbox-agent/tests/sandbox_service_manager.rs
@@ -6,9 +6,7 @@ use arcbox_agent::config::{AdapterConfig, GuestConfig};
 use arcbox_agent::error::SandboxError;
 use arcbox_agent::sandbox::SandboxService;
 use arcbox_computer_runtime::RuntimeConfig;
-use arcbox_computer_runtime::config::{
-    DefaultVmConfig, FirecrackerConfig, GrpcConfig, NetworkConfig,
-};
+use arcbox_computer_runtime::config::{ComputerConfig, DefaultVmConfig, GrpcConfig, NetworkConfig};
 use arcbox_connect::sandbox_v1::{
     CreateSandboxRequest, InspectSandboxRequest, ListSandboxesRequest, NetworkMode, NetworkSpec,
     RemoveSandboxRequest, SandboxState, StartExecutionRequest, StopSandboxRequest,
@@ -28,7 +26,7 @@ fn test_config() -> GuestConfig {
     let data_dir = format!("/tmp/arcbox-agent-test-{}", std::process::id());
 
     let runtime = RuntimeConfig {
-        firecracker: FirecrackerConfig {
+        firecracker: ComputerConfig {
             jailer: None,
             data_dir: data_dir.clone(),
             // Direct mode cannot restore (and so never pools or serves

--- a/virt/arcbox-tap-net/README.md
+++ b/virt/arcbox-tap-net/README.md
@@ -56,7 +56,7 @@ The `NetworkLease` carries VM, address, prefix, gateway, MAC and cleanup
 token; the allocation is rebuilt from it (TAP name from the address,
 resolvers from the network), so there is no side table to keep. Errors:
 `TapNetError` maps variant for variant into
-`arcbox_computer_runtime::VmmError` (`WrongState` / `Unavailable` keep
+`arcbox_computer_runtime::ComputerError` (`WrongState` / `Unavailable` keep
 their 412 / 503 meaning) and into the port's `Error` (`Unavailable` and
 `PreconditionFailed` carry the same two answers; `Io` keeps its shape, the
 faults land on `Network`).

--- a/virt/arcbox-vm-proto/src/boot.rs
+++ b/virt/arcbox-vm-proto/src/boot.rs
@@ -12,8 +12,8 @@ use std::str::FromStr;
 ///
 /// Format: `ip=<client>::<gateway>:<netmask>::eth0:off`
 ///
-/// Constructed by the sandbox manager
-/// (`arcbox_computer_runtime::SandboxManager`) when building boot args, and
+/// Constructed by the computer manager
+/// (`arcbox_computer_runtime::ComputerManager`) when building boot args, and
 /// parsed by `vm-agent` to derive the DNS nameserver from the gateway.
 ///
 /// [`fmt::Display`] and [`FromStr`] round-trip through the same format so the


### PR DESCRIPTION
The last item of vm-stack-redesign R3. `computer/AGENTS.md` recorded it as
deliberate debt: the crate is `arcbox-computer-runtime`, but its types still
read `SandboxManager` / `SandboxSpec` / `VmmError`. This is that rename, and
nothing else — no behavior change, no signature change beyond the names, no
file moves.

## The rule

**An identifier renames only if `arcbox-computer-runtime` defines it.**

"Sandbox" is also a published public API — the `arcbox.sandbox.v1` protos, the
Connect services, `abctl sandbox`, and the TypeScript / Python / Rust SDKs.
That surface is additive-only under the CI `buf breaking` gate and does not
rename. `git diff --stat origin/master -- rpc/ sdk/` is empty; the diff touches
exactly two crates, `computer/arcbox-computer-runtime` and
`guest/arcbox-agent`.

The consequence is visible in the guest agent: it now names both vocabularies
in one function, e.g.

```rust
ComputerState::Ready => sandbox_v1::SandboxState::Ready
```

That is the translation layer being what it is, not drift. Four files where the
wire spelling is used *unqualified* are untouched for the same reason
(`examples/sandbox_smoke.rs`, `tests/sandbox_service_manager.rs`,
`src/agent/linux/sandbox.rs`, `src/sandbox/events.rs`).

## The mapping

| today | after |
|---|---|
| `SandboxManager` | `ComputerManager` |
| `SandboxId` | `ComputerId` |
| `SandboxSpec` / `RestoreSandboxSpec` | `ComputerSpec` / `RestoreComputerSpec` |
| `SandboxState` / `SandboxEvent` / `SandboxInfo` / `SandboxSummary` | `Computer*` |
| `SandboxMountSpec` / `SandboxNetworkSpec` / `SandboxNetworkInfo` / `SandboxNetworkIdentity` | `Computer*` |
| `SandboxRecord` / `SandboxRecordStore` / `SandboxStateRecord` | `Computer*` |
| `SandboxPhase` / `SandboxProvisionOutcome` / `SandboxTransition` / `AdoptedSandbox` | `ComputerPhase` / `ComputerProvisionOutcome` / `ComputerTransition` / `AdoptedComputer` |
| `VmmError` | `ComputerError` |
| `FirecrackerConfig` | `ComputerConfig` |
| `create_sandbox` / `inspect_sandbox` / … | `create_computer` / `inspect_computer` / … |
| the `sandbox_id` field/param | `computer_id` |

`VmmConfig` → `RuntimeConfig` already happened in G5b. `FirecrackerConfig` is in
scope because G5 emptied it of Firecracker: what is left is a data directory, an
isolation spec, and the pool and copy-on-write policy every computer boots
under. Its `[firecracker]` TOML key is frozen and does not move.

## What did not move

- **The on-disk vocabulary**, per `computer/AGENTS.md`: `sandbox-records/`,
  `sandboxes/`, `state.json`, `sandbox-network-quarantine`, `arcbox.warm_key`,
  the `pool-` prefix, `arcbox-cow-{id}` / `arcbox-snap-{id}`.
- **Every serialized name.** Five renamed structs and one renamed enum are
  serialized. Serde emits a struct's *field* names, never its type name, and
  `ComputerPhase`'s variants (`Creating` … `Resuming`) contain no "sandbox", so
  no `#[serde(rename)]` was needed anywhere. Proven mechanically, not asserted:
  the serde-visible shape of every `Serialize`/`Deserialize` type in the crate —
  field names, variant names and every `#[serde(..)]` attribute at type and
  member level — is **identical** between `origin/master` and this branch. The
  diff changes no `#[serde` line at all.
- **Prose meaning the product concept.** "a sandbox", "sandbox creation
  parameters" and the like stay; only doc comments that *name* a renamed type
  moved with it.
- **The module path `crate::sandbox`.** It is a 35-file, 133-line edit with no
  compile-time or on-disk consequence, and Rust has no way to do it in a
  commit that both compiles and touches no content — so it was left out to keep
  the type rename reviewable.

## Aliases

None. `computer/AGENTS.md` anticipated `compat.rs` aliases for the guest agent,
but the workspace has exactly one consumer of these types (`guest/arcbox-agent`)
and this PR updates it, so aliases would be dead code from birth.

## One observable change

Structured-log field names follow the rename: the runtime now emits
`computer_id=…` where it emitted `sandbox_id=…`. Nothing in this repo parses
those fields — readiness is observed over `WatchSetupStatus`, never by
log-grep — but it is the one thing in this PR that a human watching a log will
notice.

## Checks

- `cargo fmt --check` clean
- `cargo clippy --workspace --exclude arcbox-agent -- -D warnings` clean (CI's form)
- `cargo test --workspace --exclude arcbox-agent` green
- `cargo clippy -p arcbox-agent --target aarch64-unknown-linux-musl --all-targets` —
  the agent's known pedantic backlog, with the warning multiset **identical** to
  `origin/master`'s: zero new warnings
- `cargo check -p arcbox-agent --target aarch64-unknown-linux-musl --all-targets` clean
- `cargo xtask check-layers` — 65 members, 165 edges, 2 grandfathered (unchanged)
- `git diff --stat origin/master -- rpc/ sdk/` empty

Two local failures are pre-existing and unreachable from this diff:
`arcbox-hypervisor`'s two `--all-targets`-only clippy warnings (CI does not pass
`--all-targets`), and `arcbox-fleet-agent`'s `control.rs` host-capability
assertion, which probes this dev machine. Neither crate is in the dependency
graph of anything renamed here.

## Follow-ups, deliberately not here

- `computer/AGENTS.md`'s "Transitional naming" bullet is retired by this work,
  but that file needs human approval, so its diff is handed over separately
  rather than committed here.
- `test-vm-linux.yml`'s job label `SandboxService -> SandboxManager integration`
  now names a type that no longer exists. It is display text, #689 already edits
  that file, and renaming a job mid-flight risks leaving a required check
  unreported — so it belongs with #689 or after it, not here.
- `virt/arcbox-tap-net/bpf/sandbox_nat.bpf.c:119` cites
  `arcbox_computer_runtime::network::invariant::GUEST_IP`, a path R3 PR-G5
  removed. Stale before this PR, so it belongs to that change.
