### PR TITLE
feat(fleet-agent): per-job runner logs

### DIFF
--- a/fleet/arcbox-fleet-agent/src/attach.rs
+++ b/fleet/arcbox-fleet-agent/src/attach.rs
@@ -28,6 +28,7 @@ use crate::config::AgentConfig;
 use crate::credentials::Credential;
 use crate::handover::{Handover, Reason};
 use crate::host;
+use crate::joblog::JobLogs;
 use crate::runner::RunnerSupervisor;
 use crate::state::AgentState;
 use crate::update;
@@ -143,6 +144,7 @@ pub fn spawn_supervisor(
     let supervisor = RunnerSupervisor::new(
         egress_tx,
         config.runner_script.clone(),
+        JobLogs::new(&config.data_dir.join("log")),
         backends,
         state,
         handover,
@@ -1125,6 +1127,7 @@ mod tests {
         RunnerSupervisor::new(
             events,
             None,
+            crate::joblog::JobLogs::nowhere(),
             Backends::fixed(Vec::new(), state.clone()),
             state.clone(),
             Handover::new(state),

--- a/fleet/arcbox-fleet-agent/src/control/mod.rs
+++ b/fleet/arcbox-fleet-agent/src/control/mod.rs
@@ -1081,6 +1081,7 @@ mod tests {
         let runner = crate::runner::RunnerSupervisor::new(
             events,
             None,
+            crate::joblog::JobLogs::nowhere(),
             Backends::new(false, None, None, None, agent_state.clone()),
             agent_state.clone(),
             Handover::new(agent_state.clone()),
@@ -1228,6 +1229,7 @@ mod tests {
         let runner = crate::runner::RunnerSupervisor::new(
             events,
             None,
+            crate::joblog::JobLogs::nowhere(),
             Backends::new(false, None, None, None, agent_state.clone()),
             agent_state.clone(),
             Handover::new(agent_state),

--- a/fleet/arcbox-fleet-agent/src/docker.rs
+++ b/fleet/arcbox-fleet-agent/src/docker.rs
@@ -8,12 +8,19 @@ use anyhow::{Context, Result};
 use bollard::Docker;
 use bollard::models::ContainerCreateBody;
 use bollard::query_parameters::{
-    CreateContainerOptions, CreateImageOptions, RemoveContainerOptions, WaitContainerOptions,
+    CreateContainerOptions, CreateImageOptions, LogsOptions, RemoveContainerOptions,
+    WaitContainerOptions,
 };
 use tokio_stream::StreamExt;
 use tracing::{debug, info, warn};
 
 use crate::host;
+use crate::joblog::JobLog;
+
+/// How long teardown waits for a container's log stream to end after the
+/// container has. Generous for a stream that is already closing; short
+/// enough that a wedged daemon cannot hold a job's in-flight slot.
+const LOG_DRAIN_GRACE: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Everything the Docker runner needs to execute one job.
 pub struct RunSpec<'a> {
@@ -26,6 +33,9 @@ pub struct RunSpec<'a> {
     /// Image to run this job in — the live-settable `linux_runner_image`, read
     /// fresh by the caller for each job rather than fixed at construction.
     pub runner_image: &'a str,
+    /// Where the container's combined output is captured. `None` runs the
+    /// job without a log rather than failing it.
+    pub log: Option<JobLog>,
 }
 
 /// A container that has been created and started. Held by the caller while the
@@ -37,6 +47,10 @@ pub struct RunningContainer {
     client: Docker,
     id: String,
     guard: ContainerGuard,
+    /// The task copying the container's log stream into the job's log.
+    /// Awaited by [`remove`](Self::remove) before teardown, since removing
+    /// the container ends the stream.
+    log_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl RunningContainer {
@@ -61,8 +75,28 @@ impl RunningContainer {
 
     /// Remove the (exited) container, awaited. Failures are logged, not
     /// propagated: the job itself already concluded.
+    ///
+    /// The log stream is drained first: it ends when the container does, and
+    /// removing the container tears it down mid-copy — losing exactly the
+    /// tail output that says why a job failed.
     pub async fn remove(self) {
-        let Self { client, id, guard } = self;
+        let Self {
+            client,
+            id,
+            guard,
+            log_task,
+        } = self;
+        if let Some(mut task) = log_task {
+            // Bounded: a docker daemon that never closes the stream must not
+            // wedge teardown, which holds the job's in-flight slot open.
+            if tokio::time::timeout(LOG_DRAIN_GRACE, &mut task)
+                .await
+                .is_err()
+            {
+                task.abort();
+                warn!(container = %id, "container log stream did not end; dropping its tail");
+            }
+        }
         guard.defuse();
         let options = RemoveContainerOptions {
             force: true,
@@ -281,8 +315,42 @@ impl DockerRunner {
 
         Ok(RunningContainer {
             client: self.client.clone(),
+            log_task: spec.log.map(|log| self.capture_logs(&id, log)),
             id,
             guard,
+        })
+    }
+
+    /// Copy the container's combined output into the job's log until the
+    /// stream ends, which it does when the container exits.
+    ///
+    /// `tail: "all"` is explicit: this attaches after `start_container`, and
+    /// the default of the last few lines would drop everything the runner
+    /// wrote in between. The container is created without a TTY, so the
+    /// stream arrives demultiplexed and every variant's payload — stdout and
+    /// stderr alike — goes to the same place, in arrival order.
+    fn capture_logs(&self, id: &str, log: JobLog) -> tokio::task::JoinHandle<()> {
+        let mut stream = self.client.logs(
+            id,
+            Some(LogsOptions {
+                follow: true,
+                stdout: true,
+                stderr: true,
+                tail: "all".to_owned(),
+                ..Default::default()
+            }),
+        );
+        let id = id.to_owned();
+        tokio::spawn(async move {
+            while let Some(chunk) = stream.next().await {
+                match chunk {
+                    Ok(chunk) => log.write(chunk.as_ref()).await,
+                    Err(e) => {
+                        debug!(container = %id, error = %e, "container log stream ended");
+                        return;
+                    }
+                }
+            }
         })
     }
 

--- a/fleet/arcbox-fleet-agent/src/fsutil.rs
+++ b/fleet/arcbox-fleet-agent/src/fsutil.rs
@@ -9,26 +9,57 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::Serialize;
 
-/// Write `bytes` to `path`, owner-only (`0600`) from creation — every
-/// supported target (macOS, Linux) is Unix.
-fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
-    use std::io::Write;
+/// Open `path` owner-only (`0600`) from creation — every supported target
+/// (macOS, Linux) is Unix. `truncate` picks between replacing the file's
+/// contents and appending to them.
+fn open_owner_only(path: &Path, truncate: bool) -> Result<std::fs::File> {
     use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
-    let mut file = std::fs::OpenOptions::new()
+    let file = std::fs::OpenOptions::new()
         .write(true)
         .create(true)
-        .truncate(true)
+        .truncate(truncate)
+        .append(!truncate)
         .mode(0o600)
         .open(path)
         .with_context(|| format!("creating {}", path.display()))?;
-    // `mode` only takes effect when this call creates the file; a leftover temp
-    // from a crashed run keeps its old mode, so fchmod the open handle as a
-    // backstop (operating on the fd, never racing a path lookup).
+    // `mode` only takes effect when this call creates the file; a leftover file
+    // from an earlier or umask-lenient run keeps its old mode, so fchmod the
+    // open handle as a backstop (operating on the fd, never racing a path
+    // lookup).
     file.set_permissions(std::fs::Permissions::from_mode(0o600))
         .with_context(|| format!("chmod 0600 {}", path.display()))?;
+    Ok(file)
+}
+
+/// Open `path` for appending, owner-only (`0600`), creating it if absent.
+/// Append rather than truncate so a second open never destroys what the
+/// first wrote.
+pub fn open_append_owner_only(path: &Path) -> Result<std::fs::File> {
+    open_owner_only(path, false)
+}
+
+/// Write `bytes` to `path`, owner-only (`0600`) from creation.
+fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+
+    let mut file = open_owner_only(path, true)?;
     file.write_all(bytes)
         .with_context(|| format!("writing {}", path.display()))
+}
+
+/// Create `dir` (and its parents) owner-only (`0700`).
+///
+/// The chmod is unconditional rather than creation-only so a directory left
+/// behind by an older or umask-lenient run gets the same traversal barrier
+/// `control::serve` applies at startup — the headless `quick enroll`
+/// persists into the data dir without ever running `serve`.
+pub fn ensure_owner_only_dir(dir: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("chmod 0700 {}", dir.display()))
 }
 
 /// Serialize `value` as pretty JSON and write it to `path` atomically:
@@ -38,17 +69,8 @@ fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<()> {
 /// read, and it preserves the temp file's mode so a secret is never briefly
 /// world-readable at the final path.
 pub fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("creating {}", parent.display()))?;
-        // Owner-only like the file below, and unconditional (not just on
-        // creation) so a dir left behind by an older or umask-lenient run
-        // gets the same traversal barrier `control::serve` applies at
-        // startup — the headless `quick enroll` persists here without `serve`.
-        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
-            .with_context(|| format!("chmod 0700 {}", parent.display()))?;
+        ensure_owner_only_dir(parent)?;
     }
     let json = serde_json::to_vec_pretty(value).context("serializing to JSON")?;
     let mut tmp = path.as_os_str().to_owned();

--- a/fleet/arcbox-fleet-agent/src/interop.rs
+++ b/fleet/arcbox-fleet-agent/src/interop.rs
@@ -30,6 +30,8 @@ use anyhow::{Context, Result, bail, ensure};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tracing::{debug, warn};
 
+use crate::joblog::JobLog;
+
 /// Fixed Windows locations of the interop tools, translated through
 /// `wslpath` at startup so a non-default automount root still resolves.
 /// Windows PowerShell 5.1 ships with every Windows 10/11 install (unlike
@@ -162,17 +164,33 @@ impl InteropRunner {
     /// side and carries the PID that can cancel it. Any failure past the
     /// spawn reaps the relay before returning, so an error never leaks a
     /// process.
-    pub async fn spawn(&self, encoded_jit_config: &str) -> Result<InteropJob> {
+    pub async fn spawn(&self, encoded_jit_config: &str, log: Option<JobLog>) -> Result<InteropJob> {
         validate_jit_config(&self.script, encoded_jit_config)?;
 
-        let mut child = tokio::process::Command::new(&self.powershell)
+        let mut command = tokio::process::Command::new(&self.powershell);
+        command
             .args(["-NoProfile", "-NonInteractive", "-Command"])
             .arg(wrapper_command(&self.script, encoded_jit_config))
             .stdin(Stdio::null())
+            // stdout is always piped — the `WINPID=` handshake is read from
+            // it. stderr is piped only when there is a log to drain it into:
+            // a piped stream nobody reads fills its pipe and blocks the
+            // runner, so with no log it stays inherited-free by going to the
+            // null device instead.
             .stdout(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .context("spawning the interop wrapper")?;
+            .stderr(if log.is_some() {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            })
+            .kill_on_drop(true);
+        let mut child = command.spawn().context("spawning the interop wrapper")?;
+
+        if let Some(log) = log.clone() {
+            if let Some(stderr) = child.stderr.take() {
+                tokio::spawn(async move { log.pump(stderr).await });
+            }
+        }
 
         let stdout = child
             .stdout
@@ -187,7 +205,10 @@ impl InteropRunner {
                         .parse::<u32>()
                         .with_context(|| format!("malformed handshake line {line:?}"));
                 }
-                debug!(line, "interop wrapper output before handshake");
+                // Runner output, not handshake: it belongs in the job's log
+                // like everything after the handshake. The `WINPID=` line
+                // itself does not — that is this wrapper's protocol.
+                log_line(log.as_ref(), &line).await;
             }
             bail!("interop wrapper exited without reporting WINPID");
         };
@@ -206,11 +227,13 @@ impl InteropRunner {
         // Keep the pipe drained for the rest of the job — the runner's
         // output flows through the wrapper's console — so a chatty runner
         // can never fill the pipe and wedge itself. Ends at EOF when the
-        // relay exits; detaching the handle is deliberate.
+        // relay exits; detaching the handle is deliberate. Reassembled into
+        // lines rather than copied verbatim, because the handshake above has
+        // to scan this same stream by line.
         tokio::spawn(async move {
             loop {
                 match lines.next_line().await {
-                    Ok(Some(line)) => debug!(line, "windows runner output"),
+                    Ok(Some(line)) => log_line(log.as_ref(), &line).await,
                     Ok(None) => break,
                     Err(e) => {
                         debug!(error = %e, "windows runner output stream failed");
@@ -226,6 +249,16 @@ impl InteropRunner {
             taskkill: self.taskkill.clone(),
             kill_timeout: KILL_TIMEOUT,
         })
+    }
+}
+
+/// Append one line of wrapper output to the job's log, restoring the
+/// newline `next_line` stripped. Without a log the line is debug-level
+/// only, which is where all of this output used to go.
+async fn log_line(log: Option<&JobLog>, line: &str) {
+    match log {
+        Some(log) => log.write(format!("{line}\n").as_bytes()).await,
+        None => debug!(line, "windows runner output"),
     }
 }
 
@@ -435,7 +468,7 @@ mod tests {
     /// spawns long-existing Windows binaries, never freshly written ones.
     async fn spawn_retrying(runner: &InteropRunner, jit: &str) -> Result<InteropJob> {
         for _ in 0..100 {
-            match runner.spawn(jit).await {
+            match runner.spawn(jit, None).await {
                 Err(e) if format!("{e:#}").contains("Text file busy") => {
                     tokio::time::sleep(Duration::from_millis(20)).await;
                 }
@@ -589,7 +622,7 @@ mod tests {
         std::fs::write(&staged, "@echo off\r\nping -n 60 127.0.0.1 >NUL\r\n").unwrap();
 
         let runner = InteropRunner::new(&script).await.expect("probe");
-        let mut job = runner.spawn("dGVzdA==").await.expect("spawn");
+        let mut job = runner.spawn("dGVzdA==", None).await.expect("spawn");
         assert!(job.windows_pid() > 0);
 
         let start = tokio::time::Instant::now();

--- a/fleet/arcbox-fleet-agent/src/joblog.rs
+++ b/fleet/arcbox-fleet-agent/src/joblog.rs
@@ -1,0 +1,345 @@
+//! Per-job runner logs: one file per job holding that job's stdout and
+//! stderr, combined, byte-for-byte.
+//!
+//! Every backend routes its runner's output here — the host process group,
+//! the Docker container, the macOS guest's SSH session, the WSL interop
+//! relay — so the local record of a job survives the thing that produced
+//! it. That matters exactly when GitHub's own job log is empty: a runner
+//! that died before it could ship anything, which is the case the
+//! `RunnerExited` liveness hint exists to signal.
+//!
+//! The files are owner-only under `<data_dir>/log/jobs/`, kept for
+//! [`RETENTION`], and each capped at [`MAX_BYTES`].
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use anyhow::{Context, Result, bail};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::sync::Mutex;
+use tracing::{debug, warn};
+
+use crate::fsutil;
+
+/// How long a job's log is kept. Age-based rather than counted: a burst of
+/// short jobs must not evict the log of the long one that ran alongside them.
+const RETENTION: Duration = Duration::from_secs(7 * 24 * 3600);
+
+/// Ceiling on one job's log. Past it the output is dropped (see
+/// [`Sink::write`]) — a runaway runner must not fill the disk and take the
+/// agent down with it.
+const MAX_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Read buffer of [`JobLog::pump`]. Runner output is line-ish and bursty;
+/// this is large enough that a chatty build does not syscall per line.
+const PUMP_BUF: usize = 16 * 1024;
+
+/// The job-log directory.
+///
+/// Path math only — [`new`](Self::new) does no I/O, so the `jobs` CLI
+/// command can construct one purely to read what is already there.
+#[derive(Clone)]
+pub struct JobLogs {
+    dir: PathBuf,
+}
+
+impl JobLogs {
+    /// The `jobs/` subdirectory of `log_dir` — a subdirectory so the age
+    /// sweep below can never reach the agent's own `fleet-agent.log`.
+    pub fn new(log_dir: &Path) -> Self {
+        Self {
+            dir: log_dir.join("jobs"),
+        }
+    }
+
+    /// A directory nothing is ever written to, for tests that build a
+    /// supervisor but never start a runner. `sweep` treats the missing
+    /// directory as the normal pre-first-job case, so nothing here touches
+    /// the filesystem.
+    #[cfg(test)]
+    pub fn nowhere() -> Self {
+        Self {
+            dir: PathBuf::from("/nonexistent/arcbox-fleet-agent"),
+        }
+    }
+
+    /// The log file for `job_id`, opened for appending.
+    ///
+    /// Appending, not truncating: a second open for the same job (a
+    /// redelivery after a restart) must not destroy what the first attempt
+    /// recorded.
+    pub fn open(&self, job_id: &str) -> Result<JobLog> {
+        let path = self.path_for(job_id)?;
+        fsutil::ensure_owner_only_dir(&self.dir)?;
+        let file = fsutil::open_append_owner_only(&path)?;
+        let written = file
+            .metadata()
+            .with_context(|| format!("stat {}", path.display()))?
+            .len();
+        Ok(JobLog {
+            sink: Arc::new(Mutex::new(Sink {
+                file: tokio::fs::File::from_std(file),
+                written,
+                stopped: false,
+            })),
+            path: path.into(),
+        })
+    }
+
+    /// Delete every log older than [`RETENTION`]. A missing directory is
+    /// the normal case before the first job, not an error.
+    pub fn sweep(&self) {
+        let entries = match std::fs::read_dir(&self.dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+            Err(e) => {
+                warn!(dir = %self.dir.display(), error = %e, "cannot read the job log directory");
+                return;
+            }
+        };
+        let cutoff = SystemTime::now() - RETENTION;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let aged_out = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .is_ok_and(|modified| modified < cutoff);
+            if aged_out {
+                match std::fs::remove_file(&path) {
+                    Ok(()) => debug!(path = %path.display(), "removed an expired job log"),
+                    Err(e) => {
+                        warn!(path = %path.display(), error = %e, "cannot remove an expired job log");
+                    }
+                }
+            }
+        }
+    }
+
+    /// The path `job_id` maps to, rejecting anything that is not a plain
+    /// file name.
+    ///
+    /// `job_id` is issued by the gateway and validated nowhere else in the
+    /// agent — `docker::container_name` and `vm::machine_name` interpolate
+    /// it raw — and this is the first place it reaches the filesystem. The
+    /// character set admits GitHub's `rjob_…` ids and nothing that could
+    /// carry a path separator, a `..`, or an unbounded name.
+    fn path_for(&self, job_id: &str) -> Result<PathBuf> {
+        let safe = !job_id.is_empty()
+            && job_id.len() <= 128
+            && job_id
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-'));
+        if !safe {
+            bail!("job id {job_id:?} is not a usable log file name");
+        }
+        Ok(self.dir.join(format!("{job_id}.log")))
+    }
+}
+
+/// One job's log. Clone-cheap: every clone writes to the same file, so a
+/// backend can hand one to its stdout pump and one to its stderr pump and
+/// get them interleaved in arrival order.
+#[derive(Clone)]
+pub struct JobLog {
+    sink: Arc<Mutex<Sink>>,
+    path: Arc<Path>,
+}
+
+impl JobLog {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Append `bytes` verbatim. Never fails the caller: a job's output is
+    /// not worth failing the job over.
+    pub async fn write(&self, bytes: &[u8]) {
+        self.sink.lock().await.write(bytes, &self.path).await;
+    }
+
+    /// Copy `reader` into the log until EOF.
+    ///
+    /// Read errors end the pump; write errors do not (see [`Sink::write`]).
+    /// The loop always runs to EOF, which is what keeps a runner whose
+    /// output is being discarded from wedging on a full pipe.
+    pub async fn pump<R: AsyncRead + Unpin>(&self, mut reader: R) {
+        let mut buf = vec![0_u8; PUMP_BUF];
+        loop {
+            match reader.read(&mut buf).await {
+                Ok(0) => return,
+                Ok(n) => self.write(&buf[..n]).await,
+                Err(e) => {
+                    debug!(path = %self.path.display(), error = %e, "job log source ended");
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// The open file plus its byte count. Writes are small and infrequent
+/// relative to anything else a job does, so one mutex is the whole
+/// concurrency story here.
+struct Sink {
+    file: tokio::fs::File,
+    written: u64,
+    /// Set once the cap is hit or a write fails, so neither is reported
+    /// more than once and later chunks are dropped without syscalls.
+    stopped: bool,
+}
+
+impl Sink {
+    /// Append `bytes`, or drop them once this sink has stopped.
+    ///
+    /// Both stop conditions — the cap and a write error — leave the pumps
+    /// running and silently discarding. That is deliberate: `interop`'s
+    /// relay and every piped child block once their pipe fills, so a pump
+    /// that stopped reading would stall the runner itself. Losing tail
+    /// output beats hanging a customer's job.
+    async fn write(&mut self, bytes: &[u8], path: &Path) {
+        if self.stopped {
+            return;
+        }
+        if self.written + bytes.len() as u64 > MAX_BYTES {
+            self.stopped = true;
+            warn!(path = %path.display(), "job log hit its size cap; discarding further output");
+            let notice = format!(
+                "\n[arcbox-fleet-agent] log truncated at {} MiB; further output discarded\n",
+                MAX_BYTES / (1024 * 1024)
+            );
+            let _ = self.file.write_all(notice.as_bytes()).await;
+            let _ = self.file.flush().await;
+            return;
+        }
+        // Flushed per chunk, not left in `tokio::fs::File`'s buffer: this log
+        // exists for the runner that died without reporting anything, so what
+        // it wrote has to be on disk before the process that wrote it is gone.
+        // A flush here is a `write(2)`, not an fsync.
+        let written = async {
+            self.file.write_all(bytes).await?;
+            self.file.flush().await
+        }
+        .await;
+        if let Err(e) = written {
+            self.stopped = true;
+            warn!(path = %path.display(), error = %e, "cannot write the job log; discarding further output");
+            return;
+        }
+        self.written += bytes.len() as u64;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    fn logs(dir: &Path) -> JobLogs {
+        JobLogs::new(dir)
+    }
+
+    /// A gateway-issued job id reaches the filesystem here, so anything
+    /// that is not a plain file name has to be refused rather than
+    /// escaping the directory.
+    #[test]
+    fn hostile_job_ids_are_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs = logs(dir.path());
+
+        for bad in [
+            "",
+            "..",
+            "../..",
+            "../../etc/passwd",
+            "/etc/passwd",
+            "rjob/../x",
+            "rjob abc",
+            "rjob.abc",
+            &"a".repeat(129),
+        ] {
+            assert!(logs.open(bad).is_err(), "{bad:?} was accepted");
+        }
+
+        assert!(logs.open("rjob_abc-123").is_ok());
+    }
+
+    /// Both pumps write into the same file, and the directory and file
+    /// carry the owner-only modes job output needs.
+    #[tokio::test]
+    async fn both_streams_land_in_one_owner_only_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs = logs(dir.path());
+        let log = logs.open("rjob_combined").unwrap();
+
+        log.pump(&b"from stdout\n"[..]).await;
+        log.clone().pump(&b"from stderr\n"[..]).await;
+
+        let contents = std::fs::read_to_string(log.path()).unwrap();
+        assert_eq!(contents, "from stdout\nfrom stderr\n");
+
+        let file_mode = std::fs::metadata(log.path()).unwrap().permissions().mode();
+        assert_eq!(file_mode & 0o777, 0o600);
+        let dir_mode = std::fs::metadata(logs.dir).unwrap().permissions().mode();
+        assert_eq!(dir_mode & 0o777, 0o700);
+    }
+
+    /// Reopening a job's log appends: a redelivery must not erase what the
+    /// first attempt recorded.
+    #[tokio::test]
+    async fn reopening_appends() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs = logs(dir.path());
+
+        logs.open("rjob_twice").unwrap().write(b"first\n").await;
+        logs.open("rjob_twice").unwrap().write(b"second\n").await;
+
+        let contents = std::fs::read_to_string(logs.dir.join("rjob_twice.log")).unwrap();
+        assert_eq!(contents, "first\nsecond\n");
+    }
+
+    /// Past the cap the output is dropped with a notice — but the pump
+    /// still drains its reader to EOF, because a pump that stopped reading
+    /// would block the runner on a full pipe.
+    #[tokio::test]
+    async fn the_cap_truncates_but_the_pump_still_drains() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs = logs(dir.path());
+        let log = logs.open("rjob_chatty").unwrap();
+
+        // Pre-charge the counter so the test needn't write 256 MiB.
+        log.sink.lock().await.written = MAX_BYTES;
+
+        let source = vec![b'@'; PUMP_BUF * 3];
+        let mut reader = &source[..];
+        log.pump(&mut reader).await;
+
+        assert!(reader.is_empty(), "the pump stopped short of EOF");
+        let contents = std::fs::read_to_string(log.path()).unwrap();
+        assert!(contents.contains("log truncated at 256 MiB"), "{contents}");
+        assert!(!contents.contains('@'), "output past the cap was written");
+    }
+
+    #[test]
+    fn sweep_drops_aged_logs_and_keeps_fresh_ones() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs = logs(dir.path());
+
+        // A missing directory is the pre-first-job case, not an error.
+        logs.sweep();
+
+        logs.open("rjob_fresh").unwrap();
+        logs.open("rjob_aged").unwrap();
+        let aged = logs.dir.join("rjob_aged.log");
+        let long_ago = SystemTime::now() - RETENTION - Duration::from_secs(3600);
+        std::fs::File::open(&aged)
+            .unwrap()
+            .set_modified(long_ago)
+            .unwrap();
+
+        logs.sweep();
+
+        assert!(!aged.exists(), "an expired log survived the sweep");
+        assert!(logs.dir.join("rjob_fresh.log").exists());
+    }
+}

--- a/fleet/arcbox-fleet-agent/src/joblog.rs
+++ b/fleet/arcbox-fleet-agent/src/joblog.rs
@@ -53,6 +53,32 @@ impl JobLogs {
         }
     }
 
+    /// Where the logs live, for a caller that reports the location.
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    /// Every log present, newest first, as `(job_id, path)`. A missing
+    /// directory reads as empty — the pre-first-job case, not an error.
+    pub fn list(&self) -> Vec<(String, PathBuf)> {
+        let Ok(entries) = std::fs::read_dir(&self.dir) else {
+            return Vec::new();
+        };
+        let mut logs: Vec<(SystemTime, String, PathBuf)> = entries
+            .flatten()
+            .filter_map(|entry| {
+                let path = entry.path();
+                let job_id = path.file_stem()?.to_str()?.to_owned();
+                let modified = entry.metadata().and_then(|m| m.modified()).ok()?;
+                Some((modified, job_id, path))
+            })
+            .collect();
+        logs.sort_unstable_by_key(|log| std::cmp::Reverse(log.0));
+        logs.into_iter()
+            .map(|(_, job_id, path)| (job_id, path))
+            .collect()
+    }
+
     /// A directory nothing is ever written to, for tests that build a
     /// supervisor but never start a runner. `sweep` treats the missing
     /// directory as the normal pre-first-job case, so nothing here touches
@@ -318,6 +344,26 @@ mod tests {
         let contents = std::fs::read_to_string(log.path()).unwrap();
         assert!(contents.contains("log truncated at 256 MiB"), "{contents}");
         assert!(!contents.contains('@'), "output past the cap was written");
+    }
+
+    /// `jobs` prints what `list` returns, so newest-first is the contract:
+    /// the log you want is almost always the last one written.
+    #[test]
+    fn list_is_newest_first_and_empty_before_the_first_job() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs = logs(dir.path());
+        assert!(logs.list().is_empty());
+
+        logs.open("rjob_older").unwrap();
+        logs.open("rjob_newer").unwrap();
+        let older = logs.dir.join("rjob_older.log");
+        std::fs::File::open(&older)
+            .unwrap()
+            .set_modified(SystemTime::now() - Duration::from_secs(600))
+            .unwrap();
+
+        let ids: Vec<String> = logs.list().into_iter().map(|(id, _)| id).collect();
+        assert_eq!(ids, ["rjob_newer", "rjob_older"]);
     }
 
     #[test]

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -37,6 +37,7 @@ mod fsutil;
 mod handover;
 mod host;
 mod interop;
+mod joblog;
 #[cfg(test)]
 mod mock_daemon;
 mod reexec;
@@ -242,6 +243,9 @@ fn main() -> Result<()> {
         foreground: true,
         ..LogConfig::default()
     });
+    // Collect expired job logs on every invocation, so an agent that stops
+    // running jobs (or crashed mid-job) still stops holding onto them.
+    joblog::JobLogs::new(&config.data_dir.join("log")).sweep();
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/fleet/arcbox-fleet-agent/src/main.rs
+++ b/fleet/arcbox-fleet-agent/src/main.rs
@@ -60,6 +60,7 @@ use arcbox_fleet_control_proto::v1 as control_proto;
 use arcbox_fleet_control_proto::v1::fleet_image_service_client::FleetImageServiceClient;
 use arcbox_fleet_control_proto::v1::fleet_lifecycle_service_client::FleetLifecycleServiceClient;
 use arcbox_fleet_control_proto::v1::fleet_settings_service_client::FleetSettingsServiceClient;
+use arcbox_fleet_control_proto::v1::fleet_state_service_client::FleetStateServiceClient;
 use arcbox_logging::LogConfig;
 use clap::{Args, Parser, Subcommand};
 use tracing::{info, warn};
@@ -98,6 +99,8 @@ enum Command {
     Serve,
     /// Show the running agent's enrollment/attachment status.
     Status,
+    /// List the jobs running here and the logs of those that already ran.
+    Jobs,
     /// Stop the running agent from accepting new offers; in-flight jobs
     /// finish normally.
     Drain,
@@ -436,6 +439,10 @@ async fn run(command: Command, config: AgentConfig) -> Result<Outcome> {
             }
             Ok(Outcome::Exit)
         }
+        Command::Jobs => {
+            list_jobs(&config).await;
+            Ok(Outcome::Exit)
+        }
         Command::Drain => {
             let channel = control::client::connect_default(&config).await?;
             let mut client = FleetLifecycleServiceClient::new(channel);
@@ -602,6 +609,65 @@ fn uninstall_service() -> Result<()> {
         "quick uninstall-service is only implemented for macOS; Linux systemd (user unit) \
          support is planned as a follow-up"
     )
+}
+
+/// Print the jobs running here, then the logs of the ones that already ran.
+///
+/// Only the running half needs the agent — that state lives in the process,
+/// not on disk. The logs do not, so an unreachable socket reports itself and
+/// still lists them: a stopped agent is exactly when its last job's output
+/// is what you came for.
+async fn list_jobs(config: &AgentConfig) {
+    let in_flight = match in_flight_jobs(config).await {
+        Ok(jobs) => jobs,
+        Err(e) => {
+            println!("running jobs unavailable: {e:#}");
+            Vec::new()
+        }
+    };
+    for job in &in_flight {
+        let log = if job.log_path.is_empty() {
+            "<no log>"
+        } else {
+            &job.log_path
+        };
+        println!("running   {}  {}/{}  {log}", job.job_id, job.os, job.arch);
+    }
+
+    let logs = joblog::JobLogs::new(&config.data_dir.join("log"));
+    let mut finished = 0;
+    for (job_id, path) in logs.list() {
+        if in_flight.iter().any(|job| job.job_id == job_id) {
+            continue;
+        }
+        finished += 1;
+        println!("finished  {job_id}  {}", path.display());
+    }
+    if in_flight.is_empty() && finished == 0 {
+        println!("no jobs (logs are kept in {})", logs.dir().display());
+    }
+}
+
+/// The running agent's in-flight jobs, read as the first `Watch` snapshot —
+/// which the service sends immediately, so there is no separate RPC for a
+/// point-in-time read.
+async fn in_flight_jobs(config: &AgentConfig) -> Result<Vec<control_proto::InFlightJob>> {
+    let channel = control::client::connect_default(config).await?;
+    let mut client = FleetStateServiceClient::new(channel);
+    let mut stream = client
+        .watch(control_proto::WatchRequest {})
+        .await
+        .context("Watch RPC failed")?
+        .into_inner();
+    let response = stream
+        .message()
+        .await
+        .context("Watch stream failed")?
+        .context("Watch stream closed without a snapshot")?;
+    Ok(response
+        .snapshot
+        .map(|snapshot| snapshot.in_flight)
+        .unwrap_or_default())
 }
 
 /// Resolve the enrollment token from its chosen source: a file, an explicit

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -527,7 +527,10 @@ impl RunnerSupervisor {
         let job_id = order.job_id.clone();
         let log = self.open_job_log(&job_id);
         match backend {
-            Backend::Docker => self.run_docker_job(&job_id, &order, &token, cancel).await,
+            Backend::Docker => {
+                self.run_docker_job(&job_id, &order, &token, log, cancel)
+                    .await;
+            }
             // A windows capability is host_runner-backed on the wire (it IS
             // the host's pre-installed runner, reached across the WSL
             // interop boundary), but its process management is different
@@ -540,7 +543,7 @@ impl RunnerSupervisor {
                 self.run_host_job(&job_id, &order, &token, log, cancel)
                     .await;
             }
-            Backend::Vm => self.run_vm_job(&job_id, &order, &token, cancel).await,
+            Backend::Vm => self.run_vm_job(&job_id, &order, &token, log, cancel).await,
             // Never advertised, so admit() never routes here; reject
             // defensively rather than panic if it ever slips through.
             Backend::Unspecified => {
@@ -578,6 +581,7 @@ impl RunnerSupervisor {
         job_id: &str,
         order: &ProvisionRunner,
         token: &str,
+        log: Option<JobLog>,
         cancel: CancellationToken,
     ) {
         // A vm capability is only advertised while the registry's VM slot
@@ -596,6 +600,7 @@ impl RunnerSupervisor {
                 job_id,
                 encoded_jit_config: &order.encoded_jit_config,
                 runner_image: &runner_image,
+                log,
             }));
             tokio::select! {
                 result = start => Some(result),
@@ -832,6 +837,7 @@ impl RunnerSupervisor {
         job_id: &str,
         order: &ProvisionRunner,
         token: &str,
+        log: Option<JobLog>,
         cancel: CancellationToken,
     ) {
         // A Docker-backed capability is only advertised while the registry's
@@ -852,6 +858,7 @@ impl RunnerSupervisor {
                 encoded_jit_config: &order.encoded_jit_config,
                 arch: &order.arch,
                 runner_image: &runner_image,
+                log,
             }));
             tokio::select! {
                 result = start => Some(result),

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -319,10 +319,18 @@ impl RunnerSupervisor {
                     self.inner
                         .in_flight
                         .insert(job_id.clone(), JobSlot::new(cancel.clone()));
+                    // Opened here, not in the spawned task, so the path
+                    // published below is one that exists: a client is told
+                    // where the output is, or told there is none.
+                    let log = self.open_job_log(&job_id);
                     self.inner.state.add_in_flight(control_proto::InFlightJob {
                         job_id,
                         os: order.os.clone(),
                         arch: order.arch.clone(),
+                        log_path: log
+                            .as_ref()
+                            .map(|log| log.path().display().to_string())
+                            .unwrap_or_default(),
                     });
                     let sup = self.clone();
                     tokio::spawn(async move {
@@ -332,7 +340,7 @@ impl RunnerSupervisor {
                             inner: sup.inner.clone(),
                             job_id: order.job_id.clone(),
                         };
-                        sup.run_job(order, backend, token, cancel).await;
+                        sup.run_job(order, backend, token, log, cancel).await;
                     });
                     return;
                 }
@@ -522,10 +530,10 @@ impl RunnerSupervisor {
         order: ProvisionRunner,
         backend: Backend,
         token: String,
+        log: Option<JobLog>,
         cancel: CancellationToken,
     ) {
         let job_id = order.job_id.clone();
-        let log = self.open_job_log(&job_id);
         match backend {
             Backend::Docker => {
                 self.run_docker_job(&job_id, &order, &token, log, cancel)
@@ -1579,6 +1587,7 @@ mod tests {
             job_id: "rjob_a".to_owned(),
             os: "darwin".to_owned(),
             arch: "arm64".to_owned(),
+            log_path: String::new(),
         });
         {
             let _guard = ReleaseGuard {

--- a/fleet/arcbox-fleet-agent/src/runner.rs
+++ b/fleet/arcbox-fleet-agent/src/runner.rs
@@ -28,12 +28,13 @@ use command_group::AsyncCommandGroup;
 use dashmap::DashMap;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::backends::Backends;
 use crate::docker::RunSpec;
 use crate::handover::Handover;
 use crate::host;
+use crate::joblog::{JobLog, JobLogs};
 use crate::state::AgentState;
 
 /// Watchdog on a VM job's runtime: GitHub concludes jobs at 6 h, so a
@@ -191,6 +192,8 @@ struct Inner {
     /// Path to the installed runner's entry point (`run.sh`). `None` when
     /// only Docker-based execution is configured.
     runner_script: Option<PathBuf>,
+    /// Where each job's combined stdout/stderr is written.
+    job_logs: JobLogs,
     /// The live backend registry: the runtimes behind each advertised
     /// capability and the `(os, arch)` → backend routing, read per offer so
     /// routing always agrees with what is currently advertised.
@@ -237,6 +240,7 @@ impl RunnerSupervisor {
     pub fn new(
         events: mpsc::Sender<AttachRequest>,
         runner_script: Option<PathBuf>,
+        job_logs: JobLogs,
         backends: Arc<Backends>,
         state: AgentState,
         handover: Arc<Handover>,
@@ -247,6 +251,7 @@ impl RunnerSupervisor {
                 outstanding: DashMap::new(),
                 in_flight: DashMap::new(),
                 runner_script,
+                job_logs,
                 backends,
                 draining: std::sync::atomic::AtomicBool::new(false),
                 handover,
@@ -520,6 +525,7 @@ impl RunnerSupervisor {
         cancel: CancellationToken,
     ) {
         let job_id = order.job_id.clone();
+        let log = self.open_job_log(&job_id);
         match backend {
             Backend::Docker => self.run_docker_job(&job_id, &order, &token, cancel).await,
             // A windows capability is host_runner-backed on the wire (it IS
@@ -527,14 +533,36 @@ impl RunnerSupervisor {
             // interop boundary), but its process management is different
             // enough to be its own path — see `crate::interop`.
             Backend::HostRunner if order.os == "windows" => {
-                self.run_interop_job(&job_id, &order, &token, cancel).await;
+                self.run_interop_job(&job_id, &order, &token, log, cancel)
+                    .await;
             }
-            Backend::HostRunner => self.run_host_job(&job_id, &order, &token, cancel).await,
+            Backend::HostRunner => {
+                self.run_host_job(&job_id, &order, &token, log, cancel)
+                    .await;
+            }
             Backend::Vm => self.run_vm_job(&job_id, &order, &token, cancel).await,
             // Never advertised, so admit() never routes here; reject
             // defensively rather than panic if it ever slips through.
             Backend::Unspecified => {
                 self.reject_start(&job_id, &token, "backend not supported by this agent");
+            }
+        }
+        // The job's own log is complete now, so this is the cheapest place to
+        // collect expired ones — including any a crashed run left behind.
+        self.inner.job_logs.sweep();
+    }
+
+    /// Open this job's log, or run without one. A log that cannot be opened
+    /// (a full or read-only disk) is worth a warning, never a failed job.
+    fn open_job_log(&self, job_id: &str) -> Option<JobLog> {
+        match self.inner.job_logs.open(job_id) {
+            Ok(log) => {
+                debug!(job_id, path = %log.path().display(), "capturing runner output");
+                Some(log)
+            }
+            Err(e) => {
+                warn!(job_id, error = %e, "cannot open a job log; runner output will not be kept");
+                None
             }
         }
     }
@@ -654,6 +682,7 @@ impl RunnerSupervisor {
         job_id: &str,
         order: &ProvisionRunner,
         token: &str,
+        log: Option<JobLog>,
         cancel: CancellationToken,
     ) {
         // Invariant: a windows capability is only advertised when the
@@ -668,7 +697,7 @@ impl RunnerSupervisor {
         // on degraded interop and must not make the agent deaf to
         // CancelRunner — mirror the VM startup path.
         let spawned = {
-            let spawn = std::pin::pin!(interop.spawn(&order.encoded_jit_config));
+            let spawn = std::pin::pin!(interop.spawn(&order.encoded_jit_config, log));
             tokio::select! {
                 result = spawn => Some(result),
                 () = cancel.cancelled() => None,
@@ -734,6 +763,7 @@ impl RunnerSupervisor {
         job_id: &str,
         order: &ProvisionRunner,
         token: &str,
+        log: Option<JobLog>,
         cancel: CancellationToken,
     ) {
         let Some(runner_script) = &self.inner.runner_script else {
@@ -741,7 +771,7 @@ impl RunnerSupervisor {
             return;
         };
 
-        let mut command = runner_command(runner_script, &order.encoded_jit_config);
+        let mut command = runner_command(runner_script, &order.encoded_jit_config, log.is_some());
         let mut child = match command.group_spawn() {
             Ok(child) => child,
             Err(e) => {
@@ -749,6 +779,18 @@ impl RunnerSupervisor {
                 return;
             }
         };
+        // Both pipes drain into the job's log for the lifetime of the runner.
+        // Detached: they end at EOF when the process group goes away, which a
+        // cancel's group kill guarantees.
+        if let Some(log) = log {
+            if let Some(stdout) = child.inner().stdout.take() {
+                let log = log.clone();
+                tokio::spawn(async move { log.pump(stdout).await });
+            }
+            if let Some(stderr) = child.inner().stderr.take() {
+                tokio::spawn(async move { log.pump(stderr).await });
+            }
+        }
 
         // group_spawn is synchronous, but cancellation is handled on another
         // runtime thread. Arbitrate through the slot before accepting.
@@ -994,9 +1036,28 @@ impl RunnerSupervisor {
 /// point (`run.sh`); no `.current_dir()` is set because the wrapper script
 /// locates its own sibling files via `$0`'s dirname, not the caller's
 /// working directory.
-fn runner_command(script: &Path, encoded_jit_config: &str) -> tokio::process::Command {
+/// The runner invocation. Output is never inherited — it either flows to
+/// the job's log (`capture`, the normal case) or to `/dev/null`, because
+/// inheriting put every concurrent job's output in one stream with nothing
+/// attributable. `capture` must be false when no log could be opened: a
+/// piped stream nobody drains fills its pipe and blocks the runner.
+fn runner_command(
+    script: &Path,
+    encoded_jit_config: &str,
+    capture: bool,
+) -> tokio::process::Command {
+    let sink = if capture {
+        std::process::Stdio::piped
+    } else {
+        std::process::Stdio::null
+    };
     let mut command = tokio::process::Command::new(script);
-    command.arg("--jitconfig").arg(encoded_jit_config);
+    command
+        .arg("--jitconfig")
+        .arg(encoded_jit_config)
+        .stdin(std::process::Stdio::null())
+        .stdout(sink())
+        .stderr(sink());
     command
 }
 
@@ -1057,6 +1118,7 @@ mod tests {
         let sup = RunnerSupervisor::new(
             events,
             Some(PathBuf::from("/nonexistent")),
+            JobLogs::nowhere(),
             Backends::fixed(capabilities, state.clone()),
             state,
             Arc::clone(&handover),
@@ -1092,6 +1154,7 @@ mod tests {
     /// reject — `handle_provision` reads real `host::telemetry()`.
     fn windows_supervisor_with_rx(
         interop: Option<InteropRunner>,
+        job_logs: JobLogs,
     ) -> (RunnerSupervisor, mpsc::Receiver<AttachRequest>) {
         let (events, rx) = mpsc::channel(8);
         let state = AgentState::new(&crate::settings::PersistedSettings {
@@ -1104,8 +1167,14 @@ mod tests {
             interop,
             state.clone(),
         );
-        let sup =
-            RunnerSupervisor::new(events, None, backends, state.clone(), Handover::new(state));
+        let sup = RunnerSupervisor::new(
+            events,
+            None,
+            job_logs,
+            backends,
+            state.clone(),
+            Handover::new(state),
+        );
         (sup, rx)
     }
 
@@ -1125,7 +1194,11 @@ mod tests {
     #[tokio::test]
     async fn windows_offer_runs_through_the_interop_backend() {
         let dir = tempfile::tempdir().unwrap();
-        let powershell = interop_stub(dir.path(), "powershell", "echo 'WINPID=4242'\nexit 0");
+        let powershell = interop_stub(
+            dir.path(),
+            "powershell",
+            "echo 'WINPID=4242'\necho 'runner on stdout'\necho 'runner on stderr' >&2\nexit 0",
+        );
         let taskkill = interop_stub(dir.path(), "taskkill", "exit 0");
         let interop = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
 
@@ -1133,7 +1206,7 @@ mod tests {
         // concurrently forking test can hold it open for writing until its
         // own exec) so the spawn inside handle_provision can't hit it.
         for _ in 0..100 {
-            match interop.spawn("dGVzdA==").await {
+            match interop.spawn("dGVzdA==", None).await {
                 Ok(mut job) => {
                     let _ = job.wait().await;
                     break;
@@ -1142,7 +1215,8 @@ mod tests {
             }
         }
 
-        let (sup, mut rx) = windows_supervisor_with_rx(Some(interop));
+        let logs = JobLogs::new(dir.path());
+        let (sup, mut rx) = windows_supervisor_with_rx(Some(interop), logs.clone());
 
         sup.handle_provision(ProvisionRunner {
             job_id: "rjob_win".to_owned(),
@@ -1179,6 +1253,25 @@ mod tests {
             Some(attach_request::Msg::RunnerExited(e)) => assert_eq!(e.job_id, "rjob_win"),
             other => panic!("expected RunnerExited, got {other:?}"),
         }
+
+        // Both of the runner's streams land in the job's own log. The pumps
+        // are detached, so this polls rather than reading once.
+        let log_path = dir.path().join("jobs").join("rjob_win.log");
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let contents = std::fs::read_to_string(&log_path).unwrap_or_default();
+                if contents.contains("runner on stdout") && contents.contains("runner on stderr") {
+                    assert!(
+                        !contents.contains("WINPID="),
+                        "the handshake line is wrapper protocol, not runner output: {contents}"
+                    );
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("both streams reached the job log");
     }
 
     /// A cancel that arrives while the interop spawn is still in the WINPID
@@ -1196,7 +1289,7 @@ mod tests {
         let taskkill = interop_stub(dir.path(), "taskkill", "exit 0");
         let interop = InteropRunner::with_paths(powershell, taskkill, r"C:\r\run.cmd");
 
-        let (sup, mut rx) = windows_supervisor_with_rx(Some(interop));
+        let (sup, mut rx) = windows_supervisor_with_rx(Some(interop), JobLogs::new(dir.path()));
 
         sup.handle_provision(ProvisionRunner {
             job_id: "rjob_win".to_owned(),
@@ -1235,7 +1328,7 @@ mod tests {
     /// ghost job.
     #[tokio::test]
     async fn windows_offer_without_interop_is_rejected() {
-        let (sup, mut rx) = windows_supervisor_with_rx(None);
+        let (sup, mut rx) = windows_supervisor_with_rx(None, JobLogs::nowhere());
 
         sup.handle_provision(ProvisionRunner {
             job_id: "rjob_win".to_owned(),
@@ -1386,6 +1479,7 @@ mod tests {
         let sup = RunnerSupervisor::new(
             events,
             Some(PathBuf::from("/nonexistent")),
+            JobLogs::nowhere(),
             Backends::fixed(
                 vec![capability("darwin", "arm64", Backend::HostRunner)],
                 state.clone(),
@@ -1412,6 +1506,7 @@ mod tests {
         let sup = RunnerSupervisor::new(
             events,
             Some(PathBuf::from("/nonexistent")),
+            JobLogs::nowhere(),
             Backends::fixed(
                 vec![capability("darwin", "arm64", Backend::HostRunner)],
                 state.clone(),
@@ -1822,6 +1917,7 @@ mod tests {
         RunnerSupervisor::new(
             events,
             None,
+            JobLogs::nowhere(),
             Backends::fixed(Vec::new(), drained.clone()),
             drained.clone(),
             Handover::new(drained.clone()),
@@ -1837,6 +1933,7 @@ mod tests {
         RunnerSupervisor::new(
             events,
             None,
+            JobLogs::nowhere(),
             Backends::fixed(Vec::new(), torn_down.clone()),
             torn_down.clone(),
             Handover::new(torn_down.clone()),

--- a/fleet/arcbox-fleet-agent/src/state.rs
+++ b/fleet/arcbox-fleet-agent/src/state.rs
@@ -685,6 +685,7 @@ mod tests {
             job_id: id.to_owned(),
             os: "darwin".to_owned(),
             arch: "arm64".to_owned(),
+            log_path: String::new(),
         }
     }
 

--- a/fleet/arcbox-fleet-agent/src/vm.rs
+++ b/fleet/arcbox-fleet-agent/src/vm.rs
@@ -38,6 +38,7 @@ use russh::{ChannelMsg, Disconnect};
 use tracing::{debug, info, warn};
 
 use crate::host;
+use crate::joblog::JobLog;
 
 /// Guest login and runner location — the ArcBox macOS runner image contract
 /// (see the module doc).
@@ -79,6 +80,9 @@ pub struct RunSpec<'a> {
     /// Base image the guest boots from — the live-settable
     /// `macos_runner_image`, read fresh by the caller for each job.
     pub runner_image: &'a str,
+    /// Where the guest session's combined output is captured. `None` runs
+    /// the job without a log rather than failing it.
+    pub log: Option<JobLog>,
 }
 
 /// The stream part of an image reference: `"tahoe-base@2026.07.03"` →
@@ -261,6 +265,7 @@ impl VmRunner {
                 name: name.clone(),
                 ssh,
                 channel,
+                log: spec.log.clone(),
             })
         }
         .await;
@@ -394,6 +399,7 @@ pub struct RunningVm {
     name: String,
     ssh: SshHandle<SshClient>,
     channel: russh::Channel<russh::client::Msg>,
+    log: Option<JobLog>,
 }
 
 impl RunningVm {
@@ -406,9 +412,15 @@ impl RunningVm {
         let mut code = None;
         while let Some(msg) = self.channel.wait().await {
             match msg {
-                // Runner output stays in the disposable guest; nothing to
-                // collect here.
-                ChannelMsg::Data { .. } | ChannelMsg::ExtendedData { .. } => {}
+                // The guest is destroyed when the job ends, so this session
+                // is the only chance to keep its output. `Data` is the
+                // runner's stdout, `ExtendedData` its stderr; both go to the
+                // job's log in arrival order.
+                ChannelMsg::Data { data } | ChannelMsg::ExtendedData { data, .. } => {
+                    if let Some(log) = &self.log {
+                        log.write(&data).await;
+                    }
+                }
                 ChannelMsg::ExitStatus { exit_status } => code = Some(exit_status),
                 _ => {}
             }
@@ -427,6 +439,7 @@ impl RunningVm {
             name,
             ssh,
             channel,
+            log: _,
         } = self;
         guard.defuse();
         drop(channel);
@@ -531,6 +544,7 @@ mod tests {
                     job_id: "itest",
                     encoded_jit_config: "",
                     runner_image: "tahoe-base",
+                    log: None,
                 },
                 "/usr/bin/true",
             )

--- a/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
+++ b/fleet/arcbox-fleet-control-proto/proto/arcbox/fleet/control/v1/control.proto
@@ -182,6 +182,10 @@ message InFlightJob {
   string job_id = 1;
   string os = 2;
   string arch = 3;
+  // Absolute path of the file this job's combined stdout/stderr is being
+  // written to. Empty when the agent could not open one (a full or
+  // read-only disk), which does not stop the job.
+  string log_path = 4;
 }
 
 message OfferVerdict {


### PR DESCRIPTION
## Why

Each of the four backends disposed of runner output differently, and none kept it: the host backend **inherited** it into the agent's own stdout/stderr (every concurrent job interleaved), Docker left it to the log driver and then **destroyed** the container, the macOS VM **discarded** the SSH `Data`/`ExtendedData` outright, and WSL interop dropped stdout into `debug!` lines invisible at the default filter.

So the only local record of a job was the agent's own lifecycle lines — nothing, exactly when it matters: a runner that died before it could ship anything to GitHub, the case `RunnerExited` exists to signal.

## What

One file per job, `<data_dir>/log/jobs/<job_id>.log`, holding its stdout and stderr combined and verbatim, through one shared writer (`src/joblog.rs`). Owner-only, kept 7 days, capped at 256 MiB.

Three points that are decisions rather than plumbing:

- **Past the cap, output is dropped while the pumps keep draining.** A pump that stopped reading would block the runner on a full pipe. Same reason a job whose log cannot be opened sends its streams to `/dev/null` and runs anyway, rather than into an undrained pipe.
- **`job_id` reaches the filesystem here for the first time.** It is gateway-issued and validated nowhere else in the agent (`container_name` and `machine_name` interpolate it raw), so `open()` admits only `[A-Za-z0-9_-]{1,128}`.
- **Docker teardown drains the stream before removing the container.** Removal ends it mid-copy, dropping exactly the tail that says why a job failed.

`InFlightJob` gained `log_path` (additive), and a `jobs` subcommand lists running jobs beside the logs of the ones that already ran.

Behavior change: a foreground `quick run` no longer prints runner output to the terminal.

## Verification

`cargo test -p arcbox-fleet-agent`, clippy `--all-targets`, `cargo fmt --check`, `buf breaking`/`buf lint` on the control proto — clean. Tests cover the writer's decisions (id validation, the cap truncating while the pump still reaches EOF, the sweep) plus the existing interop dispatch test, extended to echo on both fds and assert the combined file.

That caught a real bug: `tokio::fs::File` buffers, so without a per-chunk flush a job's log stayed empty until the *next* write. It now flushes per chunk — which is also what makes the log survive the crash it exists to explain.
