### PR TITLE
fix(fc): an adopted vm keeps the jail it was booted in

### DIFF
--- a/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/reconcile.rs
@@ -1332,6 +1332,11 @@ fn vm_record(
             .map(|pid| ProcessRecord {
                 pid,
                 api_socket: record.api_socket.clone(),
+                // Not journaled yet. Adoption reads a missing jail as
+                // unconfined, which is the answer the `/proc` inference it
+                // replaces reached for a jailed VMM anyway: a jailer that
+                // has pivoted shows a root of `/`.
+                jail: None,
             }),
     })
 }

--- a/virt/arcbox-fc-driver/src/adopt.rs
+++ b/virt/arcbox-fc-driver/src/adopt.rs
@@ -16,14 +16,14 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use arcbox_vm_driver::{ProcessRecord, Result, VmHandle, VmRecord};
+use arcbox_vm_driver::{JailRecord, ProcessRecord, Result, VmHandle, VmRecord};
 use fc_sdk::Client;
 use fc_sdk::types::{FullVmConfiguration, InstanceInfo, InstanceInfoState};
 
 use crate::api;
-use crate::config::FcDriverConfig;
 use crate::discover::Found;
 use crate::handle::{FcHandle, FcProcessHandle};
+use crate::jail::Jail;
 use crate::listener::VsockEndpoint;
 use crate::process::FcProcess;
 use crate::render::VmLayout;
@@ -43,17 +43,22 @@ pub const API_TIMEOUT: Duration = Duration::from_secs(2);
 /// the recorded pid may have been recycled and the VM found by the `/proc`
 /// scan instead, and the API socket may have come off its command line.
 pub(crate) async fn rebuild(
-    config: &FcDriverConfig,
     found: Found,
     record: &VmRecord,
     api_timeout: Duration,
 ) -> Result<Box<dyn VmHandle>> {
-    let layout = VmLayout::new(&record.id, &found.isolation, config, &record.runtime_dir)?;
+    let jail = recorded_jail(record);
+    let layout = VmLayout::adopted(
+        &record.id,
+        jail.clone().map(Jail::from),
+        &record.runtime_dir,
+    )?;
     let process = Arc::new(FcProcess::adopt(found.pid, found.api_socket.clone()));
     let record = VmRecord {
         process: Some(ProcessRecord {
             pid: found.pid,
             api_socket: Some(found.api_socket.clone()),
+            jail,
         }),
         ..record.clone()
     };
@@ -81,6 +86,21 @@ pub(crate) async fn rebuild(
     )))
 }
 
