### PR TITLE
fix(computer): retain checkpoint restore provenance

### DIFF
--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/boot.rs
@@ -142,6 +142,10 @@ pub async fn wait_for_agent(
     clippy::too_many_arguments,
     reason = "boot owns one exact sandbox generation and its handoff signal"
 )]
+#[allow(
+    clippy::result_large_err,
+    reason = "the failure hands back the half-built sandbox's resources; boxing it is a refactor of its own"
+)]
 pub async fn do_boot(
     id: &str,
     spec: &SandboxSpec,

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/checkpoint.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/checkpoint.rs
@@ -92,6 +92,16 @@ fn checkpoint_source(
             actual: inst.state.to_string(),
         });
     }
+    if inst.spec.kernel.is_empty() {
+        return Err(VmmError::FailedPrecondition(format!(
+            "sandbox {sandbox_id} cannot be checkpointed: its durable record has no kernel path"
+        )));
+    }
+    if inst.spec.rootfs.is_empty() {
+        return Err(VmmError::FailedPrecondition(format!(
+            "sandbox {sandbox_id} cannot be checkpointed: its durable record has no rootfs path"
+        )));
+    }
     let handle = inst.handle.clone().ok_or_else(|| VmmError::WrongState {
         id: sandbox_id.clone(),
         expected: format!("{expected_state} (VM handle available)"),

--- a/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
+++ b/computer/arcbox-computer-runtime/src/lifecycle/tasks/restore.rs
@@ -104,6 +104,10 @@ pub struct RestoreFailure {
 /// Every failure returns [`RestoreFailure`] rather than unwinding here: a
 /// pre-commit restore failure is rolled back by force-removing the whole
 /// reservation, which is the caller's transaction to end.
+#[allow(
+    clippy::result_large_err,
+    reason = "the failure hands back the half-built sandbox's resources; boxing it is a refactor of its own"
+)]
 pub async fn restore_vm(inputs: RestoreVm<'_>) -> std::result::Result<RestoredVm, RestoreFailure> {
     let RestoreVm {
         new_id,

--- a/computer/arcbox-computer-runtime/src/sandbox/boot.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/boot.rs
@@ -151,6 +151,10 @@ pub struct StagedRootfs {
 /// slot id for pre-warmed slots). `journal` persists the caller's crash
 /// record whenever CoW resources appear or disappear, so reconciliation
 /// can always identify them.
+#[allow(
+    clippy::result_large_err,
+    reason = "the failure hands back the half-built sandbox's resources; boxing it is a refactor of its own"
+)]
 pub async fn stage_rootfs_cow_or_copy(
     cow_manager: &CowManager,
     staging: &dyn Staging,

--- a/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/checkpoint.rs
@@ -197,6 +197,20 @@ impl SandboxManager {
             .join(&new_id);
         let mut restore_spec = request.spec.clone();
         restore_spec.id = Some(new_id.clone());
+        // The request owns the new computer's identity and initial workload;
+        // the snapshot owns the provenance a later checkpoint must record.
+        // Keep the effective spec aligned with what this restore actually
+        // loads so adoption and chained checkpoints can reconstruct it.
+        if let Some(kernel) = &snap_meta.kernel_path {
+            restore_spec.kernel.clone_from(kernel);
+        }
+        if let Some(rootfs) = &snap_meta.rootfs_path {
+            restore_spec.rootfs.clone_from(rootfs);
+        }
+        if let Some(geometry) = snap_meta.geometry {
+            restore_spec.vcpus = geometry.vcpus;
+            restore_spec.memory_mib = geometry.memory_mib;
+        }
         let reservation = super::reserve_actor(
             &self.computers,
             &new_id,

--- a/computer/arcbox-computer-runtime/src/sandbox/pool.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/pool.rs
@@ -152,6 +152,10 @@ struct StagedSlot {
     image: CheckpointImage,
 }
 
+#[allow(
+    clippy::result_large_err,
+    reason = "the failure hands back the half-built sandbox's resources; boxing it is a refactor of its own"
+)]
 async fn stage_slot(
     driver: &dyn VmDriver,
     config: &RuntimeConfig,

--- a/computer/arcbox-computer-runtime/src/sandbox/record/phase.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/record/phase.rs
@@ -239,8 +239,9 @@ impl SandboxRecord {
     }
 
     fn redact_runtime_inputs(&mut self) {
-        self.effective_spec.kernel.clear();
-        self.effective_spec.rootfs.clear();
+        // A successor reconstructs an adopted computer from this record,
+        // and its next checkpoint records these paths as the restore
+        // provenance. They outlive boot even though the inputs below do not.
         self.effective_spec.boot_args.clear();
         self.effective_spec.cmd.clear();
         self.effective_spec.env.clear();
@@ -481,6 +482,42 @@ mod tests {
         for (transition, phase) in projections {
             assert_eq!(transition.phase(), phase, "{transition:?}");
         }
+    }
+
+    #[test]
+    fn ready_records_keep_checkpoint_provenance_and_redact_consumed_inputs() {
+        let mut record = SandboxRecord::new(
+            "box",
+            "key",
+            SandboxSpec {
+                id: Some("box".into()),
+                kernel: "/assets/vmlinux".into(),
+                rootfs: "/assets/rootfs.ext4".into(),
+                boot_args: "console=ttyS0".into(),
+                cmd: vec!["/bin/work".into()],
+                env: std::collections::HashMap::from([("TOKEN".into(), "secret".into())]),
+                working_dir: "/work".into(),
+                user: "1000".into(),
+                ttl_seconds: 60,
+                ssh_public_key: Some("ssh-ed25519 key".into()),
+                ..SandboxSpec::default()
+            },
+        );
+        record
+            .apply(SandboxTransition::Starting(outcome()))
+            .unwrap();
+        record.apply(SandboxTransition::Ready).unwrap();
+
+        assert_eq!(record.effective_spec.kernel, "/assets/vmlinux");
+        assert_eq!(record.effective_spec.rootfs, "/assets/rootfs.ext4");
+        assert!(record.effective_spec.boot_args.is_empty());
+        assert!(record.effective_spec.cmd.is_empty());
+        assert!(record.effective_spec.env.is_empty());
+        assert!(record.effective_spec.working_dir.is_empty());
+        assert!(record.effective_spec.user.is_empty());
+        assert_eq!(record.effective_spec.ttl_seconds, 0);
+        assert_eq!(record.effective_spec.ssh_public_key, None);
+        assert!(record.ttl_deadline.is_some());
     }
 
     #[test]

--- a/computer/arcbox-computer-runtime/src/sandbox/templates.rs
+++ b/computer/arcbox-computer-runtime/src/sandbox/templates.rs
@@ -90,6 +90,10 @@ impl SandboxManager {
     /// template's lifetime from the user checkpoint. Files are reflinked
     /// where the filesystem supports it (the data dir is Btrfs), so the copy
     /// is cheap; the origin's rootfs stays pinned through the copied meta.
+    #[allow(
+        clippy::unused_async_trait_impl,
+        reason = "one of the async template operations; whether this one awaits today is an implementation detail"
+    )]
     pub async fn promote_snapshot_to_template(
         &self,
         source_snapshot_id: &str,

--- a/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
+++ b/computer/arcbox-computer-runtime/tests/manager_over_fakes.rs
@@ -866,6 +866,125 @@ async fn a_checkpoint_restores_onto_a_fresh_address() {
     assert_eq!(fixture.run(&clone, &["/bin/hello"]).await, b"hi");
 }
 
+/// Adoption reconstructs the computer from its durable record, so that
+/// record must retain every input a later checkpoint writes into its restore
+/// contract. The checkpoint must be restorable after the process that booted
+/// the origin has handed it over.
+#[tokio::test]
+async fn an_adopted_computers_checkpoint_restores() {
+    let mut fixture = Fixture::jailed().await;
+    fixture.agent().on(&["/bin/hello"], Reply::stdout(b"hi"));
+    let id = fixture.ready("origin").await;
+
+    fixture.manager.detach_all().await.unwrap();
+    fixture = fixture.restart().await;
+    fixture.await_state(&id, SandboxState::Ready).await;
+
+    let checkpoint = fixture
+        .manager
+        .checkpoint_sandbox(&id, "adopted".into(), HashMap::new())
+        .await
+        .unwrap();
+    let (clone, _) = fixture
+        .manager
+        .restore_sandbox(RestoreSandboxSpec {
+            id: Some("adopted-clone".into()),
+            snapshot_id: checkpoint.snapshot_id,
+            network_override: true,
+            ..RestoreSandboxSpec::default()
+        })
+        .await
+        .unwrap();
+
+    fixture.await_state(&clone, SandboxState::Ready).await;
+    assert_eq!(fixture.run(&clone, &["/bin/hello"]).await, b"hi");
+}
+
+/// Version-one records written before checkpoint provenance was retained
+/// remain readable and adoptable. Their lost paths cannot be reconstructed
+/// safely, so checkpoint refuses before publishing an unrestorable image.
+#[tokio::test]
+async fn an_adopted_computer_with_a_legacy_record_refuses_checkpoint() {
+    let mut fixture = Fixture::jailed().await;
+    let id = fixture.ready("legacy").await;
+    fixture.manager.detach_all().await.unwrap();
+
+    let record_path = fixture.record_path(&id);
+    let mut record: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&record_path).unwrap()).unwrap();
+    assert_eq!(record["version"], 1);
+    record["effective_spec"]["kernel"] = serde_json::Value::String(String::new());
+    record["effective_spec"]["rootfs"] = serde_json::Value::String(String::new());
+    std::fs::write(&record_path, serde_json::to_vec(&record).unwrap()).unwrap();
+
+    fixture = fixture.restart().await;
+    fixture.await_state(&id, SandboxState::Ready).await;
+    let error = fixture
+        .manager
+        .checkpoint_sandbox(&id, "legacy".into(), HashMap::new())
+        .await
+        .expect_err("the record has no safe restore provenance");
+    assert!(
+        matches!(&error, VmmError::Other(message) if message.contains("no kernel path")),
+        "unexpected checkpoint refusal: {error}"
+    );
+    assert!(
+        fixture
+            .manager
+            .list_checkpoints(Some(&id))
+            .unwrap()
+            .is_empty()
+    );
+}
+
+/// A restored computer inherits the source snapshot's restore provenance.
+/// Its own checkpoint must therefore remain restorable rather than losing
+/// the kernel, rootfs and geometry when the restore request supplies only
+/// identity fields.
+#[tokio::test]
+async fn a_restored_computers_checkpoint_restores_again() {
+    let fixture = Fixture::jailed().await;
+    fixture.agent().on(&["/bin/hello"], Reply::stdout(b"hi"));
+    let origin = fixture.ready("origin").await;
+    let first = fixture
+        .manager
+        .checkpoint_sandbox(&origin, "first".into(), HashMap::new())
+        .await
+        .unwrap();
+    let (first_clone, _) = fixture
+        .manager
+        .restore_sandbox(RestoreSandboxSpec {
+            id: Some("first-clone".into()),
+            snapshot_id: first.snapshot_id,
+            network_override: true,
+            ..RestoreSandboxSpec::default()
+        })
+        .await
+        .unwrap();
+    fixture.await_state(&first_clone, SandboxState::Ready).await;
+
+    let second = fixture
+        .manager
+        .checkpoint_sandbox(&first_clone, "second".into(), HashMap::new())
+        .await
+        .unwrap();
+    let (second_clone, _) = fixture
+        .manager
+        .restore_sandbox(RestoreSandboxSpec {
+            id: Some("second-clone".into()),
+            snapshot_id: second.snapshot_id,
+            network_override: true,
+            ..RestoreSandboxSpec::default()
+        })
+        .await
+        .unwrap();
+
+    fixture
+        .await_state(&second_clone, SandboxState::Ready)
+        .await;
+    assert_eq!(fixture.run(&second_clone, &["/bin/hello"]).await, b"hi");
+}
+
 /// A capture that fails and leaves the guest running is an error the
 /// caller can retry: the computer stays Ready with everything it holds.
 #[tokio::test]
@@ -1182,7 +1301,8 @@ async fn a_detached_computer_is_adopted_by_the_next_process_and_serves_an_exec()
     );
 }
 
-/// An adopted computer running on a copied rootfs pauses like any other.
+/// An adopted computer running on a copied rootfs pauses and resumes like
+/// one this process booted.
 ///
 /// Its disk lives in the VM's area and this process holds no prepared VM to
 /// reach in with, so until the handle grew a staging accessor the pause was
@@ -1194,20 +1314,10 @@ async fn a_detached_computer_is_adopted_by_the_next_process_and_serves_an_exec()
 ///
 /// The area is reachable from the handle now: the disk comes out ahead of
 /// the kill and lands where a resume looks for it.
-///
-/// The resume itself does not yet complete, for a reason of its own that
-/// this pause used to hide: the durable record redacts a computer's boot
-/// inputs when it reaches `Ready` (`redact_runtime_inputs`), so an adopted
-/// computer's `spec.kernel` is empty, and every checkpoint it takes records
-/// no kernel path for the staging that follows to bring in. That is a gap
-/// in adoption, not in pause — a *Checkpoint* of an adopted computer is
-/// unrestorable for the same reason, with no pause involved — and it is
-/// asserted here as it behaves: the resume fails, the computer is left back
-/// at `Paused`, and its retained disk is where the pause put it, so nothing
-/// is lost and a retry has something to succeed with.
 #[tokio::test]
-async fn an_adopted_computer_on_a_copied_rootfs_pauses_and_keeps_its_disk() {
+async fn an_adopted_computer_on_a_copied_rootfs_pauses_and_resumes_with_its_disk() {
     let mut fixture = Fixture::jailed().await;
+    fixture.agent().on(&["/bin/hello"], Reply::stdout(b"hi"));
     let id = fixture.ready("handed-over").await;
 
     fixture.manager.detach_all().await.unwrap();
@@ -1224,17 +1334,14 @@ async fn an_adopted_computer_on_a_copied_rootfs_pauses_and_keeps_its_disk() {
     );
 
     fixture.settle_network_cleanups().await;
-    let error = fixture
+    fixture
         .manager
         .resume_sandbox(&id, pause_reason::RESUME)
         .await
-        .expect_err("an adopted computer's checkpoint records no kernel to stage");
-    assert!(
-        matches!(&error, VmmError::Io(io) if io.kind() == std::io::ErrorKind::NotFound),
-        "the kernel path the checkpoint recorded is empty, so staging it is ENOENT: {error}"
-    );
-    fixture.await_state(&id, SandboxState::Paused).await;
-    assert!(parked.exists(), "a failed resume leaves the disk parked");
+        .unwrap();
+    fixture.await_state(&id, SandboxState::Ready).await;
+    assert!(!parked.exists(), "resume moved the parked disk into the vm");
+    assert_eq!(fixture.run(&id, &["/bin/hello"]).await, b"hi");
 }
 
 /// Nothing this process does may reach a VM it has handed over (CORE-145).

--- a/computer/arcbox-computer-runtime/tests/support/mod.rs
+++ b/computer/arcbox-computer-runtime/tests/support/mod.rs
@@ -248,6 +248,14 @@ impl Fixture {
         self.dir.path().join("sandboxes").join(id)
     }
 
+    /// A computer's durable lifecycle record.
+    pub fn record_path(&self, id: &str) -> PathBuf {
+        self.dir
+            .path()
+            .join("sandbox-records")
+            .join(format!("{id}.json"))
+    }
+
     /// A computer's copy-on-write overlay file, as the probe names it
     /// ([`Setup::with_cow_probe`] fixtures only — the probe assembles no
     /// device, so the file exists once the test writes it).

--- a/engine/arcbox-snapshot/src/template_catalog.rs
+++ b/engine/arcbox-snapshot/src/template_catalog.rs
@@ -330,7 +330,7 @@ impl TemplateCatalog {
             .ok_or_else(|| SnapshotError::TemplateNotFound(reference.to_string()))?;
         let removed: Vec<TemplateEntry> = match version {
             None => {
-                let mut entries: Vec<_> = record.versions.drain(..).collect();
+                let mut entries = std::mem::take(&mut record.versions);
                 entries.extend(record.draft.take());
                 self.remove_record(name)?;
                 entries

--- a/virt/arcbox-fc-driver/src/discover.rs
+++ b/virt/arcbox-fc-driver/src/discover.rs
@@ -185,12 +185,9 @@ impl<'a> Identity<'a> {
     #[cfg(target_os = "linux")]
     fn identifies(&self, proc_dir: PathBuf) -> bool {
         let by_cmdline = std::fs::read(proc_dir.join("cmdline"))
-            .ok()
-            .is_some_and(|bytes| cmdline_matches(&bytes, self.id, &self.socket));
+            .is_ok_and(|bytes| cmdline_matches(&bytes, self.id, &self.socket));
         let by_jail = self.jail_tail.as_ref().is_some_and(|tail| {
-            std::fs::read_link(proc_dir.join("root"))
-                .ok()
-                .is_some_and(|root| root.ends_with(tail))
+            std::fs::read_link(proc_dir.join("root")).is_ok_and(|root| root.ends_with(tail))
         });
         by_cmdline || by_jail
     }

--- a/virt/arcbox-vm-agent/src/main.rs
+++ b/virt/arcbox-vm-agent/src/main.rs
@@ -639,7 +639,7 @@ mod agent {
         // extension is backward compatible.
         let mut payload = [0u8; 32];
         let timings = steps.iter().copied().chain([resolv_us, handler_us]);
-        for (slot, ms) in payload[8..].chunks_exact_mut(4).zip(timings) {
+        for (slot, ms) in payload[8..].as_chunks_mut::<4>().0.iter_mut().zip(timings) {
             slot.copy_from_slice(&ms.to_le_bytes());
         }
         let _ = write_frame(&mut conn, MSG_EXIT, &payload);


### PR DESCRIPTION
## Summary

- retain kernel and rootfs provenance in durable sandbox records after runtime inputs are redacted
- rebuild the effective restore spec from snapshot provenance so adopted and restored computers can produce restorable checkpoints
- reject legacy redacted records before publishing an invalid checkpoint
- cover adopt → checkpoint → restore → exec, pause/resume after adoption, chained restores, and legacy records

## Verification

- `cargo fmt --all --check`
- `cargo test -p arcbox-computer-runtime` (268 passed, 1 ignored)
- `cargo clippy -p arcbox-computer-runtime --all-targets --no-deps -- -D warnings -A clippy::result_large_err -A clippy::unused_async_trait_impl -A clippy::map_unwrap_or -A clippy::chunks_exact_to_as_chunks`

Full unfiltered clippy is currently blocked by pre-existing Rust 1.98 lints addressed separately in #704.

Linear: CORE-144

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches durable record shape and restore/checkpoint contracts on the snapshot lifecycle path; behavior change is intentional but affects adoption, pause/resume, and chained restores.
> 
> **Overview**
> Fixes **broken checkpoints after adoption or restore** by keeping kernel/rootfs (and geometry on restore) in the durable sandbox record and snapshot lineage, so later captures write restorable metadata instead of empty paths.
> 
> **Durable records** no longer clear `kernel` and `rootfs` when redacting consumed boot inputs at `Ready`; workload secrets (`cmd`, `env`, etc.) are still stripped. **Restore** merges snapshot provenance into the journaled `restore_spec` before provisioning. **Checkpoint** fails fast with a failed precondition when the in-memory spec has no kernel or rootfs, blocking legacy v1 records that were redacted in place.
> 
> Integration coverage adds adopt → checkpoint → restore, chained restore → checkpoint → restore, legacy-record refusal, and updates the adopted pause/resume test to expect a successful resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83b3b86a871be90c6d4bd0129c5d25756857bc95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->