### PR TITLE
fix(computer): journal the VMM's socket so an adopt can reach it

### DIFF
--- a/computer/arcbox-computer-runtime/src/lifecycle/flows/restore.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/flows/restore.rs
@@ -23,7 +23,7 @@ use crate::lifecycle::tasks::resume::restore_paused;
 use crate::lifecycle::tasks::{TaskFailure, TaskResult};
 use crate::sandbox::reconcile::{JournaledLease, SandboxStateRecord, write_state_record};
 use crate::sandbox::record::SandboxProvisionOutcome;
-use crate::sandbox::{journaled_pid, pool};
+use crate::sandbox::{journaled_api_socket, journaled_pid, pool};
 
 impl ComputerFlows {
     /// The restore proper: claim a pre-warmed slot or prepare and stage a
@@ -103,7 +103,11 @@ impl ComputerFlows {
                     &services.config,
                     None,
                 )
-                .map(|record| record.with_pool_slot(pool_slot_id.as_deref()))
+                .map(|record| {
+                    record
+                        .with_api_socket(failure.prepared.as_deref().and_then(journaled_api_socket))
+                        .with_pool_slot(pool_slot_id.as_deref())
+                })
                 .and_then(|record| write_state_record(&vm_dir, &record));
                 if let Err(error) = journal {
                     warn!(sandbox_id = %self.id, %error, "the failed restore's journal was not written");

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
@@ -186,6 +186,7 @@ pub async fn do_boot(
     };
 
     let process_pid = sandbox::journaled_pid(&*prepared);
+    let api_socket = sandbox::journaled_api_socket(&*prepared);
     let journal_error = sandbox::reconcile::SandboxStateRecord::new(
         id,
         process_pid,
@@ -194,6 +195,7 @@ pub async fn do_boot(
         config,
         None,
     )
+    .map(|record| record.with_api_socket(api_socket.clone()))
     .and_then(|record| sandbox::reconcile::write_state_record(vm_dir, &record))
     .err();
 
@@ -251,6 +253,7 @@ pub async fn do_boot(
                     config,
                     None,
                 )
+                .map(|record| record.with_api_socket(api_socket.clone()))
                 .and_then(|record| sandbox::reconcile::write_state_record(vm_dir, &record))
             };
             let staged = stage_rootfs_cow_or_copy(
@@ -295,7 +298,8 @@ pub async fn do_boot(
                         cow_handle.as_ref(),
                         config,
                         None,
-                    )?;
+                    )?
+                    .with_api_socket(api_socket.clone());
                     sandbox::reconcile::write_state_record(vm_dir, &record)?;
                     create_rootfs_symlink(vm_dir, &cow_handle.as_ref().unwrap().dm_device)?
                 }

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
@@ -158,7 +158,11 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
                 config,
                 None,
             )
-            .map(|record| record.with_pool_slot(Some(&slot.slot_id)))
+            .map(|record| {
+                record
+                    .with_api_socket(sandbox::journaled_api_socket(&*slot.prepared))
+                    .with_pool_slot(Some(&slot.slot_id))
+            })
             .and_then(|record| sandbox::reconcile::write_state_record(vm_dir, &record));
             let PreparedSlot {
                 slot_id,
@@ -239,6 +243,7 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
             };
 
             let pid = sandbox::journaled_pid(&*spawned_prepared);
+            let api_socket = sandbox::journaled_api_socket(&*spawned_prepared);
             let journal = |cow: Option<&CowHandle>| {
                 sandbox::reconcile::SandboxStateRecord::new(
                     new_id,
@@ -250,6 +255,7 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
                     config,
                     None,
                 )
+                .map(|record| record.with_api_socket(api_socket.clone()))
                 .and_then(|record| sandbox::reconcile::write_state_record(vm_dir, &record))
             };
             if let Err(error) = journal(None) {
@@ -466,7 +472,11 @@ pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm
         config,
         None,
     )