+/// The jail the record names, which is where the VM is confined — or
+/// nothing, both for a VM that runs unconfined and for a record written
+/// before the jail was recorded.
+///
+/// The second case is the pre-CORE-155 behaviour, kept because it is all
+/// such a record supports: the jail cannot be recovered from the process
+/// (`discover`), and recomputing one from this process's configuration
+/// would aim a `shutdown`'s jail removal at a directory nothing checked.
+fn recorded_jail(record: &VmRecord) -> Option<JailRecord> {
+    record
+        .process
+        .as_ref()
+        .and_then(|process| process.jail.clone())
+}
+
 /// The instance's state and its devices — what a full handle is built from.
 async fn describe(client: &Client) -> crate::error::Result<(InstanceInfo, FullVmConfiguration)> {
     let info = api::describe(client).await?;
@@ -91,10 +111,10 @@ async fn describe(client: &Client) -> crate::error::Result<(InstanceInfo, FullVm
 /// The fallback, and the warning that says why: the VM stays a process
 /// this driver can kill, and nothing more.
 ///
-/// The layout still comes along. Where the VM runs is read off the process,
-/// not asked of the API, so an unreachable API costs the handle its devices
-/// — never the disks staged into its area, nor its ability to take that
-/// area down with the VM.
+/// The layout still comes along. Where the VM runs is what the record says,
+/// not something asked of the API, so an unreachable API costs the handle
+/// its devices — never the disks staged into its area, nor its ability to
+/// take that area down with the VM.
 fn process_only(
     process: Arc<FcProcess>,
     record: VmRecord,
@@ -110,7 +130,7 @@ fn process_only(
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use arcbox_vm_driver::{IsolationSpec, ShutdownMode, VmId, VmState};
+    use arcbox_vm_driver::{ShutdownMode, VmId, VmState};
 
     use super::*;
     use crate::NAME;
@@ -118,8 +138,13 @@ mod tests {
     use crate::process::UNKNOWN_EXIT;
 
     /// A `sleep` child standing in for the orphan, its `Found`, and the
-    /// record the sweep would hand over — a stale pid, no socket.
-    fn orphan(api_socket: PathBuf, runtime_dir: &Path) -> (tokio::process::Child, Found, VmRecord) {
+    /// record the sweep would hand over — a stale pid, no socket, and
+    /// `jail` as the caller wants it.
+    fn orphan(
+        api_socket: PathBuf,
+        runtime_dir: &Path,
+        jail: Option<JailRecord>,
+    ) -> (tokio::process::Child, Found, VmRecord) {
         let child = tokio::process::Command::new("sleep")
             .arg("30")
             .spawn()
@@ -127,7 +152,6 @@ mod tests {
         let found = Found {
             pid: child.id().unwrap(),
             api_socket,
-            isolation: IsolationSpec::None,
         };
         let record = VmRecord {
             id: VmId::new("box").unwrap(),
@@ -136,13 +160,10 @@ mod tests {
             process: Some(ProcessRecord {
                 pid: u32::try_from(i32::MAX - 1).unwrap(),
                 api_socket: None,
+                jail,
             }),
         };
         (child, found, record)
-    }
-
-    fn config() -> FcDriverConfig {
-        FcDriverConfig::new("/opt/fc/firecracker")
     }
 
     /// Kills through the handle and proves the child was reaped by it.
@@ -157,9 +178,9 @@ mod tests {
     #[tokio::test]
     async fn an_orphan_whose_api_socket_is_missing_is_adopted_by_its_process() {
         let dir = tempfile::tempdir().unwrap();
-        let (child, found, record) = orphan(dir.path().join("absent.sock"), dir.path());
+        let (child, found, record) = orphan(dir.path().join("absent.sock"), dir.path(), None);
         let pid = found.pid;
-        let vm = rebuild(&config(), found, &record, API_TIMEOUT)
+        let vm = rebuild(found, &record, API_TIMEOUT)
             .await
             .expect("a verified process is adopted whatever its api does");
         assert_eq!(vm.state(), VmState::Running);
@@ -189,10 +210,10 @@ mod tests {
                 });
             }
         });
-        let (child, found, record) = orphan(socket, dir.path());
+        let (child, found, record) = orphan(socket, dir.path(), None);
         let bound = Duration::from_millis(300);
         let started = tokio::time::Instant::now();
-        let vm = rebuild(&config(), found, &record, bound)
+        let vm = rebuild(found, &record, bound)
             .await
             .expect("a wedged api does not fail the adopt");
         assert!(
@@ -223,10 +244,8 @@ mod tests {
             "GET /vm/config" => (200, devices.clone()),
             other => panic!("the driver called {other} unexpectedly"),
         });
-        let (child, found, record) = orphan(fc.socket().to_path_buf(), dir.path());
-        let vm = rebuild(&config(), found, &record, API_TIMEOUT)
-            .await
-            .expect("adopt");
+        let (child, found, record) = orphan(fc.socket().to_path_buf(), dir.path(), None);
+        let vm = rebuild(found, &record, API_TIMEOUT).await.expect("adopt");
         assert_eq!(fc.calls(), ["GET /", "GET /vm/config"]);
         // The full handle: the paused state and the vsock device read back.
         assert_eq!(vm.state(), VmState::Quiesced);
@@ -234,6 +253,64 @@ mod tests {
         let listener = vm.vsock_listener().unwrap().listen(51).await.unwrap();
         assert!(dir.path().join("source/firecracker.vsock_51").exists());
         drop(listener);
+        kill_through(&*vm, child).await;
+    }
+
+    /// A jailed VM must come back jailed. Nothing about the live process
+    /// says so — the jailer has pivoted, and `/proc/<pid>/root` reads `/`
+    /// — so the record is the only witness, and an adopt that ignores it
+    /// rebuilds the VM as direct-mode: the guest is then dialled at the
+    /// in-chroot path as if it were a host path, and a checkpoint, which
+    /// needs the chroot, is refused outright (CORE-155).
+    #[tokio::test]
+    async fn a_jailed_vmm_is_adopted_into_the_jail_its_record_names() {
+        let dir = tempfile::tempdir().unwrap();
+        // An abbreviation of the real `{base}/{exec}/{id}/root`, kept to
+        // the one level that carries meaning. Shallow because the listener
+        // below binds `<root>/run/firecracker.vsock_51` and macOS caps
+        // `sun_path` at 104 bytes, of which `$TMPDIR` alone spends ~59 —
+        // the full shape would buy realism at the cost of the test binding
+        // at all. But not flat: `host_view` only joins onto the root, while
+        // `Jail::remove` deletes `root.parent()`, so the shutdown in
+        // `kill_through` takes whatever sits one level up. Here that is a
+        // per-VM directory, as in the real layout; with the root directly
+        // in the scratch dir it would be FakeFc's socket and
+        // `record.runtime_dir` too.
+        let root = dir.path().join("j/root");
+        std::fs::create_dir_all(root.join("run")).unwrap();
+        // Firecracker reports the vsock at the path it sees from inside the
+        // chroot; the host reaches it under the jail root.
+        let fc = FakeFc::start(dir.path(), |route, _| match route {
+            "GET /" => (
+                200,
+                r#"{"app_name":"fake","id":"box","state":"Running","vmm_version":"1.10.1"}"#.into(),
+            ),
+            "GET /vm/config" => (
+                200,
+                r#"{"vsock":{"guest_cid":3,"uds_path":"/run/firecracker.vsock"}}"#.into(),
+            ),
+            other => panic!("the driver called {other} unexpectedly"),
+        });
+        // This process's own ids: binding a listener in the jail chowns it
+        // to them, which only root may do across users.
+        let jail = JailRecord {
+            root: root.clone(),
+            uid: nix::unistd::getuid().as_raw(),
+            gid: nix::unistd::getgid().as_raw(),
+        };
+        let (child, found, record) =
+            orphan(fc.socket().to_path_buf(), dir.path(), Some(jail.clone()));
+
+        let vm = rebuild(found, &record, API_TIMEOUT).await.expect("adopt");
+
+        // Checkpointable, which only a jailed VM is.
+        assert!(vm.checkpoint().is_some());
+        // The vsock resolves inside the jail, not at the host's `/run`.
+        let listener = vm.vsock_listener().unwrap().listen(51).await.unwrap();
+        assert!(root.join("run/firecracker.vsock_51").exists());
+        drop(listener);
+        // And the jail travels on, so the next adopt starts from it too.
+        assert_eq!(vm.record().process.unwrap().jail, Some(jail));
         kill_through(&*vm, child).await;
     }
 }

--- a/virt/arcbox-fc-driver/src/discover.rs
+++ b/virt/arcbox-fc-driver/src/discover.rs
@@ -11,10 +11,18 @@
 //! All three read `/proc`, so nothing is adopted off Linux: an unverified
 //! pid is a VM this driver would later signal, and Firecracker needs KVM
 //! anyway.
+//!
+//! Identity is all `/proc` is asked for. What the VM *is* — its control
+//! socket, the jail it is confined to — comes off the record, because a
+//! jailer that has pivoted into its chroot leaves `/proc/<pid>/root`
+//! reading `/` to everyone outside it (CORE-149, CORE-155). The one place
+//! the jail is still consulted is a `--api-sock` read off the command
+//! line, which is chroot-relative and needs a root to be made absolute
+//! against.
 
 use std::path::{Path, PathBuf};
 
-use arcbox_vm_driver::{IsolationSpec, VmRecord};
+use arcbox_vm_driver::VmRecord;
 
 use crate::config::FcDriverConfig;
 
@@ -25,10 +33,6 @@ pub struct Found {
     pub pid: u32,
     /// The API socket as the host connects to it.
     pub api_socket: PathBuf,
-    /// The confinement the process runs under, as far as `/proc` tells:
-    /// jailed (uid, gid and chroot base read back; namespaces and cgroup
-    /// unknown) or not.
-    pub isolation: IsolationSpec,
 }
 
 /// The Firecracker `record` names, if one is still running.
@@ -41,34 +45,18 @@ pub fn find(config: &FcDriverConfig, record: &VmRecord) -> Option<Found> {
         .map(|p| p.pid)
         .filter(|pid| identity.matches(*pid))
         .or_else(|| identity.scan_proc())?;
-    let jail_root = jail_root_of(pid);
+    // The jail the record names, else whatever `/proc` will admit to —
+    // which for a jailer that has already pivoted is nothing.
+    let jail_root = record
+        .process
+        .as_ref()
+        .and_then(|process| process.jail.as_ref())
+        .map(|jail| jail.root.clone())
+        .or_else(|| jail_root_of(pid));
     let api_socket = recorded_socket
         .or_else(|| cmdline_api_socket(pid, jail_root.as_deref()))
         .unwrap_or_else(|| record.runtime_dir.join("firecracker.sock"));
-    let isolation = match jail_root {
-        Some(root) => {
-            let (uid, gid) = process_ids(pid).unwrap_or((0, 0));
-            // {chroot_base}/{exec}/{id}/root → chroot_base.
-            let chroot_base = root.ancestors().nth(3).map_or_else(
-                || PathBuf::from(crate::jail::DEFAULT_CHROOT_BASE),
-                Path::to_path_buf,
-            );
-            IsolationSpec::Jailer {
-                uid,
-                gid,
-                chroot_base,
-                netns: None,
-                new_pid_ns: false,
-                cgroup: None,
-            }
-        }
-        None => IsolationSpec::None,
-    };
-    Some(Found {
-        pid,
-        api_socket,
-        isolation,
-    })
+    Some(Found { pid, api_socket })
 }
 
 /// True when `pid` is alive and (on Linux) named like a Firecracker binary.
@@ -125,27 +113,6 @@ fn cmdline_api_socket(pid: u32, jail_root: Option<&Path>) -> Option<PathBuf> {
     #[cfg(not(target_os = "linux"))]
     {
         let _ = (pid, jail_root);
-        None
-    }
-}
-
-/// The real uid and gid of `pid`, from `/proc/<pid>/status`.
-fn process_ids(pid: u32) -> Option<(u32, u32)> {
-    #[cfg(target_os = "linux")]
-    {
-        let status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
-        let field = |name: &str| {
-            status
-                .lines()
-                .find_map(|line| line.strip_prefix(name))
-                .and_then(|rest| rest.split_whitespace().next())
-                .and_then(|value| value.parse::<u32>().ok())
-        };
-        Some((field("Uid:")?, field("Gid:")?))
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = pid;
         None
     }
 }
@@ -286,6 +253,7 @@ mod tests {
             process: Some(arcbox_vm_driver::ProcessRecord {
                 pid: std::process::id(),
                 api_socket: None,
+                jail: None,
             }),
         };
         assert!(find(&FcDriverConfig::new("/opt/fc/firecracker"), &record).is_none());
@@ -300,6 +268,7 @@ mod tests {
             process: Some(arcbox_vm_driver::ProcessRecord {
                 pid: u32::try_from(i32::MAX - 1).unwrap(),
                 api_socket: None,
+                jail: None,
             }),
         };
         assert!(find(&FcDriverConfig::new("/opt/fc/firecracker"), &record).is_none());

--- a/virt/arcbox-fc-driver/src/driver.rs
+++ b/virt/arcbox-fc-driver/src/driver.rs
@@ -150,7 +150,8 @@ impl Adopt for FcDriver {
     /// Finds the VMM `record` names — the recorded pid when it is still a
     /// Firecracker, else a `/proc` scan by `--id`, `--api-sock`, or a
     /// jail root ending in `{firecracker binary name}/{id}/root` — and
-    /// rebuilds a handle over it, its exit tracked by probing. The API is
+    /// rebuilds a handle over it, in the jail the record says it is
+    /// confined to, its exit tracked by probing. The API is
     /// reconnected best-effort within [`adopt::API_TIMEOUT`]: a VMM that
     /// answers yields the full [`FcHandle`](crate::FcHandle) with its
     /// devices and paused state read back; one whose socket is missing,
@@ -160,7 +161,7 @@ impl Adopt for FcDriver {
     async fn adopt(&self, record: &VmRecord) -> Result<Option<Box<dyn VmHandle>>> {
         match discover::find(&self.config, record) {
             Some(found) => Ok(Some(
-                adopt::rebuild(&self.config, found, record, adopt::API_TIMEOUT).await?,
+                adopt::rebuild(found, record, adopt::API_TIMEOUT).await?,
             )),
             None => Ok(None),
         }
@@ -170,16 +171,26 @@ impl Adopt for FcDriver {
     /// it — the jailer's whole per-VM directory,
     /// `{chroot base}/{firecracker binary name}/{id}`, exactly as
     /// [`PreparedVm::discard`] and an adopted handle's `shutdown` remove
-    /// it. Where the jail is comes from `isolation` and this driver's own
-    /// binary path, the same two things a boot builds it from; nothing is
-    /// asked of the VMM, which is gone.
+    /// it. Nothing is asked of the VMM, which is gone.
+    ///
+    /// Where the jail is comes from the record, which names the directory
+    /// the VM's own booter made. Only a record that predates that field
+    /// falls back to `isolation` and this driver's binary path — the two
+    /// things a boot builds a jail root from, and so the right answer only
+    /// while neither has changed since (CORE-152).
     ///
     /// Firecracker run without the jailer reads host paths as they are, has
     /// no area of its own, and leaves nothing to remove.
     async fn discard_area(&self, record: &VmRecord, isolation: &IsolationSpec) -> Result<()> {
-        let layout =
-            render::VmLayout::new(&record.id, isolation, &self.config, &record.runtime_dir)?;
-        match layout.jail() {
+        let jail = match record.process.as_ref().and_then(|p| p.jail.clone()) {
+            Some(jail) => Some(jail.into()),
+            None => {
+                render::VmLayout::new(&record.id, isolation, &self.config, &record.runtime_dir)?
+                    .jail()
+                    .cloned()
+            }
+        };
+        match jail {
             Some(jail) => jail.remove().await,
             None => Ok(()),
         }
@@ -424,6 +435,49 @@ mod tests {
         assert!(
             !dir.path().join("firecracker.log").exists(),
             "nothing was spawned"
+        );
+    }
+
+    /// The area a dead VM left is the one its own booter made, and the
+    /// record names it. Recomputing it instead — from `isolation` and this
+    /// driver's binary path — aims the removal at a directory that never
+    /// existed the moment either has changed since the boot, leaving the
+    /// real jail behind for good (CORE-152).
+    #[tokio::test]
+    async fn a_dead_vms_recorded_jail_is_removed_not_the_one_this_config_would_compute() {
+        let dir = tempfile::tempdir().unwrap();
+        // What the VM was booted under: a Firecracker that has since been
+        // renamed, so the jail sits under the *old* binary's name.
+        let recorded = dir.path().join("srv/jailer/firecracker-1.10/box");
+        std::fs::create_dir_all(recorded.join("root/run")).unwrap();
+        let record = VmRecord {
+            id: VmId::new("box").unwrap(),
+            driver: NAME.to_owned(),
+            runtime_dir: dir.path().to_path_buf(),
+            process: Some(arcbox_vm_driver::ProcessRecord {
+                pid: 4242,
+                api_socket: None,
+                jail: Some(arcbox_vm_driver::JailRecord {
+                    root: recorded.join("root"),
+                    uid: 0,
+                    gid: 0,
+                }),
+            }),
+        };
+        let isolation = IsolationSpec::Jailer {
+            uid: 0,
+            gid: 0,
+            chroot_base: dir.path().join("srv/jailer"),
+            netns: None,
+            new_pid_ns: false,
+            cgroup: None,
+        };
+
+        driver().discard_area(&record, &isolation).await.unwrap();
+
+        assert!(
+            !recorded.exists(),
+            "the jail the record named is the one that went"
         );
     }
 }

--- a/virt/arcbox-fc-driver/src/handle/process_only.rs
+++ b/virt/arcbox-fc-driver/src/handle/process_only.rs
@@ -11,9 +11,9 @@
 //! `Graceful` shutdown, whose ctrl-alt-del is an API call, kills at once.
 //!
 //! Staging is offered, though: where a VM's files live is a property of
-//! how its VMM was launched, which the adopt read off the process itself,
-//! so an unreachable API costs this handle the VM's devices and never the
-//! disks staged into its area.
+//! how its VMM was launched, which the record carries, so an unreachable
+//! API costs this handle the VM's devices and never the disks staged into
+//! its area.
 
 use std::sync::Arc;
 
@@ -37,7 +37,7 @@ pub struct FcProcessHandle {
     record: VmRecord,
     /// The area this VM runs in, and the layout that names paths in it.
     /// Reachable without the API: where the VMM was launched is a property
-    /// of the launch, which the adopt read off the process itself.
+    /// of the launch, which its record carries.
     staging: JailStaging,
 }
 
@@ -138,7 +138,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::time::Duration;
 
-    use arcbox_vm_driver::{IsolationSpec, ProcessRecord};
+    use arcbox_vm_driver::{IsolationSpec, JailRecord, ProcessRecord};
 
     use super::*;
     use crate::NAME;
@@ -170,17 +170,18 @@ mod tests {
         let pid = child.id().unwrap();
         let socket = PathBuf::from("/nonexistent/arcbox-fc-driver/api.sock");
         let id = VmId::new("box").unwrap();
+        let layout = VmLayout::new(&id, isolation, &FcDriverConfig::new(FC_BINARY), runtime_dir)
+            .expect("a layout for the adopted vm");
         let record = VmRecord {
-            id: id.clone(),
+            id,
             driver: NAME.to_owned(),
             runtime_dir: runtime_dir.to_path_buf(),
             process: Some(ProcessRecord {
                 pid,
                 api_socket: Some(socket.clone()),
+                jail: layout.jail().map(JailRecord::from),
             }),
         };
-        let layout = VmLayout::new(&id, isolation, &FcDriverConfig::new(FC_BINARY), runtime_dir)
-            .expect("a layout for the adopted vm");
         let process = Arc::new(FcProcess::adopt(pid, socket));
         (FcProcessHandle::new(process, record, layout), child)
     }

--- a/virt/arcbox-fc-driver/src/handle/tests.rs
+++ b/virt/arcbox-fc-driver/src/handle/tests.rs
@@ -1,6 +1,6 @@
 //! Handle behavior over plain children and an API socket nobody answers on.
 
-use arcbox_vm_driver::{IsolationSpec, ProcessRecord};
+use arcbox_vm_driver::{IsolationSpec, JailRecord, ProcessRecord};
 
 use super::*;
 use crate::api::fake_fc::FakeFc;
@@ -43,6 +43,7 @@ fn with_client(
         process: Some(ProcessRecord {
             pid: process.pid(),
             api_socket: Some(layout.api_socket()),
+            jail: layout.jail().map(JailRecord::from),
         }),
     };
     let vsock = vsock.then(|| VsockEndpoint::new(layout.vsock_host_uds()));
@@ -415,6 +416,7 @@ async fn listen_binds_next_to_the_socket_dial_uses_not_the_layout_path() {
         process: Some(ProcessRecord {
             pid: process.pid(),
             api_socket: Some(layout.api_socket()),
+            jail: layout.jail().map(JailRecord::from),
         }),
     };
     let vm = FcHandle::new(

--- a/virt/arcbox-fc-driver/src/jail.rs
+++ b/virt/arcbox-fc-driver/src/jail.rs
@@ -11,7 +11,7 @@
 
 use std::path::{Path, PathBuf};
 
-use arcbox_vm_driver::{Error, Result};
+use arcbox_vm_driver::{Error, JailRecord, Result};
 use nix::unistd::{Gid, Uid, chown};
 use tracing::warn;
 
@@ -29,6 +29,26 @@ pub struct Jail {
     pub uid: u32,
     /// The gid the VMM runs as.
     pub gid: u32,
+}
+
+impl From<&Jail> for JailRecord {
+    fn from(jail: &Jail) -> Self {
+        Self {
+            root: jail.root.clone(),
+            uid: jail.uid,
+            gid: jail.gid,
+        }
+    }
+}
+
+impl From<JailRecord> for Jail {
+    fn from(record: JailRecord) -> Self {
+        Self {
+            root: record.root,
+            uid: record.uid,
+            gid: record.gid,
+        }
+    }
 }
 
 impl Jail {

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -6,8 +6,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use arcbox_vm_driver::{
-    CheckpointImage, Error, ExitStatus, IsolationSpec, PreparedVm, ProcessRecord, RestoreSpec,
-    Result, Staging, VmHandle, VmId, VmRecord, VmSpec, VmState, VsockListen, VsockListener,
+    CheckpointImage, Error, ExitStatus, IsolationSpec, JailRecord, PreparedVm, ProcessRecord,
+    RestoreSpec, Result, Staging, VmHandle, VmId, VmRecord, VmSpec, VmState, VsockListen,
+    VsockListener,
 };
 use async_trait::async_trait;
 use fc_sdk::VmBuilder;
@@ -82,6 +83,7 @@ impl FcPrepared {
                 process: Some(ProcessRecord {
                     pid: process.pid(),
                     api_socket: Some(plan.api_socket.clone()),
+                    jail: layout.jail().map(JailRecord::from),
                 }),
             };
             let vsock = VsockEndpoint::new(layout.vsock_host_uds());

--- a/virt/arcbox-fc-driver/src/prepared.rs
+++ b/virt/arcbox-fc-driver/src/prepared.rs
@@ -31,6 +31,10 @@ pub struct FcPrepared {
     /// names every path in it. Shared in shape — not in value — with the
     /// handle a boot returns, which builds its own from the same layout.
     staging: JailStaging,
+    /// What the VMM was spawned under, kept to hold the boot or restore
+    /// that follows to the same confinement ([`Self::require_same_identity`]).
+    /// The layout keeps only the paths this implies.
+    isolation: IsolationSpec,
     process: Arc<FcProcess>,
     record: VmRecord,
     /// Where guest dial-outs land: the layout's vsock socket, until a
@@ -62,7 +66,7 @@ impl FcPrepared {
         if let IsolationSpec::Jailer { chroot_base, .. } = isolation {
             tokio::fs::create_dir_all(chroot_base).await?;
         }
-        let plan = layout.spawn_plan();
+        let plan = layout.spawn_plan(isolation);
         let spawned = async {
             let child = spawn::spawn(&plan, &config).await?;
             debug_assert_eq!(
@@ -84,6 +88,7 @@ impl FcPrepared {
             Ok(Self {
                 config: Arc::clone(&config),
                 staging: JailStaging::new(layout.clone()),
+                isolation: isolation.clone(),
                 process,
                 record,
                 vsock,
@@ -133,7 +138,7 @@ impl FcPrepared {
                 self.record.id
             )));
         }
-        if *isolation != *self.layout().isolation() {
+        if *isolation != self.isolation {
             return Err(Error::InvalidSpec(format!(
                 "spec isolation does not match what vm {} was prepared with",
                 self.record.id

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -84,6 +84,17 @@ impl VmLayout {
         Self::of(id, jail, runtime_dir)
     }
 
+    /// The layout of a VM this process did not spawn: the jail its record
+    /// names, which is the only place that fact survives.
+    ///
+    /// Not [`new`](Self::new): that one *computes* the jail root from a
+    /// `chroot_base` and this process's own Firecracker binary path, and a
+    /// VM booted by an earlier process is under the root that process
+    /// computed — the same one only while neither has moved (CORE-152).
+    pub fn adopted(id: &VmId, jail: Option<Jail>, runtime_dir: &Path) -> Result<Self> {
+        Self::of(id, jail, runtime_dir)
+    }
+
     /// The layout of VM `id` in `jail`, with `runtime_dir` as its scratch
     /// space.
     fn of(id: &VmId, jail: Option<Jail>, runtime_dir: &Path) -> Result<Self> {

--- a/virt/arcbox-fc-driver/src/render.rs
+++ b/virt/arcbox-fc-driver/src/render.rs
@@ -42,11 +42,15 @@ const VSOCK_NAME: &str = "firecracker.vsock";
 
 /// Where a VM's files live from the host's and Firecracker's points of
 /// view: the runtime dir, the jail if any, and the sockets in them.
+///
+/// Paths and nothing else. How the VMM is *confined* — the netns it enters,
+/// the cgroup it joins, the ids it drops to — is the spawn's business and
+/// travels with [`spawn_plan`](Self::spawn_plan); what a layout keeps of it
+/// is the [`Jail`] those paths hang off.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VmLayout {
     id: VmId,
     runtime_dir: PathBuf,
-    isolation: IsolationSpec,
     jail: Option<Jail>,
 }
 
@@ -59,13 +63,6 @@ impl VmLayout {
         config: &FcDriverConfig,
         runtime_dir: &Path,
     ) -> Result<Self> {
-        // The id is a directory name here — the jail is `{base}/{exec}/{id}/
-        // root` — so `.` and `..` would name another VM's jail, or the base
-        // itself. The port refuses them at the id; a layout is built from
-        // whatever id it is handed, so the same rule is checked here too.
-        if !is_plain_component(id.as_str()) {
-            return Err(unsupported(&format!("vm id `{id}` must be a plain name")));
-        }
         let jail = match isolation {
             IsolationSpec::None => None,
             IsolationSpec::Jailer {
@@ -84,10 +81,22 @@ impl VmLayout {
                 )));
             }
         };
+        Self::of(id, jail, runtime_dir)
+    }
+
+    /// The layout of VM `id` in `jail`, with `runtime_dir` as its scratch
+    /// space.
+    fn of(id: &VmId, jail: Option<Jail>, runtime_dir: &Path) -> Result<Self> {
+        // The id is a directory name here — the jail is `{base}/{exec}/{id}/
+        // root` — so `.` and `..` would name another VM's jail, or the base
+        // itself. The port refuses them at the id; a layout is built from
+        // whatever id it is handed, so the same rule is checked here too.
+        if !is_plain_component(id.as_str()) {
+            return Err(unsupported(&format!("vm id `{id}` must be a plain name")));
+        }
         Ok(Self {
             id: id.clone(),
             runtime_dir: runtime_dir.to_path_buf(),
-            isolation: isolation.clone(),
             jail,
         })
     }
@@ -100,11 +109,6 @@ impl VmLayout {
     /// The per-VM scratch directory the driver was given.
     pub fn runtime_dir(&self) -> &Path {
         &self.runtime_dir
-    }
-
-    /// The confinement the layout was built for.
-    pub fn isolation(&self) -> &IsolationSpec {
-        &self.isolation
     }
 
     /// The jail, when the VM runs under the jailer.
@@ -146,11 +150,15 @@ impl VmLayout {
         }
     }
 
-    /// The process to spawn for this VM.
-    pub fn spawn_plan(&self) -> SpawnPlan {
+    /// The process to spawn for this VM under `isolation`.
+    ///
+    /// `isolation` is the same one the layout was built from — it carries
+    /// the rest of the confinement (netns, cgroup, PID namespace), which
+    /// names no path and so is not a layout's to keep.
+    pub fn spawn_plan(&self, isolation: &IsolationSpec) -> SpawnPlan {
         let mode = match &self.jail {
             Some(jail) => SpawnMode::Jailer {
-                isolation: self.isolation.clone(),
+                isolation: isolation.clone(),
                 jail_root: jail.root.clone(),
             },
             None => SpawnMode::Direct {

--- a/virt/arcbox-fc-driver/src/render/tests.rs
+++ b/virt/arcbox-fc-driver/src/render/tests.rs
@@ -59,7 +59,7 @@ fn direct_layout_names_the_runtime_dir_sockets_and_passes_paths_verbatim() {
         layout.host_view("/run/vms/other/firecracker.vsock"),
         Path::new("/run/vms/other/firecracker.vsock")
     );
-    let plan = layout.spawn_plan();
+    let plan = layout.spawn_plan(&IsolationSpec::None);
     assert_eq!(plan.api_socket, Path::new("/run/vms/box/firecracker.sock"));
     assert_eq!(plan.vsock_uds, Path::new("/run/vms/box/firecracker.vsock"));
     let SpawnMode::Direct { log, metrics } = plan.mode else {
@@ -96,7 +96,7 @@ fn jailer_layout_relativizes_inside_paths_and_stages_outside_ones() {
         layout.host_view("/run/firecracker.vsock"),
         root.join("run/firecracker.vsock")
     );
-    let plan = layout.spawn_plan();
+    let plan = layout.spawn_plan(&jailed(&base));
     assert_eq!(plan.api_socket, root.join("run/firecracker.socket"));
     assert_eq!(plan.vsock_uds, root.join("run/firecracker.vsock"));
     let SpawnMode::Jailer {

--- a/virt/arcbox-vm-driver/src/capability.rs
+++ b/virt/arcbox-vm-driver/src/capability.rs
@@ -326,6 +326,15 @@ pub trait Adopt: Send + Sync {
     ///
     /// `Ok(None)` means nothing survived — a stale record, a dead pid — which
     /// is an outcome, not an absence of the capability.
+    ///
+    /// The handle is rebuilt from what the record says, not from what the
+    /// live process can be made to admit: a VMM's control socket and the
+    /// jail it is confined to
+    /// ([`ProcessRecord::api_socket`](crate::ProcessRecord::api_socket),
+    /// [`JailRecord`](crate::JailRecord)) are both invisible from outside
+    /// once it is running. A record that carries neither — one written
+    /// before they existed — is adopted as best the driver can, which for a
+    /// jailed VM is a handle that can only kill it.
     async fn adopt(&self, record: &VmRecord) -> Result<Option<Box<dyn VmHandle>>>;
 
     /// Removes the host area of the VM `record` names, which is gone.
@@ -339,7 +348,11 @@ pub trait Adopt: Send + Sync {
     ///
     /// `isolation` is what the VM was configured to run under, because
     /// nothing can be read back off a process that is gone. A driver that
-    /// confines nothing has no area to remove and succeeds.
+    /// confines nothing has no area to remove and succeeds. Where the
+    /// record names the area itself
+    /// ([`JailRecord`](crate::JailRecord)) that is the better answer —
+    /// `isolation` describes what *this* process would have built, which is
+    /// the same area only while the configuration has not moved under it.
     ///
     /// Already removed is success: a startup sweep runs this on every
     /// journal it does not keep, and may find what an earlier sweep

--- a/virt/arcbox-vm-driver/src/driver.rs
+++ b/virt/arcbox-vm-driver/src/driver.rs
@@ -382,6 +382,37 @@ pub struct ProcessRecord {
     /// The VMM's control socket, when it has one.
     #[serde(default)]
     pub api_socket: Option<PathBuf>,
+    /// The jail the VMM runs in, when it is confined to one.
+    ///
+    /// `None` means unconfined — and, in a record written before this field
+    /// existed, means the same, because a record that predates it can no
+    /// longer be asked.
+    #[serde(default)]
+    pub jail: Option<JailRecord>,
+}
+
+/// The jail a running VMM is in, as the process that put it there knew it.
+///
+/// Recorded rather than derived, because neither half survives the spawn:
+/// a jailer unshares its mount namespace and pivots into the chroot, so
+/// `/proc/<pid>/root` reads back as `/` from outside and the confinement
+/// cannot be observed at all; and re-deriving the root instead — from an
+/// [`IsolationSpec`]'s `chroot_base` and the adopting process's own config
+/// — names a different directory the moment that config differs from the
+/// one the VM was booted with.
+///
+/// What follows from getting it wrong is not a wrong path but a wrong VM:
+/// an adopter that concludes "unconfined" rebuilds the VM as one, and every
+/// operation that needs the jail — reaching the guest, checkpointing it —
+/// is then refused or aimed outside it (CORE-155).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JailRecord {
+    /// The chroot the VMM is confined to, as the host names it.
+    pub root: PathBuf,
+    /// The uid the VMM runs as.
+    pub uid: u32,
+    /// The gid the VMM runs as.
+    pub gid: u32,
 }
 
 /// What may change when a checkpoint is restored into a new VM.
@@ -494,6 +525,11 @@ mod tests {
             process: Some(ProcessRecord {
                 pid: 4242,
                 api_socket: Some("/run/arcbox/vm-1/api.sock".into()),
+                jail: Some(JailRecord {
+                    root: "/srv/jailer/firecracker/vm-1/root".into(),
+                    uid: 123,
+                    gid: 456,
+                }),
             }),
         };
         let json = serde_json::to_string(&record).unwrap();
@@ -506,5 +542,16 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(in_process.process, None);
+
+        // A record written before the jail was recorded still loads, and
+        // says what it can: a process, confined to nothing it can name.
+        let older: VmRecord = serde_json::from_value(serde_json::json!({
+            "id": "vm-3",
+            "driver": "fc",
+            "runtime_dir": "/run/arcbox/vm-3",
+            "process": { "pid": 7, "api_socket": "/run/arcbox/vm-3/api.sock" },
+        }))
+        .unwrap();
+        assert_eq!(older.process.unwrap().jail, None);
     }
 }

--- a/virt/arcbox-vm-driver/src/lib.rs
+++ b/virt/arcbox-vm-driver/src/lib.rs
@@ -60,8 +60,8 @@ pub use capability::{
     PreparedVm, Staging, Vsock, VsockListen, VsockListener,
 };
 pub use driver::{
-    DriverCapabilities, ExitStatus, IoMode, NestedVirt, ProcessRecord, RestoreSpec, ShutdownMode,
-    VmDriver, VmEvent, VmHandle, VmRecord, VmState, VsockConn,
+    DriverCapabilities, ExitStatus, IoMode, JailRecord, NestedVirt, ProcessRecord, RestoreSpec,
+    ShutdownMode, VmDriver, VmEvent, VmHandle, VmRecord, VmState, VsockConn,
 };
 pub use error::{Error, Result};
 pub use spec::{

--- a/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
+++ b/virt/arcbox-vm-driver/src/testkit/contract/checks.rs
@@ -169,6 +169,13 @@ pub async fn restore_yields_a_live_vm(h: &dyn ContractHarness) {
 
 /// `detach` leaves the VM running for `adopt` to pick up; after that VM
 /// is gone, `adopt` reports `None`.
+///
+/// An adopted VM is the same VM, not merely a live pid: it answers on the
+/// same vsock and offers whatever the driver claims it can do. Both are
+/// asserted because a driver that loses how its VMM is confined — a fact
+/// no live process reveals, so one only the record carries — rebuilds it
+/// unconfined, and an unconfined rebuild of a jailed VM is exactly a
+/// running pid that can no longer be reached or checkpointed (CORE-155).
 pub async fn detach_then_adopt_round_trip(h: &dyn ContractHarness) {
     let driver = h.driver();
     let vm = boot(h, "adopt").await;
@@ -193,6 +200,19 @@ pub async fn detach_then_adopt_round_trip(h: &dyn ContractHarness) {
         .expect("the detached vm survived");
     assert_eq!(*adopted.id(), record.id);
     assert_eq!(adopted.state(), VmState::Running);
+    assert_eq!(
+        adopted.checkpoint().is_some(),
+        driver.capabilities().checkpoint,
+        "an adopted vm offers what this driver claims it can do"
+    );
+    if let Some(port) = h.dial_port() {
+        let vsock = adopted.vsock().expect("an adopted vm keeps its vsock");
+        let conn = tokio::time::timeout(DEADLINE, vsock.dial(port))
+            .await
+            .expect("dial the adopted guest before the deadline")
+            .expect("dial the adopted guest");
+        drop(conn);
+    }
     adopted.shutdown(ShutdownMode::Kill).await.expect("kill");
     assert!(
         adopt

--- a/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
+++ b/virt/arcbox-vm-driver/src/testkit/fake_prepared.rs
@@ -15,7 +15,9 @@ use super::lock;
 use crate::capability::{
     CheckpointImage, CheckpointKind, Prepare, PreparedVm, Staging, VsockListen, VsockListener,
 };
-use crate::driver::{ExitStatus, ProcessRecord, RestoreSpec, VmHandle, VmRecord, VmState};
+use crate::driver::{
+    ExitStatus, JailRecord, ProcessRecord, RestoreSpec, VmHandle, VmRecord, VmState,
+};
 use crate::error::{Error, Result};
 use crate::spec::{IsolationSpec, VmId, VmSpec};
 
@@ -43,6 +45,7 @@ impl Preparer {
             process: Some(ProcessRecord {
                 pid: self.0.next_pid(),
                 api_socket: Some(runtime_dir.join("api.sock")),
+                jail: jail_of(id, isolation),
             }),
         };
         PreparedFake {
@@ -53,6 +56,28 @@ impl Preparer {
             record,
             phase: Mutex::new(Phase::Prepared),
         }
+    }
+}
+
+/// The jail a fake VMM would be confined to: `{chroot_base}/{id}`, the
+/// simplest layout that is a *path* rather than a repeat of the spec.
+///
+/// The fake records one because a real driver does, and because a record
+/// that loses it is a VM adopted back as unconfined (CORE-155) — a contract
+/// check can only see that if the fake has a jail to lose.
+fn jail_of(id: &VmId, isolation: &IsolationSpec) -> Option<JailRecord> {
+    match isolation {
+        IsolationSpec::None => None,
+        IsolationSpec::Jailer {
+            uid,
+            gid,
+            chroot_base,
+            ..
+        } => Some(JailRecord {
+            root: chroot_base.join(id.as_str()),
+            uid: *uid,
+            gid: *gid,
+        }),
     }
 }
 


### PR DESCRIPTION
Adoption concluded direct mode for every jailed VM. It inferred the confinement from `/proc/<pid>/root`, which reads `/` for a jailer'd Firecracker — it unshares its mount namespace and pivots into the chroot — so the rebuilt handle was a direct-mode one: exec dialled `/run/firecracker.vsock` as if the in-chroot path were a host path, and a checkpoint was refused outright. The VM was alive and reclaimed; it just could not be used.

Same fact as CORE-149 (#697, this stack's trunk), one field over: `ProcessRecord` carries a `JailRecord`, and an adopt builds its layout from that. Additive and defaulting to `None`, so a record written before it adopts exactly as it did. `discover` stops inferring confinement altogether — identity is all `/proc` can answer.

**Why the resolved root, not a chroot base.** The root is the fact; everything else recomputes it. `{chroot_base}/{firecracker binary name}/{id}/root` names a different directory the moment the adopting process's binary path differs from the booting one's. `discard_area` prefers the recorded jail for the same reason, so this also closes CORE-152 — a removal aimed at a computed path strands the real jail forever.

**The contract could not see this.** Its adopt check asserted the adopted handle's id, its state, and that a kill worked — all true of a VM rebuilt with the wrong confinement. It now also asserts the adopted VM answers on its vsock and offers what the driver claims it can do. Against this PR's parent that fails under the jailer (`checkpoint()` is `None`) and passes in direct mode, which is the bug's exact shape.

Verified against real Firecracker v1.10.1 on a KVM host: the 36-check driver contract passes in both modes (direct and jailer).

Closes CORE-152. CORE-155 is closed by the top of this stack.