-    .map(|record| record.with_pool_slot(adopted_slot.as_deref()))
+    .map(|record| {
+        record
+            .with_api_socket(sandbox::journaled_api_socket(&*prepared))
+            .with_pool_slot(adopted_slot.as_deref())
+    })
     .and_then(|record| sandbox::reconcile::write_state_record(vm_dir, &record));
     if let Err(error) = final_journal {
         return Err(RestoreFailure {

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/resume.rs
@@ -70,14 +70,29 @@ pub async fn restore_paused(
                     .await?,
             );
         }
-        let journal = |pid: Option<i32>, cow: Option<&CowHandle>, net: Option<&NetworkLease>| {
+        // The VMM travels as itself rather than as a pid, so its socket cannot
+        // be left behind: a record naming a live VMM without one is not
+        // adoptable under the jailer, and resume is jailer-only.
+        let journal = |vmm: Option<&Arc<dyn PreparedVm>>,
+                       cow: Option<&CowHandle>,
+                       net: Option<&NetworkLease>| {
             // The lease attaches the way the snapshot says, exactly as
             // the `activate` below does — the same expression, so the
             // journal and the datapath cannot disagree.
             let net =
                 net.map(|lease| JournaledLease::from_snapshot(lease, snap_meta.net_invariant));
-            sandbox::reconcile::SandboxStateRecord::new(id, pid, net, cow, config, None)
-                .and_then(|record| sandbox::reconcile::write_state_record(vm_dir, &record))
+            sandbox::reconcile::SandboxStateRecord::new(
+                id,
+                vmm.and_then(|vmm| sandbox::journaled_pid(&**vmm)),
+                net,
+                cow,
+                config,
+                None,
+            )
+            .map(|record| {
+                record.with_api_socket(vmm.and_then(|vmm| sandbox::journaled_api_socket(&**vmm)))
+            })
+            .and_then(|record| sandbox::reconcile::write_state_record(vm_dir, &record))
         };
         journal(None, None, lease.as_ref())?;
         if let Some(lease) = &lease {
@@ -99,10 +114,9 @@ pub async fn restore_paused(
                 .prepare(&VmId::new(id)?, &IsolationSpec::try_from(jailer)?, vm_dir)
                 .await?,
         );
-        let pid = sandbox::journaled_pid(&*spawned);
         let staging = sandbox::staging_capability(spawned.staging());
         prepared = Some(Arc::clone(&spawned));
-        journal(pid, None, lease.as_ref())?;
+        journal(Some(&spawned), None, lease.as_ref())?;
 
         // Bring the kernel, the retained disk and the checkpoint into the
         // area the fresh VMM reads from.
@@ -117,7 +131,7 @@ pub async fn restore_paused(
                 ))
             })?;
             let handle = cow_manager.reattach(id, template).await?;
-            journal(pid, Some(&handle), lease.as_ref())?;
+            journal(prepared.as_ref(), Some(&handle), lease.as_ref())?;
             let staged = staging
                 .stage_disk(
                     ROOTFS_DISK_ID,
@@ -212,7 +226,7 @@ pub async fn restore_paused(
             .and_then(|r| r)?;
         }
 
-        journal(pid, cow_handle.as_ref(), lease.as_ref())?;
+        journal(prepared.as_ref(), cow_handle.as_ref(), lease.as_ref())?;
         Ok(ResumedRuntime {
             prepared: prepared.take().expect("prepared set above"),
             handle,

--- a/computer/arcbox-computer-runtime/src/sandbox.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox.rs
@@ -615,6 +615,19 @@ pub(crate) fn journaled_pid(prepared: &dyn PreparedVm) -> Option<i32> {
         .and_then(|process| i32::try_from(process.pid).ok())
 }
 
+/// The VMM's API socket as the crash journal records it: what lets the next
+/// process adopt this VM instead of killing it.
+///
+/// The driver knows the path because it spawned the VMM there. Nothing else
+/// can work it out afterwards — see
+/// [`SandboxStateRecord::api_socket`](crate::sandbox::reconcile::SandboxStateRecord::api_socket).
+pub(crate) fn journaled_api_socket(prepared: &dyn PreparedVm) -> Option<PathBuf> {
+    prepared
+        .record()
+        .process
+        .and_then(|process| process.api_socket)
+}
+
 /// The isolation every sandbox VMM runs under: the jailer's, when one is
 /// configured; none otherwise (direct mode).
 pub(crate) fn isolation_spec(config: &RuntimeConfig) -> Result<IsolationSpec> {

--- a/computer/arcbox-computer-runtime/src/sandbox/pool.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/pool.rs
@@ -176,10 +176,12 @@ async fn stage_slot(
             .map_err(VmmError::from)?,
     );
     let pid = super::journaled_pid(&*prepared);
+    let api_socket = super::journaled_api_socket(&*prepared);
     let journal = |cow: Option<&CowHandle>| {
         reconcile::write_state_record(
             vm_dir,
-            &SandboxStateRecord::new(slot_id, pid, None, cow, config, None)?,
+            &SandboxStateRecord::new(slot_id, pid, None, cow, config, None)?
+                .with_api_socket(api_socket.clone()),
         )
     };
     let carry = |error: VmmError, prepared, cow_handle| SlotFailure {

--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -202,6 +202,20 @@ pub struct SandboxStateRecord {
     /// there.
     #[serde(default)]
     pub net_invariant: bool,
+    /// The VMM's API socket, as this host reaches it.
+    ///
+    /// Written because a jailed VMM's socket cannot be re-derived by the
+    /// process that adopts it. The jailer unshares a mount namespace and
+    /// pivots into the chroot, so `/proc/<pid>/root` reads back as `/` from
+    /// outside and nothing there names the jail; it also execs Firecracker
+    /// without `--api-sock`, so the command line does not carry the path
+    /// either. An adopt that cannot reach the API settles for a handle it can
+    /// only kill, and the sweep then takes down a live guest.
+    ///
+    /// `None` for a record with no VMM of its own, and in every record
+    /// written before this field existed — those adopt exactly as before.
+    #[serde(default)]
+    pub api_socket: Option<PathBuf>,
 }
 
 /// How a lease's host side was attached, in the journal's own vocabulary.
@@ -346,7 +360,18 @@ impl SandboxStateRecord {
             pool_slot_id: None,
             attach_mode: network.map(|net| net.mode.into()),
             net_invariant: network.is_some_and(|net| net.invariant_identity),
+            api_socket: None,
         })
+    }
+
+    /// Record where the VMM's API socket is, for the process that adopts it.
+    ///
+    /// Separate from [`Self::new`] because only the paths that hold a VMM can
+    /// answer it: a cleanup record written after teardown has none. See
+    /// [`Self::api_socket`] for why it cannot be re-derived later.
+    pub fn with_api_socket(mut self, socket: Option<PathBuf>) -> Self {
+        self.api_socket = socket;
+        self
     }
 
     /// The lease this record's network field stands for, for a sweep that
@@ -1306,7 +1331,7 @@ fn vm_record(
             .and_then(|pid| u32::try_from(pid).ok())
             .map(|pid| ProcessRecord {
                 pid,
-                api_socket: None,
+                api_socket: record.api_socket.clone(),
             }),
     })
 }
@@ -1543,6 +1568,10 @@ mod tests {
             fields.remove("net_invariant"),
             Some(serde_json::json!(true))
         );
+        // Null here rather than absent, and null for exactly the reason a
+        // cleanup record has no socket: the constructor never knows one, only
+        // the boot and restore paths that hold the VMM do.
+        assert_eq!(fields.remove("api_socket"), Some(serde_json::Value::Null));
         assert_eq!(
             value,
             serde_json::from_str::<serde_json::Value>(LEGACY_RECORD).unwrap()
@@ -1746,16 +1775,54 @@ mod tests {
             pool_slot_id: Some("pool-1".into()),
             attach_mode: Some(JournaledAttachMode::Invariant),
             net_invariant: true,
+            api_socket: Some("/srv/jailer/firecracker/sb-1/root/run/firecracker.socket".into()),
         };
         let bytes = serde_json::to_vec(&record).unwrap();
         let parsed: SandboxStateRecord = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(parsed.id, "sb-1");
         assert_eq!(parsed.pid, Some(42));
+        // The socket has to survive the round trip: an adopt that cannot read
+        // it back kills the VM it was meant to reclaim.
+        assert_eq!(
+            parsed.api_socket.as_deref(),
+            Some(Path::new(
+                "/srv/jailer/firecracker/sb-1/root/run/firecracker.socket"
+            ))
+        );
         assert!(parsed.jailer);
         assert_eq!(parsed.pool_slot_id.as_deref(), Some("pool-1"));
         assert_eq!(parsed.resource_owner(), "pool-1");
         let handle = parsed.cow.unwrap().to_handle();
         assert_eq!(handle.dm_name, "arcbox-snap-sb-1");
+    }
+
+    /// The journal is the only place a jailed VMM's socket survives, so the
+    /// record the sweep hands `Adopt` has to carry it: without it the driver
+    /// re-derives one from `/proc/<pid>/root`, which reads `/` for a jailed
+    /// VMM, dials a path nothing bound, and settles for a kill-only handle.
+    #[test]
+    fn the_adopt_record_carries_the_journaled_api_socket() {
+        use arcbox_vm_driver::testkit::FakeDriver;
+
+        let socket = Path::new("/srv/jailer/firecracker/box/root/run/firecracker.socket");
+        let journaled = SandboxStateRecord {
+            id: "box".into(),
+            pid: Some(4242),
+            network: None,
+            cow: None,
+            jailer: true,
+            restore_origin_dir: None,
+            pool_slot_id: None,
+            attach_mode: None,
+            net_invariant: false,
+            api_socket: Some(socket.to_path_buf()),
+        };
+
+        let record = vm_record(&FakeDriver::new(), Path::new("/data/box"), &journaled).unwrap();
+
+        let process = record.process.expect("a journaled pid is a process");
+        assert_eq!(process.pid, 4242);
+        assert_eq!(process.api_socket.as_deref(), Some(socket));
     }
 
     #[test]
@@ -1782,6 +1849,7 @@ mod tests {
             pool_slot_id: slot.map(str::to_owned),
             attach_mode: None,
             net_invariant: false,
+            api_socket: None,
         };
 
         // Slot-keyed resources validate against the slot id, not the sandbox id.

--- a/engine/arcbox-snapshot/src/snapshot_cow.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow.rs
@@ -79,6 +79,29 @@ const TEMPLATE_LOOP_DIR: &str = ".template-loops";
 const TEMPLATE_PENDING_PREFIX: &str = "pending-";
 const TEMPLATE_MARKER_TEMP_PREFIX: &str = ".tmp-";
 
+/// Whether device-mapper holds a device by this name.
+///
+/// Asked of the kernel rather than of `/dev/mapper`, for the same reason
+/// [`dm_device_path`] does not trust that directory: a teardown that reads a
+/// missing symlink as a missing device skips the removal and reports success,
+/// leaving the device and everything under it attached for good.
+fn dm_present(dm_name: &str) -> bool {
+    Path::new(&format!("/dev/mapper/{dm_name}")).exists() || devtmpfs_dm_node(dm_name).is_some()
+}
+
+/// The kernel's own node for `dm_name`, found by matching `dm/name` in sysfs.
+fn devtmpfs_dm_node(dm_name: &str) -> Option<String> {
+    std::fs::read_dir("/sys/block")
+        .ok()?
+        .flatten()
+        .find_map(|entry| -> Option<String> {
+            let name = entry.file_name();
+            let device = name.to_str().filter(|name| name.starts_with("dm-"))?;
+            let mapped = std::fs::read_to_string(entry.path().join("dm/name")).ok()?;
+            (mapped.trim() == dm_name).then(|| format!("/dev/{device}"))
+        })
+}
+
 /// Validate that `sandbox_id` can be used as the suffix of a dm-name.
 ///
 /// Device-mapper allows `[A-Za-z0-9_+.-]` (see kernel `validate_name`).
@@ -597,7 +620,7 @@ impl CowManager {
         let mut failures = Vec::new();
 
         // 1. Remove dm device.
-        let dm_removed = if !Path::new(&handle.dm_device).exists() {
+        let dm_removed = if !dm_present(&handle.dm_name) {
             true
         } else {
             match dmsetup_remove(dmsetup, &handle.dm_name).await {
@@ -680,7 +703,7 @@ impl CowManager {
             .ok_or_else(|| SnapshotError::DeviceMapper("dmsetup binary not found".into()))?;
         let mut failures = Vec::new();
 
-        if Path::new(&handle.dm_device).exists()
+        if dm_present(&handle.dm_name)
             && let Err(error) = dmsetup_remove(dmsetup, &handle.dm_name).await
         {
             failures.push(format!("remove {}: {error}", handle.dm_name));
@@ -748,6 +771,20 @@ async fn run_cmd(mut cmd: Command) -> Result<std::process::Output> {
 }
 
 /// Create a dm-snapshot device via `dmsetup create`.
+///
+/// Followed by `dmsetup mknodes`, which is what makes `/dev/mapper/<name>`
+/// exist on a host running no udevd. Whether `dmsetup create` creates that
+/// node itself depends on how the binary was built: the System VM's makes it
+/// directly, while a distro's is built against libudev and defers to rules
+/// that never run when there is no daemon — leaving the device live, listed
+/// by `dmsetup ls`, and reachable only through the kernel's own `/dev/dm-N`.
+/// Everything downstream names the device by its `/dev/mapper` path, so it
+/// has to be there: without it the guest's disk is staged as a full rootfs
+/// copy instead of an overlay, and teardown reads a live device as gone.
+///
+/// A no-op where udev already made the node, and not fatal if it fails —
+/// the caller's first use of the path reports a missing node far more
+/// specifically than a failed `mknodes` could.
 async fn dmsetup_create(bin: &Path, name: &str, table: &str) -> Result<()> {
     let mut cmd = Command::new(bin);
     cmd.args(["create", name, "--table", table]);
@@ -759,6 +796,18 @@ async fn dmsetup_create(bin: &Path, name: &str, table: &str) -> Result<()> {
         return Err(SnapshotError::DeviceMapper(format!(
             "dmsetup create {name}: {stderr}"
         )));
+    }
+
+    let mut mknodes = Command::new(bin);
+    mknodes.args(["mknodes", name]);
+    match run_cmd(mknodes).await {
+        Ok(output) if !output.status.success() => debug!(
+            name,
+            stderr = %String::from_utf8_lossy(&output.stderr),
+            "dmsetup mknodes reported a failure"
+        ),
+        Err(error) => debug!(name, %error, "could not run dmsetup mknodes"),
+        Ok(_) => {}
     }
     Ok(())
 }

--- a/engine/arcbox-snapshot/src/snapshot_cow.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow.rs
@@ -81,8 +81,8 @@ const TEMPLATE_MARKER_TEMP_PREFIX: &str = ".tmp-";
 
 /// Whether device-mapper holds a device by this name.
 ///
-/// Asked of the kernel rather than of `/dev/mapper`, for the same reason
-/// [`dm_device_path`] does not trust that directory: a teardown that reads a
+/// Asked of the kernel rather than of `/dev/mapper`, because that directory
+/// is only as good as the udev rules that populate it: a teardown reading a
 /// missing symlink as a missing device skips the removal and reports success,
 /// leaving the device and everything under it attached for good.
 fn dm_present(dm_name: &str) -> bool {
@@ -782,9 +782,11 @@ async fn run_cmd(mut cmd: Command) -> Result<std::process::Output> {
 /// has to be there: without it the guest's disk is staged as a full rootfs
 /// copy instead of an overlay, and teardown reads a live device as gone.
 ///
-/// A no-op where udev already made the node, and not fatal if it fails —
-/// the caller's first use of the path reports a missing node far more
-/// specifically than a failed `mknodes` could.
+/// A no-op where udev already made the node. If the node is still missing
+/// afterwards this fails rather than returning a handle whose device path
+/// resolves to nothing: the caller's next step stats that path, reads ENOENT
+/// as "no dm-snapshot here", and stages a full copy of the rootfs instead —
+/// so a setup that returned `Ok` would have quietly cost a Computer 32 GB.
 async fn dmsetup_create(bin: &Path, name: &str, table: &str) -> Result<()> {
     let mut cmd = Command::new(bin);
     cmd.args(["create", name, "--table", table]);
@@ -800,14 +802,21 @@ async fn dmsetup_create(bin: &Path, name: &str, table: &str) -> Result<()> {
 
     let mut mknodes = Command::new(bin);
     mknodes.args(["mknodes", name]);
-    match run_cmd(mknodes).await {
-        Ok(output) if !output.status.success() => debug!(
+    let mknodes = run_cmd(mknodes).await?;
+    if !mknodes.status.success() {
+        warn!(
             name,
-            stderr = %String::from_utf8_lossy(&output.stderr),
-            "dmsetup mknodes reported a failure"
-        ),
-        Err(error) => debug!(name, %error, "could not run dmsetup mknodes"),
-        Ok(_) => {}
+            stderr = %String::from_utf8_lossy(&mknodes.stderr),
+            "dmsetup mknodes failed"
+        );
+    }
+    let node = format!("/dev/mapper/{name}");
+    if !Path::new(&node).exists() {
+        return Err(SnapshotError::DeviceMapper(format!(
+            "dm device {name} exists but has no node at {node}, and dmsetup mknodes did not \
+             create one; a sandbox would silently copy its whole rootfs instead of using this \
+             overlay"
+        )));
     }
     Ok(())
 }

--- a/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
+++ b/engine/arcbox-snapshot/src/snapshot_cow/persistence.rs
@@ -409,7 +409,11 @@ impl CowManager {
         let mut failures = Vec::new();
         let mut orphan = SetupOrphan::default();
         let dm_removed = match dm_name {
-            Some(dm_name) if Path::new(&format!("/dev/mapper/{dm_name}")).exists() => {
+            // Asked of device-mapper rather than of `/dev/mapper`: a setup
+            // that failed *because* the node was never created still has a
+            // live device to reclaim, and stat-ing the absent node would
+            // strand exactly what this rollback exists to remove.
+            Some(dm_name) if super::dm_present(dm_name) => {
                 let cleanup = match self.dmsetup_bin.as_deref() {
                     Some(dmsetup) => dmsetup_remove(dmsetup, dm_name).await,
                     None => Err(SnapshotError::DeviceMapper(


### PR DESCRIPTION
Closes CORE-149. Supersedes #696, which does not work — see below.

Two fixes, both found by running platform's node-agent acceptance suite on a Debian 13 node with nested KVM. All six of its tests pass with this branch; three of them failed without it.

## Why #696 does not fix it

#696 makes the fallback jail-aware, but the branch it adds is never reached. `default_api_socket` only takes it when `jail_root_of(pid)` resolves a jail, and that reads `/proc/<pid>/root` and discards `/`. For a jailed VMM that link **is** `/`:

```
pid=6996 root=/ cmd=/firecracker --id inst-019e409e-…
```

The jailer unshares a mount namespace and pivots into the chroot, so from outside there is no host path for its root and the kernel reports `/`. `jail_root_of` returns `None`, the direct-mode fallback wins exactly as before, and the adopt still ends at the kill-only handle. Measured on the same box, with #696 in the build.

Anything else deriving the chroot base from `jail_root` (`root.ancestors().nth(3)`) is dead for the same reason.

## What actually goes wrong

The socket is not something adoption should be deriving at all. The driver knows it, because it spawned the VMM there — but the runtime's crash journal records only a pid, so `vm_record` builds the record the sweep hands `Adopt` with `api_socket: None` hardcoded, and `journaled_pid` throws away the rest of a `VmRecord` that already carried the path.

So the first commit journals it beside the pid and hands it back. Adoption derives nothing, and the fix holds in direct mode and under the jailer alike.

The field is additive, `#[serde(default)]`, and the struct does not deny unknown fields: a record written before it exists adopts exactly as it did, and an older agent ignores the key. `RECORD_VERSION` is a different record type and is untouched. The legacy-shape test declares the new key, as it does for `attach_mode` and `net_invariant`.

## The second bug, found in the same run

With adoption fixed, the suite still failed on leaked dm devices and a guest whose rootfs had been copied rather than overlaid. Cause is a build difference this file already half-documents:

> Follows symlinks, so `/dev/mapper/<name>` resolves whether device-mapper created a node there itself (no udev, the System VM) or udev left a symlink to `/dev/dm-N` (a stock distro).

The System VM's `dmsetup` does create the node itself. A distro's is built against libudev and defers to rules that never fire when no udevd runs, so `/dev/mapper/<name>` is never created while the device is live and listed by `dmsetup ls`. Two paths then read a missing symlink as a missing device:

- staging stats it to mknod the guest's disk into the jail, fails with ENOENT, and **silently falls back to copying the whole rootfs** — 32 GB per sandbox for a Computer, at `debug` level
- `teardown_checked` treats it as already removed, never issues `dmsetup remove`, logs `dm-snapshot teardown complete`, and leaves the device and both loops attached until the next agent's stale sweep

`dmsetup mknodes` after create is libdevmapper's own answer to this and a no-op where udev already ran. Teardown now asks device-mapper whether the device exists rather than stat-ing the symlink.

An earlier attempt recorded `/dev/dm-N` in the handle instead. It fixed the boot path and then broke the sweep, which validates a record's CoW resources against the `/dev/mapper` form and rejected its own journal. The canonical name stays in the record.

## Verification

- `arcbox-computer-runtime` 209 tests, `arcbox-snapshot` 79 tests, clippy and fmt clean
- `arcbox-agent` and `arcbox-vm-proto` check clean with `--all-targets`; nothing outside the runtime crate constructs `SandboxStateRecord`
- platform `bins/arcbox-e2e/tests/agent_lifecycle.rs`, all six tests, on Debian 13 (trixie) with nested KVM, jailer on, eBPF datapath: cold boot, image rejection, repeat create, egress, delete-with-no-residue, and re-adopt across an agent restart
- a new unit test asserts the adopt record carries the journaled socket, which is the assertion #696's test could not make

The full workspace does not build on Linux (`arcbox-vz`, `arcbox-helper` are macOS-only), so CI on a Mac runner is the real gate for everything outside these two crates.
